### PR TITLE
(PC-34987) feat(a11y): update autoComplete and textContentType in som…

### DIFF
--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
@@ -566,7 +566,7 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
                       <TextInput
                         accessibilityDescribedBy="testUuidV4"
                         autoCapitalize="none"
-                        autoComplete="off"
+                        autoComplete="tel"
                         editable={true}
                         isEmpty={true}
                         keyboardType="number-pad"
@@ -598,7 +598,7 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
                         }
                         testID="Entrée pour le numéro de téléphone"
                         textAlignVertical="center"
-                        textContentType="none"
+                        textContentType="telephoneNumber"
                         value=""
                       />
                     </View>

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
@@ -575,7 +575,7 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
                       <TextInput
                         accessibilityDescribedBy="testUuidV4"
                         autoCapitalize="none"
-                        autoComplete="off"
+                        autoComplete="tel"
                         editable={true}
                         isEmpty={true}
                         keyboardType="number-pad"
@@ -607,7 +607,7 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
                         }
                         testID="Entrée pour le numéro de téléphone"
                         textAlignVertical="center"
-                        textContentType="none"
+                        textContentType="telephoneNumber"
                       />
                     </View>
                   </View>

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
@@ -436,6 +436,7 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
                       <TextInput
                         accessibilityDescribedBy="testUuidV4"
                         autoCapitalize="none"
+                        autoComplete="one-time-code"
                         editable={true}
                         isEmpty={true}
                         keyboardType="number-pad"

--- a/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
@@ -372,6 +372,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
                 <TextInput
                   accessibilityDescribedBy="testUuidV4"
                   accessibilityHidden={false}
+                  autoComplete="street-address"
                   autoCorrect={false}
                   editable={true}
                   enablesReturnKeyAutomatically={true}
@@ -406,7 +407,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
                   }
                   testID="Entrée pour l’adresse"
                   textAlignVertical="center"
-                  textContentType="addressState"
+                  textContentType="fullStreetAddress"
                   value=""
                 />
               </View>

--- a/__snapshots__/features/identityCheck/pages/profile/SetAddress.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetAddress.web.test.tsx.web-snap
@@ -249,7 +249,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
               >
                 <input
                   autocapitalize="sentences"
-                  autocomplete="on"
+                  autocomplete="street-address"
                   autocorrect="off"
                   class="css-textinput-11aywtz r-placeholderTextColor-6taxm2 r-color-1rmcaf9 r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-fontFamily-1nu0hr2 r-fontSize-cygvgh r-height-1pi2tsx r-paddingBottom-1mdbw0j r-paddingLeft-gy4na3 r-paddingRight-9aemit r-paddingTop-wk8lta r-width-lnhwgy"
                   data-testid="Entrée pour l’adresse"

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
@@ -381,6 +381,7 @@ exports[`<SetCity/> should render correctly 1`] = `
                   <TextInput
                     accessibilityDescribedBy="testUuidV4"
                     accessibilityHidden={false}
+                    autoComplete="postal-code"
                     autoCorrect={false}
                     editable={true}
                     enablesReturnKeyAutomatically={true}

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.web.test.tsx.web-snap
@@ -252,7 +252,7 @@ exports[`<SetCity/> should render correctly 1`] = `
                 >
                   <input
                     autocapitalize="sentences"
-                    autocomplete="on"
+                    autocomplete="postal-code"
                     autocorrect="off"
                     class="css-textinput-11aywtz r-placeholderTextColor-6taxm2 r-color-1rmcaf9 r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-fontFamily-1nu0hr2 r-fontSize-cygvgh r-height-1pi2tsx r-paddingBottom-1mdbw0j r-paddingLeft-gy4na3 r-paddingRight-9aemit r-paddingTop-wk8lta r-width-lnhwgy"
                     data-testid="Entrée pour la ville"

--- a/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
@@ -471,6 +471,7 @@ Nous les vérifions et ils ne pourront plus être modifiés par la suite.
                   <TextInput
                     accessibilityDescribedBy="testUuidV4"
                     accessibilityRequired={true}
+                    autoComplete="given-name"
                     editable={true}
                     isEmpty={true}
                     multiline={false}
