### PR TITLE
(BSR) chore(dependencies): upgrade Maestro

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
             pkgs.jdk17 # needed by Android
             pkgs.jq # needed by some scripts run in the pipeline
             pkgs.python3 # needed by scripts/add_tracker.py
-            pkgs-old.maestro # needed to run end to end test locally
+            pkgs.maestro # needed to run end to end test locally
             pkgs.act # needed to debug pipeline locally
             pkgs.gh # needed to debug pipeline locally
             pkgs.podman # needed to debug pipeline locally


### PR DESCRIPTION
`maestro --version`
* avant : `1.37.9`
* arpès : `1.39.13`


## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] `yarn test:e2e:android:testing .maestro/tests/AccessSignupFromBlock.yml` sur un simulateur Pixel a3 33

[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
