### PR TITLE
(PC-34760) refactor(profile): queries

### DIFF
--- a/src/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx
+++ b/src/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx
@@ -22,7 +22,7 @@ jest.mock('libs/firebase/analytics/analytics')
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue(DEFAULT_REMOTE_CONFIG)
 
-jest.mock('features/profile/api/useResetRecreditAmountToShow')
+jest.mock('queries/profile/useResetRecreditAmountToShowMutation')
 jest.mock('features/navigation/helpers/navigateToHome')
 jest.mock('features/navigation/navigationRef')
 jest.mock('features/auth/context/AuthContext')

--- a/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.native.test.tsx
+++ b/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.native.test.tsx
@@ -12,7 +12,7 @@ import { RecreditBirthdayNotification } from './RecreditBirthdayNotification'
 
 jest.mock('libs/firebase/analytics/analytics')
 jest.mock('features/auth/context/AuthContext')
-jest.mock('features/profile/api/usePatchProfile', () => ({
+jest.mock('/queries/profile/usePatchProfileMutation', () => ({
   useResetRecreditAmountToShow: jest.fn().mockReturnValue({ mutate: jest.fn() }),
 }))
 

--- a/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.native.test.tsx
+++ b/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.native.test.tsx
@@ -12,7 +12,7 @@ import { RecreditBirthdayNotification } from './RecreditBirthdayNotification'
 
 jest.mock('libs/firebase/analytics/analytics')
 jest.mock('features/auth/context/AuthContext')
-jest.mock('/queries/profile/usePatchProfileMutation', () => ({
+jest.mock('queries/profile/usePatchProfileMutation', () => ({
   useResetRecreditAmountToShow: jest.fn().mockReturnValue({ mutate: jest.fn() }),
 }))
 

--- a/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.tsx
+++ b/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.tsx
@@ -3,8 +3,8 @@ import styled, { useTheme } from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
-import { useResetRecreditAmountToShow } from 'features/profile/api/useResetRecreditAmountToShow'
 import { storage } from 'libs/storage'
+import { useResetRecreditAmountToShowMutation } from 'queries/profile/useResetRecreditAmountToShowMutation'
 import { formatCurrencyFromCents } from 'shared/currency/formatCurrencyFromCents'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { useGetPacificFrancToEuroRate } from 'shared/exchangeRates/useGetPacificFrancToEuroRate'
@@ -41,7 +41,7 @@ export const RecreditBirthdayNotification = () => {
   const { showErrorSnackBar } = useSnackBarContext()
 
   const { mutate: resetRecreditAmountToShow, isLoading: isResetRecreditAmountToShowLoading } =
-    useResetRecreditAmountToShow({
+    useResetRecreditAmountToShowMutation({
       onSuccess: () => navigateToHome(),
       onError: () => showErrorSnackBar({ message: 'Une erreur est survenue' }),
     })

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.web.test.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.web.test.tsx
@@ -19,7 +19,7 @@ import { BookingDetails as BookingDetailsDefault } from './BookingDetails'
 
 const BookingDetails = withAsyncErrorBoundary(BookingDetailsDefault)
 
-jest.mock('features/profile/api/useResetRecreditAmountToShow')
+jest.mock('queries/profile/useResetRecreditAmountToShowMutation')
 jest.mock('libs/itinerary/useItinerary')
 jest.mock('features/navigation/navigationRef')
 jest.mock('features/navigation/helpers/openUrl')

--- a/src/features/cookies/components/CookiesSettings.native.test.tsx
+++ b/src/features/cookies/components/CookiesSettings.native.test.tsx
@@ -7,7 +7,7 @@ import { analytics } from 'libs/analytics/provider'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent, waitFor } from 'tests/utils'
 
-jest.mock('/queries/profile/usePatchProfileMutation')
+jest.mock('queries/profile/usePatchProfileMutation')
 
 jest.mock('libs/firebase/analytics/analytics')
 

--- a/src/features/cookies/components/CookiesSettings.native.test.tsx
+++ b/src/features/cookies/components/CookiesSettings.native.test.tsx
@@ -7,7 +7,7 @@ import { analytics } from 'libs/analytics/provider'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent, waitFor } from 'tests/utils'
 
-jest.mock('features/profile/api/usePatchProfile')
+jest.mock('/queries/profile/usePatchProfileMutation')
 
 jest.mock('libs/firebase/analytics/analytics')
 

--- a/src/features/cookies/pages/CookiesDetails.native.test.tsx
+++ b/src/features/cookies/pages/CookiesDetails.native.test.tsx
@@ -4,7 +4,7 @@ import { CookiesDetails } from 'features/cookies/pages/CookiesDetails'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { screen, render } from 'tests/utils'
 
-jest.mock('features/profile/api/usePatchProfile')
+jest.mock('/queries/profile/usePatchProfileMutation')
 
 jest.mock('libs/firebase/analytics/analytics')
 

--- a/src/features/cookies/pages/CookiesDetails.native.test.tsx
+++ b/src/features/cookies/pages/CookiesDetails.native.test.tsx
@@ -4,7 +4,7 @@ import { CookiesDetails } from 'features/cookies/pages/CookiesDetails'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { screen, render } from 'tests/utils'
 
-jest.mock('/queries/profile/usePatchProfileMutation')
+jest.mock('queries/profile/usePatchProfileMutation')
 
 jest.mock('libs/firebase/analytics/analytics')
 

--- a/src/features/cookies/pages/CookiesDetails.web.test.tsx
+++ b/src/features/cookies/pages/CookiesDetails.web.test.tsx
@@ -4,7 +4,7 @@ import { CookiesDetails } from 'features/cookies/pages/CookiesDetails'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, checkAccessibilityFor, render } from 'tests/utils/web'
 
-jest.mock('/queries/profile/usePatchProfileMutation')
+jest.mock('queries/profile/usePatchProfileMutation')
 
 // Fix the error "IDs used in ARIA and labels must be unique (duplicate-id-aria)" because the UUIDV4 mock return "testUuidV4"
 jest.mock('uuid', () => {

--- a/src/features/cookies/pages/CookiesDetails.web.test.tsx
+++ b/src/features/cookies/pages/CookiesDetails.web.test.tsx
@@ -4,7 +4,7 @@ import { CookiesDetails } from 'features/cookies/pages/CookiesDetails'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, checkAccessibilityFor, render } from 'tests/utils/web'
 
-jest.mock('features/profile/api/usePatchProfile')
+jest.mock('/queries/profile/usePatchProfileMutation')
 
 // Fix the error "IDs used in ARIA and labels must be unique (duplicate-id-aria)" because the UUIDV4 mock return "testUuidV4"
 jest.mock('uuid', () => {

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
@@ -4,11 +4,11 @@ import styled, { useTheme } from 'styled-components/native'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { creditActions } from 'features/identityCheck/api/useCreditStore'
 import { navigateToHome, navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
-import { useResetRecreditAmountToShow } from 'features/profile/api/useResetRecreditAmountToShow'
 import { isUserUnderageBeneficiary } from 'features/profile/helpers/isUserUnderageBeneficiary'
 import { useShareAppContext } from 'features/share/context/ShareAppWrapper'
 import { ShareAppModalType } from 'features/share/types'
 import { BatchEvent, BatchProfile } from 'libs/react-native-batch'
+import { useResetRecreditAmountToShowMutation } from 'queries/profile/useResetRecreditAmountToShowMutation'
 import { defaultCreditByAge } from 'shared/credits/defaultCreditByAge'
 import { useShouldShowCulturalSurveyForBeneficiaryUser } from 'shared/culturalSurvey/useShouldShowCulturalSurveyForBeneficiaryUser'
 import { formatCurrencyFromCents } from 'shared/currency/formatCurrencyFromCents'
@@ -43,7 +43,7 @@ export function BeneficiaryAccountCreated() {
   )
   const subtitle = `${recreditAmount} viennent d’être crédités sur ton compte pass Culture`
 
-  const { mutate: resetRecreditAmountToShow } = useResetRecreditAmountToShow({
+  const { mutate: resetRecreditAmountToShow } = useResetRecreditAmountToShowMutation({
     onSuccess: () => {
       refetchUser()
     },

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
@@ -17,7 +17,7 @@ import {
   phoneNumberSchema,
 } from 'features/identityCheck/pages/phoneValidation/helpers/phoneNumberSchema'
 import { IdentityCheckStep } from 'features/identityCheck/types'
-import { usePatchProfile } from 'features/profile/api/usePatchProfile'
+import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation'
 import { InfoBanner } from 'ui/components/banners/InfoBanner'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { Form } from 'ui/components/Form'
@@ -43,7 +43,7 @@ export const SetPhoneNumberWithoutValidation = () => {
 
   const { navigateForwardToStepper } = useNavigateForwardToStepper()
   const saveStep = useSaveStep()
-  const { mutate: patchProfile } = usePatchProfile({
+  const { mutate: patchProfile } = usePatchProfileMutation({
     onSuccess: () => {
       const { phoneNumber, countryId } = getValues()
       const country = findCountry(countryId)

--- a/src/features/profile/components/Header/CreditHeader/CreditHeader.native.test.tsx
+++ b/src/features/profile/components/Header/CreditHeader/CreditHeader.native.test.tsx
@@ -19,7 +19,7 @@ import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRem
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { fireEvent, render, screen } from 'tests/utils'
 
-jest.mock('features/profile/api/useResetRecreditAmountToShow')
+jest.mock('queries/profile/useResetRecreditAmountToShowMutation')
 
 jest
   .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')

--- a/src/features/profile/components/Header/NonBeneficiaryHeader/NonBeneficiaryHeader.native.test.tsx
+++ b/src/features/profile/components/Header/NonBeneficiaryHeader/NonBeneficiaryHeader.native.test.tsx
@@ -24,7 +24,7 @@ jest.mock('libs/network/NetInfoWrapper')
 jest.mock('libs/jwt/jwt')
 jest.mock('features/auth/context/AuthContext')
 
-jest.mock('/queries/profile/usePatchProfileMutation')
+jest.mock('queries/profile/usePatchProfileMutation')
 
 const mockedSubscriptionMessage = {
   popOverIcon: 'FILE',

--- a/src/features/profile/components/Header/NonBeneficiaryHeader/NonBeneficiaryHeader.native.test.tsx
+++ b/src/features/profile/components/Header/NonBeneficiaryHeader/NonBeneficiaryHeader.native.test.tsx
@@ -24,7 +24,7 @@ jest.mock('libs/network/NetInfoWrapper')
 jest.mock('libs/jwt/jwt')
 jest.mock('features/auth/context/AuthContext')
 
-jest.mock('features/profile/api/usePatchProfile')
+jest.mock('/queries/profile/usePatchProfileMutation')
 
 const mockedSubscriptionMessage = {
   popOverIcon: 'FILE',

--- a/src/features/profile/components/Header/ProfileHeader/ProfileHeader.native.test.tsx
+++ b/src/features/profile/components/Header/ProfileHeader/ProfileHeader.native.test.tsx
@@ -62,7 +62,7 @@ const exUnderageBeneficiaryUser: UserProfileResponse = {
 }
 
 jest.mock('libs/jwt/jwt')
-jest.mock('/queries/profile/usePatchProfileMutation')
+jest.mock('queries/profile/usePatchProfileMutation')
 jest.mock('features/profile/helpers/isUserUnderageBeneficiary')
 const mockedisUserUnderageBeneficiary = jest.mocked(isUserUnderageBeneficiary)
 

--- a/src/features/profile/components/Header/ProfileHeader/ProfileHeader.native.test.tsx
+++ b/src/features/profile/components/Header/ProfileHeader/ProfileHeader.native.test.tsx
@@ -62,7 +62,7 @@ const exUnderageBeneficiaryUser: UserProfileResponse = {
 }
 
 jest.mock('libs/jwt/jwt')
-jest.mock('features/profile/api/usePatchProfile')
+jest.mock('/queries/profile/usePatchProfileMutation')
 jest.mock('features/profile/helpers/isUserUnderageBeneficiary')
 const mockedisUserUnderageBeneficiary = jest.mocked(isUserUnderageBeneficiary)
 

--- a/src/features/profile/components/Header/ProfileHeader/ProfileHeader.web.test.tsx
+++ b/src/features/profile/components/Header/ProfileHeader/ProfileHeader.web.test.tsx
@@ -38,7 +38,7 @@ const user: UserProfileResponse = {
   achievements: [],
 }
 
-jest.mock('/queries/profile/usePatchProfileMutation')
+jest.mock('queries/profile/usePatchProfileMutation')
 
 const exBeneficiaryUser: UserProfileResponse = {
   ...user,

--- a/src/features/profile/components/Header/ProfileHeader/ProfileHeader.web.test.tsx
+++ b/src/features/profile/components/Header/ProfileHeader/ProfileHeader.web.test.tsx
@@ -38,7 +38,7 @@ const user: UserProfileResponse = {
   achievements: [],
 }
 
-jest.mock('features/profile/api/usePatchProfile')
+jest.mock('/queries/profile/usePatchProfileMutation')
 
 const exBeneficiaryUser: UserProfileResponse = {
   ...user,

--- a/src/features/profile/pages/ChangeCity/ChangeCity.tsx
+++ b/src/features/profile/pages/ChangeCity/ChangeCity.tsx
@@ -8,9 +8,9 @@ import { CityForm, cityResolver } from 'features/identityCheck/pages/profile/Set
 import { cityActions, useCity } from 'features/identityCheck/pages/profile/store/cityStore'
 import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { usePatchProfile } from 'features/profile/api/usePatchProfile'
 import { CitySearchInput } from 'features/profile/components/CitySearchInput/CitySearchInput'
 import { analytics } from 'libs/analytics/provider'
+import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
@@ -32,7 +32,7 @@ export const ChangeCity = () => {
     resolver: yupResolver(cityResolver),
     defaultValues: { city: storedCity ?? undefined },
   })
-  const { mutate: patchProfile } = usePatchProfile({
+  const { mutate: patchProfile } = usePatchProfileMutation({
     onSuccess: (_, variables) => {
       analytics.logUpdatePostalCode({
         newCity: variables.city ?? '',

--- a/src/features/profile/pages/ChangeStatus/useSubmitChangeStatus.tsx
+++ b/src/features/profile/pages/ChangeStatus/useSubmitChangeStatus.tsx
@@ -8,8 +8,8 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { StatusForm } from 'features/identityCheck/pages/profile/StatusFlatList'
 import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { usePatchProfile } from 'features/profile/api/usePatchProfile'
 import { analytics } from 'libs/analytics/provider'
+import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 
 const schema = yup.object().shape({
@@ -20,7 +20,7 @@ export const useSubmitChangeStatus = () => {
   const { user } = useAuthContext()
   const { navigate } = useNavigation<UseNavigationType>()
   const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()
-  const { mutate: patchProfile, isLoading } = usePatchProfile({
+  const { mutate: patchProfile, isLoading } = usePatchProfileMutation({
     onSuccess: (_, variables) => {
       analytics.logUpdateStatus({
         oldStatus: user?.activityId ?? '',

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
 import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { useAnonymizeAccount } from 'features/profile/api/useAnonymizeAccount'
+import { useAnonymizeAccountMutation } from 'features/profile/queries/useAnonymizeAccountMutation'
 import { env } from 'libs/environment/env'
 import { InfoBanner } from 'ui/components/banners/InfoBanner'
 import { ButtonQuaternarySecondary } from 'ui/components/buttons/ButtonQuaternarySecondary'
@@ -20,7 +20,7 @@ export const DeleteProfileConfirmation = () => {
   const { navigate } = useNavigation<UseNavigationType>()
   const signOut = useLogoutRoutine()
   const { showErrorSnackBar } = useSnackBarContext()
-  const { anonymizeAccount } = useAnonymizeAccount({
+  const { anonymizeAccount } = useAnonymizeAccountMutation({
     onSuccess: async () => {
       await signOut()
       navigate(...getProfileStackConfig('DeleteProfileSuccess'))

--- a/src/features/profile/pages/FeedbackInApp/FeedbackInApp.tsx
+++ b/src/features/profile/pages/FeedbackInApp/FeedbackInApp.tsx
@@ -6,11 +6,11 @@ import styled from 'styled-components/native'
 import { contactSupport } from 'features/auth/helpers/contactSupport'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
-import { useFeedback } from 'features/profile/api/useFeedback'
 import {
   FEEDBACK_IN_APP_VALUE_MAX_LENGTH,
   setFeedbackInAppSchema,
 } from 'features/profile/pages/FeedbackInApp/setFeedbackInAppShema'
+import { useFeedbackMutation } from 'features/profile/queries/useFeedbackMutation'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
 import { LargeTextInput } from 'ui/components/inputs/LargeTextInput/LargeTextInput'
@@ -36,7 +36,7 @@ export const FeedbackInApp = () => {
     mode: 'onChange',
   })
 
-  const { mutate: sendFeedback } = useFeedback()
+  const { mutate: sendFeedback } = useFeedbackMutation()
 
   const onSubmit = ({ feedback }: FormValue) => {
     sendFeedback({ feedback })

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -7,7 +7,6 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { PushNotificationsModal } from 'features/notifications/pages/PushNotificationsModal'
-import { usePatchProfile } from 'features/profile/api/usePatchProfile'
 import { SectionWithSwitch } from 'features/profile/components/SectionWithSwitch/SectionWithSwitch'
 import { UnsavedSettingsModal } from 'features/profile/pages/NotificationSettings/components/UnsavedSettingsModal'
 import {
@@ -22,6 +21,7 @@ import {
   TOTAL_NUMBER_OF_THEME,
 } from 'features/subscription/types'
 import { analytics } from 'libs/analytics/provider'
+import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation'
 import { InfoBanner } from 'ui/components/banners/InfoBanner'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { Form } from 'ui/components/Form'
@@ -64,7 +64,7 @@ export const NotificationsSettings = () => {
 
   const { pushPermission } = usePushPermission(updatePushPermissionFromSettings)
 
-  const { mutate: patchProfile, isLoading: isUpdatingProfile } = usePatchProfile({
+  const { mutate: patchProfile, isLoading: isUpdatingProfile } = usePatchProfileMutation({
     onSuccess: () => {
       showSuccessSnackBar({
         message: 'Tes modifications ont été enregistrées\u00a0!',

--- a/src/features/profile/queries/useAnonymizeAccountMutation.ts
+++ b/src/features/profile/queries/useAnonymizeAccountMutation.ts
@@ -7,7 +7,7 @@ type Options = {
   onError?: (error: Error) => void
 }
 
-export const useAnonymizeAccount = ({ onSuccess, onError }: Options) => {
+export const useAnonymizeAccountMutation = ({ onSuccess, onError }: Options) => {
   const { mutate: anonymizeAccount } = useMutation(() => api.postNativeV1AccountAnonymize(), {
     onSuccess,
     onError,

--- a/src/features/profile/queries/useFeedbackMutation.ts
+++ b/src/features/profile/queries/useFeedbackMutation.ts
@@ -7,7 +7,8 @@ import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 
-export const useFeedback = () => {
+export const useFeedbackMutation = () => {
+  // TODO(PC-35699): Move onSuccess and onError callback functions out of this mutation
   const { navigate } = useNavigation<UseNavigationType>()
   const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
   const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()

--- a/src/features/profile/types.ts
+++ b/src/features/profile/types.ts
@@ -1,10 +1,5 @@
 import { StepVariant } from 'ui/components/VerticalStepper/types'
 
-export type ResetRecreditAmountToShowMutationOptions = {
-  onSuccess?: () => void
-  onError?: (error: unknown) => void
-}
-
 export type FirstOrLastProps = {
   isFirst?: boolean
   isLast?: boolean

--- a/src/features/search/components/sections/Category/Category.native.test.tsx
+++ b/src/features/search/components/sections/Category/Category.native.test.tsx
@@ -24,7 +24,7 @@ jest.mock('libs/subcategories/useSubcategories', () => ({
   }),
 }))
 
-jest.mock('features/profile/api/usePatchProfile')
+jest.mock('/queries/profile/usePatchProfileMutation')
 
 const mockHasNextPage = true
 const mockFetchNextPage = jest.fn()

--- a/src/features/search/components/sections/Category/Category.native.test.tsx
+++ b/src/features/search/components/sections/Category/Category.native.test.tsx
@@ -24,7 +24,7 @@ jest.mock('libs/subcategories/useSubcategories', () => ({
   }),
 }))
 
-jest.mock('/queries/profile/usePatchProfileMutation')
+jest.mock('queries/profile/usePatchProfileMutation')
 
 const mockHasNextPage = true
 const mockFetchNextPage = jest.fn()

--- a/src/features/search/components/sections/Price/Price.native.test.tsx
+++ b/src/features/search/components/sections/Price/Price.native.test.tsx
@@ -18,7 +18,7 @@ jest.mock('features/search/context/SearchWrapper', () => ({
   }),
 }))
 
-jest.mock('/queries/profile/usePatchProfileMutation')
+jest.mock('queries/profile/usePatchProfileMutation')
 
 jest.mock('libs/firebase/analytics/analytics')
 

--- a/src/features/search/components/sections/Price/Price.native.test.tsx
+++ b/src/features/search/components/sections/Price/Price.native.test.tsx
@@ -18,7 +18,7 @@ jest.mock('features/search/context/SearchWrapper', () => ({
   }),
 }))
 
-jest.mock('features/profile/api/usePatchProfile')
+jest.mock('/queries/profile/usePatchProfileMutation')
 
 jest.mock('libs/firebase/analytics/analytics')
 

--- a/src/features/subscription/helpers/useThematicSubscription.tsx
+++ b/src/features/subscription/helpers/useThematicSubscription.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react'
 import { Platform } from 'react-native'
 
 import { UserProfileResponse } from 'api/gen'
-import { usePatchProfile } from 'features/profile/api/usePatchProfile'
 import { usePushPermission } from 'features/profile/pages/NotificationSettings/usePushPermission'
 import { SubscriptionAnalyticsParams, SubscriptionTheme } from 'features/subscription/types'
 import { analytics } from 'libs/analytics/provider'
+import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 
 type AnalyticsInfos = { venueId: string; homeId?: never } | { homeId: string; venueId?: never }
@@ -53,7 +53,7 @@ export const useThematicSubscription = ({
 
   const isSubscribeButtonActive = isAtLeastOneNotificationTypeActivated && isThemeSubscribed
 
-  const { mutate: patchProfile, isLoading: isUpdatingProfile } = usePatchProfile({
+  const { mutate: patchProfile, isLoading: isUpdatingProfile } = usePatchProfileMutation({
     onSuccess: async () => {
       analytics.logNotificationToggle(!!state.allowEmails, !!state.allowPush)
       const analyticsParams = homeId

--- a/src/features/subscription/page/OnboardingSubscription.tsx
+++ b/src/features/subscription/page/OnboardingSubscription.tsx
@@ -9,7 +9,6 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getTabNavConfig, homeNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
-import { usePatchProfile } from 'features/profile/api/usePatchProfile'
 import { usePushPermission } from 'features/profile/pages/NotificationSettings/usePushPermission'
 import { SubscriptionThematicButton } from 'features/subscription/components/buttons/SubscriptionThematicButton'
 import { mapSubscriptionThemeToName } from 'features/subscription/helpers/mapSubscriptionThemeToName'
@@ -19,6 +18,7 @@ import { SubscriptionTheme, SUSBCRIPTION_THEMES } from 'features/subscription/ty
 import { analytics } from 'libs/analytics/provider'
 import { createAnimatableComponent, AnimatedViewRefType } from 'libs/react-native-animatable'
 import { storage } from 'libs/storage'
+import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
 import { EmptyHeader } from 'ui/components/headers/EmptyHeader'
@@ -65,7 +65,7 @@ export const OnboardingSubscription = () => {
     initialSubscribedThemes
   )
 
-  const { mutate: patchProfile, isLoading: isUpdatingProfile } = usePatchProfile({
+  const { mutate: patchProfile, isLoading: isUpdatingProfile } = usePatchProfileMutation({
     onSuccess: () => {
       analytics.logSubscriptionUpdate({ type: 'update', from: 'home' })
       showSuccessSnackBar({

--- a/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/helpers/adaptOffersPlaylistParameters.native.test.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/helpers/adaptOffersPlaylistParameters.native.test.ts
@@ -12,7 +12,7 @@ import { adaptOffersPlaylistParameters } from './adaptOffersPlaylistParameters'
 
 jest.mock('libs/subcategories/useSubcategories')
 
-jest.mock('/queries/profile/usePatchProfileMutation')
+jest.mock('queries/profile/usePatchProfileMutation')
 mockdate.set(new Date('2020-10-01T00:00+00:00'))
 
 const defaultSearchParameters = omit(

--- a/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/helpers/adaptOffersPlaylistParameters.native.test.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/helpers/adaptOffersPlaylistParameters.native.test.ts
@@ -12,7 +12,7 @@ import { adaptOffersPlaylistParameters } from './adaptOffersPlaylistParameters'
 
 jest.mock('libs/subcategories/useSubcategories')
 
-jest.mock('features/profile/api/usePatchProfile')
+jest.mock('/queries/profile/usePatchProfileMutation')
 mockdate.set(new Date('2020-10-01T00:00+00:00'))
 
 const defaultSearchParameters = omit(

--- a/src/libs/utm/getUtmParamsConsent.native.test.ts
+++ b/src/libs/utm/getUtmParamsConsent.native.test.ts
@@ -7,7 +7,7 @@ import { getUtmParamsConsent } from 'libs/utm/getUtmParamsConsent'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, renderHook } from 'tests/utils'
 
-jest.mock('/queries/profile/usePatchProfileMutation')
+jest.mock('queries/profile/usePatchProfileMutation')
 jest.mock('api/api')
 
 const COOKIES_CONSENT_KEY = 'cookies'

--- a/src/libs/utm/getUtmParamsConsent.native.test.ts
+++ b/src/libs/utm/getUtmParamsConsent.native.test.ts
@@ -7,7 +7,7 @@ import { getUtmParamsConsent } from 'libs/utm/getUtmParamsConsent'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, renderHook } from 'tests/utils'
 
-jest.mock('features/profile/api/usePatchProfile')
+jest.mock('/queries/profile/usePatchProfileMutation')
 jest.mock('api/api')
 
 const COOKIES_CONSENT_KEY = 'cookies'

--- a/src/queries/profile/usePatchProfileMutation.ts
+++ b/src/queries/profile/usePatchProfileMutation.ts
@@ -9,7 +9,7 @@ type Options = {
   onError?: (error: unknown) => void
 }
 
-export function usePatchProfile({ onError, onSuccess }: Options) {
+export function usePatchProfileMutation({ onError, onSuccess }: Options) {
   const client = useQueryClient()
   return useMutation((body: UserProfilePatchRequest) => api.patchNativeV1Profile(body), {
     onSuccess(response: UserProfileResponse, variables) {

--- a/src/queries/profile/useResetRecreditAmountToShowMutation.ts
+++ b/src/queries/profile/useResetRecreditAmountToShowMutation.ts
@@ -1,9 +1,13 @@
 import { useMutation } from 'react-query'
 
 import { api } from 'api/api'
-import { ResetRecreditAmountToShowMutationOptions } from 'features/profile/types'
 
-export function useResetRecreditAmountToShow({
+type ResetRecreditAmountToShowMutationOptions = {
+  onSuccess?: () => void
+  onError?: (error: unknown) => void
+}
+
+export function useResetRecreditAmountToShowMutation({
   onSuccess,
   onError,
 }: ResetRecreditAmountToShowMutationOptions) {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34760

Refactor des queries dans `features/profile`
Certains hooks ont été bougé dans le dossier global `src/queries`

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
