### PR TITLE
(BSR) chore(dependencies): update devbox

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -1,6 +1,9 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/096478927c360bc18ea80c8274f013709cf7bdcd?lastModified=1742206328&narHash=sha256-q%2BAQ%2F%2F%2FoMnyyFzzF4H9ShSRENt3Zsx37jTiRkLkXXE0%3D"
+    },
     "nodejs@20.10.0": {
       "last_modified": "2024-01-14T03:55:27Z",
       "plugin_version": "0.0.2",

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         in
         pkgs.mkShellNoCC {
           packages = [
-            pkgs-old.devbox
+            pkgs.devbox
             pkgs.jdk17 # needed by Android
             pkgs.jq # needed by some scripts run in the pipeline
             pkgs.python3 # needed by scripts/add_tracker.py

--- a/scripts/load_certificate.sh
+++ b/scripts/load_certificate.sh
@@ -6,7 +6,5 @@ SSL_CERT_FILE="$(realpath '/Library/Application Support'/*/*/data/*cacert.pem 2>
 SCRIPT_FOLDER="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 if sh "$SCRIPT_FOLDER/is_proxy_enabled.sh"; then
-	export SSL_CERT_FILE="$SSL_CERT_FILE"
 	export NODE_EXTRA_CA_CERTS="$SSL_CERT_FILE"
-	export NIX_SSL_CERT_FILE="$SSL_CERT_FILE"
 fi


### PR DESCRIPTION
try to avoid the following error

```txt
/nix/store/559pz0w6zlvw8yyxah9s10fhaz400vaj-stdenv-darwin/setup: line 138: pop_var_context: head of shell_variables not a function context
```

which need to re-run `direnv allow`

`devbox version`
* before : `0.12.0`
* after : `0.14.0`

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)

[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
