### PR TITLE
(PC-35367) refactor(offer): use interaction tag react node rather than just likes counter

### DIFF
--- a/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
@@ -14,7 +14,7 @@ import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
 import { mockAuthContextWithoutUser } from 'tests/AuthContextUtils'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render, screen, waitFor, userEvent } from 'tests/utils/web'
+import { render, screen, userEvent, waitFor } from 'tests/utils/web'
 import * as useModalAPI from 'ui/components/modals/useModal'
 
 import { OfferContent } from './OfferContent.web'
@@ -177,7 +177,8 @@ describe('<OfferContent />', () => {
 
     user.click(await screen.findByLabelText('Carousel image 1'))
 
-    await waitFor(() => expect(mockShowModal).not.toHaveBeenCalled())
+    expect(mockShowModal).not.toHaveBeenCalled()
+
     unmount()
   })
 })

--- a/src/features/offer/components/OfferTile/OfferTile.stories.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.stories.tsx
@@ -2,6 +2,11 @@ import { NavigationContainer } from '@react-navigation/native'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
 import { View } from 'react-native'
+import styled from 'styled-components/native'
+
+import { Tag } from 'ui/components/Tag/Tag'
+import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
+import { getSpacing } from 'ui/theme'
 
 import { OfferTile } from './OfferTile'
 
@@ -18,6 +23,17 @@ const meta: ComponentMeta<typeof OfferTile> = {
 }
 
 export default meta
+
+const CustomThumbUp = styled(ThumbUpFilled).attrs(({ theme }) => ({
+  size: getSpacing(4),
+  color: theme.colors.primary,
+}))``
+
+const LikeTag = styled(Tag).attrs(() => ({
+  Icon: CustomThumbUp,
+}))(({ theme }) => ({
+  backgroundColor: theme.colors.white,
+}))
 
 const Template: ComponentStory<typeof OfferTile> = (props) => <OfferTile {...props} />
 
@@ -40,6 +56,6 @@ WithTags.args = {
   categoryLabel: 'Cinéma',
   width: 200,
   height: 300,
-  likes: 99,
+  interactionTag: <LikeTag label="100" />,
   offerLocation: { lat: 48.94374, lng: 2.48171 },
 }

--- a/src/features/offer/components/OfferTile/OfferTile.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.tsx
@@ -32,7 +32,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
     apiRecoParams,
     index,
     artistName,
-    likes,
+    interactionTag,
     navigationMethod = NAVIGATION_METHOD.NAVIGATE,
     ...offer
   } = props
@@ -108,7 +108,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
           categoryId={categoryId}
           thumbnailUrl={thumbUrl}
           distance={distanceFromOffer}
-          likes={likes}
+          interactionTag={interactionTag}
           name={name}
           date={date}
           price={price}

--- a/src/features/offer/components/OfferTile/PlaylistCardOffer.native.test.tsx
+++ b/src/features/offer/components/OfferTile/PlaylistCardOffer.native.test.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import { HomepageLabelNameEnumv2 } from 'api/gen'
 import { render, screen } from 'tests/utils'
+import { Tag } from 'ui/components/Tag/Tag'
+import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
 
 import { PlaylistCardOffer } from './PlaylistCardOffer'
 
@@ -36,9 +38,21 @@ describe('PlaylistCardOffer component', () => {
     expect(screen.getByTestId('DistanceId')).toHaveTextContent('à 100m')
   })
 
-  it('should display likes count', () => {
-    render(<PlaylistCardOffer {...props} distance="100m" likes={100} />)
+  it('should display interaction tag when specified', () => {
+    render(
+      <PlaylistCardOffer
+        {...props}
+        distance="100m"
+        interactionTag={<Tag label="100" Icon={ThumbUpFilled} />}
+      />
+    )
 
     expect(screen.getByTestId('tagIcon')).toBeOnTheScreen()
+  })
+
+  it('should not display interaction tag when not specified', () => {
+    render(<PlaylistCardOffer {...props} distance="100m" />)
+
+    expect(screen.queryByTestId('tagIcon')).not.toBeOnTheScreen()
   })
 })

