### PR TITLE
(PC-35258) refactor(getDisplayedPrice): fix naming, introduce early return, add return for readability

### DIFF
--- a/src/features/artist/components/ArtistPlaylist/ArtistPlaylist.tsx
+++ b/src/features/artist/components/ArtistPlaylist/ArtistPlaylist.tsx
@@ -7,7 +7,7 @@ import { AlgoliaOfferWithArtistAndEan } from 'libs/algolia/types'
 import { usePlaylistItemDimensionsFromLayout } from 'libs/contentful/usePlaylistItemDimensionsFromLayout'
 import {
   getDisplayedPrice,
-  getIfPricesShouldBeFix,
+  getIfPricesShouldBeFixed,
   formatStartPrice,
 } from 'libs/parsers/getDisplayedPrice'
 import { useCategoryIdMapping } from 'libs/subcategories'
@@ -54,7 +54,7 @@ export const ArtistPlaylist: FunctionComponent<ArtistPlaylistProps> = ({
             item.offer.prices,
             currency,
             euroToPacificFrancRate,
-            getIfPricesShouldBeFix(item.offer.subcategoryId) ? undefined : formatStartPrice
+            getIfPricesShouldBeFixed(item.offer.subcategoryId) ? undefined : formatStartPrice
           ),
       })}
       itemWidth={itemWidth}

--- a/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
@@ -16,7 +16,7 @@ import { getOfferPrices } from 'features/offer/helpers/getOfferPrice/getOfferPri
 import { useOfferBatchTracking } from 'features/offer/helpers/useOfferBatchTracking/useOfferBatchTracking'
 import {
   getDisplayedPrice,
-  getIfPricesShouldBeFix,
+  getIfPricesShouldBeFixed,
   formatPrice,
 } from 'libs/parsers/getDisplayedPrice'
 import { useSubcategoriesMapping } from 'libs/subcategories'
