### PR TITLE
(PC-34982) feat(a11y): More precise accessibilityLabels when possible

### DIFF
--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
@@ -740,7 +740,7 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
               }
             />
             <View
-              accessibilityLabel="Continuer"
+              accessibilityLabel="Continuer vers l’étape suivante"
               accessibilityState={
                 {
                   "busy": undefined,
@@ -794,7 +794,7 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
                   },
                 ]
               }
-              testID="Continuer"
+              testID="Continuer vers l’étape suivante"
             >
               <View
                 style={

--- a/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
@@ -455,7 +455,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
           }
         >
           <View
-            accessibilityLabel="Continuer vers l’étape suivante"
+            accessibilityLabel="Continuer vers le statut"
             accessibilityState={
               {
                 "busy": undefined,
@@ -509,7 +509,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
                 },
               ]
             }
-            testID="Continuer vers l’étape suivante"
+            testID="Continuer vers le statut"
           >
             <View
               style={

--- a/__snapshots__/features/identityCheck/pages/profile/SetAddress.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetAddress.web.test.tsx.web-snap
@@ -279,9 +279,9 @@ exports[`<SetAddress/> should render correctly 1`] = `
           class="css-view-175oi2r r-backgroundColor-14lw9ot r-bottom-1p0dtai r-left-1d2f490 r-paddingBottom-k8qxaj r-paddingHorizontal-d9fdf6 r-paddingTop-ttdzmv r-position-u8s1d r-right-zchlnj"
         >
           <button
-            aria-label="Continuer vers l’étape suivante"
+            aria-label="Continuer vers le statut"
             class="c5 c6"
-            data-testid="Continuer vers l’étape suivante"
+            data-testid="Continuer vers le statut"
             disabled=""
             type="submit"
           >

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
@@ -468,7 +468,7 @@ exports[`<SetCity/> should render correctly 1`] = `
           }
         >
           <View
-            accessibilityLabel="Continuer vers l’étape suivante"
+            accessibilityLabel="Continuer vers l’adresse"
             accessibilityState={
               {
                 "busy": undefined,
@@ -522,7 +522,7 @@ exports[`<SetCity/> should render correctly 1`] = `
                 },
               ]
             }
-            testID="Continuer vers l’étape suivante"
+            testID="Continuer vers l’adresse"
           >
             <View
               style={

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.web.test.tsx.web-snap
@@ -285,9 +285,9 @@ exports[`<SetCity/> should render correctly 1`] = `
           class="css-view-175oi2r r-backgroundColor-14lw9ot r-bottom-1p0dtai r-left-1d2f490 r-paddingBottom-k8qxaj r-paddingHorizontal-d9fdf6 r-paddingTop-ttdzmv r-position-u8s1d r-right-zchlnj"
         >
           <button
-            aria-label="Continuer vers l’étape suivante"
+            aria-label="Continuer vers l’adresse"
             class="c5 c6"
-            data-testid="Continuer vers l’étape suivante"
+            data-testid="Continuer vers l’adresse"
             disabled=""
             type="submit"
           >

--- a/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
@@ -668,7 +668,7 @@ Nous les vérifions et ils ne pourront plus être modifiés par la suite.
           }
         >
           <View
-            accessibilityLabel="Continuer vers l’étape suivante"
+            accessibilityLabel="Continuer vers la ville de résidence"
             accessibilityState={
               {
                 "busy": undefined,
@@ -722,7 +722,7 @@ Nous les vérifions et ils ne pourront plus être modifiés par la suite.
                 },
               ]
             }
