### PR TITLE
(PC-34337) fix(keychain): add more logs for localstorage errors and h…

### DIFF
--- a/src/libs/keychain/keychain.web.ts
+++ b/src/libs/keychain/keychain.web.ts
@@ -2,29 +2,34 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 
 const REFRESH_TOKEN_KEY = 'PASSCULTURE_REFRESH_TOKEN'
 
+function handleKeychainError(error: unknown, operation: string): never {
+  const errorMessage = error instanceof Error ? error.message : 'unknown error'
+  throw Error(`[Keychain]: ${operation} error: ${errorMessage}`)
+}
+
 export async function saveRefreshToken(refreshToken: string | undefined): Promise<void> {
   if (!refreshToken) {
-    throw Error('Aucun refresh token à sauvegarder')
+    throw Error('[Keychain]: No refresh token to save')
   }
   try {
     await AsyncStorage.setItem(REFRESH_TOKEN_KEY, refreshToken)
-  } catch {
-    throw Error('Keychain non accessible')
+  } catch (error: unknown) {
+    handleKeychainError(error, 'saving')
   }
 }
 
 export async function clearRefreshToken(): Promise<void> {
   try {
     await AsyncStorage.removeItem(REFRESH_TOKEN_KEY)
-  } catch {
-    throw Error('Keychain non accessible')
+  } catch (error: unknown) {
+    handleKeychainError(error, 'deletion')
   }
 }
 
 export async function getRefreshToken(): Promise<string | null> {
   try {
     return await AsyncStorage.getItem(REFRESH_TOKEN_KEY)
-  } catch {
-    throw Error('Keychain non accessible')
+  } catch (error: unknown) {
+    handleKeychainError(error, 'access')
   }
 }

--- a/src/libs/monitoring/config.ts
+++ b/src/libs/monitoring/config.ts
@@ -41,6 +41,9 @@ export async function getSentryConfig() {
     enableAppHangTracking: false,
     ignoreErrors: [
       'Non-Error promise rejection captured with value: Timeout', // Sentry Issue: APPLICATION-NATIVE-77ZQ
+      'Could not decrypt data with alias', // Sentry Issue: APPLICATION-NATIVE-1GTFR
+      'Could not encrypt data with alias:', // Sentry Issue: APPLICATION-NATIVE-1GTGN
+      'No keychain is available. You may need to restart your computer.', // Sentry Issue: APPLICATION-NATIVE-1GTTT
     ],
   } satisfies ReactNativeOptions
 }


### PR DESCRIPTION
## Contexte

Certaines erreurs liées à l’utilisation de react-native-keychain (notamment “Could not decrypt data with alias”, “Could not encrypt data with alias” et “No keychain is available. You may need to restart your computer.”) sont régulièrement remontées par Sentry. Ces erreurs semblent provenir des comportements intrinsèques des systèmes (Android Keystore et iOS Keychain) et non d’un dysfonctionnement de notre application.

Plusieurs issues sur le dépôt de [react-native-keychain](https://github.com/oblador/react-native-keychain) documentent ces cas, par exemple :

- [Issue #458](https://github.com/oblador/react-native-keychain/issues/458) – "Could not decrypt data with alias"

- [Issue #430](https://github.com/oblador/react-native-keychain/issues/430) – Erreurs lors du chiffrement/déchiffrement

- [Issue #341](https://github.com/oblador/react-native-keychain/issues/341) – "No keychain is available"

- [Issue #567](https://github.com/oblador/react-native-keychain/issues/567) – Erreurs spécifiques sur Android 12/13

## Objectif de la PR

Cette PR vise à :

- Réduire le bruit dans Sentry en ignorant les erreurs connues liées au comportement du système (par exemple, suite à des réinitialisations de l’appareil, des mises à jour de sécurité ou des limitations du Keystore).
- Ajouts de nouveaux logs dans la version web afin de recevoir plus d'informations sur [cette erreur](https://sentry.passculture.team/organizations/sentry/issues/1626857/?project=6&query=is%3Aunresolved+Keychain+non+accessible&referrer=issue-stream&statsPeriod=14d&stream_index=0) encore présente

## Discussion

Les recherches indiquent que ces erreurs sont principalement dues à des limitations ou comportements intrinsèques du Keystore Android et du Keychain iOS.

- Android : Des erreurs de déchiffrement/chiffrement peuvent survenir suite à une restauration de sauvegarde ou à des limites d’utilisation du Keystore (cf. [Issue #458](https://github.com/oblador/react-native-keychain/issues/458) et [Issue #430](https://github.com/oblador/react-native-keychain/issues/430)).

- iOS : L’erreur “No keychain is available” a été documentée notamment dans [Issue #341](https://github.com/oblador/react-native-keychain/issues/341).

L’approche actuelle consiste à filtrer ces erreurs dans Sentry pour éviter de polluer nos logs avec des événements non-actionnables, tout en gardant la possibilité de surveiller leur fréquence via d’autres moyens. Cette solution est acceptable tant que nous continuons à documenter et suivre ces cas pour détecter d’éventuels changements dans leur comportement.

## Autres liens utiles

- https://stackoverflow.com/questions/68433383/react-native-keychain-aes-storage-throwing-could-not-encrypt-data-with-alias#:~:text=I%20recently%20change%20the%20keychain,is%20run

- https://forum.developer.samsung.com/t/could-not-decrypt-data-with-alias/35942

- https://forum.authpass.app/t/error-while-error-retrieving-item-25291-25291-no-keychain-is-available-you-may-need-to-restart-your-computer/103