@@ -52,10 +52,10 @@ export const Chronicles: FunctionComponent = () => {
     prices,
     currency,
     euroToPacificFrancRate,
-    formatPrice(
-      getIfPricesShouldBeFix(offer?.subcategoryId),
-      !!(offer?.isDuo && user?.isBeneficiary)
-    ),
+    formatPrice({
+      isFixed: getIfPricesShouldBeFixed(offer?.subcategoryId),
+      isDuo: !!(offer?.isDuo && user?.isBeneficiary),
+    }),
     {
       fractionDigits: 2,
     }

--- a/src/features/headlineOffer/adapters/offerToHeadlineOfferData.ts
+++ b/src/features/headlineOffer/adapters/offerToHeadlineOfferData.ts
@@ -4,7 +4,7 @@ import { formatDistance } from 'libs/parsers/formatDistance'
 import {
   formatStartPrice,
   getDisplayedPrice,
-  getIfPricesShouldBeFix,
+  getIfPricesShouldBeFixed,
 } from 'libs/parsers/getDisplayedPrice'
 import { CategoryHomeLabelMapping, CategoryIdMapping } from 'libs/subcategories/types'
 import { Currency } from 'shared/currency/useGetCurrencyToDisplay'
@@ -37,7 +37,7 @@ export function offerToHeadlineOfferData({
     hitOffer.prices,
     currency,
     euroToPacificFrancRate,
-    getIfPricesShouldBeFix(hitOffer.subcategoryId) ? formatStartPrice : undefined
+    getIfPricesShouldBeFixed(hitOffer.subcategoryId) ? formatStartPrice : undefined
   )
 
   return {

--- a/src/features/home/components/AttachedModuleCard/AttachedOfferCard.tsx
+++ b/src/features/home/components/AttachedModuleCard/AttachedOfferCard.tsx
@@ -9,7 +9,7 @@ import { formatDates, getTimeStampInMillis } from 'libs/parsers/formatDates'
 import {
   formatPrice,
   getDisplayedPrice,
-  getIfPricesShouldBeFix,
+  getIfPricesShouldBeFixed,
 } from 'libs/parsers/getDisplayedPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
@@ -40,10 +40,10 @@ export const AttachedOfferCard: React.FC<Props> = ({ offer, shouldFixHeight, com
     attachedOffer.prices,
     currency,
     euroToPacificFrancRate,
-    formatPrice(
-      getIfPricesShouldBeFix(attachedOffer.subcategoryId),
-      !!(attachedOffer.isDuo && user?.isBeneficiary)
-    )
+    formatPrice({
+      isFixed: getIfPricesShouldBeFixed(attachedOffer.subcategoryId),
+      isDuo: !!(attachedOffer.isDuo && user?.isBeneficiary),
+    })
   )
   const distance = getDistance(offer._geoloc, { userLocation, selectedPlace, selectedLocationMode })
   const distanceLabel = distance ? `à ${distance}` : undefined

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
@@ -13,7 +13,7 @@ import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import {
   formatPrice,
   getDisplayedPrice,
-  getIfPricesShouldBeFix,
+  getIfPricesShouldBeFixed,
 } from 'libs/parsers/getDisplayedPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
@@ -62,10 +62,10 @@ export const VideoMonoOfferTile: FunctionComponent<Props> = ({
     offer?.offer?.prices,
     currency,
     euroToPacificFrancRate,
-    formatPrice(
-      getIfPricesShouldBeFix(offer.offer.subcategoryId),
-      !!(offer.offer.isDuo && user?.isBeneficiary)
-    )
+    formatPrice({
+      isFixed: getIfPricesShouldBeFixed(offer.offer.subcategoryId),
+      isDuo: !!(offer.offer.isDuo && user?.isBeneficiary),
+    })
   )
 
   const offerHeight = theme.isDesktopViewport ? getSpacing(45) : getSpacing(35)

--- a/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
@@ -13,7 +13,7 @@ import { getDistance } from 'libs/location/getDistance'
 import {
   formatPrice,
   getDisplayedPrice,
-  getIfPricesShouldBeFix,
+  getIfPricesShouldBeFixed,
 } from 'libs/parsers/getDisplayedPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
@@ -51,10 +51,10 @@ export const VideoMultiOfferTile: FunctionComponent<Props> = ({
     offer?.offer?.prices,
     currency,
     euroToPacificFrancRate,
-    formatPrice(
-      getIfPricesShouldBeFix(offer.offer.subcategoryId),
-      !!(offer.offer.isDuo && user?.isBeneficiary)
-    )
+    formatPrice({
+      isFixed: getIfPricesShouldBeFixed(offer.offer.subcategoryId),
+      isDuo: !!(offer.offer.isDuo && user?.isBeneficiary),
+    })
   )
 
   const displayDate = getOfferDates(

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -27,7 +27,7 @@ import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import {
   formatPrice,
   getDisplayedPrice,
-  getIfPricesShouldBeFix,
+  getIfPricesShouldBeFixed,
 } from 'libs/parsers/getDisplayedPrice'
 import { Subcategory } from 'libs/subcategories/types'
 import { formatFullAddress } from 'shared/address/addressFormatter'
@@ -75,10 +75,10 @@ export const OfferBody: FunctionComponent<Props> = ({
     prices,
     currency,
     euroToPacificFrancRate,
-    formatPrice(
-      getIfPricesShouldBeFix(offer.subcategoryId),
-      !!(offer.isDuo && user?.isBeneficiary)
-    ),
+    formatPrice({
+      isFixed: getIfPricesShouldBeFixed(offer.subcategoryId),
+      isDuo: !!(offer.isDuo && user?.isBeneficiary),
+    }),
     { fractionDigits: 2 }
   )
 

--- a/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
+++ b/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
@@ -15,7 +15,7 @@ import { usePlaylistItemDimensionsFromLayout } from 'libs/contentful/usePlaylist
 import {
   formatStartPrice,
   getDisplayedPrice,
-  getIfPricesShouldBeFix,
+  getIfPricesShouldBeFixed,
 } from 'libs/parsers/getDisplayedPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
@@ -165,7 +165,9 @@ export function OfferPlaylistList({
                     item.offer.prices,
                     currency,
                     euroToPacificFrancRate,
-                    getIfPricesShouldBeFix(item.offer.subcategoryId) ? undefined : formatStartPrice
+                    getIfPricesShouldBeFixed(item.offer.subcategoryId)
+                      ? undefined
+                      : formatStartPrice
                   ),
               })}
               title={playlist.title}

--- a/src/features/offer/components/OfferTile/OfferTileWrapper.tsx
+++ b/src/features/offer/components/OfferTile/OfferTileWrapper.tsx
@@ -6,7 +6,7 @@ import { OfferTileProps } from 'features/offer/types'
 import {
   formatPrice,
   getDisplayedPrice,
-  getIfPricesShouldBeFix,
+  getIfPricesShouldBeFixed,
 } from 'libs/parsers/getDisplayedPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
@@ -38,10 +38,10 @@ export const OfferTileWrapper = (props: Props) => {
     item.offer?.prices,
     currency,
     euroToPacificFrancRate,
-    formatPrice(
-      getIfPricesShouldBeFix(item.offer.subcategoryId),
-      !!(item.offer.isDuo && user?.isBeneficiary)
-    )
+    formatPrice({
+      isFixed: getIfPricesShouldBeFixed(item.offer.subcategoryId),
+      isDuo: !!(item.offer.isDuo && user?.isBeneficiary),
+    })
   )
 
   return (

--- a/src/features/venue/components/VenueOffers/VenueOffersList.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffersList.tsx
@@ -17,7 +17,7 @@ import { formatDates, getTimeStampInMillis } from 'libs/parsers/formatDates'
 import {
   formatPrice,
   getDisplayedPrice,
-  getIfPricesShouldBeFix,
+  getIfPricesShouldBeFixed,
 } from 'libs/parsers/getDisplayedPrice'
 import { VenueTypeCode } from 'libs/parsers/venueType'
 import { CategoryHomeLabelMapping, CategoryIdMapping } from 'libs/subcategories/types'
@@ -95,10 +95,10 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
           item.offer.prices,
           currency,
           euroToPacificFrancRate,
-          formatPrice(
-            getIfPricesShouldBeFix(item.offer.subcategoryId),
-            !!(item.offer.isDuo && user?.isBeneficiary)
-          )
+          formatPrice({
+            isFixed: getIfPricesShouldBeFixed(item.offer.subcategoryId),
+            isDuo: !!(item.offer.isDuo && user?.isBeneficiary),
+          })
         )}
         venueId={venue?.id}
         width={width}

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueMapOfferPlaylist.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueMapOfferPlaylist.tsx
@@ -7,7 +7,7 @@ import { PlaylistType } from 'features/offer/enums'
 import {
   formatStartPrice,
   getDisplayedPrice,
-  getIfPricesShouldBeFix,
+  getIfPricesShouldBeFixed,
 } from 'libs/parsers/getDisplayedPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
@@ -54,7 +54,7 @@ export const VenueMapOfferPlaylist = ({
           item.offer.prices,
           currency,
           euroToPacificFrancRate,
-          getIfPricesShouldBeFix(item.offer.subcategoryId) ? undefined : formatStartPrice
+          getIfPricesShouldBeFixed(item.offer.subcategoryId) ? undefined : formatStartPrice
         )}
         width={PLAYLIST_ITEM_WIDTH}
         height={PLAYLIST_ITEM_HEIGHT}

--- a/src/libs/parsers/getDisplayedPrice.native.test.ts
+++ b/src/libs/parsers/getDisplayedPrice.native.test.ts
@@ -7,7 +7,7 @@ import {
   formatPrice,
   formatStartPrice,
   getDisplayedPrice,
-  getIfPricesShouldBeFix,
+  getIfPricesShouldBeFixed,
   identityPrice,
 } from './getDisplayedPrice'
 
@@ -61,7 +61,10 @@ describe('getDisplayedPrice', () => {
           prices,
           currency,
           DEFAULT_PACIFIC_FRANC_TO_EURO_RATE,
-          formatPrice(getIfPricesShouldBeFix(subcategoryId), isDuoDisplayable),
+          formatPrice({
+            isFixed: getIfPricesShouldBeFixed(subcategoryId),
+            isDuo: isDuoDisplayable,
+          }),
           {
             fractionDigits: 2,
           }
@@ -105,19 +108,19 @@ describe('formatPrice', () => {
     ${false} | ${true}  | ${`Dès ${price} - Duo`}
     ${false} | ${false} | ${`Dès ${price}`}
   `('$should render \t= $expected', ({ isFixed, isDuo, expected }) => {
-    const formatDisplayedPrice = formatPrice(isFixed, isDuo)
+    const formatDisplayedPrice = formatPrice({ isFixed, isDuo })
 
     expect(formatDisplayedPrice(price)).toBe(expected)
   })
 })
 
-describe('getIfPricesShouldBeFix', () => {
+describe('getIfPricesShouldBeFixed', () => {
   it.each`
     subcategoryId                             | expected
     ${SubcategoryIdEnum.LIVRE_PAPIER}         | ${true}
     ${undefined}                              | ${false}
     ${SubcategoryIdEnum.MATERIEL_ART_CREATIF} | ${false}
-  `('getIfPricesShouldBeFix($subcategoryId) \t= $expected', ({ subcategoryId, expected }) => {
-    expect(getIfPricesShouldBeFix(subcategoryId)).toBe(expected)
+  `('getIfPricesShouldBeFixed($subcategoryId) \t= $expected', ({ subcategoryId, expected }) => {
+    expect(getIfPricesShouldBeFixed(subcategoryId)).toBe(expected)
   })
 })

--- a/src/libs/parsers/getDisplayedPrice.ts
+++ b/src/libs/parsers/getDisplayedPrice.ts
@@ -39,9 +39,15 @@ export const getDisplayedPrice = (
 export const identityPrice = (price: string): string => price
 export const formatDuoPrice = (price: string): string => `${price} - Duo`
 export const formatStartPrice = (price: string): string => `Dès ${price}`
-export const formatPrice = (isFixed: boolean, isDuo: boolean) =>
-  compose([isFixed ? identityPrice : formatStartPrice, isDuo ? formatDuoPrice : identityPrice])
+export const formatPrice = ({ isFixed, isDuo }: { isFixed: boolean; isDuo: boolean }) => {
+  return compose([
+    isFixed ? identityPrice : formatStartPrice,
+    isDuo ? formatDuoPrice : identityPrice,
+  ])
+}
 
-export const getIfPricesShouldBeFix = (subcategoryId?: SubcategoryIdEnum | undefined): boolean => {
+export const getIfPricesShouldBeFixed = (
+  subcategoryId?: SubcategoryIdEnum | undefined
+): boolean => {
   return subcategoryId == SubcategoryIdEnum.LIVRE_PAPIER
 }

--- a/src/libs/parsers/getDisplayedPrice.ts
+++ b/src/libs/parsers/getDisplayedPrice.ts
@@ -15,24 +15,23 @@ export const getDisplayedPrice = (
   formatDisplayedPrice = identityPrice,
   options?: FormatPriceOptions
 ): string => {
-  if (prices?.length) {
-    if (prices.includes(0)) {
-      return 'Gratuit'
-    }
+  if (!prices?.length) return ''
+  if (prices.includes(0)) {
+    return 'Gratuit'
+  }
 
-    const uniquePrices = Array.from(new Set(prices.filter((p) => p > 0)))
+  const uniquePrices = Array.from(new Set(prices.filter((p) => p > 0)))
 
-    const sortedPrices = [...uniquePrices].sort((a, b) => a - b)
-    const firstPrice = sortedPrices[0]
-    if (firstPrice !== undefined) {
-      const displayedPrice = formatCurrencyFromCents(
-        firstPrice,
-        currency,
-        euroToPacificFrancRate,
-        options
-      )
-      return formatDisplayedPrice(displayedPrice)
-    }
+  const sortedPrices = [...uniquePrices].sort((a, b) => a - b)
+  const firstPrice = sortedPrices[0]
+  if (firstPrice !== undefined) {
+    const displayedPrice = formatCurrencyFromCents(
+      firstPrice,
+      currency,
+      euroToPacificFrancRate,
+      options
+    )
+    return formatDisplayedPrice(displayedPrice)
   }
   return ''
 }

--- a/src/ui/components/tiles/HorizontalOfferTile.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.tsx
@@ -13,7 +13,7 @@ import { LocationMode } from 'libs/location/types'
 import {
   formatPrice,
   getDisplayedPrice,
-  getIfPricesShouldBeFix,
+  getIfPricesShouldBeFixed,
 } from 'libs/parsers/getDisplayedPrice'
 import { useSubcategory } from 'libs/subcategories'
 import { tileAccessibilityLabel, TileContentType } from 'libs/tileAccessibilityLabel'
@@ -89,10 +89,10 @@ export const HorizontalOfferTile = ({
     prices,
     currency,
     euroToPacificFrancRate,
-    formatPrice(
-      getIfPricesShouldBeFix(offerDetails.subcategoryId),
-      !!(offerDetails.isDuo && user?.isBeneficiary)
-    )
+    formatPrice({
+      isFixed: getIfPricesShouldBeFixed(offerDetails.subcategoryId),
+      isDuo: !!(offerDetails.isDuo && user?.isBeneficiary),
+    })
   )
 
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.OFFER, {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35258

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
