### PR TITLE
(PC-35280) feat(tests): add describe in some tests

### DIFF
--- a/src/features/bookOffer/helpers/useModalContent.native.test.tsx
+++ b/src/features/bookOffer/helpers/useModalContent.native.test.tsx
@@ -181,33 +181,33 @@ describe('useModalContent', () => {
     expect(result.current.onLeftIconPress).not.toBeUndefined()
     expect(result.current.title).toBe('Choix des options')
   })
-})
 
-it('shows modal AlreadyBooked when isEndedUsedBooking is true', () => {
-  mockOffer = baseOffer
-  mockOffer.subcategoryId = SubcategoryIdEnum.CINE_PLEIN_AIR
-  mockStep = Step.CONFIRMATION
+  it('shows modal AlreadyBooked when isEndedUsedBooking is true', () => {
+    mockOffer = baseOffer
+    mockOffer.subcategoryId = SubcategoryIdEnum.CINE_PLEIN_AIR
+    mockStep = Step.CONFIRMATION
 
-  const { result } = renderHook(() => useModalContent(onPressBookOffer, undefined, true))
+    const { result } = renderHook(() => useModalContent(onPressBookOffer, undefined, true))
 
-  expect((result.current.children as any).type.name).toBe('AlreadyBooked')
-  expect(result.current.onLeftIconPress).toBeUndefined()
-  expect(result.current.title).toBe('Réservation impossible')
-})
+    expect((result.current.children as any).type.name).toBe('AlreadyBooked')
+    expect(result.current.onLeftIconPress).toBeUndefined()
+    expect(result.current.title).toBe('Réservation impossible')
+  })
 
-it('should not show back arrow if receives bookingDataMovieScreening', () => {
-  const bookingDataMovieScreening = {
-    date: new Date('2024-03-02'),
-    hour: 4,
-    stockId: 44,
-  }
-  mockOffer = baseOffer
-  mockOffer.subcategoryId = SubcategoryIdEnum.SEANCE_CINE
-  mockStep = Step.DUO
+  it('should not show back arrow if receives bookingDataMovieScreening', () => {
+    const bookingDataMovieScreening = {
+      date: new Date('2024-03-02'),
+      hour: 4,
+      stockId: 44,
+    }
+    mockOffer = baseOffer
+    mockOffer.subcategoryId = SubcategoryIdEnum.SEANCE_CINE
+    mockStep = Step.DUO
 
-  const { result } = renderHook(() =>
-    useModalContent(onPressBookOffer, undefined, true, bookingDataMovieScreening)
-  )
+    const { result } = renderHook(() =>
+      useModalContent(onPressBookOffer, undefined, true, bookingDataMovieScreening)
+    )
 
-  expect(result.current.leftIcon).toBeUndefined()
+    expect(result.current.leftIcon).toBeUndefined()
+  })
 })

--- a/src/features/search/pages/ThematicSearch/api/useThematicSearchPlaylists.native.test.ts
+++ b/src/features/search/pages/ThematicSearch/api/useThematicSearchPlaylists.native.test.ts
@@ -1,8 +1,9 @@
-import { useThematicSearchPlaylists } from 'features/search/pages/ThematicSearch/api/useThematicSearchPlaylists'
 import { LocationMode, Position } from 'libs/location/types'
 import { mockBuilder } from 'tests/mockBuilder'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, renderHook } from 'tests/utils'
+
+import { useThematicSearchPlaylists } from './useThematicSearchPlaylists'
 
 jest.mock('libs/network/NetInfoWrapper')
 
@@ -23,54 +24,56 @@ jest.mock('libs/firebase/analytics/analytics')
 
 const PLAYLISTS_TITLES = ['Titre de la playlist - 1', 'Titre de la playlist - 2']
 