@@ -500,7 +501,7 @@ Nous les vérifions et ils ne pourront plus être modifiés par la suite.
                     }
                     testID="Entrée pour le prénom"
                     textAlignVertical="center"
-                    textContentType="username"
+                    textContentType="givenName"
                     value=""
                   />
                 </View>
@@ -610,6 +611,7 @@ Nous les vérifions et ils ne pourront plus être modifiés par la suite.
                   <TextInput
                     accessibilityDescribedBy="testUuidV4"
                     accessibilityRequired={true}
+                    autoComplete="family-name"
                     editable={true}
                     isEmpty={true}
                     multiline={false}
@@ -639,7 +641,7 @@ Nous les vérifions et ils ne pourront plus être modifiés par la suite.
                     }
                     testID="Entrée pour le nom"
                     textAlignVertical="center"
-                    textContentType="username"
+                    textContentType="familyName"
                     value=""
                   />
                 </View>

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
@@ -369,6 +369,7 @@ exports[`ChangeCity should render correctly 1`] = `
                   <TextInput
                     accessibilityDescribedBy="testUuidV4"
                     accessibilityHidden={false}
+                    autoComplete="postal-code"
                     autoCorrect={false}
                     editable={true}
                     enablesReturnKeyAutomatically={true}

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
@@ -248,7 +248,7 @@ exports[`ChangeCity should render correctly 1`] = `
                 >
                   <input
                     autocapitalize="sentences"
-                    autocomplete="on"
+                    autocomplete="postal-code"
                     autocorrect="off"
                     class="css-textinput-11aywtz r-placeholderTextColor-6taxm2 r-color-1rmcaf9 r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-fontFamily-1nu0hr2 r-fontSize-cygvgh r-height-1pi2tsx r-paddingBottom-1mdbw0j r-paddingLeft-gy4na3 r-paddingRight-9aemit r-paddingTop-wk8lta r-width-lnhwgy"
                     data-testid="Entrée pour la ville"

