### PR TITLE
(BSR) chore(dependencies): update some tools

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,22 @@
         "type": "github"
       }
     },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742206328,
+        "narHash": "sha256-q+AQ///oMnyyFzzF4H9ShSRENt3Zsx37jTiRkLkXXE0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "096478927c360bc18ea80c8274f013709cf7bdcd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-old": {
       "locked": {
         "lastModified": 1725910328,
@@ -37,6 +53,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
         "nixpkgs-old": "nixpkgs-old"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -29,8 +29,8 @@
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "5775c2583f1801df7b790bf7f7d710a19bac66f4",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,7 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
+    "nixpkgs-old": {
       "locked": {
         "lastModified": 1725910328,
         "narHash": "sha256-n9pCtzGZ0httmTwMuEbi5E78UQ4ZbQMr1pzi5N0LAG8=",
@@ -37,7 +37,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs-old": "nixpkgs-old"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,28 +1,28 @@
 {
-  inputs.nixpkgs.url = "github:nixos/nixpkgs?rev=5775c2583f1801df7b790bf7f7d710a19bac66f4";
+  inputs.nixpkgs-old.url = "github:nixos/nixpkgs?rev=5775c2583f1801df7b790bf7f7d710a19bac66f4";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs =
     {
       self,
-      nixpkgs,
+      nixpkgs-old,
       flake-utils,
     }:
     flake-utils.lib.eachDefaultSystem (system: {
       devShells.default =
         let
-          pkgs = nixpkgs.legacyPackages.${system};
+          pkgs-old = nixpkgs-old.legacyPackages.${system};
         in
-        pkgs.mkShellNoCC {
+        pkgs-old.mkShellNoCC {
           packages = [
-            pkgs.devbox
-            pkgs.jdk17 # needed by Android
-            pkgs.jq # needed by some scripts run in the pipeline
-            pkgs.python3 # needed by scripts/add_tracker.py
-            pkgs.maestro # needed to run end to end test locally
-            pkgs.act # needed to debug pipeline locally
-            pkgs.gh # needed to debug pipeline locally
-            pkgs.podman # needed to debug pipeline locally
+            pkgs-old.devbox
+            pkgs-old.jdk17 # needed by Android
+            pkgs-old.jq # needed by some scripts run in the pipeline
+            pkgs-old.python3 # needed by scripts/add_tracker.py
+            pkgs-old.maestro # needed to run end to end test locally
+            pkgs-old.act # needed to debug pipeline locally
+            pkgs-old.gh # needed to debug pipeline locally
+            pkgs-old.podman # needed to debug pipeline locally
           ];
         };
     });

--- a/flake.nix
+++ b/flake.nix
@@ -16,16 +16,16 @@
           pkgs = nixpkgs.legacyPackages.${system};
           pkgs-old = nixpkgs-old.legacyPackages.${system};
         in
-        pkgs-old.mkShellNoCC {
+        pkgs.mkShellNoCC {
           packages = [
             pkgs-old.devbox
-            pkgs-old.jdk17 # needed by Android
-            pkgs-old.jq # needed by some scripts run in the pipeline
-            pkgs-old.python3 # needed by scripts/add_tracker.py
+            pkgs.jdk17 # needed by Android
+            pkgs.jq # needed by some scripts run in the pipeline
+            pkgs.python3 # needed by scripts/add_tracker.py
             pkgs-old.maestro # needed to run end to end test locally
-            pkgs-old.act # needed to debug pipeline locally
-            pkgs-old.gh # needed to debug pipeline locally
-            pkgs-old.podman # needed to debug pipeline locally
+            pkgs.act # needed to debug pipeline locally
+            pkgs.gh # needed to debug pipeline locally
+            pkgs.podman # needed to debug pipeline locally
           ];
         };
     });

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,19 @@
 {
   inputs.nixpkgs-old.url = "github:nixos/nixpkgs?rev=5775c2583f1801df7b790bf7f7d710a19bac66f4";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs =
     {
       self,
       nixpkgs-old,
+      nixpkgs,
       flake-utils,
     }:
     flake-utils.lib.eachDefaultSystem (system: {
       devShells.default =
         let
+          pkgs = nixpkgs.legacyPackages.${system};
           pkgs-old = nixpkgs-old.legacyPackages.${system};
         in
         pkgs-old.mkShellNoCC {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs?rev=5775c2583f1801df7b790bf7f7d710a19bac66f4";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs =


### PR DESCRIPTION
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

- [x] `yarn android:testing`

||Before|After|
|:--|:--|:--|
|`java --version`|openjdk 17.0.10 2024-01-16 LTS|openjdk 17.0.12 2024-07-16 LTS|
|`jq --version`|jq-1.7.1|jq-1.7.1|
|`python3 --version`|Python 3.12.5|Python 3.12.9|
|`act --version`|act version 0.2.66|act version 0.2.75|
|`gh --version`|gh version 2.55.0 (1980-01-01)|gh version 2.68.1 (1980-01-01)|
|`podman --version`|podman version 5.2.2|podman version 5.4.1|

## End of Life

- [Java](https://endoflife.date/azul-zulu) ✅ 
- [podman](https://endoflife.date/podman) ✅ 
- [python](https://endoflife.date/python) ✅ 

[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