-it('should fetch thematic search playlists offers', async () => {
-  renderHook(
-    () =>
-      useThematicSearchPlaylists({
-        playlistTitles: PLAYLISTS_TITLES,
-        fetchMethod: fetchThematicSearchPlaylistsOffers,
-        queryKey: '',
-      }),
-    {
-      wrapper: ({ children }) => reactQueryProviderHOC(children),
-    }
-  )
+describe('useThematicSearchPlaylists', () => {
+  it('should fetch thematic search playlists offers', async () => {
+    renderHook(
+      () =>
+        useThematicSearchPlaylists({
+          playlistTitles: PLAYLISTS_TITLES,
+          fetchMethod: fetchThematicSearchPlaylistsOffers,
+          queryKey: '',
+        }),
+      {
+        wrapper: ({ children }) => reactQueryProviderHOC(children),
+      }
+    )
 
-  await act(() => {})
+    await act(() => {})
 
-  expect(fetchThematicSearchPlaylistsOffers).toHaveBeenCalledWith(mockUserLocation),
-    expect.any(Object),
-    false,
-    undefined
-})
+    expect(fetchThematicSearchPlaylistsOffers).toHaveBeenCalledWith(mockUserLocation),
+      expect.any(Object),
+      false,
+      undefined
+  })
 
-it('should only return offers with images', async () => {
-  const OFFER_WITH_IMAGE = defaultThematicSearchOffer.hits.find((hit) => hit.offer.thumbUrl)
-  const { result } = renderHook(
-    () =>
-      useThematicSearchPlaylists({
-        playlistTitles: PLAYLISTS_TITLES,
-        fetchMethod: fetchThematicSearchPlaylistsOffers,
-        queryKey: '',
-      }),
-    {
-      wrapper: ({ children }) => reactQueryProviderHOC(children),
-    }
-  )
+  it('should only return offers with images', async () => {
+    const OFFER_WITH_IMAGE = defaultThematicSearchOffer.hits.find((hit) => hit.offer.thumbUrl)
+    const { result } = renderHook(
+      () =>
+        useThematicSearchPlaylists({
+          playlistTitles: PLAYLISTS_TITLES,
+          fetchMethod: fetchThematicSearchPlaylistsOffers,
+          queryKey: '',
+        }),
+      {
+        wrapper: ({ children }) => reactQueryProviderHOC(children),
+      }
+    )
 
-  await act(() => {})
+    await act(() => {})
 
-  expect(result).toEqual({
-    current: {
-      playlists: [
-        {
-          title: PLAYLISTS_TITLES[0],
-          offers: {
-            hits: [OFFER_WITH_IMAGE],
+    expect(result).toEqual({
+      current: {
+        playlists: [
+          {
+            title: PLAYLISTS_TITLES[0],
+            offers: {
+              hits: [OFFER_WITH_IMAGE],
+            },
           },
-        },
-      ],
-      isLoading: false,
-    },
+        ],
+        isLoading: false,
+      },
+    })
   })
 })

--- a/src/queries/favorites/useAddFavoriteMutation.native.test.tsx
+++ b/src/queries/favorites/useAddFavoriteMutation.native.test.tsx
@@ -80,25 +80,25 @@ describe('useAddFavoriteMutation', () => {
       })
     })
   })
-})
 