--- a/src/cheatcodes/pages/others/CheatcodesScreenNewCaledonia.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenNewCaledonia.tsx
@@ -61,13 +61,13 @@ export const CheatcodesScreenNewCaledonia = () => {
       <StyledSeparator />
       <TextInput
         label="Montant en&nbsp;€ pour conversion&nbsp;:"
-        autoComplete="off"
+        autoComplete="off" // Keep autocomplete="off" to prevent incorrect suggestions.
         autoCapitalize="none"
         value={inputEuro}
         onChangeText={setInputEuro}
         keyboardType="numeric"
         placeholder="Entrez le montant en&nbsp;€"
-        textContentType="none"
+        textContentType="none" // Keep textContentType="none" to prevent incorrect suggestions.
       />
       <Spacer.Column numberOfSpaces={4} />
       <TypoDS.Body>Franc Pacifique sans arrondi&nbsp;:</TypoDS.Body>

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
@@ -125,14 +125,14 @@ export const SetPhoneNumber = () => {
               <Spacer.Column numberOfSpaces={6} />
               <InputContainer>
                 <TextInput
-                  autoComplete="off" // disable autofill on android
+                  autoComplete="tel"
                   autoCapitalize="none"
                   isError={false}
                   keyboardType="number-pad"
                   label="Numéro de téléphone"
                   value={phoneNumber}
                   onChangeText={onChangeText}
-                  textContentType="none" // disable autofill on iOS
+                  textContentType="telephoneNumber"
                   onSubmitEditing={requestSendPhoneValidationCode}
                   accessibilityDescribedBy={phoneNumberInputErrorId}
                   leftComponent={<CountryPicker selectedCountry={country} onSelect={setCountry} />}

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
@@ -116,7 +116,7 @@ export const SetPhoneNumberWithoutValidation = () => {
               render={({ field, fieldState }) => (
                 <ViewGap gap={2}>
                   <TextInput
-                    autoComplete="off" // disable autofill on android
+                    autoComplete="tel"
                     autoCapitalize="none"
                     isError={!!fieldState.error}
                     keyboardType="number-pad"
@@ -124,7 +124,7 @@ export const SetPhoneNumberWithoutValidation = () => {
                     value={field.value}
                     onChangeText={field.onChange}
                     onSubmitEditing={submit}
-                    textContentType="none" // disable autofill on iOS
+                    textContentType="telephoneNumber"
                     accessibilityDescribedBy={phoneNumberInputErrorId}
                     leftComponent={
                       <Controller

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.tsx
@@ -131,6 +131,7 @@ export const SetPhoneValidationCode = () => {
                 value={codeInputState.code}
                 onChangeText={onChangeValue}
                 placeholder="012345"
+                autoComplete="one-time-code"
                 textContentType="oneTimeCode"
                 onSubmitEditing={validateCode}
                 accessibilityDescribedBy={validationCodeInputErrorId}

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -122,7 +122,8 @@ export const SetAddress = () => {
               value={query}
               label={label}
               placeholder="Ex&nbsp;: 34 avenue de l’Opéra"
-              textContentType="addressState"
+              autoComplete="street-address"
+              textContentType="fullStreetAddress"
               accessibilityDescribedBy={addressInputErrorId}
               onPressRightIcon={resetSearch}
               returnKeyType="next"

--- a/src/features/identityCheck/pages/profile/SetName.tsx
+++ b/src/features/identityCheck/pages/profile/SetName.tsx
@@ -76,10 +76,11 @@ Nous les vérifions et ils ne pourront plus être modifiés par la suite."
                   autoFocus
                   onChangeText={onChange}
                   placeholder="Ton prénom"
-                  textContentType="username"
                   isRequiredField
                   accessibilityDescribedBy={firstNameInputErrorId}
                   testID="Entrée pour le prénom"
+                  textContentType="givenName"
+                  autoComplete="given-name"
                 />
                 <InputError
                   visible={firstName.length > 0 && !!error}
@@ -101,10 +102,11 @@ Nous les vérifions et ils ne pourront plus être modifiés par la suite."
                   value={value}
                   onChangeText={onChange}
                   placeholder="Ton nom"
-                  textContentType="username"
                   isRequiredField
                   accessibilityDescribedBy={lastNameInputErrorId}
                   testID="Entrée pour le nom"
+                  textContentType="familyName"
+                  autoComplete="family-name"
                 />
                 <InputError
                   visible={lastName.length > 0 && !!error}

--- a/src/features/profile/components/CitySearchInput/CitySearchInput.tsx
+++ b/src/features/profile/components/CitySearchInput/CitySearchInput.tsx
@@ -126,11 +126,12 @@ export const CitySearchInput = ({ city, onCitySelected }: CitySearchInputProps) 
                 value={value}
                 label="Indique ton code postal et choisis ta ville"
                 placeholder="Ex&nbsp;: 75017"
-                textContentType="postalCode"
                 onPressRightIcon={resetSearch}
                 keyboardType="number-pad"
                 accessibilityDescribedBy={postalCodeInputId}
                 testID="Entrée pour la ville"
+                autoComplete="postal-code"
+                textContentType="postalCode"
               />
               <InputError
                 messageId={error?.message}

--- a/src/features/search/components/PriceInputController/PriceInputController.tsx
+++ b/src/features/search/components/PriceInputController/PriceInputController.tsx
@@ -44,11 +44,11 @@ export const PriceInputController = <
             rightLabel={rightLabel}
             disabled={isDisabled}
             isError={!!error && value.length > 0}
-            textContentType="none"
             accessibilityDescribedBy={accessibilityId}
             keyboardType="numeric"
-            autoComplete="off"
             autoCapitalize="none"
+            autoComplete="off" // Keep autocomplete="off" to prevent incorrect suggestions.
+            textContentType="none" // Keep textContentType="none" to prevent incorrect suggestions.
             {...textInputProps}
           />
           <InputError


### PR DESCRIPTION
…e inputs

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34987

## Why ? 

`autoComplete` et `textContentType` sont utilisés pour améliorer l'expérience de saisie de texte :

- `autoComplete` : Indique au système qu'il peut proposer des suggestions de remplissage automatique basées sur des valeurs précédemment enregistrées (par exemple, des adresses ou des numéros).

- `textContentType` : Aide le système (notamment iOS) à déterminer le type de contenu attendu dans le champ, optimisant ainsi l'affichage du clavier et les suggestions contextuelles adaptées au type de donnée (ex. email, mot de passe, etc.).

Les deux propriétés travaillent ensemble pour faciliter la saisie en offrant des suggestions appropriées et un clavier adapté.


## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
