### PR TITLE
(PC-35130) refactor(OfferPlaylist): expose viewable items changed event

### DIFF
--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -4036,11 +4036,17 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "onEndReached": [Function],
                           "onEndReachedThreshold": 0.2,
                           "onScroll": [Function],
+                          "onViewableItemsChanged": undefined,
                           "renderItem": [Function],
                           "scrollEnabled": true,
                           "scrollEventThrottle": 16,
                           "showsHorizontalScrollIndicator": false,
                           "testID": "offersModuleList",
+                          "viewabilityConfig": {
+                            "minimumViewTime": 300,
+                            "viewAreaCoveragePercentThreshold": 20,
+                            "waitForInteraction": true,
+                          },
                         },
                         "renderWindowInsets": {
                           "height": 0,
@@ -4098,6 +4104,13 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     }
                     suppressBoundedSizeException={true}
                     testID="offersModuleList"
+                    viewabilityConfig={
+                      {
+                        "minimumViewTime": 300,
+                        "viewAreaCoveragePercentThreshold": 20,
+                        "waitForInteraction": true,
+                      }
+                    }
                     windowCorrectionConfig={
                       {
                         "applyToInitialOffset": true,

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -1338,11 +1338,17 @@ exports[`<Venue /> should match snapshot 1`] = `
                               "onEndReached": undefined,
                               "onEndReachedThreshold": 0.2,
                               "onScroll": [Function],
+                              "onViewableItemsChanged": undefined,
                               "renderItem": [Function],
                               "scrollEnabled": true,
                               "scrollEventThrottle": 16,
                               "showsHorizontalScrollIndicator": false,
                               "testID": "offersModuleList",
+                              "viewabilityConfig": {
+                                "minimumViewTime": 300,
+                                "viewAreaCoveragePercentThreshold": 20,
+                                "waitForInteraction": true,
+                              },
                             },
                             "renderWindowInsets": {
                               "height": 0,
@@ -1400,6 +1406,13 @@ exports[`<Venue /> should match snapshot 1`] = `
                         }
                         suppressBoundedSizeException={true}
                         testID="offersModuleList"
+                        viewabilityConfig={
+                          {
+                            "minimumViewTime": 300,
+                            "viewAreaCoveragePercentThreshold": 20,
+                            "waitForInteraction": true,
+                          }
+                        }
                         windowCorrectionConfig={
                           {
                             "applyToInitialOffset": true,
@@ -2755,11 +2768,17 @@ exports[`<Venue /> should match snapshot 1`] = `
                                 "onEndReached": [Function],
                                 "onEndReachedThreshold": 0.2,
                                 "onScroll": [Function],
+                                "onViewableItemsChanged": undefined,
                                 "renderItem": [Function],
                                 "scrollEnabled": true,
                                 "scrollEventThrottle": 16,
                                 "showsHorizontalScrollIndicator": false,
                                 "testID": "offersModuleList",
+                                "viewabilityConfig": {
+                                  "minimumViewTime": 300,
+                                  "viewAreaCoveragePercentThreshold": 20,
+                                  "waitForInteraction": true,
+                                },
                               },
                               "renderWindowInsets": {
                                 "height": 0,
@@ -2817,6 +2836,13 @@ exports[`<Venue /> should match snapshot 1`] = `
                           }
                           suppressBoundedSizeException={true}
                           testID="offersModuleList"
+                          viewabilityConfig={
+                            {
+                              "minimumViewTime": 300,
+                              "viewAreaCoveragePercentThreshold": 20,
+                              "waitForInteraction": true,
+                            }
+                          }
                           windowCorrectionConfig={
                             {
                               "applyToInitialOffset": true,
@@ -6418,11 +6444,17 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                               "onEndReached": undefined,
                               "onEndReachedThreshold": 0.2,
                               "onScroll": [Function],
+                              "onViewableItemsChanged": undefined,
                               "renderItem": [Function],
                               "scrollEnabled": true,
                               "scrollEventThrottle": 16,
                               "showsHorizontalScrollIndicator": false,
                               "testID": "offersModuleList",
+                              "viewabilityConfig": {
+                                "minimumViewTime": 300,
+                                "viewAreaCoveragePercentThreshold": 20,
+                                "waitForInteraction": true,
+                              },
                             },
                             "renderWindowInsets": {
                               "height": 0,
@@ -6480,6 +6512,13 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                         }
                         suppressBoundedSizeException={true}
                         testID="offersModuleList"
+                        viewabilityConfig={
+                          {
+                            "minimumViewTime": 300,
+                            "viewAreaCoveragePercentThreshold": 20,
+                            "waitForInteraction": true,
+                          }
+                        }
                         windowCorrectionConfig={
                           {
                             "applyToInitialOffset": true,
@@ -7835,11 +7874,17 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                                 "onEndReached": [Function],
                                 "onEndReachedThreshold": 0.2,
                                 "onScroll": [Function],
+                                "onViewableItemsChanged": undefined,
                                 "renderItem": [Function],
                                 "scrollEnabled": true,
                                 "scrollEventThrottle": 16,
                                 "showsHorizontalScrollIndicator": false,
                                 "testID": "offersModuleList",
+                                "viewabilityConfig": {
+                                  "minimumViewTime": 300,
+                                  "viewAreaCoveragePercentThreshold": 20,
+                                  "waitForInteraction": true,
+                                },
                               },
                               "renderWindowInsets": {
                                 "height": 0,
@@ -7897,6 +7942,13 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                           }
                           suppressBoundedSizeException={true}
                           testID="offersModuleList"
+                          viewabilityConfig={
+                            {
+                              "minimumViewTime": 300,
+                              "viewAreaCoveragePercentThreshold": 20,
+                              "waitForInteraction": true,
+                            }
+                          }
                           windowCorrectionConfig={
                             {
                               "applyToInitialOffset": true,

--- a/src/features/offer/components/OfferPlaylist/OfferPlaylist.tsx
+++ b/src/features/offer/components/OfferPlaylist/OfferPlaylist.tsx
@@ -1,25 +1,14 @@
-import React from 'react'
+import React, { ComponentProps } from 'react'
 import { View } from 'react-native'
 import styled from 'styled-components/native'
 
-import { PlaylistType } from 'features/offer/enums'
 import { AlgoliaOfferWithArtistAndEan } from 'libs/algolia/types'
 import { Offer } from 'shared/offer/types'
 import { PassPlaylist } from 'ui/components/PassPlaylist'
 
-interface OfferPlaylistProps {
+interface OfferPlaylistProps
+  extends Omit<ComponentProps<typeof PassPlaylist>, 'data' | 'keyExtractor'> {
   items: Offer[] | AlgoliaOfferWithArtistAndEan[]
-  renderItem: (props: {
-    item: Offer
-    width: number
-    height: number
-    playlistType?: PlaylistType
-  }) => React.ReactElement
-  itemWidth: number
-  itemHeight: number
-  title: string
-  playlistType: PlaylistType
-  onEndReached?: () => void
 }
 
 const keyExtractor = (item: Offer | AlgoliaOfferWithArtistAndEan) => item.objectID
@@ -32,6 +21,8 @@ export function OfferPlaylist({
   title,
   playlistType,
   onEndReached,
+  playlistRef,
+  onViewableItemsChanged,
 }: Readonly<OfferPlaylistProps>) {
   return (
     <View>
@@ -44,6 +35,8 @@ export function OfferPlaylist({
         title={title}
         playlistType={playlistType}
         onEndReached={onEndReached}
+        onViewableItemsChanged={onViewableItemsChanged}
+        playlistRef={playlistRef}
       />
     </View>
   )

--- a/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.native.test.tsx
+++ b/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.native.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { InViewProps } from 'react-native-intersection-observer'
 
 import { push } from '__mocks__/@react-navigation/native'
 import { mockOffer } from 'features/bookOffer/fixtures/offer'
@@ -13,9 +14,21 @@ import {
 } from 'libs/algolia/fixtures/algoliaFixtures'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { userEvent, render, screen } from 'tests/utils'
+import { userEvent, render, screen, waitFor } from 'tests/utils'
 
 jest.mock('libs/subcategories/useSubcategories')
+
+const mockInView = jest.fn()
+jest.mock('react-native-intersection-observer', () => {
+  const InView = (props: InViewProps) => {
+    mockInView.mockImplementation(props.onChange)
+    return null
+  }
+  return {
+    ...jest.requireActual('react-native-intersection-observer'),
+    InView,
+  }
+})
 
 const mockSearchHits = [...mockedAlgoliaResponse.hits, ...moreHitsForSimilarOffersPlaylist]
 
@@ -41,6 +54,8 @@ jest.mock('@shopify/flash-list', () => {
 
 const user = userEvent.setup()
 jest.useFakeTimers()
+
+const mockPlaylistViewableItemsChanged = jest.fn()
 
 describe('<OfferPlaylistList />', () => {
   beforeEach(() => {
@@ -113,6 +128,62 @@ describe('<OfferPlaylistList />', () => {
         })
       })
     })
+
+    describe('For tracking purpose...', () => {
+      it('should expose viewable items of visible playlists', async () => {
+        renderOfferPlaylistList({
+          ...offerPlaylistListProps,
+          sameCategorySimilarOffers: mockSearchHits,
+        })
+
+        const allPlaylistElements = await screen.findAllByTestId('offersModuleList')
+        const playlistElement = allPlaylistElements.at(0)
+
+        if (!playlistElement) {
+          throw new Error('Playlist not found')
+        }
+        mockInView(true)
+
+        await user.scrollTo(playlistElement, {
+          layoutMeasurement: { width: 600, height: 300 },
+          contentSize: { width: 1200, height: 300 },
+          x: 0,
+        })
+
+        await waitFor(() =>
+          expect(mockPlaylistViewableItemsChanged).toHaveBeenCalledWith('Dans la même catégorie', [
+            '102280',
+            '102272',
+            '102249',
+            '102310',
+            '102281',
+          ])
+        )
+      })
+
+      it('should not expose viewable items when playlists are offscreen', async () => {
+        renderOfferPlaylistList({
+          ...offerPlaylistListProps,
+          sameCategorySimilarOffers: mockSearchHits,
+        })
+
+        const allPlaylistElements = await screen.findAllByTestId('offersModuleList')
+        const playlistElement = allPlaylistElements.at(0)
+
+        if (!playlistElement) {
+          throw new Error('Playlist not found')
+        }
+        mockInView(false)
+
+        await user.scrollTo(playlistElement, {
+          layoutMeasurement: { width: 600, height: 300 },
+          contentSize: { width: 1200, height: 300 },
+          x: 0,
+        })
+
+        await waitFor(() => expect(mockPlaylistViewableItemsChanged).not.toHaveBeenCalled())
+      })
+    })
   })
 })
 
@@ -127,6 +198,7 @@ const renderOfferPlaylistList = ({
         offer={offer}
         sameCategorySimilarOffers={sameCategorySimilarOffers}
         otherCategoriesSimilarOffers={otherCategoriesSimilarOffers}
+        onPlaylistViewableItemsChanged={mockPlaylistViewableItemsChanged}
       />
     )
   )

--- a/src/ui/components/PassPlaylist.tsx
+++ b/src/ui/components/PassPlaylist.tsx
@@ -1,4 +1,5 @@
-import React, { ComponentProps, ComponentType, useCallback } from 'react'
+import React, { ComponentProps, ComponentType, Ref, useCallback } from 'react'
+import { FlatList } from 'react-native-gesture-handler'
 import styled, { useTheme } from 'styled-components/native'
 
 import { Playlist, RenderFooterItem } from 'ui/components/Playlist'
@@ -19,6 +20,7 @@ type Props = Pick<
   | 'keyExtractor'
   | 'renderItem'
   | 'onEndReached'
+  | 'onViewableItemsChanged'
   | 'playlistType'
   | 'tileType'
 > & {
@@ -28,6 +30,7 @@ type Props = Pick<
   onPressSeeMore?: () => void
   renderFooter?: RenderFooterItem
   titleSeeMoreLink?: InternalNavigationProps['navigateTo']
+  playlistRef?: Ref<FlatList>
 }
 
 export const PassPlaylist = ({
@@ -36,6 +39,7 @@ export const PassPlaylist = ({
   TitleComponent,
   onPressSeeMore,
   onEndReached,
+  onViewableItemsChanged,
   titleSeeMoreLink,
   data,
   itemHeight,
@@ -45,6 +49,7 @@ export const PassPlaylist = ({
   playlistType,
   tileType,
   keyExtractor,
+  playlistRef,
   testID: _testID,
   ...props
 }: Props) => {
@@ -101,6 +106,8 @@ export const PassPlaylist = ({
         onEndReached={onEndReached}
         playlistType={playlistType}
         tileType={tileType}
+        ref={playlistRef}
+        onViewableItemsChanged={onViewableItemsChanged}
       />
     </Container>
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35130

Implémentation d'un prop `onPlaylistViewableItemsChanged` sur le composant `OfferPlaylistList` qui permet d'avoir une information sur les item d'offre visibles à l'écran

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
