### PR TITLE
(PC-35107) feat(allure): add allure history

### DIFF
--- a/.github/workflows/dev_on_workflow_tester.yml
+++ b/.github/workflows/dev_on_workflow_tester.yml
@@ -194,6 +194,14 @@ jobs:
           done
           rm -rf allure-results-*
 
+      - name: 'Retrieve previous Allure history from bucket'
+        run: |
+          mkdir -p allure-results/history
+          # Check if history exists and copy it directly
+          if gsutil ls 'gs://${{ inputs.CACHE_BUCKET_NAME }}/pass-culture/pass-culture-app-native/v1-allure-history/' >/dev/null 2>&1; then
+            gsutil cp -r 'gs://${{ inputs.CACHE_BUCKET_NAME }}/pass-culture/pass-culture-app-native/v1-allure-history/*' allure-results/history/ || true
+          fi
+
       - name: Generate Allure Report
         run: yarn generate:allure-report
 
@@ -203,6 +211,15 @@ jobs:
         with:
           secrets: |-
             API_TOKEN_GITHUB:passculture-metier-ehp/passculture-main-sa-access-token
+
+      - name: 'Save Allure history to bucket'
+        run: |
+          # Check if history was generated and save it
+          if [ -d "allure-report/history" ] && [ "$(ls -A allure-report/history)" ]; then
+            gsutil cp -r allure-report/history/* 'gs://${{ inputs.CACHE_BUCKET_NAME }}/pass-culture/pass-culture-app-native/v1-allure-history/' || true
+          else
+            echo "Warning: No history generated in allure-report/history"
+          fi
 
       - name: 'Author'
         run: |

--- a/doc/decision-records/DR004 - allure-report.md
+++ b/doc/decision-records/DR004 - allure-report.md
@@ -16,7 +16,7 @@ Tout est référencé dans les actions `dev_on_workflow_tester.yml`
 La pipeline de tests est divisée en 10 shards (les jobs tournent simultanément pour plus de rapidité), 7 pour les tests natifs et 3 pour le web.
 Un rapport sera créé pour chacun des shards
 Chacun des job tourne sur une machine virtuelle différente, donc un nouveau job doit cloner (checkout) le repo, créer les node_modules, etc.
-Les différentss moyen de passer des fichiers d'un job à un autre est de créer un artefact, un cache sur Github (comme pour les node_modules), ou utiliser le service Google Cloud. On a décider d'utiliser Google Cloud à l'instar du job de coverage, qui est relativement similaire.
+Les différents moyens de passer des fichiers d'un job à un autre est de créer un artefact, un cache sur Github (comme pour les node_modules), ou utiliser le service Google Cloud. On a décider d'utiliser Google Cloud à l'instar du job de coverage, qui est relativement similaire.
 Les jobs de tests, qui créent les rapports Allure tournent donc sur 10 machines virtuelles différentes
 Il faut dans un premier temps les uploader vers Google Cloud
 


### PR DESCRIPTION
## Contexte

Cette PR apporte les modifications suivantes dans le fichier .github/workflows/dev_app_workflow_tester.yml :

- Récupération de l’historique Allure depuis un bucket Google
- Génération du rapport Allure
- Synchronisation automatique de l’historique généré vers le bucket GCS pour une utilisation future.

## Détails techniques

- Utilisation de la commande gsutil pour transférer l’historique depuis/vers le bucket GCS.
- Vérification de l’existence du dossier allure-report/history avant la synchronisation pour éviter les erreurs lorsque le dossier est vide.
- Messages d’avertissement ou de confirmation intégrés (echo) pour mieux comprendre le statut de la synchronisation.

## Motivation

Amélioration du suivi des tests : conserver l’historique Allure d’une exécution à l’autre permet de visualiser l’évolution des tests dans le temps et d’identifier plus facilement les régressions.