--- a/src/features/offer/components/OfferTile/PlaylistCardOffer.tsx
+++ b/src/features/offer/components/OfferTile/PlaylistCardOffer.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 import { View } from 'react-native'
 import styled from 'styled-components/native'
 
@@ -7,7 +7,6 @@ import { ImageTile } from 'ui/components/ImageTile'
 import { NewOfferCaption } from 'ui/components/NewOfferCaption'
 import { Tag } from 'ui/components/Tag/Tag'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
-import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
 import { getSpacing } from 'ui/theme'
 
 type Props = {
@@ -20,17 +19,23 @@ type Props = {
   width: number
   height: number
   distance?: string
-  likes?: number
+  interactionTag?: ReactNode
 }
 
-const renderTags = ({ distance = '', likes = 0 }: { distance?: string; likes?: number }) => {
-  if (!distance && !likes) {
+const renderTags = ({
+  distance = '',
+  interactionTag,
+}: {
+  distance?: string
+  interactionTag?: ReactNode
+}) => {
+  if (!distance && !interactionTag) {
     return null
   }
   return (
     <TagContainer>
       {distance ? <DistanceTag label={`à ${distance}`} /> : null}
-      {likes ? <LikeTag label={likes.toString()} /> : null}
+      {interactionTag ?? null}
     </TagContainer>
   )
 }
@@ -45,13 +50,13 @@ export const PlaylistCardOffer: FC<Props> = ({
   width,
   height,
   distance,
-  likes,
+  interactionTag,
 }) => {
   return (
     <Container maxWidth={width}>
       <NewOfferCaption name={name} date={date} price={price} categoryLabel={categoryLabel} />
       <View>
-        {renderTags({ distance, likes })}
+        {renderTags({ distance, interactionTag })}
         <ImageTile categoryId={categoryId} uri={thumbnailUrl} width={width} height={height} />
       </View>
     </Container>
@@ -78,17 +83,6 @@ const TagContainer = styled.View({
 
 const DistanceTag = styled(Tag).attrs(() => ({
   testID: 'DistanceId',
-}))(({ theme }) => ({
-  backgroundColor: theme.colors.white,
-}))
-
-const CustomThumbUp = styled(ThumbUpFilled).attrs(({ theme }) => ({
-  size: getSpacing(4),
-  color: theme.colors.primary,
-}))``
-
-const LikeTag = styled(Tag).attrs(() => ({
-  Icon: CustomThumbUp,
 }))(({ theme }) => ({
   backgroundColor: theme.colors.white,
 }))

--- a/src/features/offer/types.ts
+++ b/src/features/offer/types.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react'
 import { SharedValue } from 'react-native-reanimated'
 
 import {
@@ -43,9 +44,9 @@ export interface OfferTileProps {
   searchId?: string
   apiRecoParams?: RecommendationApiParams
   index?: number
-  likes?: number
   artistName?: string
   navigationMethod?: NavigationMethod
+  interactionTag?: ReactNode
 }
 
 export type FavoriteProps = {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35367

Utilisation d'un ReactNode pour prévoir la possibilité d'avoir aussi bien un tag de likes, qu'un tag de recommandations ou encore un tag d'avis (1 seul tag d'interaction possible sur l'item d'une playlist)

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |![Capture d’écran 2025-03-26 à 17 20 47](https://github.com/user-attachments/assets/66ca809e-9e3b-4ec5-be6c-033b003c258b)|
| Android          |               |![Capture d’écran 2025-03-26 à 17 22 19](https://github.com/user-attachments/assets/34a28120-1c46-4059-8b31-f31dc6fe8512)|
| Phone - Chrome   |               |<img width="379" alt="Capture d’écran 2025-03-26 à 17 16 33" src="https://github.com/user-attachments/assets/c4bc824c-b4db-495d-945a-cec2d4459f6e" />|
| Desktop - Chrome |               |<img width="1725" alt="Capture d’écran 2025-03-26 à 17 16 26" src="https://github.com/user-attachments/assets/f5fa846b-d6b5-44cc-b642-7e2a4cb2b6a0" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