-it('should show snack bar when too many favorites when trying to add favorite', async () => {
-  simulateBackend({
-    id: offerId,
-    hasAddFavoriteError: false,
-    hasTooManyFavorites: true,
-    hasRemoveFavoriteError: false,
-  })
-  const result = renderUseAddFavorite()
+  it('should show snack bar when too many favorites when trying to add favorite', async () => {
+    simulateBackend({
+      id: offerId,
+      hasAddFavoriteError: false,
+      hasTooManyFavorites: true,
+      hasRemoveFavoriteError: false,
+    })
+    const result = renderUseAddFavorite()
 
-  expect(result.current.isLoading).toBeFalsy()
+    expect(result.current.isLoading).toBeFalsy()
 
-  result.current.mutate({ offerId })
+    result.current.mutate({ offerId })
 
-  await waitFor(() => {
-    expect(showErrorSnackBar).toHaveBeenCalledWith({
-      message: 'Trop de favoris enregistrés. Supprime des favoris pour en ajouter de nouveaux.',
-      timeout: SNACK_BAR_TIME_OUT,
+    await waitFor(() => {
+      expect(showErrorSnackBar).toHaveBeenCalledWith({
+        message: 'Trop de favoris enregistrés. Supprime des favoris pour en ajouter de nouveaux.',
+        timeout: SNACK_BAR_TIME_OUT,
+      })
     })
   })
 })

--- a/src/shared/Banners/GeolocationBanner.native.test.tsx
+++ b/src/shared/Banners/GeolocationBanner.native.test.tsx
@@ -27,60 +27,60 @@ describe('<GeolocationBanner />', () => {
 
     expect(screen.getByTestId('systemBanner')).toBeOnTheScreen()
   })
-})
 
-it('should open "Paramètres de localisation" modal when pressing button and permission is never ask again', async () => {
-  mockUseLocation.mockReturnValueOnce({
-    permissionState: GeolocPermissionState.NEVER_ASK_AGAIN,
-    showGeolocPermissionModal,
+  it('should open "Paramètres de localisation" modal when pressing button and permission is never ask again', async () => {
+    mockUseLocation.mockReturnValueOnce({
+      permissionState: GeolocPermissionState.NEVER_ASK_AGAIN,
+      showGeolocPermissionModal,
+    })
+    render(
+      <GeolocationBanner
+        title="Géolocalise-toi"
+        subtitle="Pour trouver des offres autour de toi."
+        analyticsFrom="thematicHome"
+      />
+    )
+    const button = screen.getByText('Géolocalise-toi')
+
+    await user.press(button)
+
+    expect(showGeolocPermissionModal).toHaveBeenCalledWith()
   })
-  render(
-    <GeolocationBanner
-      title="Géolocalise-toi"
-      subtitle="Pour trouver des offres autour de toi."
-      analyticsFrom="thematicHome"
-    />
-  )
-  const button = screen.getByText('Géolocalise-toi')
 
-  await user.press(button)
+  it('should ask for permission when pressing button and permission is denied', async () => {
+    mockUseLocation.mockReturnValueOnce({
+      permissionState: GeolocPermissionState.DENIED,
+      requestGeolocPermission,
+    })
+    render(
+      <GeolocationBanner
+        title="Géolocalise-toi"
+        subtitle="Pour trouver des offres autour de toi."
+        analyticsFrom="thematicHome"
+      />
+    )
+    const button = screen.getByText('Géolocalise-toi')
 
-  expect(showGeolocPermissionModal).toHaveBeenCalledWith()
-})
+    await user.press(button)
 
-it('should ask for permission when pressing button and permission is denied', async () => {
-  mockUseLocation.mockReturnValueOnce({
-    permissionState: GeolocPermissionState.DENIED,
-    requestGeolocPermission,
+    expect(requestGeolocPermission).toHaveBeenCalledWith()
   })
-  render(
-    <GeolocationBanner
-      title="Géolocalise-toi"
-      subtitle="Pour trouver des offres autour de toi."
-      analyticsFrom="thematicHome"
-    />
-  )
-  const button = screen.getByText('Géolocalise-toi')
 
-  await user.press(button)
+  it('should call onPress externaly when specified', async () => {
+    const mockOnPress = jest.fn()
+    render(
+      <GeolocationBanner
+        title="Géolocalise-toi"
+        subtitle="Pour trouver des offres autour de toi."
+        analyticsFrom="thematicHome"
+        onPress={mockOnPress}
+      />
+    )
 
-  expect(requestGeolocPermission).toHaveBeenCalledWith()
-})
+    const button = screen.getByText('Géolocalise-toi')
 
-it('should call onPress externaly when specified', async () => {
-  const mockOnPress = jest.fn()
-  render(
-    <GeolocationBanner
-      title="Géolocalise-toi"
-      subtitle="Pour trouver des offres autour de toi."
-      analyticsFrom="thematicHome"
-      onPress={mockOnPress}
-    />
-  )
+    await user.press(button)
 
-  const button = screen.getByText('Géolocalise-toi')
-
-  await user.press(button)
-
-  expect(mockOnPress).toHaveBeenCalledTimes(1)
+    expect(mockOnPress).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35280

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