-            testID="Continuer vers l’étape suivante"
+            testID="Continuer vers la ville de résidence"
           >
             <View
               style={

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx
@@ -103,7 +103,7 @@ describe('SetPhoneNumber', () => {
 
     it('should enable the button when the phone number is valid', async () => {
       renderSetPhoneNumber()
-      const button = screen.getByTestId('Continuer')
+      const button = screen.getByTestId('Continuer vers l’étape suivante')
 
       await waitFor(() => expect(button).toBeDisabled())
 
@@ -120,7 +120,7 @@ describe('SetPhoneNumber', () => {
       '33224354m', // includes char
     ])('should disable the button when the phone number is not valid (%s)', async (phoneNumber) => {
       renderSetPhoneNumber()
-      const button = screen.getByTestId('Continuer')
+      const button = screen.getByTestId('Continuer vers l’étape suivante')
 
       await waitFor(() => expect(button).toBeDisabled())
 
@@ -133,7 +133,7 @@ describe('SetPhoneNumber', () => {
     it('should navigate to SetPhoneValidationCode on /send_phone_validation_code request success', async () => {
       renderSetPhoneNumber()
 
-      const continueButton = screen.getByTestId('Continuer')
+      const continueButton = screen.getByTestId('Continuer vers l’étape suivante')
       const input = screen.getByTestId('Entrée pour le numéro de téléphone')
       fireEvent.changeText(input, '612345678')
       fireEvent.press(continueButton)
@@ -152,7 +152,7 @@ describe('SetPhoneNumber', () => {
       )
       renderSetPhoneNumber()
 
-      const continueButton = screen.getByTestId('Continuer')
+      const continueButton = screen.getByTestId('Continuer vers l’étape suivante')
       const input = screen.getByTestId('Entrée pour le numéro de téléphone')
       fireEvent.changeText(input, '600000000')
 
@@ -173,7 +173,7 @@ describe('SetPhoneNumber', () => {
 
       renderSetPhoneNumber()
 
-      const continueButton = screen.getByTestId('Continuer')
+      const continueButton = screen.getByTestId('Continuer vers l’étape suivante')
       const input = screen.getByTestId('Entrée pour le numéro de téléphone')
       fireEvent.changeText(input, '612345678')
       fireEvent.press(continueButton)
@@ -184,7 +184,7 @@ describe('SetPhoneNumber', () => {
     it('should log event HasRequestedCode when pressing "Continuer" button', async () => {
       renderSetPhoneNumber()
 
-      const continueButton = screen.getByTestId('Continuer')
+      const continueButton = screen.getByTestId('Continuer vers l’étape suivante')
       const input = screen.getByTestId('Entrée pour le numéro de téléphone')
 
       await act(async () => {
@@ -201,7 +201,7 @@ describe('SetPhoneNumber', () => {
     it('should log analytics when pressing "Continuer" button', async () => {
       renderSetPhoneNumber()
 
-      const continueButton = screen.getByTestId('Continuer')
+      const continueButton = screen.getByTestId('Continuer vers l’étape suivante')
       const input = screen.getByTestId('Entrée pour le numéro de téléphone')
 
       await act(async () => {

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
@@ -174,6 +174,7 @@ export const SetPhoneNumber = () => {
             type="submit"
             onPress={requestSendPhoneValidationCode}
             wording="Continuer"
+            accessibilityLabel="Continuer vers l’étape suivante"
             disabled={!isContinueButtonEnabled}
             isLoading={isLoading}
           />

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -157,7 +157,7 @@ export const SetAddress = () => {
           type="submit"
           onPress={submitAddress}
           wording="Continuer"
-          accessibilityLabel="Continuer vers l’étape suivante"
+          accessibilityLabel="Continuer vers le statut"
           disabled={!enabled}
         />
       }

--- a/src/features/identityCheck/pages/profile/SetCity.tsx
+++ b/src/features/identityCheck/pages/profile/SetCity.tsx
@@ -68,7 +68,7 @@ export const SetCity = () => {
           type="submit"
           onPress={handleSubmit(onSubmit)}
           wording="Continuer"
-          accessibilityLabel="Continuer vers l’étape suivante"
+          accessibilityLabel="Continuer vers l’adresse"
           disabled={!isValid}
         />
       }

--- a/src/features/identityCheck/pages/profile/SetName.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/SetName.native.test.tsx
@@ -25,7 +25,7 @@ describe('<SetName/>', () => {
   it('should enable the submit button when first name and last name is not empty', async () => {
     render(<SetName />)
 
-    const continueButton = screen.getByTestId('Continuer vers l’étape suivante')
+    const continueButton = screen.getByTestId('Continuer vers la ville de résidence')
 
     expect(continueButton).toBeDisabled()
 

--- a/src/features/identityCheck/pages/profile/SetName.tsx
+++ b/src/features/identityCheck/pages/profile/SetName.tsx
@@ -123,7 +123,7 @@ Nous les vérifions et ils ne pourront plus être modifiés par la suite."
         <ButtonPrimary
           type="submit"
           wording="Continuer"
-          accessibilityLabel="Continuer vers l’étape suivante"
+          accessibilityLabel="Continuer vers la ville de résidence"
           onPress={handleSubmit(submitName)}
           disabled={disabled}
         />


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34982

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
