### PR TITLE
(BSR) refactor(tests): replace fireEvent by userEvent

### DIFF
--- a/src/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx
+++ b/src/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx
@@ -14,7 +14,7 @@ import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { AccountCreated } from './AccountCreated'
 
@@ -37,6 +37,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<AccountCreated />', () => {
   beforeEach(() => {
     setFeatureFlags()
@@ -53,25 +56,23 @@ describe('<AccountCreated />', () => {
   it('should redirect to native cultural survey page WHEN "On y va !" button is clicked', async () => {
     renderAccountCreated()
 
-    fireEvent.press(await screen.findByLabelText('On y va\u00a0!'))
+    await user.press(await screen.findByLabelText('On y va\u00a0!'))
 
-    await waitFor(() => {
-      expect(navigateFromRef).not.toHaveBeenCalled()
-      expect(navigate).toHaveBeenNthCalledWith(1, 'CulturalSurveyIntro', undefined)
-    })
+    expect(navigateFromRef).not.toHaveBeenCalled()
+    expect(navigate).toHaveBeenNthCalledWith(1, 'CulturalSurveyIntro', undefined)
   })
 
   it('should redirect to home page WHEN "On y va !" button is clicked BUT feature flag enableCulturalSurveyMandatory is enabled', async () => {
     setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_CULTURAL_SURVEY_MANDATORY])
     renderAccountCreated()
-    fireEvent.press(await screen.findByLabelText('On y va\u00a0!'))
-    await waitFor(() => {
-      expect(navigateFromRef).toHaveBeenCalledWith(
-        navigateToHomeConfig.screen,
-        navigateToHomeConfig.params
-      )
-      expect(navigate).not.toHaveBeenCalledWith('CulturalSurvey', undefined)
-    })
+
+    await user.press(await screen.findByLabelText('On y va\u00a0!'))
+
+    expect(navigateFromRef).toHaveBeenCalledWith(
+      navigateToHomeConfig.screen,
+      navigateToHomeConfig.params
+    )
+    expect(navigate).not.toHaveBeenCalledWith('CulturalSurvey', undefined)
   })
 
   it('should redirect to home page WHEN "On y va !" button is clicked and user needs not to fill cultural survey', async () => {
@@ -79,21 +80,19 @@ describe('<AccountCreated />', () => {
     mockAuthContextWithUser({ ...beneficiaryUser, needsToFillCulturalSurvey: false }) // re-render because local storage value has been read and set
     renderAccountCreated()
 
-    fireEvent.press(await screen.findByLabelText('On y va\u00a0!'))
+    await user.press(await screen.findByLabelText('On y va\u00a0!'))
 
-    await waitFor(() => {
-      expect(navigateFromRef).toHaveBeenCalledWith(
-        navigateToHomeConfig.screen,
-        navigateToHomeConfig.params
-      )
-      expect(navigate).not.toHaveBeenCalledWith('CulturalSurvey', undefined)
-    })
+    expect(navigateFromRef).toHaveBeenCalledWith(
+      navigateToHomeConfig.screen,
+      navigateToHomeConfig.params
+    )
+    expect(navigate).not.toHaveBeenCalledWith('CulturalSurvey', undefined)
   })
 
   it('should track Batch event when "On y va !" button is clicked', async () => {
     renderAccountCreated()
 
-    fireEvent.press(await screen.findByLabelText('On y va\u00a0!'))
+    await user.press(await screen.findByLabelText('On y va\u00a0!'))
 
     expect(BatchProfile.trackEvent).toHaveBeenCalledWith('has_validated_account')
   })
@@ -109,7 +108,7 @@ describe('<AccountCreated />', () => {
   it('should show non eligible share app modal when "On y va !" button is clicked', async () => {
     renderAccountCreated()
 
-    fireEvent.press(await screen.findByLabelText('On y va\u00a0!'))
+    await user.press(await screen.findByLabelText('On y va\u00a0!'))
 
     expect(mockShowAppModal).toHaveBeenNthCalledWith(1, ShareAppModalType.NOT_ELIGIBLE)
   })
@@ -117,7 +116,7 @@ describe('<AccountCreated />', () => {
   it('should log analytics when "On y va !" button is clicked', async () => {
     renderAccountCreated()
 
-    fireEvent.press(await screen.findByLabelText('On y va\u00a0!'))
+    await user.press(await screen.findByLabelText('On y va\u00a0!'))
 
     expect(analytics.logAccountCreatedStartClicked).toHaveBeenCalledTimes(1)
   })

--- a/src/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx
+++ b/src/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { navigateFromRef } from 'features/navigation/navigationRef'
 import { RootStackParamList } from 'features/navigation/RootNavigator/types'
-import { render, fireEvent, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { NotYetUnderageEligibility } from './NotYetUnderageEligibility'
 
@@ -21,6 +21,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<NotYetUnderageEligibility />', () => {
   it('should render properly', () => {
     render(<NotYetUnderageEligibility {...navigationProps} />)
@@ -28,11 +31,11 @@ describe('<NotYetUnderageEligibility />', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should redirect to home page WHEN go back to home button is clicked', () => {
+  it('should redirect to home page WHEN go back to home button is clicked', async () => {
     render(<NotYetUnderageEligibility {...navigationProps} />)
 
     const button = screen.getByText('Retourner à l’accueil')
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(navigateFromRef).toHaveBeenCalledWith(
       navigateToHomeConfig.screen,

--- a/src/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx
+++ b/src/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { SignupStep } from 'features/auth/enums'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { analytics } from 'libs/analytics/provider'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { QuitSignupModal } from './QuitSignupModal'
 
@@ -16,6 +16,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('QuitSignupModal', () => {
   beforeEach(() => {
@@ -45,39 +48,39 @@ describe('QuitSignupModal', () => {
     expect(button).toBeOnTheScreen()
   })
 
-  it('should call resume function when clicking on "Continuer l’inscription"', () => {
+  it('should call resume function when clicking on "Continuer l’inscription"', async () => {
     renderQuitSignupModal(true)
 
     const resumeButton = screen.getByText('Continuer l’inscription')
-    fireEvent.press(resumeButton)
+    await user.press(resumeButton)
 
     expect(resumeMock).toHaveBeenCalledTimes(1)
   })
 
-  it('should go back to homepage when clicking on "Abandonner l’inscription"', () => {
+  it('should go back to homepage when clicking on "Abandonner l’inscription"', async () => {
     renderQuitSignupModal(true)
 
     const abandonButton = screen.getByText('Abandonner l’inscription')
-    fireEvent.press(abandonButton)
+    await user.press(abandonButton)
 
     expect(navigateToHome).toHaveBeenCalledTimes(1)
   })
 
   describe('QuitSignupModal - Analytics', () => {
-    it('should log CancelSignup when clicking on "Continuer l’inscription"', () => {
+    it('should log CancelSignup when clicking on "Continuer l’inscription"', async () => {
       renderQuitSignupModal(true)
 
       const resumeButton = screen.getByText('Continuer l’inscription')
-      fireEvent.press(resumeButton)
+      await user.press(resumeButton)
 
       expect(analytics.logContinueSignup).toHaveBeenCalledTimes(1)
     })
 
-    it('should log CancelSignup when clicking on "Abandonner l’inscription"', () => {
+    it('should log CancelSignup when clicking on "Abandonner l’inscription"', async () => {
       renderQuitSignupModal(true)
 
       const abandonButton = screen.getByText('Abandonner l’inscription')
-      fireEvent.press(abandonButton)
+      await user.press(abandonButton)
 
       expect(analytics.logCancelSignup).toHaveBeenCalledTimes(1)
       expect(analytics.logCancelSignup).toHaveBeenCalledWith('Birthday')

--- a/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx
+++ b/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx
@@ -9,7 +9,7 @@ import { eventMonitoring } from 'libs/monitoring/services'
 import { MODAL_TO_SHOW_TIME } from 'tests/constants'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { act, render, screen, userEvent, waitFor } from 'tests/utils'
 
 import { EmailResendModal } from './EmailResendModal'
 
@@ -29,6 +29,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<EmailResendModal />', () => {
   it('should render correctly', async () => {
     renderEmailResendModal({})
@@ -40,10 +43,10 @@ describe('<EmailResendModal />', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should dismiss modal when close icon is pressed', () => {
+  it('should dismiss modal when close icon is pressed', async () => {
     renderEmailResendModal({})
 
-    fireEvent.press(screen.getByLabelText('Fermer la modale'))
+    await user.press(screen.getByLabelText('Fermer la modale'))
 
     expect(onDismissMock).toHaveBeenCalledTimes(1)
   })
@@ -56,7 +59,7 @@ describe('<EmailResendModal />', () => {
     })
 
     await act(async () => {
-      fireEvent.press(screen.getByLabelText('Demander un nouveau lien'))
+      user.press(screen.getByLabelText('Demander un nouveau lien'))
     })
 
     expect(analytics.logResendEmailValidation).toHaveBeenCalledTimes(1)
@@ -68,7 +71,7 @@ describe('<EmailResendModal />', () => {
       expect(screen.getByText('Demander un nouveau lien')).toBeEnabled()
     })
 
-    await act(async () => fireEvent.press(screen.getByText('Demander un nouveau lien')))
+    await act(async () => user.press(screen.getByText('Demander un nouveau lien')))
 
     expect(resendEmailValidationSpy).toHaveBeenCalledTimes(1)
   })
@@ -80,7 +83,7 @@ describe('<EmailResendModal />', () => {
       expect(screen.getByText('Demander un nouveau lien')).toBeEnabled()
     })
 
-    fireEvent.press(screen.getByText('Demander un nouveau lien'))
+    await user.press(screen.getByText('Demander un nouveau lien'))
 
     expect(
       await screen.findByText(
@@ -95,7 +98,7 @@ describe('<EmailResendModal />', () => {
       expect(screen.getByText('Demander un nouveau lien')).toBeEnabled()
     })
 
-    fireEvent.press(screen.getByText('Demander un nouveau lien'))
+    user.press(screen.getByText('Demander un nouveau lien'))
 
     expect(
       await screen.findByText(
@@ -110,7 +113,7 @@ describe('<EmailResendModal />', () => {
       expect(screen.getByText('Demander un nouveau lien')).toBeEnabled()
     })
 
-    fireEvent.press(screen.getByText('Demander un nouveau lien'))
+    user.press(screen.getByText('Demander un nouveau lien'))
 
     expect(
       await screen.findByText('Tu as dépassé le nombre de renvois autorisés.')
@@ -126,7 +129,7 @@ describe('<EmailResendModal />', () => {
       expect(screen.getByText('Demander un nouveau lien')).toBeEnabled()
     })
 
-    await act(async () => fireEvent.press(screen.getByText('Demander un nouveau lien')))
+    await act(async () => user.press(screen.getByText('Demander un nouveau lien')))
 
     expect(
       screen.queryByText(
@@ -166,7 +169,7 @@ describe('<EmailResendModal />', () => {
         expect(screen.getByText('Demander un nouveau lien')).toBeEnabled()
       })
 
-      await act(async () => fireEvent.press(screen.getByText('Demander un nouveau lien')))
+      await user.press(screen.getByText('Demander un nouveau lien'))
 
       expect(eventMonitoring.captureException).toHaveBeenCalledTimes(0)
     })
@@ -190,7 +193,7 @@ describe('<EmailResendModal />', () => {
         expect(screen.getByText('Demander un nouveau lien')).toBeEnabled()
       })
 
-      fireEvent.press(screen.getByText('Demander un nouveau lien'))
+      user.press(screen.getByText('Demander un nouveau lien'))
 
       await waitFor(() => {
         expect(eventMonitoring.captureException).toHaveBeenCalledWith(

--- a/src/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx
+++ b/src/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx
@@ -6,7 +6,7 @@ import { analytics } from 'libs/analytics/provider'
 import { EmptyResponse } from 'libs/fetch'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 import * as SnackBarContextModule from 'ui/components/snackBar/SnackBarContext'
 
 import { SuspendedAccountUponUserRequest } from './SuspendedAccountUponUserRequest'
@@ -36,6 +36,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<SuspendedAccountUponUserRequest />', () => {
   it('should match snapshot', () => {
     render(reactQueryProviderHOC(<SuspendedAccountUponUserRequest />))
@@ -47,7 +50,7 @@ describe('<SuspendedAccountUponUserRequest />', () => {
     mockServer.postApi('/v1/account/unsuspend', {})
     render(reactQueryProviderHOC(<SuspendedAccountUponUserRequest />))
 
-    await act(async () => fireEvent.press(screen.getByText('Réactiver mon compte')))
+    await user.press(screen.getByText('Réactiver mon compte'))
 
     expect(replace).toHaveBeenNthCalledWith(1, 'AccountReactivationSuccess')
   })
@@ -56,7 +59,7 @@ describe('<SuspendedAccountUponUserRequest />', () => {
     mockServer.postApi('/v1/account/unsuspend', {})
     render(reactQueryProviderHOC(<SuspendedAccountUponUserRequest />))
 
-    await act(async () => fireEvent.press(screen.getByText('Réactiver mon compte')))
+    await user.press(screen.getByText('Réactiver mon compte'))
 
     expect(analytics.logAccountReactivation).toHaveBeenCalledWith('suspendedaccountuponuserrequest')
   })
@@ -69,13 +72,11 @@ describe('<SuspendedAccountUponUserRequest />', () => {
     })
     render(reactQueryProviderHOC(<SuspendedAccountUponUserRequest />))
 
-    await act(async () => fireEvent.press(screen.getByText('Réactiver mon compte')))
+    await user.press(screen.getByText('Réactiver mon compte'))
 
-    await waitFor(() => {
-      expect(mockShowErrorSnackBar).toHaveBeenNthCalledWith(1, {
-        message: 'Une erreur s’est produite pendant la réactivation.',
-        timeout: SnackBarContextModule.SNACK_BAR_TIME_OUT,
-      })
+    expect(mockShowErrorSnackBar).toHaveBeenNthCalledWith(1, {
+      message: 'Une erreur s’est produite pendant la réactivation.',
+      timeout: SnackBarContextModule.SNACK_BAR_TIME_OUT,
     })
   })
 
@@ -87,28 +88,22 @@ describe('<SuspendedAccountUponUserRequest />', () => {
     })
     render(reactQueryProviderHOC(<SuspendedAccountUponUserRequest />))
 
-    await act(async () => fireEvent.press(screen.getByText('Réactiver mon compte')))
+    await user.press(screen.getByText('Réactiver mon compte'))
 
-    await waitFor(() => {
-      expect(analytics.logAccountReactivation).toHaveBeenCalledWith(
-        'suspendedaccountuponuserrequest'
-      )
-    })
+    expect(analytics.logAccountReactivation).toHaveBeenCalledWith('suspendedaccountuponuserrequest')
   })
 
   it('should go to home page when clicking on "Retourner à l’accueil" button', async () => {
     render(reactQueryProviderHOC(<SuspendedAccountUponUserRequest />))
 
     const homeButton = screen.getByText('Retourner à l’accueil')
-    fireEvent.press(homeButton)
+    await user.press(homeButton)
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenNthCalledWith(
-        1,
-        navigateToHomeConfig.screen,
-        navigateToHomeConfig.params
-      )
-      expect(mockSignOut).toHaveBeenCalledTimes(1)
-    })
+    expect(navigate).toHaveBeenNthCalledWith(
+      1,
+      navigateToHomeConfig.screen,
+      navigateToHomeConfig.params
+    )
+    expect(mockSignOut).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/features/bookOffer/components/AlreadyBooked.native.test.tsx
+++ b/src/features/bookOffer/components/AlreadyBooked.native.test.tsx
@@ -4,7 +4,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { OfferResponseV2 } from 'api/gen'
 import { initialBookingState, Step } from 'features/bookOffer/context/reducer'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { AlreadyBooked } from './AlreadyBooked'
 
@@ -22,20 +22,23 @@ jest.mock('features/bookOffer/context/useBookingContext', () => ({
 
 jest.mock('libs/firebase/analytics/analytics')
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<AlreadyBooked />', () => {
   beforeEach(() => {
     setFeatureFlags()
   })
 
-  it('should dismiss modal when clicking on cta', () => {
-    render(<AlreadyBooked offer={{ name: 'hello' } as OfferResponseV2} />)
-    fireEvent.press(screen.getByText('Mes réservations terminées'))
+  it('should dismiss modal when clicking on cta', async () => {
+    renderAlreadyBookedModal()
+    await user.press(screen.getByText('Mes réservations terminées'))
 
     expect(mockDismissModal).toHaveBeenCalledTimes(1)
   })
 
   it('should change booking step from date to confirmation', () => {
-    render(<AlreadyBooked offer={{ name: 'hello' } as OfferResponseV2} />)
+    renderAlreadyBookedModal()
 
     expect(mockDispatch).toHaveBeenNthCalledWith(1, {
       type: 'CHANGE_STEP',
@@ -44,9 +47,13 @@ describe('<AlreadyBooked />', () => {
   })
 
   it('should navigate to bookings when clicking on cta', async () => {
-    render(<AlreadyBooked offer={{ name: 'hello' } as OfferResponseV2} />)
-    await fireEvent.press(screen.getByText('Mes réservations terminées'))
+    renderAlreadyBookedModal()
+    await user.press(screen.getByText('Mes réservations terminées'))
 
     expect(navigate).toHaveBeenCalledWith('Bookings', undefined)
   })
 })
+
+const renderAlreadyBookedModal = () => {
+  render(<AlreadyBooked offer={{ name: 'hello' } as OfferResponseV2} />)
+}

--- a/src/features/bookOffer/components/BookHourChoice.native.test.tsx
+++ b/src/features/bookOffer/components/BookHourChoice.native.test.tsx
@@ -6,7 +6,7 @@ import { mockOffer as mockBaseOffer } from 'features/bookOffer/fixtures/offer'
 import { stock1, stock2, stock3, stock4 } from 'features/bookOffer/fixtures/stocks'
 import { IBookingContext } from 'features/bookOffer/types'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { BookHourChoice } from './BookHourChoice'
 
@@ -47,6 +47,9 @@ jest.mock('features/offer/helpers/useHasEnoughCredit/useHasEnoughCredit', () => 
   useCreditForOffer: jest.fn(() => mockCreditOffer),
 }))
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('BookHourChoice when hour is already selected', () => {
   beforeEach(() => {
     mockUseBookingContext.mockReturnValueOnce({
@@ -61,12 +64,12 @@ describe('BookHourChoice when hour is already selected', () => {
     setFeatureFlags()
   })
 
-  it('should change step to Hour', () => {
+  it('should change step to Hour', async () => {
     render(<BookHourChoice />)
 
     const selectedHour = screen.getByText('20:00')
 
-    fireEvent.press(selectedHour)
+    await user.press(selectedHour)
 
     expect(mockDispatch).toHaveBeenCalledWith({ type: 'CHANGE_STEP', payload: Step.HOUR })
   })
@@ -100,12 +103,12 @@ describe('BookHourChoice', () => {
     expect(thirdStock).toHaveLength(1)
   })
 
-  it('should select an item when pressed', () => {
+  it('should select an item when pressed', async () => {
     render(<BookHourChoice />)
 
     // firstStock correspond to 2021-03-02 stock
     const firstStock = screen.getByTestId('HourChoice148409-label')
-    fireEvent.press(firstStock)
+    await user.press(firstStock)
 
     expect(mockDispatch).toHaveBeenCalledWith({ type: 'SELECT_STOCK', payload: 148409 })
   })
@@ -193,10 +196,10 @@ describe('BookHourChoice when there are several stocks', () => {
     expect(screen.getByText('épuisé')).toBeOnTheScreen()
   })
 
-  it('should set the hour selected when pressing hour item', () => {
+  it('should set the hour selected when pressing hour item', async () => {
     render(<BookHourChoice />)
 
-    fireEvent.press(screen.getByText('20h00'))
+    await user.press(screen.getByText('20h00'))
 
     expect(mockDispatch).toHaveBeenNthCalledWith(1, {
       type: 'SELECT_HOUR',
@@ -204,7 +207,7 @@ describe('BookHourChoice when there are several stocks', () => {
     })
   })
 
-  it('should set the stock selected when pressing hour item and there is only one stock', () => {
+  it('should set the stock selected when pressing hour item and there is only one stock', async () => {
     mockOffer = {
       ...mockOffer,
       stocks: [stock1],
@@ -212,7 +215,7 @@ describe('BookHourChoice when there are several stocks', () => {
 
     render(<BookHourChoice />)
 
-    fireEvent.press(screen.getByText('22h00'))
+    await user.press(screen.getByText('22h00'))
 
     expect(mockDispatch).toHaveBeenNthCalledWith(1, {
       type: 'SELECT_STOCK',
@@ -220,14 +223,14 @@ describe('BookHourChoice when there are several stocks', () => {
     })
   })
 
-  it('should not set the stock selected when pressing hour item and there are several stock', () => {
+  it('should not set the stock selected when pressing hour item and there are several stock', async () => {
     mockOffer = {
       ...mockOffer,
       stocks: [stock1, { ...stock1, price: 22000, priceCategoryLabel: 'Pelouse or' }],
     }
     render(<BookHourChoice />)
 
-    fireEvent.press(screen.getByText('20h00'))
+    await user.press(screen.getByText('20h00'))
 
     expect(mockDispatch).not.toHaveBeenCalledWith({
       type: 'SELECT_STOCK',
@@ -235,14 +238,14 @@ describe('BookHourChoice when there are several stocks', () => {
     })
   })
 
-  it('should set the quantity at 1 when pressing hour item and offer is not duo', () => {
+  it('should set the quantity at 1 when pressing hour item and offer is not duo', async () => {
     mockOffer = {
       ...mockOffer,
       isDuo: false,
     }
     render(<BookHourChoice />)
 
-    fireEvent.press(screen.getByText('20h00'))
+    await user.press(screen.getByText('20h00'))
 
     expect(mockDispatch).not.toHaveBeenCalledWith(1, {
       type: 'SELECT_QUANTITY',
@@ -250,10 +253,10 @@ describe('BookHourChoice when there are several stocks', () => {
     })
   })
 
-  it('should not set the quantity at 1 when pressing hour item and offer is duo', () => {
+  it('should not set the quantity at 1 when pressing hour item and offer is duo', async () => {
     render(<BookHourChoice />)
 
-    fireEvent.press(screen.getByText('20h00'))
+    await user.press(screen.getByText('20h00'))
 
     expect(mockDispatch).not.toHaveBeenCalledWith(1, {
       type: 'SELECT_QUANTITY',
@@ -296,9 +299,9 @@ describe('BookHourChoice when there is only one stock', () => {
     expect(screen.queryByTestId('HourChoice2023-04-01T20:00:00Z-label')).not.toBeOnTheScreen()
   })
 
-  it('should select the stock when pressing an hour item', () => {
+  it('should select the stock when pressing an hour item', async () => {
     render(<BookHourChoice />)
-    fireEvent.press(screen.getByTestId('HourChoice18758-label'))
+    await user.press(screen.getByTestId('HourChoice18758-label'))
 
     expect(mockDispatch).toHaveBeenCalledWith({ type: 'SELECT_STOCK', payload: stock1.id })
   })

--- a/src/features/bookings/components/CancelBookingModal.native.test.tsx
+++ b/src/features/bookings/components/CancelBookingModal.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
+import { BookingReponse } from 'api/gen'
 import { CancelBookingModal } from 'features/bookings/components/CancelBookingModal'
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
@@ -9,7 +10,7 @@ import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/
 import * as useNetInfoContextDefault from 'libs/network/NetInfoWrapper'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 
@@ -40,6 +41,11 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const booking = bookingsSnap.ongoing_bookings[0]
+
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<CancelBookingModal />', () => {
   beforeEach(() => {
     setFeatureFlags()
@@ -47,86 +53,52 @@ describe('<CancelBookingModal />', () => {
 
   mockUseNetInfoContext.mockReturnValue({ isConnected: true })
 
-  it('should dismiss modal on press rightIconButton', () => {
-    const booking = bookingsSnap.ongoing_bookings[0]
-    render(
-      reactQueryProviderHOC(
-        <CancelBookingModal visible dismissModal={mockDismissModal} booking={booking} />
-      )
-    )
+  it('should dismiss modal on press rightIconButton', async () => {
+    renderCancelBookingModal(booking)
 
     const dismissModalButton = screen.getByTestId('Ne pas annuler')
 
-    fireEvent.press(dismissModalButton)
+    await user.press(dismissModalButton)
 
     expect(mockDismissModal).toHaveBeenCalledTimes(1)
   })
 
-  it('should dismiss modal on press "retourner à ma réservation', () => {
-    const booking = bookingsSnap.ongoing_bookings[0]
-
-    render(
-      reactQueryProviderHOC(
-        <CancelBookingModal visible dismissModal={mockDismissModal} booking={booking} />
-      )
-    )
+  it('should dismiss modal on press "retourner à ma réservation', async () => {
+    renderCancelBookingModal(booking)
 
     const goBackButton = screen.getByText('Retourner à ma réservation')
 
-    fireEvent.press(goBackButton)
+    await user.press(goBackButton)
 
     expect(mockDismissModal).toHaveBeenCalledTimes(1)
   })
 
   it('should log "ConfirmBookingCancellation" on press "Annuler ma réservation"', async () => {
-    const booking = bookingsSnap.ongoing_bookings[0]
-
     mockServer.postApi(`/v1/bookings/${booking.id}/cancel`, {})
 
-    render(
-      reactQueryProviderHOC(
-        <CancelBookingModal visible dismissModal={mockDismissModal} booking={booking} />
-      )
-    )
+    renderCancelBookingModal(booking)
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Annuler ma réservation'))
-    })
+    await user.press(screen.getByText('Annuler ma réservation'))
 
     expect(analytics.logConfirmBookingCancellation).toHaveBeenCalledWith(booking.stock.offer.id)
   })
 
   it('should close modal on success', async () => {
-    const booking = bookingsSnap.ongoing_bookings[0]
-
     mockServer.postApi(`/v1/bookings/${booking.id}/cancel`, {})
 
-    render(
-      reactQueryProviderHOC(
-        <CancelBookingModal visible dismissModal={mockDismissModal} booking={booking} />
-      )
-    )
+    renderCancelBookingModal(booking)
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Annuler ma réservation'))
-    })
+    await user.press(screen.getByText('Annuler ma réservation'))
 
     expect(mockDismissModal).toHaveBeenCalledTimes(1)
   })
 
   it('should showErrorSnackBar and close modal on press "Annuler ma réservation"', async () => {
     mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
-    const booking = bookingsSnap.ongoing_bookings[0]
 
-    render(
-      reactQueryProviderHOC(
-        <CancelBookingModal visible dismissModal={mockDismissModal} booking={booking} />
-      )
-    )
+    renderCancelBookingModal(booking)
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Annuler ma réservation'))
-    })
+    await user.press(screen.getByText('Annuler ma réservation'))
 
     expect(mockDismissModal).toHaveBeenCalledTimes(1)
     expect(mockShowErrorSnackBar).toHaveBeenCalledWith({
@@ -136,38 +108,21 @@ describe('<CancelBookingModal />', () => {
   })
 
   it('should display offer name', () => {
-    const booking = bookingsSnap.ongoing_bookings[0]
-
-    render(
-      reactQueryProviderHOC(
-        <CancelBookingModal visible dismissModal={mockDismissModal} booking={booking} />
-      )
-    )
+    renderCancelBookingModal(booking)
 
     expect(screen.getByText('Avez-vous déjà vu ?')).toBeOnTheScreen()
   })
 
   it('should display refund rule if user is beneficiary and offer is not free', () => {
-    const booking = bookingsSnap.ongoing_bookings[0]
-
-    render(
-      reactQueryProviderHOC(
-        <CancelBookingModal visible dismissModal={mockDismissModal} booking={booking} />
-      )
-    )
+    renderCancelBookingModal(booking)
 
     expect(screen.getByText('19\u00a0€ seront recrédités sur ton pass Culture.')).toBeOnTheScreen()
   })
 
   it('should display refund rule if user is ex beneficiary and offer is not free', () => {
     mockIsCreditExpired = true
-    const booking = bookingsSnap.ongoing_bookings[0]
 
-    render(
-      reactQueryProviderHOC(
-        <CancelBookingModal visible dismissModal={mockDismissModal} booking={booking} />
-      )
-    )
+    renderCancelBookingModal(booking)
 
     expect(
       screen.getByText(
@@ -187,22 +142,24 @@ describe('<CancelBookingModal />', () => {
       responseOptions: { statusCode: 401, data: response },
     })
 
-    render(
-      reactQueryProviderHOC(
-        <CancelBookingModal visible dismissModal={mockDismissModal} booking={booking} />
-      )
-    )
+    renderCancelBookingModal(booking)
 
     const cancelButton = screen.getByText('Annuler ma réservation')
 
-    fireEvent.press(cancelButton)
+    await user.press(cancelButton)
 
-    await waitFor(async () => {
-      expect(navigate).toHaveBeenCalledWith(...getTabNavConfig('Bookings'))
-      expect(mockShowErrorSnackBar).toHaveBeenCalledWith({
-        message: response.message,
-        timeout: 5000,
-      })
+    expect(navigate).toHaveBeenCalledWith(...getTabNavConfig('Bookings'))
+    expect(mockShowErrorSnackBar).toHaveBeenCalledWith({
+      message: response.message,
+      timeout: 5000,
     })
   })
 })
+
+const renderCancelBookingModal = (booking: BookingReponse) => {
+  render(
+    reactQueryProviderHOC(
+      <CancelBookingModal visible dismissModal={mockDismissModal} booking={booking} />
+    )
+  )
+}

--- a/src/features/bookings/components/EndedBookingsSection.native.test.tsx
+++ b/src/features/bookings/components/EndedBookingsSection.native.test.tsx
@@ -4,9 +4,12 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { EndedBookingsSection } from 'features/bookings/components/EndedBookingsSection'
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<EndedBookingsSection/>', () => {
   beforeEach(() => {
@@ -25,9 +28,9 @@ describe('<EndedBookingsSection/>', () => {
     expect(screen.queryByText('Réservations terminées')).not.toBeOnTheScreen()
   })
 
-  it('should navigate to bookings when clicking on cta', () => {
+  it('should navigate to ended bookings when clicking on cta', async () => {
     render(<EndedBookingsSection endedBookings={bookingsSnap.ended_bookings} />)
-    fireEvent.press(screen.getByText('Réservations terminées'))
+    await user.press(screen.getByText('Réservations terminées'))
 
     expect(navigate).toHaveBeenCalledWith('Bookings', undefined)
   })

--- a/src/features/bookings/components/Ticket/ControlComponent.native.test.tsx
+++ b/src/features/bookings/components/Ticket/ControlComponent.native.test.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { ControlComponent, ControlComponentProps } from './ControlComponent'
 
 jest.unmock('react-native/Libraries/Animated/createAnimatedComponent')
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<ControlComponent />', () => {
   const onPress = jest.fn()
@@ -38,14 +41,14 @@ describe('<ControlComponent />', () => {
     expect(() => screen.getByTestId('arrowPrevious')).toThrow()
   })
 
-  it('renders trigger onPress when pressed', () => {
+  it('renders trigger onPress when pressed', async () => {
     renderControlComponent({
       onPress,
       title: 'Previous',
       type: 'prev',
     })
 
-    fireEvent.press(screen.getByTestId('Previous'))
+    await user.press(screen.getByTestId('Previous'))
 
     expect(onPress).toHaveBeenCalledTimes(1)
   })

--- a/src/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { act } from 'react-test-renderer'
 
 import { navigate, reset } from '__mocks__/@react-navigation/native'
 import { CulturalSurveyQuestionEnum } from 'api/gen'
@@ -9,7 +8,7 @@ import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { storage } from 'libs/storage'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
@@ -33,6 +32,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('CulturalSurveyIntro page', () => {
   beforeEach(() => {
@@ -54,7 +55,7 @@ describe('CulturalSurveyIntro page', () => {
       render(<CulturalSurveyIntro />)
 
       const StartButton = screen.getByText('Commencer le questionnaire')
-      fireEvent.press(StartButton)
+      user.press(StartButton)
 
       await waitFor(() => {
         expect(navigate).toHaveBeenCalledWith('CulturalSurveyQuestions', {
@@ -63,11 +64,11 @@ describe('CulturalSurveyIntro page', () => {
       })
     })
 
-    it('should log hasStartedCulturalSurvey event when pressing "Commencer le questionnaire" button', () => {
+    it('should log hasStartedCulturalSurvey event when pressing "Commencer le questionnaire" button', async () => {
       render(<CulturalSurveyIntro />)
 
       const StartButton = screen.getByText('Commencer le questionnaire')
-      fireEvent.press(StartButton)
+      await user.press(StartButton)
 
       expect(analytics.logHasStartedCulturalSurvey).toHaveBeenCalledTimes(1)
     })
@@ -76,13 +77,11 @@ describe('CulturalSurveyIntro page', () => {
       render(<CulturalSurveyIntro />)
 
       const LaterButton = screen.getByText('Plus tard')
-      fireEvent.press(LaterButton)
+      await user.press(LaterButton)
 
-      await waitFor(() => {
-        expect(reset).toHaveBeenCalledWith({
-          index: 0,
-          routes: [{ name: 'TabNavigator' }],
-        })
+      expect(reset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'TabNavigator' }],
       })
     })
 
@@ -90,18 +89,16 @@ describe('CulturalSurveyIntro page', () => {
       render(<CulturalSurveyIntro />)
 
       const LaterButton = screen.getByText('Plus tard')
-      await act(() => {
-        fireEvent.press(LaterButton)
-      })
+      await user.press(LaterButton)
 
       expect(analytics.logHasSkippedCulturalSurvey).toHaveBeenCalledTimes(1)
     })
 
-    it('should navigate to FAQWebview when pressing "En savoir plus" button', () => {
+    it('should navigate to FAQWebview when pressing "En savoir plus" button', async () => {
       render(<CulturalSurveyIntro />)
 
       const FAQButton = screen.getByText('En savoir plus')
-      fireEvent.press(FAQButton)
+      await user.press(FAQButton)
 
       expect(navigate).toHaveBeenCalledWith('FAQWebview', undefined)
     })
@@ -136,7 +133,7 @@ describe('CulturalSurveyIntro page', () => {
       render(<CulturalSurveyIntro />)
 
       const goBackButton = screen.getByText('Retour')
-      fireEvent.press(goBackButton)
+      await user.press(goBackButton)
 
       expect(mockGoBack).toHaveBeenCalledTimes(1)
     })

--- a/src/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx
@@ -4,7 +4,7 @@ import { reset } from '__mocks__/@react-navigation/native'
 import { CulturalSurveyThanks } from 'features/culturalSurvey/pages/CulturalSurveyThanks'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { render, fireEvent, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
@@ -16,6 +16,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('CulturalSurveyThanksPage page', () => {
   describe('When FF is disabled', () => {
@@ -33,7 +36,7 @@ describe('CulturalSurveyThanksPage page', () => {
       render(<CulturalSurveyThanks />)
 
       const discoverButton = screen.getByText('Découvrir le catalogue')
-      fireEvent.press(discoverButton)
+      await user.press(discoverButton)
 
       expect(reset).toHaveBeenCalledWith({
         index: 0,
@@ -57,7 +60,7 @@ describe('CulturalSurveyThanksPage page', () => {
       render(<CulturalSurveyThanks />)
 
       const continueButton = screen.getByText('Continuer')
-      fireEvent.press(continueButton)
+      await user.press(continueButton)
 
       expect(reset).toHaveBeenCalledWith({
         index: 0,

--- a/src/features/favorites/components/NoFavoritesResult.native.test.tsx
+++ b/src/features/favorites/components/NoFavoritesResult.native.test.tsx
@@ -4,7 +4,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { NoFavoritesResult } from 'features/favorites/components/NoFavoritesResult'
 import { initialFavoritesState } from 'features/favorites/context/reducer'
 import { analytics } from 'libs/analytics/provider'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 const mockFavoritesState = initialFavoritesState
 const mockDispatch = jest.fn()
@@ -22,6 +22,9 @@ jest.mock('features/search/context/SearchWrapper', () => ({
   }),
 }))
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('NoFavoritesResult component', () => {
   it('should show the message', () => {
     render(<NoFavoritesResult />)
@@ -34,14 +37,12 @@ describe('NoFavoritesResult component', () => {
     render(<NoFavoritesResult />)
 
     const button = screen.getByText('Découvrir le catalogue')
-    fireEvent.press(button)
+    await user.press(button)
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-        params: { params: undefined, screen: 'SearchLanding' },
-        screen: 'SearchStackNavigator',
-      })
-      expect(analytics.logDiscoverOffers).toHaveBeenCalledWith('favorites')
+    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
+      params: { params: undefined, screen: 'SearchLanding' },
+      screen: 'SearchStackNavigator',
     })
+    expect(analytics.logDiscoverOffers).toHaveBeenCalledWith('favorites')
   })
 })

--- a/src/features/favorites/pages/NotConnectedFavorites.native.test.tsx
+++ b/src/features/favorites/pages/NotConnectedFavorites.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { NotConnectedFavorites } from './NotConnectedFavorites'
 
@@ -13,6 +13,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('NotConnectedFavorites component', () => {
   it('should render not connected favorites', () => {
     render(<NotConnectedFavorites />)
@@ -20,26 +23,43 @@ describe('NotConnectedFavorites component', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should navigate to SignupForm on button click and log analytics', async () => {
+  it('should navigate to SignupForm  when click on "Créer un compte"', async () => {
     render(<NotConnectedFavorites />)
 
-    fireEvent.press(screen.getByText(`Créer un compte`))
+    await user.press(screen.getByText(`Créer un compte`))
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('SignupForm', { from: StepperOrigin.FAVORITE })
-      expect(analytics.logSignUpFromFavorite).toHaveBeenCalledTimes(1)
-      expect(analytics.logSignUpClicked).toHaveBeenNthCalledWith(1, { from: 'favorite' })
-    })
+    expect(navigate).toHaveBeenCalledWith('SignupForm', { from: StepperOrigin.FAVORITE })
   })
 
-  it('should navigate to Login on button click log analytics', async () => {
+  it('should log analytic "logSignUpFromFavorite" when click on "Créer un compte"', async () => {
     render(<NotConnectedFavorites />)
 
-    fireEvent.press(screen.getByText(`Se connecter`))
+    await user.press(screen.getByText(`Créer un compte`))
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('Login', { from: StepperOrigin.FAVORITE })
-      expect(analytics.logSignInFromFavorite).toHaveBeenCalledTimes(1)
-    })
+    expect(analytics.logSignUpFromFavorite).toHaveBeenCalledTimes(1)
+  })
+
+  it('should log analytic "logSignUpClicked" when click on "Créer un compte"', async () => {
+    render(<NotConnectedFavorites />)
+
+    await user.press(screen.getByText(`Créer un compte`))
+
+    expect(analytics.logSignUpClicked).toHaveBeenNthCalledWith(1, { from: 'favorite' })
+  })
+
+  it('should navigate to Login when click on "Se connecter"', async () => {
+    render(<NotConnectedFavorites />)
+
+    await user.press(screen.getByText(`Se connecter`))
+
+    expect(navigate).toHaveBeenCalledWith('Login', { from: StepperOrigin.FAVORITE })
+  })
+
+  it('should log analytic "logSignInFromFavorite" when click on "Se connecter"', async () => {
+    render(<NotConnectedFavorites />)
+
+    await user.press(screen.getByText(`Se connecter`))
+
+    expect(analytics.logSignInFromFavorite).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/features/home/pages/NoContentError.native.test.tsx
+++ b/src/features/home/pages/NoContentError.native.test.tsx
@@ -2,13 +2,15 @@ import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { NoContentError } from 'features/home/pages/NoContentError'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   return function createAnimatedComponent(Component: unknown) {
     return Component
   }
 })
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('NoContentError', () => {
   it('should render correctly', () => {
@@ -17,10 +19,10 @@ describe('NoContentError', () => {
     expect(screen.toJSON()).toMatchSnapshot()
   })
 
-  it('should redirect to Search tab when pressing the button', () => {
+  it('should redirect to Search tab when pressing the button', async () => {
     render(<NoContentError />)
     const searchButton = screen.getByText('Rechercher une offre')
-    fireEvent.press(searchButton)
+    await user.press(searchButton)
 
     expect(navigate).toHaveBeenCalledWith('TabNavigator', {
       screen: 'SearchStackNavigator',

--- a/src/features/identityCheck/components/countryPicker/CountryPicker.native.test.tsx
+++ b/src/features/identityCheck/components/countryPicker/CountryPicker.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { METROPOLITAN_FRANCE } from 'features/identityCheck/components/countryPicker/constants'
 import { CountryPicker } from 'features/identityCheck/components/countryPicker/CountryPicker'
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 const onSelectCountry = jest.fn()
 
@@ -11,6 +11,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<CountryPicker />', () => {
   it('should render correctly', async () => {
@@ -24,17 +27,15 @@ describe('<CountryPicker />', () => {
   it('should select the correct country calling code when the user select a calling code', async () => {
     render(<CountryPicker selectedCountry={METROPOLITAN_FRANCE} onSelect={onSelectCountry} />)
 
-    fireEvent.press(
+    await user.press(
       await screen.findByTestId('Ouvrir la modale de choix de l’indicatif téléphonique')
     )
-    fireEvent.press(screen.getByLabelText('Guadeloupe +590'))
+    await user.press(screen.getByLabelText('Guadeloupe +590'))
 
-    await act(async () => {
-      expect(onSelectCountry).toHaveBeenCalledWith({
-        id: 'GP',
-        name: 'Guadeloupe',
-        callingCode: '590',
-      })
+    expect(onSelectCountry).toHaveBeenCalledWith({
+      id: 'GP',
+      name: 'Guadeloupe',
+      callingCode: '590',
     })
   })
 })

--- a/src/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx
+++ b/src/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { QuitIdentityCheckModal } from 'features/identityCheck/components/modals/QuitIdentityCheckModal'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { analytics } from 'libs/analytics/provider'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('features/navigation/helpers/navigateToHome')
 const mockHideModal = jest.fn()
@@ -18,6 +18,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<QuitIdentityCheckModal/>', () => {
   it('should render correctly', () => {
@@ -42,23 +45,39 @@ describe('<QuitIdentityCheckModal/>', () => {
     expect(title).toBeOnTheScreen()
   })
 
-  it('should call resume function when clicking on "Continuer la vérification"', () => {
+  it('should log analytics when clicking on "Continuer la vérification"', async () => {
     renderQuitIdentityCheckModal(true)
 
     const resumeButton = screen.getByText('Continuer la vérification')
-    fireEvent.press(resumeButton)
+    await user.press(resumeButton)
 
     expect(analytics.logContinueIdentityCheck).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call hideModal when clicking on "Continuer la vérification"', async () => {
+    renderQuitIdentityCheckModal(true)
+
+    const resumeButton = screen.getByText('Continuer la vérification')
+    await user.press(resumeButton)
+
     expect(mockHideModal).toHaveBeenCalledTimes(1)
   })
 
-  it('should go back to homepage when clicking on "Abandonner la vérification"', () => {
+  it('should log analytics when clicking on "Abandonner la vérification"', async () => {
     renderQuitIdentityCheckModal(true)
 
     const abandonButton = screen.getByText('Abandonner la vérification')
-    fireEvent.press(abandonButton)
+    await user.press(abandonButton)
 
     expect(analytics.logQuitIdentityCheck).toHaveBeenNthCalledWith(1, mockStep)
+  })
+
+  it('should go back to homepage when clicking on "Abandonner la vérification"', async () => {
+    renderQuitIdentityCheckModal(true)
+
+    const abandonButton = screen.getByText('Abandonner la vérification')
+    await user.press(abandonButton)
+
     expect(navigateToHome).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 
 import { PhoneValidationTipsModal } from 'features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   return function createAnimatedComponent(Component: unknown) {
     return Component
   }
 })
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<PhoneValidationTipsModal />', () => {
   it('should match snapshot', () => {
@@ -16,7 +18,7 @@ describe('<PhoneValidationTipsModal />', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it("should call dismissModal upon pressing 'j'ai compris'", () => {
+  it("should call dismissModal upon pressing 'j'ai compris'", async () => {
     const dismissModalMock = jest.fn()
 
     render(
@@ -24,8 +26,7 @@ describe('<PhoneValidationTipsModal />', () => {
     )
 
     const gotItButton = screen.getByText('J’ai compris')
-
-    fireEvent.press(gotItButton)
+    await user.press(gotItButton)
 
     expect(dismissModalMock).toHaveBeenCalledTimes(1)
   })

--- a/src/features/offer/components/VenueSelectionList/VenueSelectionList.native.test.tsx
+++ b/src/features/offer/components/VenueSelectionList/VenueSelectionList.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 import { theme } from 'theme'
 
 import { VenueListItem, VenueSelectionList } from './VenueSelectionList'
@@ -30,6 +30,9 @@ const items: VenueListItem[] = [
 const nbLoadedHits = 3
 const nbHits = 40
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<VenueSelectionList />', () => {
   beforeEach(() => {
     setFeatureFlags()
@@ -54,7 +57,7 @@ describe('<VenueSelectionList />', () => {
     expect(screen.queryAllByTestId('venue-selection-list-item')).toHaveLength(3)
   })
 
-  it('should select item on press', () => {
+  it('should select item on press', async () => {
     const onItemSelect = jest.fn()
 
     render(
@@ -72,7 +75,7 @@ describe('<VenueSelectionList />', () => {
       />
     )
 
-    fireEvent.press(screen.getByText('Envie de lire'))
+    await user.press(screen.getByText('Envie de lire'))
 
     expect(onItemSelect).toHaveBeenNthCalledWith(1, 1)
   })

--- a/src/features/offer/components/VenueSelectionListItem/VenueSelectionListItem.native.test.tsx
+++ b/src/features/offer/components/VenueSelectionListItem/VenueSelectionListItem.native.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 import { theme } from 'theme'
 
 import { VenueSelectionListItem } from './VenueSelectionListItem'
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<VenueSelectionListItem />', () => {
   it('should apply different styles when selected', () => {
@@ -31,14 +34,14 @@ describe('<VenueSelectionListItem />', () => {
     })
   })
 
-  it('should call `onSelect` when selecting', () => {
+  it('should call `onSelect` when selecting', async () => {
     const onSelect = jest.fn()
 
     render(
       <VenueSelectionListItem title="Jest" address="Somewhere in you memory" onSelect={onSelect} />
     )
 
-    fireEvent.press(screen.getByText('Jest'))
+    await user.press(screen.getByText('Jest'))
 
     expect(onSelect).toHaveBeenCalledTimes(1)
   })

--- a/src/features/profile/components/Badges/SubscriptionMessageBadge.native.test.tsx
+++ b/src/features/profile/components/Badges/SubscriptionMessageBadge.native.test.tsx
@@ -7,7 +7,7 @@ import {
   RemoteBannerRedirectionType,
   RemoteBannerType,
 } from 'features/remoteBanners/utils/remoteBannerSchema'
-import { fireEvent, render, screen, act } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('features/auth/helpers/useIsMailAppAvailable', () => ({
   useIsMailAppAvailable: jest.fn(() => true),
@@ -19,6 +19,9 @@ jest.mock('features/profile/helpers/shouldOpenInbox', () => ({
 }))
 
 jest.mock('libs/firebase/analytics/analytics')
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<SubscriptionMessageBadge />', () => {
   it('should display the subscription message', () => {
@@ -46,10 +49,8 @@ describe('<SubscriptionMessageBadge />', () => {
       callToAction: { callToActionTitle: 'hey2', callToActionLink: 'https://fake.net' },
     })
 
-    await act(() => {
-      const button = screen.getByText('hey2')
-      fireEvent.press(button)
-    })
+    const button = screen.getByText('hey2')
+    await user.press(button)
 
     expect(openInbox).not.toHaveBeenCalled()
   })
@@ -60,10 +61,8 @@ describe('<SubscriptionMessageBadge />', () => {
       callToAction: { callToActionTitle: 'hey2', callToActionLink: 'https://fake.net' },
     })
 
-    await act(() => {
-      const button = screen.getByText('hey2')
-      fireEvent.press(button)
-    })
+    const button = screen.getByText('hey2')
+    await user.press(button)
 
     expect(openInbox).toHaveBeenCalledTimes(1)
   })

--- a/src/features/profile/components/Buttons/ContactSupportButton/ContactSupportButton.native.test.tsx
+++ b/src/features/profile/components/Buttons/ContactSupportButton/ContactSupportButton.native.test.tsx
@@ -3,18 +3,21 @@ import React from 'react'
 import { contactSupport } from 'features/auth/helpers/contactSupport'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { AccessibilityEngagement } from 'features/profile/pages/Accessibility/AccessibilityEngagement'
-import { render, fireEvent, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 const openURLSpy = jest.spyOn(NavigationHelpers, 'openUrl')
 
 jest.mock('libs/firebase/analytics/analytics')
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('ContactSupportButton', () => {
-  it('should open mail app when clicking on contact service button', () => {
+  it('should open mail app when clicking on contact service button', async () => {
     render(<AccessibilityEngagement />)
 
     const button = screen.getByText('support@passculture.app')
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(openURLSpy).toHaveBeenCalledWith(
       contactSupport.forGenericQuestion.url,

--- a/src/features/profile/components/CreditExplanation/CreditExplanation.native.test.tsx
+++ b/src/features/profile/components/CreditExplanation/CreditExplanation.native.test.tsx
@@ -4,7 +4,10 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { setSettings } from 'features/auth/tests/setSettings'
 import { CreditExplanation } from 'features/profile/components/CreditExplanation/CreditExplanation'
 import { analytics } from 'libs/analytics/provider'
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<CreditExplanation/>', () => {
   it('should render correctly for expired deposit', () => {
@@ -26,10 +29,10 @@ describe('<CreditExplanation/>', () => {
       expect(screen.queryByTestId('modalHeader')).not.toBeOnTheScreen()
     })
 
-    it('should display modal when button is triggered', () => {
+    it('should display modal when button is triggered', async () => {
       render(<CreditExplanation isDepositExpired age={18} />)
       const explanationButton = screen.getByTestId('Mon crédit est expiré, que\u00a0faire\u00a0?')
-      fireEvent.press(explanationButton)
+      await user.press(explanationButton)
 
       expect(screen.getByTestId('modalHeader')).toBeOnTheScreen()
     })
@@ -43,7 +46,7 @@ describe('<CreditExplanation/>', () => {
     it('should navigate to tutorial when button is triggered', async () => {
       render(<CreditExplanation isDepositExpired={false} age={18} />)
       const explanationButton = screen.getByTestId('Comment ça marche\u00a0?')
-      await act(() => fireEvent.press(explanationButton))
+      await user.press(explanationButton)
 
       expect(navigate).toHaveBeenCalledWith('ProfileTutorialAgeInformation', { age: 18 })
     })
@@ -53,7 +56,7 @@ describe('<CreditExplanation/>', () => {
 
       render(<CreditExplanation isDepositExpired={false} age={18} />)
       const explanationButton = screen.getByTestId('Comment ça marche\u00a0?')
-      await act(() => fireEvent.press(explanationButton))
+      await user.press(explanationButton)
 
       expect(navigate).toHaveBeenCalledWith('ProfileTutorialAgeInformationCreditV3', undefined)
     })
@@ -61,18 +64,18 @@ describe('<CreditExplanation/>', () => {
     it('should navigate to 17 years old tutorial when button is triggered and user is 17', async () => {
       render(<CreditExplanation isDepositExpired={false} age={17} />)
       const explanationButton = screen.getByTestId('Comment ça marche\u00a0?')
-      await act(() => fireEvent.press(explanationButton))
+      await user.press(explanationButton)
 
       expect(navigate).toHaveBeenCalledWith('ProfileTutorialAgeInformation', { age: 17 })
     })
   })
 
   describe('Analytics', () => {
-    it('should log logConsultModalExpiredGrant analytics when expired deposit and press the button "Mon crédit est expiré, que faire ?"', () => {
+    it('should log logConsultModalExpiredGrant analytics when expired deposit and press the button "Mon crédit est expiré, que faire ?"', async () => {
       render(<CreditExplanation isDepositExpired age={18} />)
 
       const explanationButton = screen.getByText('Mon crédit est expiré, que faire ?')
-      fireEvent.press(explanationButton)
+      await user.press(explanationButton)
 
       expect(analytics.logConsultModalExpiredGrant).toHaveBeenCalledTimes(1)
     })
@@ -81,7 +84,7 @@ describe('<CreditExplanation/>', () => {
       render(<CreditExplanation isDepositExpired={false} age={18} />)
 
       const explanationButton = screen.getByText('Comment ça marche ?')
-      fireEvent.press(explanationButton)
+      await user.press(explanationButton)
 
       expect(analytics.logConsultTutorial).toHaveBeenCalledWith({ from: 'CreditBlock', age: 18 })
     })

--- a/src/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx
+++ b/src/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { useRoute } from '__mocks__/@react-navigation/native'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 
 import { ChangeEmail } from './ChangeEmail'
 
@@ -13,6 +13,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<ChangeEmail/>', () => {
   it('should render correctly', async () => {
@@ -65,7 +68,7 @@ describe('<ChangeEmail/>', () => {
       renderChangeEmail()
 
       const closeButton = screen.getByLabelText('Fermer la modale')
-      fireEvent.press(closeButton)
+      user.press(closeButton)
 
       await waitFor(() => {
         expect(screen.queryByText('Modifie ton adresse e-mail sur ce compte')).not.toBeOnTheScreen()

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { DeleteProfileAccountHacked } from './DeleteProfileAccountHacked'
 
@@ -12,6 +12,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('DeleteProfileAccountHacked', () => {
   it('should render correctly', () => {
@@ -24,7 +27,7 @@ describe('DeleteProfileAccountHacked', () => {
     render(<DeleteProfileAccountHacked />)
     const button = screen.getByText('Ne pas sécuriser mon compte')
 
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(navigate).toHaveBeenCalledWith('TabNavigator', {
       params: {
@@ -39,7 +42,7 @@ describe('DeleteProfileAccountHacked', () => {
     render(<DeleteProfileAccountHacked />)
     const button = screen.getByText('Suspendre mon compte')
 
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(navigate).toHaveBeenCalledWith('TabNavigator', {
       params: {


### PR DESCRIPTION
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
