### PR TITLE
(PC-35355) fix(OfferImage): correct condition for subcatgeories and aspectRatio

### DIFF
--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -248,9 +248,7 @@ describe('<OfferContent />', () => {
 
     await user.press(await screen.findByLabelText('Carousel image 1'))
 
-    await waitFor(() =>
-      expect(mockNavigate).toHaveBeenCalledWith('OfferPreview', { id: 116656, defaultIndex: 0 })
-    )
+    await waitFor(() => expect(mockNavigate).not.toHaveBeenCalled())
   })
 
   it('should animate on scroll', async () => {

--- a/src/features/offer/components/OfferContent/OfferContent.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.tsx
@@ -22,6 +22,7 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
   const handlePress = (defaultIndex = 0) => {
+    if (!offer.images) return
     navigate('OfferPreview', { id: offer.id, defaultIndex })
   }
 

--- a/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
@@ -168,7 +168,7 @@ describe('<OfferContent />', () => {
     unmount()
   })
 
-  it('should show preview modal when carousel is not ready and clicking on offer placeholder image', async () => {
+  it('should not show preview modal when clicking on offer placeholder image', async () => {
     const offer: OfferResponseV2 = {
       ...offerResponseSnap,
       images: null,
@@ -177,7 +177,7 @@ describe('<OfferContent />', () => {
 
     user.click(await screen.findByLabelText('Carousel image 1'))
 
-    await waitFor(() => expect(mockShowModal).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(mockShowModal).not.toHaveBeenCalled())
     unmount()
   })
 })

--- a/src/features/offer/components/OfferContent/OfferContent.web.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.tsx
@@ -32,6 +32,7 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   const offerImagesUrl = useMemo(() => offerImages.map((image) => image.url), [offerImages])
 
   const handlePress = (defaultIndex = 0) => {
+    if (!offer.images) return
     setCarouselDefaultIndex(defaultIndex)
     showModal()
   }

--- a/src/features/offer/components/OfferImageCarousel/OfferImageCarouselItem.tsx
+++ b/src/features/offer/components/OfferImageCarousel/OfferImageCarouselItem.tsx
@@ -26,7 +26,7 @@ export const OfferImageCarouselItem = ({
 }: PropsWithChildren<OfferImageCarouselItemProps>) => (
   <TouchableOpacity
     disabled={!onPress}
-    onPress={() => onPress?.(index)}
+    onPress={() => (imageURL ? onPress?.(index) : null)}
     accessibilityLabel={`Carousel image ${index + 1}`}
     accessibilityRole={AccessibilityRole.BUTTON}
     delayPressIn={70}>

--- a/src/features/offer/components/OfferImageCarousel/OfferImageCarouselItem.tsx
+++ b/src/features/offer/components/OfferImageCarousel/OfferImageCarouselItem.tsx
@@ -26,7 +26,7 @@ export const OfferImageCarouselItem = ({
 }: PropsWithChildren<OfferImageCarouselItemProps>) => (
   <TouchableOpacity
     disabled={!onPress}
-    onPress={() => (imageURL ? onPress?.(index) : null)}
+    onPress={() => onPress?.(index)}
     accessibilityLabel={`Carousel image ${index + 1}`}
     accessibilityRole={AccessibilityRole.BUTTON}
     delayPressIn={70}>

--- a/src/features/offer/helpers/useOfferImageContainerDimensions.ts
+++ b/src/features/offer/helpers/useOfferImageContainerDimensions.ts
@@ -7,6 +7,7 @@ import { MARGIN_DP } from 'ui/theme/grid'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 const RATIO_PORTRAIT = 2 / 3
+const RATIO_SQUARE = 1
 
 export const blurImageHeight = getSpacing(74)
 export const offerImageContainerMarginTop = MARGIN_DP + getSpacing(2)
@@ -14,7 +15,7 @@ const HEADER_HEIGHT = getSpacing(64.5)
 
 const PORTRAIT_DIMENSIONS = {
   default: { height: getSpacing(95), width: getSpacing(95) * RATIO_PORTRAIT },
-  music: { height: getSpacing(95) * RATIO_PORTRAIT, width: getSpacing(95) * RATIO_PORTRAIT },
+  music: { height: getSpacing(60), width: getSpacing(60) },
 } as const
 
 export const useOfferImageContainerDimensions = (
@@ -24,18 +25,21 @@ export const useOfferImageContainerDimensions = (
   const { appContentWidth, borderRadius } = useTheme()
   const fullWidth = appContentWidth - 2 * MARGIN_DP
 
-  const isMusicSupport =
-    subcategoryId ===
-    (SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_CD ||
-      SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE)
+  const isMusicSupport = subcategoryId
+    ? [
+        SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_CD,
+        SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE,
+      ].includes(subcategoryId)
+    : false
 
   const { height, width } = isMusicSupport ? PORTRAIT_DIMENSIONS.music : PORTRAIT_DIMENSIONS.default
+  const aspectRatio = isMusicSupport ? RATIO_SQUARE : RATIO_PORTRAIT
 
   const getImageStyle = (borderRadiusValue: number) => ({
     height,
     width,
     maxWidth: fullWidth,
-    aspectRatio: RATIO_PORTRAIT,
+    aspectRatio,
     borderRadius: borderRadiusValue,
   })
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35355

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |<img width="424" alt="Capture d’écran 2025-03-26 à 15 52 52" src="https://github.com/user-attachments/assets/4ea4076c-802b-4c8b-a423-71784beb09dd" /><img width="424" alt="Capture d’écran 2025-03-26 à 15 53 14" src="https://github.com/user-attachments/assets/538cfd91-1d0f-4c84-b9a0-9b9d3e1d207e" />|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
