### PR TITLE
(PC-34740) refactor(contentful): adapter

### DIFF
--- a/src/libs/contentful/adapters/adaptHomepageModules.native.test.ts
+++ b/src/libs/contentful/adapters/adaptHomepageModules.native.test.ts
@@ -1,75 +1,68 @@
 import {
+  adaptedHomepage,
   formattedBusinessModule,
-  formattedCategoryListModule,
-  formattedExclusivityModule,
   formattedOffersModule,
-  formattedRecommendedOffersModule,
-  formattedThematicHighlightModule,
-  formattedTrendsModule,
-  formattedVenuesModule,
-  formattedVideoCarouselModule,
 } from 'features/home/fixtures/homepage.fixture'
-import { adaptHomepageNatifModules } from 'libs/contentful/adapters/adaptHomepageModules'
-import { algoliaNatifModuleFixture } from 'libs/contentful/fixtures/algoliaModules.fixture'
-import { businessNatifModuleFixture } from 'libs/contentful/fixtures/businessModule.fixture'
-import { categoryListFixture } from 'libs/contentful/fixtures/categoryList.fixture'
-import { exclusivityNatifModuleFixture } from 'libs/contentful/fixtures/exclusivityModule.fixture'
-import { recommendationNatifModuleFixture } from 'libs/contentful/fixtures/recommendationNatifModule.fixture'
-import { thematicHighlightModuleFixture } from 'libs/contentful/fixtures/thematicHighlightModule.fixture'
-import { trendsModuleFixture } from 'libs/contentful/fixtures/trendsModule.fixture'
-import { venuesNatifModuleFixture } from 'libs/contentful/fixtures/venuesModule.fixture'
-import { videoCarouselFixture } from 'libs/contentful/fixtures/videoCarousel.fixture'
+import { homepageNatifEntryFixture } from 'libs/contentful/fixtures/homepageNatifEntry.fixture'
 import { eventMonitoring } from 'libs/monitoring/services'
 
