### PR TITLE
(PC-34900) fix(useMustUpdate): improve logging

### DIFF
--- a/src/features/forceUpdate/helpers/useMinimalBuildNumber.ts
+++ b/src/features/forceUpdate/helpers/useMinimalBuildNumber.ts
@@ -4,15 +4,15 @@ import { getMinimalBuildNumber } from 'libs/firebase/firestore/getMinimalBuildNu
 import { QueryKeys } from 'libs/queryKeys'
 
 export const useMinimalBuildNumber = () => {
-  const { data: minimalBuildNumber, isLoading } = useQuery(
-    QueryKeys.MINIMAL_BUILD_NUMBER,
-    getMinimalBuildNumber,
-    {
-      staleTime: 1000 * 30,
-      cacheTime: 1000 * 30,
-      enabled: onlineManager.isOnline(),
-    }
-  )
+  const {
+    data: minimalBuildNumber,
+    isLoading,
+    error,
+  } = useQuery(QueryKeys.MINIMAL_BUILD_NUMBER, getMinimalBuildNumber, {
+    staleTime: 1000 * 30,
+    cacheTime: 1000 * 30,
+    enabled: onlineManager.isOnline(),
+  })
 
-  return { minimalBuildNumber, isLoading }
+  return { minimalBuildNumber, isLoading, error }
 }

