### PR TITLE
(PC-35220) feat(ProposedBySection): add a props borderRadius to have more control on Avatar component

### DIFF
--- a/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
+++ b/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
@@ -12,7 +12,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { Venue } from 'ui/svg/icons/Venue'
 import { Typo } from 'ui/theme'
-import { AVATAR_SMALL } from 'ui/theme/constants'
+import { AVATAR_BORDER_RADIUS_XSMALL, AVATAR_SMALL } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type ProposedBySectionProps = {
@@ -42,7 +42,10 @@ export const ProposedBySection: FunctionComponent<ProposedBySectionProps> = ({
             }
             defaultThumbnailSize={AVATAR_SMALL}
             thumbnailComponent={
-              <Avatar borderWidth={3} size={AVATAR_SMALL}>
+              <Avatar
+                size={AVATAR_SMALL}
+                rounded={false}
+                borderRadius={AVATAR_BORDER_RADIUS_XSMALL}>
                 {imageUrl ? (
                   <FullSizeImage url={imageUrl} testID="VenueImage" />
                 ) : (

--- a/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
+++ b/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
@@ -12,7 +12,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { Venue } from 'ui/svg/icons/Venue'
 import { Typo } from 'ui/theme'
-import { AVATAR_BORDER_RADIUS_XSMALL, AVATAR_SMALL } from 'ui/theme/constants'
+import { AVATAR_BORDER_RADIUS_SMALL, AVATAR_SMALL } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type ProposedBySectionProps = {
@@ -42,10 +42,7 @@ export const ProposedBySection: FunctionComponent<ProposedBySectionProps> = ({
             }
             defaultThumbnailSize={AVATAR_SMALL}
             thumbnailComponent={
-              <Avatar
-                size={AVATAR_SMALL}
-                rounded={false}
-                borderRadius={AVATAR_BORDER_RADIUS_XSMALL}>
+              <Avatar size={AVATAR_SMALL} rounded={false} borderRadius={AVATAR_BORDER_RADIUS_SMALL}>
                 {imageUrl ? (
                   <FullSizeImage url={imageUrl} testID="VenueImage" />
                 ) : (

--- a/src/ui/components/Avatar/Avatar.stories.tsx
+++ b/src/ui/components/Avatar/Avatar.stories.tsx
@@ -7,7 +7,13 @@ import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storyboo
 import { BicolorProfile } from 'ui/svg/icons/BicolorProfile'
 import { Profile } from 'ui/svg/icons/Profile'
 import { Typo } from 'ui/theme'
-import { AVATAR_LARGE, AVATAR_MEDIUM, AVATAR_SMALL, AVATAR_XSMALL } from 'ui/theme/constants'
+import {
+  AVATAR_LARGE,
+  AVATAR_MEDIUM,
+  AVATAR_SMALL,
+  AVATAR_XSMALL,
+  AVATAR_BORDER_RADIUS_SMALL,
+} from 'ui/theme/constants'
 
 import { Avatar } from './Avatar'
 
@@ -70,6 +76,16 @@ const variantConfig: Variants<typeof Avatar> = [
       rounded: false,
       borderWidth: 6,
       backgroundColor: theme.colors.coralLight,
+      children: <Typo.Title1>M.M</Typo.Title1>,
+    },
+  },
+  {
+    label: 'Avatar square with border radius',
+    props: {
+      size: AVATAR_LARGE,
+      rounded: false,
+      backgroundColor: theme.colors.coralLight,
+      borderRadius: AVATAR_BORDER_RADIUS_SMALL,
       children: <Typo.Title1>M.M</Typo.Title1>,
     },
   },

--- a/src/ui/components/Avatar/Avatar.tsx
+++ b/src/ui/components/Avatar/Avatar.tsx
@@ -19,6 +19,7 @@ export type AvatarProps = {
   borderColor?: string
   borderWidth?: number
   rounded?: boolean
+  borderRadius?: number
 }
 export const Avatar = ({
   size = AVATAR_SMALL,
@@ -26,13 +27,19 @@ export const Avatar = ({
   borderColor = 'white',
   borderWidth = 0,
   rounded = true,
+  borderRadius,
   children,
 }: PropsWithChildren<AvatarProps>) => {
   // Fix for iOS wich crop shadows when container has "overflow:hidden"
   const Wrapper = Platform.OS === 'ios' ? ShadowWrapper : Fragment
   return (
     <Wrapper>
-      <Container rounded={rounded} size={size} borderWidth={borderWidth} borderColor={borderColor}>
+      <Container
+        rounded={rounded}
+        size={size}
+        borderWidth={borderWidth}
+        borderColor={borderColor}
+        borderRadius={borderRadius}>
         <AvatarBody size={size} backgroundColor={backgroundColor} borderWidth={borderWidth}>
           {children}
         </AvatarBody>
@@ -57,14 +64,14 @@ const AvatarBody = styled.View<Pick<AvatarProps, 'size' | 'backgroundColor' | 'b
 )
 
 const Container = styled.View<
-  Pick<AvatarProps, 'rounded' | 'size' | 'borderWidth' | 'borderColor'>
->(({ size = AVATAR_SMALL, rounded, borderColor, borderWidth }) => ({
+  Pick<AvatarProps, 'rounded' | 'size' | 'borderWidth' | 'borderColor' | 'borderRadius'>
+>(({ size = AVATAR_SMALL, rounded, borderColor, borderWidth, borderRadius }) => ({
   width: size,
   height: size,
   overflow: 'hidden',
   borderWidth,
   borderColor,
-  borderRadius: rounded ? size * 0.5 : 0,
+  borderRadius: borderRadius ?? (rounded ? size * 0.5 : 0),
 
   ...(Platform.OS === 'ios' ? undefined : SHADOW),
 }))

--- a/src/ui/theme/constants.ts
+++ b/src/ui/theme/constants.ts
@@ -25,6 +25,8 @@ export const AVATAR_XSMALL = getSpacing(8)
 export const AVATAR_SMALL = getSpacing(13.5)
 export const AVATAR_MEDIUM = getSpacing(18)
 export const AVATAR_LARGE = getSpacing(26)
+export const AVATAR_BORDER_RADIUS_XSMALL = getSpacing(1)
+export const AVATAR_BORDER_RADIUS_SMALL = getSpacing(2)
 
 // icons used for Secondary buttons or bigger should be imported with STANDARD_ICON_SIZE
 export const STANDARD_ICON_SIZE = getSpacing(8)

--- a/src/ui/theme/constants.ts
+++ b/src/ui/theme/constants.ts
@@ -25,7 +25,6 @@ export const AVATAR_XSMALL = getSpacing(8)
 export const AVATAR_SMALL = getSpacing(13.5)
 export const AVATAR_MEDIUM = getSpacing(18)
 export const AVATAR_LARGE = getSpacing(26)
-export const AVATAR_BORDER_RADIUS_XSMALL = getSpacing(1)
 export const AVATAR_BORDER_RADIUS_SMALL = getSpacing(2)
 
 // icons used for Secondary buttons or bigger should be imported with STANDARD_ICON_SIZE


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35220

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |<img width="426" alt="Capture d’écran 2025-03-21 à 15 55 59" src="https://github.com/user-attachments/assets/cde1d868-223c-4e12-bbcf-b4fb685684d1" />|
| Android          |               |       |
| Phone - Chrome   |               |![Capture d’écran 2025-03-21 à 15 47 01](https://github.com/user-attachments/assets/87b1a006-a354-48e4-861d-3a7175d04c65)|
| Desktop - Chrome |               |![Capture d’écran 2025-03-21 à 15 48 22](https://github.com/user-attachments/assets/2e405eeb-07bf-4a4c-83e7-3684a941ec4f)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