-describe('adaptHomepageModules', () => {
-  it('should adapt a list of HomepageNatifModules', () => {
-    const rawHomepageNatifModules = [
-      algoliaNatifModuleFixture,
-      businessNatifModuleFixture,
-      venuesNatifModuleFixture,
-      exclusivityNatifModuleFixture,
-      recommendationNatifModuleFixture,
-      thematicHighlightModuleFixture,
-      categoryListFixture,
-      videoCarouselFixture,
-      trendsModuleFixture,
-    ]
+import { algoliaNatifModuleFixture } from '../fixtures/algoliaModules.fixture'
+import { businessNatifModuleFixture } from '../fixtures/businessModule.fixture'
 
-    const formattedHomepageModules = [
-      formattedOffersModule,
-      formattedBusinessModule,
-      formattedVenuesModule,
-      formattedExclusivityModule,
-      formattedRecommendedOffersModule,
-      formattedThematicHighlightModule,
-      formattedCategoryListModule,
-      formattedVideoCarouselModule,
-      formattedTrendsModule,
-    ]
+import { adaptHomepageEntries } from './adaptHomepageEntries'
 
-    expect(adaptHomepageNatifModules(rawHomepageNatifModules)).toStrictEqual(
-      formattedHomepageModules
-    )
+describe('adaptHomepageEntries', () => {
+  it('should adapt a list of HomepageNatifEntries without modules', () => {
+    const adaptedHomepageList = adaptHomepageEntries([
+      {
+        ...homepageNatifEntryFixture,
+        fields: { ...homepageNatifEntryFixture.fields, modules: [] },
+      },
+    ])
+
+    expect(adaptedHomepageList).toStrictEqual([{ ...adaptedHomepage, modules: [] }])
   })
 
-  it('should catch the error and log to Sentry if the provided data is corrupted', () => {
-    const spyWarn = jest.spyOn(global.console, 'warn').mockImplementationOnce(() => null)
+  describe('modules', () => {
+    it('should adapt a list of HomepageNatifModules', () => {
+      const rawHomepageNatifModules = [algoliaNatifModuleFixture, businessNatifModuleFixture]
 
-    const contentModel = structuredClone(businessNatifModuleFixture)
-    // @ts-ignore: the following content model is voluntarily broken, cf. PC-21362
-    contentModel.fields.image = undefined
+      const formattedHomepageModules = [formattedOffersModule, formattedBusinessModule]
+      const adaptedHomepageList = adaptHomepageEntries([
+        {
+          ...homepageNatifEntryFixture,
+          fields: { ...homepageNatifEntryFixture.fields, modules: rawHomepageNatifModules },
+        },
+      ])
 
-    adaptHomepageNatifModules([contentModel])
+      expect(adaptedHomepageList).toStrictEqual([
+        { ...adaptedHomepage, modules: formattedHomepageModules },
+      ])
+    })
 
-    expect(spyWarn).toHaveBeenNthCalledWith(
-      1,
-      'Error while computing home modules, with module of ID: 20SId61p6EFTG7kgBTFrOa',
-      expect.objectContaining({}) // is supposed to be a TypeError, but we don't care
-    )
-    expect(eventMonitoring.captureException).toHaveBeenNthCalledWith(
-      1,
-      'Error while computing home modules',
-      { extra: { moduleId: '20SId61p6EFTG7kgBTFrOa' } }
-    )
+    it('should catch the error and log to Sentry if the provided data is corrupted', () => {
+      const spyWarn = jest.spyOn(global.console, 'warn').mockImplementationOnce(() => null)
+
+      const contentModel = structuredClone(businessNatifModuleFixture)
+
+      // @ts-ignore: the following content model is voluntarily broken, cf. PC-21362
+      contentModel.fields.image = undefined
+
+      adaptHomepageEntries([
+        {
+          ...homepageNatifEntryFixture,
+          fields: { ...homepageNatifEntryFixture.fields, modules: [contentModel] },
+        },
+      ])
+
+      expect(spyWarn).toHaveBeenNthCalledWith(
+        1,
+        'Error while computing home modules, with module of ID: 20SId61p6EFTG7kgBTFrOa',
+        expect.objectContaining({}) // is supposed to be a TypeError, but we don't care
+      )
+      expect(eventMonitoring.captureException).toHaveBeenNthCalledWith(1, expect.any(TypeError), {
+        extra: { moduleId: '20SId61p6EFTG7kgBTFrOa' },
+      })
+    })
   })
 })

--- a/src/libs/contentful/adapters/adaptHomepageModules.ts
+++ b/src/libs/contentful/adapters/adaptHomepageModules.ts
@@ -1,101 +1,38 @@
 import { isEmpty } from 'lodash'
 
 import { HomepageModule } from 'features/home/types'
-import { adaptBusinessModule } from 'libs/contentful/adapters/modules/adaptBusinessModule'
-import { adaptCategoryListModule } from 'libs/contentful/adapters/modules/adaptCategoryListModule'
-import { adaptExclusivityModule } from 'libs/contentful/adapters/modules/adaptExclusivityModule'
-import { adaptHighlightOfferModule } from 'libs/contentful/adapters/modules/adaptHighlightOfferModule'
-import { adaptOffersModule } from 'libs/contentful/adapters/modules/adaptOffersModule'
-import { adaptRecommendationModule } from 'libs/contentful/adapters/modules/adaptRecommendationModule'
-import { adaptThematicHighlightModule } from 'libs/contentful/adapters/modules/adaptThematicHighlightModule'
-import { adaptTrendsModule } from 'libs/contentful/adapters/modules/adaptTrendsModule'
-import { adaptVenueMapModule } from 'libs/contentful/adapters/modules/adaptVenueMapModule'
-import { adaptVenuesModule } from 'libs/contentful/adapters/modules/adaptVenuesModule'
-import { adaptVideoCarouselModule } from 'libs/contentful/adapters/modules/adaptVideoCarouselModule'
-import { adaptVideoModule } from 'libs/contentful/adapters/modules/adaptVideoModule'
-import {
-  HomepageNatifModule,
-  isAlgoliaContentModel,
-  isBusinessContentModel,
-  isCategoryListContentModel,
-  isExclusivityContentModel,
-  isHighlightOfferContentModel,
-  isRecommendationContentModel,
-  isThematicHighlightContentModel,
-  isTrendsContentModel,
-  isVenueMapBlockContentModel,
-  isVenuesContentModel,
-  isVideoCarouselContentModel,
-  isVideoContentModel,
-} from 'libs/contentful/types'
+import { contentfulAdapters } from 'libs/contentful/adapters/contentfulAdapters'
+import { HomepageNatifModule } from 'libs/contentful/types'
 import { eventMonitoring } from 'libs/monitoring/services'
 
-export const adaptHomepageNatifModules = (modules: HomepageNatifModule[]): HomepageModule[] => {
-  const adaptedHomepageNatifModules = modules.map((module) => {
-    const { fields } = module
-    if (!fields || isEmpty(fields)) return null
+export const adaptHomepageNatifModules = (modules: HomepageNatifModule[]): HomepageModule[] =>
+  modules.filter(moduleContainFields).map(adaptModule).filter(isNotNull)
 
-    try {
-      if (isAlgoliaContentModel(module)) {
-        return adaptOffersModule(module)
-      }
+const adaptModule = (module: HomepageNatifModule) => {
+  const contentType = module.sys.contentType?.sys.id
+  if (!contentType) {
+    throw new Error(`Missing contentType`)
+  }
 
-      if (isBusinessContentModel(module)) {
-        return adaptBusinessModule(module)
-      }
-
-      if (isRecommendationContentModel(module)) {
-        return adaptRecommendationModule(module)
-      }
-
-      if (isThematicHighlightContentModel(module)) {
-        return adaptThematicHighlightModule(module)
-      }
-
-      if (isVenuesContentModel(module)) {
-        return adaptVenuesModule(module)
-      }
-
-      if (isExclusivityContentModel(module)) {
-        return adaptExclusivityModule(module)
-      }
-
-      if (isCategoryListContentModel(module)) {
-        return adaptCategoryListModule(module)
-      }
-
-      if (isVideoContentModel(module)) {
-        return adaptVideoModule(module)
-      }
-
-      if (isHighlightOfferContentModel(module)) {
-        return adaptHighlightOfferModule(module)
-      }
-
-      if (isVenueMapBlockContentModel(module)) {
-        return adaptVenueMapModule(module)
-      }
-
-      if (isVideoCarouselContentModel(module)) {
-        return adaptVideoCarouselModule(module)
-      }
-
-      if (isTrendsContentModel(module)) {
-        return adaptTrendsModule(module)
-      }
-    } catch (error) {
-      console.warn(`Error while computing home modules, with module of ID: ${module.sys.id}`, error)
-      eventMonitoring.captureException('Error while computing home modules', {
-        extra: { moduleId: module.sys.id },
-      })
+  try {
+    const adapter = contentfulAdapters[contentType]
+    if (!adapter) {
+      throw new Error(`Missing adapter for contentType: ${contentType}`)
     }
-
-    return null
-  })
-
-  const adaptedHomepageNatifModulesWithoutNull = adaptedHomepageNatifModules.filter(
-    (module) => module != null
-  ) as HomepageModule[]
-
-  return adaptedHomepageNatifModulesWithoutNull
+    return adapter(module)
+  } catch (error) {
+    monitorError(error, module)
+  }
+  return null
 }
+
+const monitorError = (error: unknown, module: HomepageNatifModule) => {
+  console.warn(`Error while computing home modules, with module of ID: ${module.sys.id}`, error)
+  eventMonitoring.captureException(error, {
+    extra: { moduleId: module.sys.id },
+  })
+}
+
+const moduleContainFields = ({ fields }: HomepageNatifModule) => fields || !isEmpty(fields)
+
+const isNotNull = <T>(item: T | null): item is T => !!item

--- a/src/libs/contentful/adapters/contentfulAdapters.ts
+++ b/src/libs/contentful/adapters/contentfulAdapters.ts
@@ -1,0 +1,35 @@
+import { ContentTypes, Entry } from '../types'
+
+import { adaptBusinessModule } from './modules/adaptBusinessModule'
+import { adaptCategoryListModule } from './modules/adaptCategoryListModule'
+import { adaptExclusivityModule } from './modules/adaptExclusivityModule'
+import { adaptHighlightOfferModule } from './modules/adaptHighlightOfferModule'
+import { adaptOffersModule } from './modules/adaptOffersModule'
+import { adaptRecommendationModule } from './modules/adaptRecommendationModule'
+import { adaptThematicHighlightModule } from './modules/adaptThematicHighlightModule'
+import { adaptTrendsModule } from './modules/adaptTrendsModule'
+import { adaptVenueMapModule } from './modules/adaptVenueMapModule'
+import { adaptVenuesModule } from './modules/adaptVenuesModule'
+import { adaptVideoCarouselModule } from './modules/adaptVideoCarouselModule'
+import { adaptVideoModule } from './modules/adaptVideoModule'
+
+export type ContentfulAdapter<
+  Contentful extends Entry<unknown, ContentTypes>,
+  Module extends Record<string, unknown>,
+> = (module: Contentful) => Module | null
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const contentfulAdapters: Record<string, ContentfulAdapter<any, any>> = {
+  [ContentTypes.ALGOLIA]: adaptOffersModule,
+  [ContentTypes.BUSINESS]: adaptBusinessModule,
+  [ContentTypes.RECOMMENDATION]: adaptRecommendationModule,
+  [ContentTypes.THEMATIC_HIGHLIGHT]: adaptThematicHighlightModule,
+  [ContentTypes.VENUES_PLAYLIST]: adaptVenuesModule,
+  [ContentTypes.EXCLUSIVITY]: adaptExclusivityModule,
+  [ContentTypes.CATEGORY_LIST]: adaptCategoryListModule,
+  [ContentTypes.VIDEO]: adaptVideoModule,
+  [ContentTypes.HIGHLIGHT_OFFER]: adaptHighlightOfferModule,
+  [ContentTypes.VENUE_MAP_BLOCK]: adaptVenueMapModule,
+  [ContentTypes.VIDEO_CAROUSEL]: adaptVideoCarouselModule,
+  [ContentTypes.TRENDS]: adaptTrendsModule,
+}

--- a/src/libs/contentful/adapters/contentfulAdapters.ts
+++ b/src/libs/contentful/adapters/contentfulAdapters.ts
@@ -20,6 +20,7 @@ export type ContentfulAdapter<
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const contentfulAdapters: Record<string, ContentfulAdapter<any, any>> = {
+  // with unknown instead of any: Type 'unknown' is not assignable to type 'AlgoliaContentModel'
   [ContentTypes.ALGOLIA]: adaptOffersModule,
   [ContentTypes.BUSINESS]: adaptBusinessModule,
   [ContentTypes.RECOMMENDATION]: adaptRecommendationModule,

--- a/src/libs/contentful/adapters/modules/adaptBusinessModule.native.test.ts
+++ b/src/libs/contentful/adapters/modules/adaptBusinessModule.native.test.ts
@@ -1,7 +1,6 @@
 import { BusinessModule, HomepageModuleType } from 'features/home/types'
 import { adaptBusinessModule } from 'libs/contentful/adapters/modules/adaptBusinessModule'
 import { businessNatifModuleFixture } from 'libs/contentful/fixtures/businessModule.fixture'
-import { isBusinessContentModel } from 'libs/contentful/types'
 
 describe('adaptBusinessModule', () => {
   it('should adapt a business module', () => {
@@ -22,7 +21,6 @@ describe('adaptBusinessModule', () => {
     }
     const rawBusinessModule = businessNatifModuleFixture
 
-    expect(isBusinessContentModel(rawBusinessModule)).toBe(true)
     expect(adaptBusinessModule(rawBusinessModule)).toEqual(formattedBusinessModule)
   })
 

--- a/src/libs/contentful/adapters/modules/adaptBusinessModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptBusinessModule.ts
@@ -3,7 +3,11 @@ import { buildImageUrl } from 'libs/contentful/adapters/helpers/buildImageUrl'
 import { buildLocalization } from 'libs/contentful/adapters/modules/helpers/buildLocalization'
 import { BusinessContentModel } from 'libs/contentful/types'
 
-export const adaptBusinessModule = (module: BusinessContentModel): BusinessModule | null => {
+import { ContentfulAdapter } from '../contentfulAdapters'
+
+export const adaptBusinessModule: ContentfulAdapter<BusinessContentModel, BusinessModule> = (
+  module
+) => {
   // if a mandatory module is unpublished/deleted, we can't handle the module, so we return null
   if (module.fields?.image.fields === undefined) return null
 

--- a/src/libs/contentful/adapters/modules/adaptCategoryListModule.native.test.ts
+++ b/src/libs/contentful/adapters/modules/adaptCategoryListModule.native.test.ts
@@ -1,13 +1,11 @@
 import { formattedCategoryListModule } from 'features/home/fixtures/homepage.fixture'
 import { adaptCategoryListModule } from 'libs/contentful/adapters/modules/adaptCategoryListModule'
 import { categoryListFixture } from 'libs/contentful/fixtures/categoryList.fixture'
-import { isCategoryListContentModel } from 'libs/contentful/types'
 
 describe('adaptCategoryListModule', () => {
   it('should adapt a CategoryList module', () => {
     const rawCategoryListModule = categoryListFixture
 
-    expect(isCategoryListContentModel(rawCategoryListModule)).toBe(true)
     expect(adaptCategoryListModule(rawCategoryListModule)).toEqual(formattedCategoryListModule)
   })
 })

--- a/src/libs/contentful/adapters/modules/adaptCategoryListModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptCategoryListModule.ts
@@ -6,9 +6,12 @@ import {
   ProvidedCategoryBlockContentModel,
 } from 'libs/contentful/types'
 
-export const adaptCategoryListModule = (
-  module: CategoryListContentModel
-): CategoryListModule | null => {
+import { ContentfulAdapter } from '../contentfulAdapters'
+
+export const adaptCategoryListModule: ContentfulAdapter<
+  CategoryListContentModel,
+  CategoryListModule
+> = (module) => {
   if (module.fields === undefined) return null
 
   return {

--- a/src/libs/contentful/adapters/modules/adaptExclusivityModule.native.test.ts
+++ b/src/libs/contentful/adapters/modules/adaptExclusivityModule.native.test.ts
@@ -1,13 +1,11 @@
 import { formattedExclusivityModule } from 'features/home/fixtures/homepage.fixture'
 import { adaptExclusivityModule } from 'libs/contentful/adapters/modules/adaptExclusivityModule'
 import { exclusivityNatifModuleFixture } from 'libs/contentful/fixtures/exclusivityModule.fixture'
-import { isExclusivityContentModel } from 'libs/contentful/types'
 
 describe('adaptExclusivityModule', () => {
   it('should adapt an exclusivity module', () => {
     const rawExclusivityNatifModule = exclusivityNatifModuleFixture
 
-    expect(isExclusivityContentModel(rawExclusivityNatifModule)).toBe(true)
     expect(adaptExclusivityModule(rawExclusivityNatifModule)).toEqual(formattedExclusivityModule)
   })
 

--- a/src/libs/contentful/adapters/modules/adaptExclusivityModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptExclusivityModule.ts
@@ -3,9 +3,12 @@ import { buildImageUrl } from 'libs/contentful/adapters/helpers/buildImageUrl'
 import { parseStringToNumber } from 'libs/contentful/adapters/helpers/parseStringToNumber'
 import { ExclusivityContentModel } from 'libs/contentful/types'
 
-export const adaptExclusivityModule = (
-  modules: ExclusivityContentModel
-): ExclusivityModule | null => {
+import { ContentfulAdapter } from '../contentfulAdapters'
+
+export const adaptExclusivityModule: ContentfulAdapter<
+  ExclusivityContentModel,
+  ExclusivityModule
+> = (modules) => {
   // if a mandatory module is unpublished/deleted, we can't handle the module, so we return null
   if (modules.fields === undefined) return null
 

--- a/src/libs/contentful/adapters/modules/adaptHighlightOfferModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptHighlightOfferModule.ts
@@ -2,9 +2,12 @@ import { HighlightOfferModule, HomepageModuleType } from 'features/home/types'
 import { buildImageUrl } from 'libs/contentful/adapters/helpers/buildImageUrl'
 import { HighlightOfferContentModel } from 'libs/contentful/types'
 
-export const adaptHighlightOfferModule = (
-  module: HighlightOfferContentModel
-): HighlightOfferModule | null => {
+import { ContentfulAdapter } from '../contentfulAdapters'
+
+export const adaptHighlightOfferModule: ContentfulAdapter<
+  HighlightOfferContentModel,
+  HighlightOfferModule
+> = (module) => {
   if (module.fields === undefined) return null
 
   const offerImage = buildImageUrl(module.fields.offerImage.fields?.file.url)

--- a/src/libs/contentful/adapters/modules/adaptOffersModule.native.test.ts
+++ b/src/libs/contentful/adapters/modules/adaptOffersModule.native.test.ts
@@ -6,13 +6,11 @@ import {
   additionalAlgoliaParametersWithoutOffersFixture,
   algoliaNatifModuleFixture,
 } from 'libs/contentful/fixtures/algoliaModules.fixture'
-import { AlgoliaFields, AlgoliaParameters, isAlgoliaContentModel } from 'libs/contentful/types'
+import { AlgoliaFields, AlgoliaParameters } from 'libs/contentful/types'
 
 describe('adaptOffersModule', () => {
   it('should adapt an offers module without additional offers', () => {
     const rawAlgoliaNatifModule = algoliaNatifModuleFixture
-
-    expect(isAlgoliaContentModel(rawAlgoliaNatifModule)).toBe(true)
 
     expect(adaptOffersModule(rawAlgoliaNatifModule)).toEqual(formattedOffersModule)
   })

--- a/src/libs/contentful/adapters/modules/adaptOffersModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptOffersModule.ts
@@ -3,7 +3,9 @@ import { buildOffersParams } from 'libs/contentful/adapters/helpers/buildOffersP
 import { buildRecommendationParams } from 'libs/contentful/adapters/modules/adaptRecommendationModule'
 import { AlgoliaContentModel } from 'libs/contentful/types'
 
-export const adaptOffersModule = (module: AlgoliaContentModel): OffersModule | null => {
+import { ContentfulAdapter } from '../contentfulAdapters'
+
+export const adaptOffersModule: ContentfulAdapter<AlgoliaContentModel, OffersModule> = (module) => {
   // if a mandatory module is unpublished/deleted, we can't handle the module, so we return null
   if (module.fields === undefined) return null
   if (module.fields.displayParameters.fields === undefined) return null

--- a/src/libs/contentful/adapters/modules/adaptRecommendationModule.native.test.ts
+++ b/src/libs/contentful/adapters/modules/adaptRecommendationModule.native.test.ts
@@ -1,13 +1,12 @@
 import { formattedRecommendedOffersModule } from 'features/home/fixtures/homepage.fixture'
 import { adaptRecommendationModule } from 'libs/contentful/adapters/modules/adaptRecommendationModule'
 import { recommendationNatifModuleFixture } from 'libs/contentful/fixtures/recommendationNatifModule.fixture'
-import { RecommendationFields, isRecommendationContentModel } from 'libs/contentful/types'
+import { RecommendationFields } from 'libs/contentful/types'
 
 describe('adaptRecommendationModule', () => {
   it('should adapt a recommendedOffers module', () => {
     const rawRecommendationModule = recommendationNatifModuleFixture
 
-    expect(isRecommendationContentModel(rawRecommendationModule)).toBe(true)
     expect(adaptRecommendationModule(rawRecommendationModule)).toEqual(
       formattedRecommendedOffersModule
     )

--- a/src/libs/contentful/adapters/modules/adaptRecommendationModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptRecommendationModule.ts
@@ -5,6 +5,8 @@ import {
   RecommendationParametersFields,
 } from 'libs/contentful/types'
 
+import { ContentfulAdapter } from '../contentfulAdapters'
+
 const mapRecommendationSubcategories = (
   recoSubcategories: RecommendationParametersFields['recommendationSubcategories']
 ) => recoSubcategories?.fields?.subcategories
@@ -50,9 +52,10 @@ export const buildRecommendationParams = (
     categories: mapRecommendationCategories(recommendationCategories),
   }
 }
-export const adaptRecommendationModule = (
-  modules: RecommendationContentModel
-): RecommendedOffersModule | null => {
+export const adaptRecommendationModule: ContentfulAdapter<
+  RecommendationContentModel,
+  RecommendedOffersModule
+> = (modules) => {
   // if a mandatory module is unpublished/deleted, we can't handle the module, so we return null
   if (modules.fields === undefined) return null
   if (modules.fields.displayParameters.fields === undefined) return null

--- a/src/libs/contentful/adapters/modules/adaptThematicHighlightModule.native.test.ts
+++ b/src/libs/contentful/adapters/modules/adaptThematicHighlightModule.native.test.ts
@@ -1,6 +1,6 @@
 import { formattedThematicHighlightModule } from 'features/home/fixtures/homepage.fixture'
 import { thematicHighlightModuleFixture } from 'libs/contentful/fixtures/thematicHighlightModule.fixture'
-import { ThematicHighlightFields, isThematicHighlightContentModel } from 'libs/contentful/types'
+import { ThematicHighlightFields } from 'libs/contentful/types'
 
 import { adaptThematicHighlightModule } from './adaptThematicHighlightModule'
 
@@ -8,7 +8,6 @@ describe('adaptThematicHighlightModule', () => {
   it('should adapt an thematic highlight module', () => {
     const rawThematicHighlightModule = thematicHighlightModuleFixture
 
-    expect(isThematicHighlightContentModel(rawThematicHighlightModule)).toBe(true)
     expect(adaptThematicHighlightModule(rawThematicHighlightModule)).toEqual(
       formattedThematicHighlightModule
     )

--- a/src/libs/contentful/adapters/modules/adaptThematicHighlightModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptThematicHighlightModule.ts
@@ -2,9 +2,12 @@ import { ThematicHighlightModule, HomepageModuleType } from 'features/home/types
 import { buildImageUrl } from 'libs/contentful/adapters/helpers/buildImageUrl'
 import { ThematicHighlightContentModel } from 'libs/contentful/types'
 
-export const adaptThematicHighlightModule = (
-  module: ThematicHighlightContentModel
-): ThematicHighlightModule | null => {
+import { ContentfulAdapter } from '../contentfulAdapters'
+
+export const adaptThematicHighlightModule: ContentfulAdapter<
+  ThematicHighlightContentModel,
+  ThematicHighlightModule
+> = (module) => {
   // if a mandatory module is unpublished/deleted, we can't handle the module, so we return null
   if (module.fields === undefined) return null
 

--- a/src/libs/contentful/adapters/modules/adaptTrendsModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptTrendsModule.ts
@@ -12,7 +12,9 @@ import {
 } from 'libs/contentful/types'
 import { isNonNullable } from 'shared/typeguards/isNonNullable'
 
-export const adaptTrendsModule = (module: TrendsContentModel): TrendsModule | null => {
+import { ContentfulAdapter } from '../contentfulAdapters'
+
+export const adaptTrendsModule: ContentfulAdapter<TrendsContentModel, TrendsModule> = (module) => {
   if (module.fields === undefined) return null
 
   return {

--- a/src/libs/contentful/adapters/modules/adaptVenueMapModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptVenueMapModule.ts
@@ -1,7 +1,11 @@
 import { HomepageModuleType, VenueMapModule } from 'features/home/types'
 import { VenueMapBlockContentModel } from 'libs/contentful/types'
 
-export const adaptVenueMapModule = (module: VenueMapBlockContentModel): VenueMapModule | null => {
+import { ContentfulAdapter } from '../contentfulAdapters'
+
+export const adaptVenueMapModule: ContentfulAdapter<VenueMapBlockContentModel, VenueMapModule> = (
+  module
+) => {
   if (module.fields === undefined) return null
 
   return {

--- a/src/libs/contentful/adapters/modules/adaptVenuesModule.native.test.ts
+++ b/src/libs/contentful/adapters/modules/adaptVenuesModule.native.test.ts
@@ -1,13 +1,12 @@
 import { formattedVenuesModule } from 'features/home/fixtures/homepage.fixture'
 import { adaptVenuesModule } from 'libs/contentful/adapters/modules/adaptVenuesModule'
 import { venuesNatifModuleFixture } from 'libs/contentful/fixtures/venuesModule.fixture'
-import { VenuesFields, isVenuesContentModel } from 'libs/contentful/types'
+import { VenuesFields } from 'libs/contentful/types'
 
 describe('adaptVenuesModule', () => {
   it('should adapt a venues module', () => {
     const rawVenuesModule = venuesNatifModuleFixture
 
-    expect(isVenuesContentModel(rawVenuesModule)).toBe(true)
     expect(adaptVenuesModule(rawVenuesModule)).toEqual(formattedVenuesModule)
   })
 

--- a/src/libs/contentful/adapters/modules/adaptVenuesModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptVenuesModule.ts
@@ -5,10 +5,12 @@ import {
   VenuesParameters,
 } from 'libs/contentful/types'
 
+import { ContentfulAdapter } from '../contentfulAdapters'
+
 const venuesHaveFields = (parameters: VenuesParameters): parameters is ProvidedVenuesParameters =>
   !!parameters?.fields
 
-export const adaptVenuesModule = (modules: VenuesContentModel): VenuesModule | null => {
+export const adaptVenuesModule: ContentfulAdapter<VenuesContentModel, VenuesModule> = (modules) => {
   // if a mandatory module is unpublished/deleted, we can't handle the module, so we return null
   if (modules.fields === undefined) return null
   if (modules.fields.displayParameters.fields === undefined) return null

--- a/src/libs/contentful/adapters/modules/adaptVideoCarouselModule.native.test.ts
+++ b/src/libs/contentful/adapters/modules/adaptVideoCarouselModule.native.test.ts
@@ -1,13 +1,11 @@
 import { formattedVideoCarouselModule } from 'features/home/fixtures/homepage.fixture'
 import { adaptVideoCarouselModule } from 'libs/contentful/adapters/modules/adaptVideoCarouselModule'
 import { videoCarouselFixture } from 'libs/contentful/fixtures/videoCarousel.fixture'
-import { isVideoCarouselContentModel } from 'libs/contentful/types'
 
 describe('adaptVideoCarouselModule', () => {
   it('should adapt a VideoCarousel module', () => {
     const rawVideoCarouselModule = videoCarouselFixture
 
-    expect(isVideoCarouselContentModel(rawVideoCarouselModule)).toBe(true)
     expect(adaptVideoCarouselModule(rawVideoCarouselModule)).toEqual(formattedVideoCarouselModule)
   })
 })

--- a/src/libs/contentful/adapters/modules/adaptVideoCarouselModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptVideoCarouselModule.ts
@@ -4,9 +4,12 @@ import {
   VideoCarouselItemContentModel as VideoCarouselItemListContentModel,
 } from 'libs/contentful/types'
 
-export const adaptVideoCarouselModule = (
-  module: VideoCarouselContentModel
-): VideoCarouselModule | null => {
+import { ContentfulAdapter } from '../contentfulAdapters'
+
+export const adaptVideoCarouselModule: ContentfulAdapter<
+  VideoCarouselContentModel,
+  VideoCarouselModule
+> = (module) => {
   if (module.fields === undefined) return null
 
   return {

--- a/src/libs/contentful/adapters/modules/adaptVideoModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptVideoModule.ts
@@ -3,7 +3,9 @@ import { buildImageUrl } from 'libs/contentful/adapters/helpers/buildImageUrl'
 import { buildOffersParams } from 'libs/contentful/adapters/helpers/buildOffersParams'
 import { VideoContentModel } from 'libs/contentful/types'
 
-export const adaptVideoModule = (module: VideoContentModel): VideoModule | null => {
+import { ContentfulAdapter } from '../contentfulAdapters'
+
+export const adaptVideoModule: ContentfulAdapter<VideoContentModel, VideoModule> = (module) => {
   if (module.fields === undefined) return null
 
   const videoThumbnail = buildImageUrl(module.fields.videoThumbnail.fields?.file.url)

--- a/src/libs/contentful/types.ts
+++ b/src/libs/contentful/types.ts
@@ -39,7 +39,7 @@ export enum ContentTypes {
 
 export type Layout = 'three-items' | 'two-items' | 'one-item-medium'
 
-interface Entry<T, ContentType extends ContentTypes> {
+export interface Entry<T, ContentType extends ContentTypes> {
   sys: Sys<ContentType>
   // if the content model is unpublished/deleted, `fields` won't be provided
   fields?: T
@@ -543,35 +543,6 @@ type TrendsFields = {
 
 export type TrendsContentModel = Entry<TrendsFields, ContentTypes.TRENDS>
 
-export const isAlgoliaContentModel = (module: HomepageNatifModule): module is AlgoliaContentModel =>
-  module.sys.contentType?.sys.id === ContentTypes.ALGOLIA
-
-export const isBusinessContentModel = (
-  module: HomepageNatifModule
-): module is BusinessContentModel => module.sys.contentType?.sys.id === ContentTypes.BUSINESS
-
-export const isExclusivityContentModel = (
-  module: HomepageNatifModule
-): module is ExclusivityContentModel => module.sys.contentType?.sys.id === ContentTypes.EXCLUSIVITY
-
-export const isRecommendationContentModel = (
-  module: HomepageNatifModule
-): module is RecommendationContentModel =>
-  module.sys.contentType?.sys.id === ContentTypes.RECOMMENDATION
-
-export const isThematicHighlightContentModel = (
-  module: HomepageNatifModule
-): module is ThematicHighlightContentModel =>
-  module.sys.contentType?.sys.id === ContentTypes.THEMATIC_HIGHLIGHT
-
-export const isVenuesContentModel = (module: HomepageNatifModule): module is VenuesContentModel =>
-  module.sys.contentType?.sys.id === ContentTypes.VENUES_PLAYLIST
-
-export const isCategoryListContentModel = (
-  module: HomepageNatifModule
-): module is CategoryListContentModel =>
-  module.sys.contentType?.sys.id === ContentTypes.CATEGORY_LIST
-
 export const isThematicHighlightInfo = (
   thematicHeader?: ThematicHeader
 ): thematicHeader is ThematicHighlightInfo =>
@@ -582,9 +553,6 @@ export const isThematicCategoryInfo = (
 ): thematicHeader is ThematicCategoryInfo =>
   thematicHeader?.sys.contentType?.sys.id === ContentTypes.THEMATIC_CATEGORY_INFO
 
-export const isTrendsContentModel = (module: HomepageNatifModule): module is TrendsContentModel =>
-  module.sys.contentType?.sys.id === ContentTypes.TRENDS
-
 export const isClassicThematicHeader = (
   thematicHeader?: ThematicHeader
 ): thematicHeader is ClassicThematicHeader =>
@@ -594,16 +562,3 @@ export const isVenueMapBlockContentModel = (
   module: HomepageNatifModule
 ): module is VenueMapBlockContentModel =>
   module.sys.contentType?.sys.id === ContentTypes.VENUE_MAP_BLOCK
-
-export const isVideoContentModel = (module: HomepageNatifModule): module is VideoContentModel =>
-  module.sys.contentType?.sys.id === ContentTypes.VIDEO
-
-export const isHighlightOfferContentModel = (
-  module: HomepageNatifModule
-): module is HighlightOfferContentModel =>
-  module.sys.contentType?.sys.id === ContentTypes.HIGHLIGHT_OFFER
-
-export const isVideoCarouselContentModel = (
-  module: HomepageNatifModule
-): module is VideoCarouselContentModel =>
-  module.sys.contentType?.sys.id === ContentTypes.VIDEO_CAROUSEL


### PR DESCRIPTION
Reprise de: https://github.com/pass-culture/pass-culture-app-native/pull/6546

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34740

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