--- a/src/features/forceUpdate/helpers/useMustUpdateApp.native.test.ts
+++ b/src/features/forceUpdate/helpers/useMustUpdateApp.native.test.ts
@@ -16,6 +16,7 @@ describe('useMustUpdateApp', () => {
     useGetMinimalBuildNumberSpy.mockReturnValueOnce({
       minimalBuildNumber: 10_303_999,
       isLoading: false,
+      error: undefined,
     })
 
     const { result } = renderUseMustUpdateApp()
@@ -29,6 +30,7 @@ describe('useMustUpdateApp', () => {
     useGetMinimalBuildNumberSpy.mockReturnValueOnce({
       minimalBuildNumber: 10_304_001,
       isLoading: false,
+      error: undefined,
     })
 
     const { result } = renderUseMustUpdateApp()
@@ -42,6 +44,7 @@ describe('useMustUpdateApp', () => {
     useGetMinimalBuildNumberSpy.mockReturnValueOnce({
       minimalBuildNumber: buildVersion,
       isLoading: false,
+      error: undefined,
     })
 
     const { result } = renderUseMustUpdateApp()

--- a/src/features/forceUpdate/helpers/useMustUpdateApp.ts
+++ b/src/features/forceUpdate/helpers/useMustUpdateApp.ts
@@ -13,16 +13,17 @@ export enum MustUpdateAppState {
 }
 
 export const useMustUpdateApp: () => MustUpdateAppState = () => {
-  const { minimalBuildNumber, isLoading } = useMinimalBuildNumber()
+  const { minimalBuildNumber, isLoading, error } = useMinimalBuildNumber()
   const appBuildVersion = getAppBuildVersion()
 
   useEffect(() => {
     const timer = globalThis.setTimeout(() => {
-      if (!isLoading && !minimalBuildNumber) {
+      if (!isLoading && !minimalBuildNumber && error) {
         eventMonitoring.captureException(new Error('MustUpdateNoMinimalBuildNumberError'), {
           extra: {
             minimalBuildNumber,
             build: appBuildVersion,
+            error,
           },
         })
       }
@@ -30,7 +31,7 @@ export const useMustUpdateApp: () => MustUpdateAppState = () => {
     return () => {
       clearInterval(timer)
     }
-  }, [appBuildVersion, isLoading, minimalBuildNumber])
+  }, [appBuildVersion, error, isLoading, minimalBuildNumber])
 
   if (isLoading) return MustUpdateAppState.PENDING
 

--- a/src/features/forceUpdate/helpers/useMustUpdateApp.ts
+++ b/src/features/forceUpdate/helpers/useMustUpdateApp.ts
@@ -18,7 +18,7 @@ export const useMustUpdateApp: () => MustUpdateAppState = () => {
 
   useEffect(() => {
     const timer = globalThis.setTimeout(() => {
-      if (!minimalBuildNumber) {
+      if (!isLoading && !minimalBuildNumber) {
         eventMonitoring.captureException(new Error('MustUpdateNoMinimalBuildNumberError'), {
           extra: {
             minimalBuildNumber,
@@ -30,7 +30,7 @@ export const useMustUpdateApp: () => MustUpdateAppState = () => {
     return () => {
       clearInterval(timer)
     }
-  }, [appBuildVersion, minimalBuildNumber])
+  }, [appBuildVersion, isLoading, minimalBuildNumber])
 
   if (isLoading) return MustUpdateAppState.PENDING
 

--- a/src/features/forceUpdate/helpers/useMustUpdateApp.ts
+++ b/src/features/forceUpdate/helpers/useMustUpdateApp.ts
@@ -4,8 +4,6 @@ import { useMinimalBuildNumber } from 'features/forceUpdate/helpers/useMinimalBu
 import { eventMonitoring } from 'libs/monitoring/services'
 import { getAppBuildVersion } from 'libs/packageJson'
 
-const DELAY_BEFORE_VALUE_SHOULD_BE_SET_IN_MS = 15000
-
 export enum MustUpdateAppState {
   PENDING = 'pending',
   SHOULD_UPDATE = 'shouldUpdate',
@@ -17,19 +15,14 @@ export const useMustUpdateApp: () => MustUpdateAppState = () => {
   const appBuildVersion = getAppBuildVersion()
 
   useEffect(() => {
-    const timer = globalThis.setTimeout(() => {
-      if (!isLoading && !minimalBuildNumber && error) {
-        eventMonitoring.captureException(new Error('MustUpdateNoMinimalBuildNumberError'), {
-          extra: {
-            minimalBuildNumber,
-            build: appBuildVersion,
-            error,
-          },
-        })
-      }
-    }, DELAY_BEFORE_VALUE_SHOULD_BE_SET_IN_MS)
-    return () => {
-      clearInterval(timer)
+    if (!isLoading && !minimalBuildNumber && error) {
+      eventMonitoring.captureException(new Error('MustUpdateNoMinimalBuildNumberError'), {
+        extra: {
+          minimalBuildNumber,
+          build: appBuildVersion,
+          error,
+        },
+      })
     }
   }, [appBuildVersion, error, isLoading, minimalBuildNumber])
 

--- a/src/features/forceUpdate/helpers/useResetOnMinimalBuild.native.test.ts
+++ b/src/features/forceUpdate/helpers/useResetOnMinimalBuild.native.test.ts
@@ -35,6 +35,7 @@ describe('useResetOnMinimalBuild', () => {
     jest.spyOn(useMinimalBuildNumberModule, 'useMinimalBuildNumber').mockReturnValueOnce({
       minimalBuildNumber: undefined,
       isLoading: false,
+      error: undefined,
     })
     jest.spyOn(packageJson, 'getAppBuildVersion').mockReturnValueOnce(123)
 
@@ -47,6 +48,7 @@ describe('useResetOnMinimalBuild', () => {
     jest.spyOn(useMinimalBuildNumberModule, 'useMinimalBuildNumber').mockReturnValueOnce({
       minimalBuildNumber: 200,
       isLoading: false,
+      error: undefined,
     })
     jest.spyOn(packageJson, 'getAppBuildVersion').mockReturnValueOnce(123)
 
@@ -59,6 +61,7 @@ describe('useResetOnMinimalBuild', () => {
     jest.spyOn(useMinimalBuildNumberModule, 'useMinimalBuildNumber').mockReturnValueOnce({
       minimalBuildNumber: 100,
       isLoading: false,
+      error: undefined,
     })
     jest.spyOn(packageJson, 'getAppBuildVersion').mockReturnValueOnce(123)
 

--- a/src/features/forceUpdate/pages/ForceUpdateWithResetErrorBoundary.native.test.tsx
+++ b/src/features/forceUpdate/pages/ForceUpdateWithResetErrorBoundary.native.test.tsx
@@ -18,6 +18,7 @@ describe('<ForceUpdateWithResetErrorBoundary/>', () => {
     jest.spyOn(useMinimalBuildNumberModule, 'useMinimalBuildNumber').mockReturnValueOnce({
       minimalBuildNumber: 10_304_000,
       isLoading: false,
+      error: undefined,
     })
 
     await render(<ForceUpdateWithResetErrorBoundary resetErrorBoundary={() => null} />)

--- a/src/features/forceUpdate/pages/ForceUpdateWithResetErrorBoundary.web.test.tsx
+++ b/src/features/forceUpdate/pages/ForceUpdateWithResetErrorBoundary.web.test.tsx
@@ -15,6 +15,7 @@ describe('<ForceUpdateWithResetErrorBoundary/>', () => {
       jest.spyOn(useMinimalBuildNumberModule, 'useMinimalBuildNumber').mockReturnValueOnce({
         minimalBuildNumber: 10_304_000,
         isLoading: false,
+        error: undefined,
       })
 
       const { container } = render(


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34900

This error pops up every time we force an update on our users.
After 15 seconds, if the user is unable to get the minimal build number from firestoreRemoteStore we log to sentry.

My assumption is that this log is sent to sentry when the user has a degraded internet access.

There is a global effort led by the Architecture Guild to better handle degraded internet access in our app, so for the moment I'll attempt these quick changes: 
- log to sentry only if attempting to call firestore is done (and not stuck in loading in the case of a very slow connection). 
- get the error from useQuery and pass it to sentry in case getMinimalBuildNumber throws an error for more precise logging.
- remove the interval all together as the dependencies of the useEffect should be sufficient to trigger the log if needed. We should rely on useQuery and not attempt custom error handling mechanisms based on an arbitrary timeout.

To judge if this change is sufficient, we will have to wait for the next time we bump the minimal version of the app.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
