### PR TITLE
(PC-34902) feat(HomePlaylistsTtitles): emojis should appear but not be readable by voicOver

### DIFF
--- a/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
@@ -514,6 +514,7 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
                   },
                 ]
               }
+              testID="videoMonoOfferTile"
             >
               <View
                 style={

--- a/__snapshots__/features/home/pages/GenericHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/GenericHome.native.test.tsx.native-snap
@@ -18,6 +18,7 @@ exports[`GenericHome With not displayed skeleton by default should display real 
       [
         {
           "height": "100%",
+          "marginVertical": 24,
           "overflow": "hidden",
         },
       ]
@@ -185,16 +186,6 @@ exports[`GenericHome With not displayed skeleton by default should display real 
       </View>
     </RCTScrollView>
   </View>
-  <View
-    numberOfSpaces={6}
-    style={
-      [
-        {
-          "height": 24,
-        },
-      ]
-    }
-  />
 </View>
 `;
 
@@ -216,6 +207,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
       [
         {
           "height": "100%",
+          "marginVertical": 24,
           "overflow": "hidden",
         },
       ]
@@ -383,15 +375,5 @@ exports[`GenericHome With not displayed skeleton by default should display skele
       </View>
     </RCTScrollView>
   </View>
-  <View
-    numberOfSpaces={6}
-    style={
-      [
-        {
-          "height": 24,
-        },
-      ]
-    }
-  />
 </View>
 `;

--- a/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
@@ -19,6 +19,7 @@ exports[`Home page should render correctly 1`] = `
         [
           {
             "height": "100%",
+            "marginVertical": 24,
             "overflow": "hidden",
           },
         ]
@@ -539,16 +540,6 @@ exports[`Home page should render correctly 1`] = `
         </View>
       </RCTScrollView>
     </View>
-    <View
-      numberOfSpaces={6}
-      style={
-        [
-          {
-            "height": 24,
-          },
-        ]
-      }
-    />
     <View
       height={16}
       style={

--- a/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
@@ -30,6 +30,7 @@ exports[`ThematicHome should render correctly 1`] = `
         [
           {
             "height": "100%",
+            "marginVertical": 24,
             "overflow": "hidden",
           },
         ]
@@ -319,16 +320,6 @@ exports[`ThematicHome should render correctly 1`] = `
         />
       </View>
     </View>
-    <View
-      numberOfSpaces={6}
-      style={
-        [
-          {
-            "height": 24,
-          },
-        ]
-      }
-    />
   </View>
   <View
     collapsable={false}

--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -1694,23 +1694,47 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                 ]
               }
             >
-              <Text
+              <View
                 numberOfLines={2}
                 style={
                   [
                     {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 19,
-                      "lineHeight": 30.4,
+                      "alignItems": "center",
+                      "flexDirection": "row",
                       "marginHorizontal": 24,
                     },
                   ]
                 }
                 testID="playlistTitle"
               >
-                GTL playlist
-              </Text>
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 19,
+                        "lineHeight": 30.4,
+                      },
+                    ]
+                  }
+                >
+                  GTL playlist
+                </Text>
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 19,
+                        "lineHeight": 30.4,
+                      },
+                    ]
+                  }
+                />
+              </View>
             </View>
           </View>
           <View

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -867,23 +867,47 @@ exports[`<Venue /> should match snapshot 1`] = `
                           ]
                         }
                       >
-                        <Text
+                        <View
                           numberOfLines={2}
                           style={
                             [
                               {
-                                "color": "#161617",
-                                "fontFamily": "Montserrat-Bold",
-                                "fontSize": 19,
-                                "lineHeight": 30.4,
+                                "alignItems": "center",
+                                "flexDirection": "row",
                                 "marginHorizontal": 24,
                               },
                             ]
                           }
                           testID="playlistTitle"
                         >
-                          Toutes les offres
-                        </Text>
+                          <Text
+                            style={
+                              [
+                                {
+                                  "color": "#161617",
+                                  "fontFamily": "Montserrat-Bold",
+                                  "fontSize": 19,
+                                  "lineHeight": 30.4,
+                                },
+                              ]
+                            }
+                          >
+                            Toutes les offres
+                          </Text>
+                          <Text
+                            accessibilityHidden={true}
+                            style={
+                              [
+                                {
+                                  "color": "#161617",
+                                  "fontFamily": "Montserrat-Bold",
+                                  "fontSize": 19,
+                                  "lineHeight": 30.4,
+                                },
+                              ]
+                            }
+                          />
+                        </View>
                       </View>
                     </View>
                     <View
@@ -2484,23 +2508,47 @@ exports[`<Venue /> should match snapshot 1`] = `
                             ]
                           }
                         >
-                          <Text
+                          <View
                             numberOfLines={2}
                             style={
                               [
                                 {
-                                  "color": "#161617",
-                                  "fontFamily": "Montserrat-Bold",
-                                  "fontSize": 19,
-                                  "lineHeight": 30.4,
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
                                   "marginHorizontal": 24,
                                 },
                               ]
                             }
                             testID="playlistTitle"
                           >
-                            Test
-                          </Text>
+                            <Text
+                              style={
+                                [
+                                  {
+                                    "color": "#161617",
+                                    "fontFamily": "Montserrat-Bold",
+                                    "fontSize": 19,
+                                    "lineHeight": 30.4,
+                                  },
+                                ]
+                              }
+                            >
+                              Test
+                            </Text>
+                            <Text
+                              accessibilityHidden={true}
+                              style={
+                                [
+                                  {
+                                    "color": "#161617",
+                                    "fontFamily": "Montserrat-Bold",
+                                    "fontSize": 19,
+                                    "lineHeight": 30.4,
+                                  },
+                                ]
+                              }
+                            />
+                          </View>
                         </View>
                       </View>
                       <View
@@ -6000,23 +6048,47 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                           ]
                         }
                       >
-                        <Text
+                        <View
                           numberOfLines={2}
                           style={
                             [
                               {
-                                "color": "#161617",
-                                "fontFamily": "Montserrat-Bold",
-                                "fontSize": 19,
-                                "lineHeight": 30.4,
+                                "alignItems": "center",
+                                "flexDirection": "row",
                                 "marginHorizontal": 24,
                               },
                             ]
                           }
                           testID="playlistTitle"
                         >
-                          Toutes les offres
-                        </Text>
+                          <Text
+                            style={
+                              [
+                                {
+                                  "color": "#161617",
+                                  "fontFamily": "Montserrat-Bold",
+                                  "fontSize": 19,
+                                  "lineHeight": 30.4,
+                                },
+                              ]
+                            }
+                          >
+                            Toutes les offres
+                          </Text>
+                          <Text
+                            accessibilityHidden={true}
+                            style={
+                              [
+                                {
+                                  "color": "#161617",
+                                  "fontFamily": "Montserrat-Bold",
+                                  "fontSize": 19,
+                                  "lineHeight": 30.4,
+                                },
+                              ]
+                            }
+                          />
+                        </View>
                       </View>
                     </View>
                     <View
@@ -7617,23 +7689,47 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                             ]
                           }
                         >
-                          <Text
+                          <View
                             numberOfLines={2}
                             style={
                               [
                                 {
-                                  "color": "#161617",
-                                  "fontFamily": "Montserrat-Bold",
-                                  "fontSize": 19,
-                                  "lineHeight": 30.4,
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
                                   "marginHorizontal": 24,
                                 },
                               ]
                             }
                             testID="playlistTitle"
                           >
-                            Test
-                          </Text>
+                            <Text
+                              style={
+                                [
+                                  {
+                                    "color": "#161617",
+                                    "fontFamily": "Montserrat-Bold",
+                                    "fontSize": 19,
+                                    "lineHeight": 30.4,
+                                  },
+                                ]
+                              }
+                            >
+                              Test
+                            </Text>
+                            <Text
+                              accessibilityHidden={true}
+                              style={
+                                [
+                                  {
+                                    "color": "#161617",
+                                    "fontFamily": "Montserrat-Bold",
+                                    "fontSize": 19,
+                                    "lineHeight": 30.4,
+                                  },
+                                ]
+                              }
+                            />
+                          </View>
                         </View>
                       </View>
                       <View

--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -2,9 +2,9 @@
 ./src/features/home/api/helpers/mapVenuesDataAndModules.ts:13
 ./src/features/home/api/helpers/mapVenuesDataAndModules.ts:15
 ./src/features/home/components/modules/OffersModule.tsx:66
-./src/features/home/components/modules/video/OldVideoModuleDesktop.tsx:97
-./src/features/home/components/modules/video/OldVideoModuleMobile.tsx:71
-./src/features/home/components/modules/video/VideoModuleDesktop.tsx:87
+./src/features/home/components/modules/video/OldVideoModuleDesktop.tsx:99
+./src/features/home/components/modules/video/OldVideoModuleMobile.tsx:70
+./src/features/home/components/modules/video/VideoModuleDesktop.tsx:89
 ./src/features/home/components/modules/video/VideoModuleMobile.tsx:71
 ./src/features/identityCheck/api/useProfileInfo.ts:21
 ./src/features/identityCheck/pages/helpers/parseUrlParams.ts:8

--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -4,7 +4,6 @@
 ./src/features/home/components/modules/OffersModule.tsx:66
 ./src/features/home/components/modules/video/OldVideoModuleDesktop.tsx:99
 ./src/features/home/components/modules/video/OldVideoModuleMobile.tsx:70
-./src/features/home/components/modules/video/VideoModuleDesktop.tsx:89
 ./src/features/home/components/modules/video/VideoModuleMobile.tsx:71
 ./src/features/identityCheck/api/useProfileInfo.ts:21
 ./src/features/identityCheck/pages/helpers/parseUrlParams.ts:8

--- a/src/features/home/components/AccessibleTitle.native.test.tsx
+++ b/src/features/home/components/AccessibleTitle.native.test.tsx
@@ -1,0 +1,16 @@
+import { separateTitleAndEmojis } from 'features/home/components/AccessibleTitle'
+
+describe('separateTitleAndEmojis', () => {
+  it.each`
+    title                                             | expected
+    ${'Cas classique 💥'}                             | ${{ titleEmoji: '💥', titleText: 'Cas classique ' }}
+    ${'Cas sans emojis'}                              | ${{ titleEmoji: '', titleText: 'Cas sans emojis' }}
+    ${'Cas avec un espace à la fin 🚀 '}              | ${{ titleEmoji: '🚀', titleText: 'Cas avec un espace à la fin ' }}
+    ${'Cas avec des accents œŒéàèêËëù ⭐'}            | ${{ titleEmoji: '⭐', titleText: 'Cas avec des accents œŒéàèêËëù ' }}
+    ${'Cas avec un chiffre 3 🎸'}                     | ${{ titleEmoji: '🎸', titleText: 'Cas avec un chiffre 3 ' }}
+    ${`Cas avec de la ponctuation ?,;.:!" 😀`}        | ${{ titleEmoji: '😀', titleText: `Cas avec de la ponctuation ?,;.:!" ` }}
+    ${`Cas avec des caractères spéciaux €@#‰()[] 💾`} | ${{ titleEmoji: '💾', titleText: `Cas avec des caractères spéciaux €@#‰()[] ` }}
+  `('should return $expected when title is $title', ({ title, expected }) => {
+    expect(separateTitleAndEmojis(title)).toStrictEqual(expected)
+  })
+})

--- a/src/features/home/components/AccessibleTitle.tsx
+++ b/src/features/home/components/AccessibleTitle.tsx
@@ -1,0 +1,39 @@
+import React, { ComponentProps, ComponentType } from 'react'
+import styled from 'styled-components/native'
+
+import { Typo } from 'ui/theme'
+
+export const separateTitleAndEmojis = (title: string) => {
+  const titleWithoutEndSpace = title.trimEnd()
+  const emojiRegex = /(\p{Emoji})(?=\s*$)/gu
+  const titleText = titleWithoutEndSpace.replace(emojiRegex, '')
+  const titleEmoji = titleWithoutEndSpace.replace(titleText, '')
+  return { titleText, titleEmoji }
+}
+
+export const AccessibleTitle = ({
+  title,
+  testID,
+  TitleComponent,
+}: {
+  title: string
+  testID?: string
+  TitleComponent?: ComponentType<ComponentProps<typeof Typo.Title3>>
+}) => {
+  const { titleText, titleEmoji } = separateTitleAndEmojis(title)
+
+  const StyledTitleComponent = styled(TitleComponent || Typo.Title3)({})
+
+  return (
+    <InlineView numberOfLines={2} testID={testID}>
+      <StyledTitleComponent>{titleText}</StyledTitleComponent>
+      <StyledTitleComponent accessibilityHidden>{titleEmoji}</StyledTitleComponent>
+    </InlineView>
+  )
+}
+
+const InlineView = styled.View(({ theme }) => ({
+  marginHorizontal: theme.contentPage.marginHorizontal,
+  flexDirection: 'row',
+  alignItems: 'center',
+}))

--- a/src/features/home/components/modules/HighlightOfferModule.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.tsx
@@ -2,10 +2,11 @@ import React, { memo, useEffect } from 'react'
 import styled from 'styled-components/native'
 
 import { useHighlightOffer } from 'features/home/api/useHighlightOffer'
+import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
 import { HighlightOfferModule as HighlightOfferModuleType } from 'features/home/types'
 import { analytics } from 'libs/analytics/provider'
 import { ContentTypes } from 'libs/contentful/types'
-import { Spacer, Typo } from 'ui/theme'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 
 import { MarketingBlockExclusivity } from './marketing/MarketingBlockExclusivity'
 
@@ -46,15 +47,11 @@ const UnmemoizedHighlightOfferModule = (props: HighlightOfferModuleProps) => {
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-
   if (!highlightOffer) return null
 
   return (
-    <Container>
-      <StyledTitleContainer>
-        <StyledTitle>{props.highlightTitle}</StyledTitle>
-      </StyledTitleContainer>
-      <Spacer.Column numberOfSpaces={5} />
+    <StyledViewGap gap={5}>
+      <AccessibleTitle title={props.highlightTitle} />
       <MarketingBlockExclusivity
         offer={highlightOffer}
         homeEntryId={homeEntryId}
@@ -62,20 +59,12 @@ const UnmemoizedHighlightOfferModule = (props: HighlightOfferModuleProps) => {
         moduleId={props.id}
         shouldDisplayPublicationDate={displayPublicationDate}
       />
-    </Container>
+    </StyledViewGap>
   )
 }
 
 export const HighlightOfferModule = memo(UnmemoizedHighlightOfferModule)
 
-const Container = styled.View(({ theme }) => ({
+const StyledViewGap = styled(ViewGap)(({ theme }) => ({
   paddingBottom: theme.home.spaceBetweenModules,
 }))
-
-const StyledTitleContainer = styled.View(({ theme }) => ({
-  marginHorizontal: theme.contentPage.marginHorizontal,
-}))
-
-const StyledTitle = styled(Typo.Title3).attrs({
-  numberOfLines: 2,
-})``

--- a/src/features/home/components/modules/HomeModule.native.test.tsx
+++ b/src/features/home/components/modules/HomeModule.native.test.tsx
@@ -129,7 +129,7 @@ describe('<HomeModule />', () => {
     renderHomeModule(highlightOfferModuleFixture)
 
     await act(async () => {
-      expect(screen.getByText(highlightOfferModuleFixture.highlightTitle)).toBeOnTheScreen()
+      expect(screen.getByText('L’offre du moment')).toBeOnTheScreen()
     })
   })
 

--- a/src/features/home/components/modules/HomeModule.web.test.tsx
+++ b/src/features/home/components/modules/HomeModule.web.test.tsx
@@ -107,7 +107,7 @@ describe('<HomeModule />', () => {
       const { container } = renderHomeModule(highlightOfferModuleFixture)
 
       await act(async () => {
-        expect(screen.getByText(highlightOfferModuleFixture.highlightTitle)).toBeInTheDocument()
+        expect(screen.getByText('L’offre du moment')).toBeInTheDocument()
       })
 
       const results = await checkAccessibilityFor(container)

--- a/src/features/home/components/modules/categories/CategoryListModule.tsx
+++ b/src/features/home/components/modules/categories/CategoryListModule.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react'
 import styled from 'styled-components/native'
 
+import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
 import { CategoryBlock as CategoryBlockData } from 'features/home/types'
 import { analytics } from 'libs/analytics/provider'
 import { ContentTypes } from 'libs/contentful/types'
 import { CategoryButton } from 'shared/categoryButton/CategoryButton'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing } from 'ui/theme'
 import { colorMapping } from 'ui/theme/colorMapping'
 
 type CategoryListProps = {
@@ -39,7 +40,7 @@ export const CategoryListModule = ({
 
   return (
     <Container>
-      <StyledTitle numberOfLines={2}>{title}</StyledTitle>
+      <AccessibleTitle title={title} />
       <StyledView>
         {categoryBlockList.map((item) => (
           <StyledCategoryButton
@@ -86,10 +87,6 @@ const StyledView = styled.View(({ theme }) => ({
         gap: DESKTOP_GAPS_AND_PADDINGS,
         paddingVertical: DESKTOP_GAPS_AND_PADDINGS,
       }),
-}))
-
-const StyledTitle = styled(Typo.Title3)(({ theme }) => ({
-  marginHorizontal: theme.contentPage.marginHorizontal,
 }))
 
 const Container = styled.View({

--- a/src/features/home/components/modules/video/OldVideoModuleDesktop.tsx
+++ b/src/features/home/components/modules/video/OldVideoModuleDesktop.tsx
@@ -5,6 +5,7 @@ import { ImageBackground, View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
 
+import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
 import { BlackCaption } from 'features/home/components/BlackCaption'
 import { BlackGradient } from 'features/home/components/BlackGradient'
 import { TEXT_BACKGROUND_OPACITY } from 'features/home/components/constants'
@@ -38,16 +39,17 @@ export const OldVideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props
   const nbOfSeparators = hasOnlyTwoOffers ? 1 : 2
 
   function renderTitleSeeMore() {
-    return <SeeMoreWithEye title={props.videoTitle} onPressSeeMore={props.showVideoModal} />
+    return showSeeMore && props.isMultiOffer ? (
+      <SeeMoreWithEye title={props.videoTitle} onPressSeeMore={props.showVideoModal} />
+    ) : null
   }
 
   return (
     <React.Fragment>
       <StyledTitleContainer>
-        <StyledTitleComponent>{props.title}</StyledTitleComponent>
-        {showSeeMore && props.isMultiOffer && renderTitleSeeMore()}
+        <AccessibleTitle testID="playlistTitle" title={props.title} />
+        {renderTitleSeeMore()}
       </StyledTitleContainer>
-      <Spacer.Column numberOfSpaces={5} />
 
       <StyledWrapper isMultiOffer={props.isMultiOffer} testID="desktop-video-module">
         <ColorCategoryBackground
@@ -190,15 +192,11 @@ const StyledTouchableHighlight = styled.TouchableHighlight.attrs(({ theme }) => 
   width: isMultiOffer ? THUMBNAIL_WIDTH_MULTI_OFFER : THUMBNAIL_WIDTH_MONO_OFFER,
 }))
 
-const StyledTitleContainer = styled.View(({ theme }) => ({
-  marginHorizontal: theme.contentPage.marginHorizontal,
+const StyledTitleContainer = styled.View({
   flexDirection: 'row',
+  marginBottom: getSpacing(5),
   alignItems: 'center',
-}))
-
-const StyledTitleComponent = styled(Typo.Title3).attrs({
-  numberOfLines: 2,
-})({})
+})
 
 const StyledVideoMonoOfferTile = styled(VideoMonoOfferTile)({
   flex: 1,

--- a/src/features/home/components/modules/video/OldVideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/OldVideoModuleMobile.tsx
@@ -4,6 +4,7 @@ import { View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
 
+import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
 import { BlackCaption } from 'features/home/components/BlackCaption'
 import { BlackGradient } from 'features/home/components/BlackGradient'
 import { TEXT_BACKGROUND_OPACITY } from 'features/home/components/constants'
@@ -35,10 +36,8 @@ export const OldVideoModuleMobile: FunctionComponent<VideoModuleProps> = (props)
   return (
     <Container>
       <StyledTitleContainer>
-        <StyledTitleComponent>{props.title}</StyledTitleComponent>
+        <AccessibleTitle testID="playlistTitle" title={props.title} />
       </StyledTitleContainer>
-      <Spacer.Column numberOfSpaces={5} />
-
       <View testID="mobile-video-module">
         <ColorCategoryBackground
           colorCategoryBackgroundHeightUniqueOffer={colorCategoryBackgroundHeightUniqueOffer}
@@ -159,13 +158,7 @@ const StyledTouchableHighlight = styled.TouchableHighlight.attrs(({ theme }) => 
   borderRadius: theme.borderRadius.radius,
 }))
 
-const StyledTitleContainer = styled.View(({ theme }) => ({
-  marginHorizontal: theme.contentPage.marginHorizontal,
-}))
-
-const StyledTitleComponent = styled(Typo.Title3).attrs({
-  numberOfLines: 2,
-})({})
+const StyledTitleContainer = styled.View({ marginBottom: getSpacing(5), alignItems: 'center' })
 
 const StyledVideoMonoOfferTile = styled(VideoMonoOfferTile)({
   flexGrow: 1,

--- a/src/features/home/components/modules/video/VideoModule.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoModule.native.test.tsx
@@ -85,6 +85,13 @@ describe('VideoModule', () => {
     expect(multiOfferList).toBeOnTheScreen()
   })
 
+  it('should render one offer component when one offer', async () => {
+    mockUseVideoOffers.mockReturnValueOnce({ offers: [offerFixture] })
+    renderVideoModule()
+
+    expect(await screen.findByTestId('videoMonoOfferTile')).toBeOnTheScreen()
+  })
+
   it('should render mobile design if mobile viewport', async () => {
     mockUseVideoOffers.mockReturnValueOnce({ offers: [offerFixture] })
     renderVideoModule()
@@ -105,6 +112,32 @@ describe('VideoModule', () => {
     await screen.findByText(offerFixture.offer.name)
 
     expect(multiOfferList).toBeOnTheScreen()
+  })
+
+  it('should show SeeMore button when is multiples offers and more than three offers', async () => {
+    mockUseVideoOffers.mockReturnValueOnce({
+      offers: [offerFixture, offerFixture2, offerFixture3, offerFixture4],
+    })
+    renderVideoModule(true)
+
+    const seeMoreWording = screen.getByText('Voir tout')
+
+    await screen.findByText(videoModuleFixture.title)
+
+    expect(seeMoreWording).toBeOnTheScreen()
+  })
+
+  it('should not show SeeMore button when is multiples offers and less than three offers', async () => {
+    mockUseVideoOffers.mockReturnValueOnce({
+      offers: [offerFixture, offerFixture2],
+    })
+    renderVideoModule(true)
+
+    const seeMoreWording = screen.queryByText('Voir tout')
+
+    await screen.findByText(videoModuleFixture.title)
+
+    expect(seeMoreWording).not.toBeOnTheScreen()
   })
 })
 
@@ -128,6 +161,26 @@ const offerFixture2 = {
   objectID: 9876,
   venue: {
     id: 5432,
+  },
+}
+const offerFixture3 = {
+  offer: {
+    thumbUrl: 'http://thumbnail',
+    subcategoryId: 'CONFERENCE',
+  },
+  objectID: 9877,
+  venue: {
+    id: 5433,
+  },
+}
+const offerFixture4 = {
+  offer: {
+    thumbUrl: 'http://thumbnail',
+    subcategoryId: 'CONFERENCE',
+  },
+  objectID: 9878,
+  venue: {
+    id: 5434,
   },
 }
 

--- a/src/features/home/components/modules/video/VideoModuleDesktop.tsx
+++ b/src/features/home/components/modules/video/VideoModuleDesktop.tsx
@@ -13,7 +13,7 @@ import { SeeMoreWithEye } from 'ui/components/SeeMoreWithEye'
 import { Separator } from 'ui/components/Separator'
 import { HorizontalOfferTile } from 'ui/components/tiles/HorizontalOfferTile'
 import { Play } from 'ui/svg/icons/Play'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Typo } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
 import { videoModuleColorsMapping } from 'ui/theme/videoModuleColorsMapping'
@@ -35,13 +35,23 @@ export const VideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) =
     ) : null
   }
 
+  function renderSoloOffer() {
+    return props.offers[0] ? (
+      <StyledVideoMonoOfferTile
+        offer={props.offers[0]}
+        color={props.color}
+        hideModal={props.hideVideoModal}
+        analyticsParams={props.analyticsParams}
+      />
+    ) : null
+  }
+
   return (
     <React.Fragment>
       <StyledTitleContainer>
         <AccessibleTitle testID="playlistTitle" title={props.title} />
         {renderTitleSeeMore()}
       </StyledTitleContainer>
-
       <View>
         <ColorCategoryBackgroundWrapper>
           <ColorCategoryBackground
@@ -68,7 +78,6 @@ export const VideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) =
             </Thumbnail>
           </StyledTouchableHighlight>
           <StyledView>
-            <Spacer.Row numberOfSpaces={4} />
             {props.isMultiOffer ? (
               <StyledMultiOfferList hasOnlyTwoOffers={hasOnlyTwoOffers}>
                 {props.offers.slice(0, 3).map((offer: Offer, index) => (
@@ -85,14 +94,7 @@ export const VideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) =
                 ))}
               </StyledMultiOfferList>
             ) : (
-              <StyledVideoMonoOfferTile
-                // @ts-expect-error: because of noUncheckedIndexedAccess
-                offer={props.offers[0]}
-                color={props.color}
-                hideModal={props.hideVideoModal}
-                analyticsParams={props.analyticsParams}
-                homeEntryId={props.homeEntryId}
-              />
+              renderSoloOffer()
             )}
           </StyledView>
         </VideoOfferContainer>

--- a/src/features/home/components/modules/video/VideoModuleDesktop.tsx
+++ b/src/features/home/components/modules/video/VideoModuleDesktop.tsx
@@ -4,6 +4,7 @@ import React, { FunctionComponent } from 'react'
 import { ImageBackground, View } from 'react-native'
 import styled from 'styled-components/native'
 
+import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
 import { VideoMonoOfferTile } from 'features/home/components/modules/video/VideoMonoOfferTile'
 import { VideoModuleProps } from 'features/home/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
@@ -29,16 +30,17 @@ export const VideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) =
   const nbOfSeparators = hasOnlyTwoOffers ? 1 : 2
 
   function renderTitleSeeMore() {
-    return <SeeMoreWithEye title={props.videoTitle} onPressSeeMore={props.showVideoModal} />
+    return showSeeMore && props.isMultiOffer ? (
+      <SeeMoreWithEye title={props.videoTitle} onPressSeeMore={props.showVideoModal} />
+    ) : null
   }
 
   return (
     <React.Fragment>
       <StyledTitleContainer>
-        <Typo.Title3 numberOfLines={2}>{props.title}</Typo.Title3>
-        {showSeeMore && props.isMultiOffer && renderTitleSeeMore()}
+        <AccessibleTitle testID="playlistTitle" title={props.title} />
+        {renderTitleSeeMore()}
       </StyledTitleContainer>
-      <Spacer.Column numberOfSpaces={5} />
 
       <View>
         <ColorCategoryBackgroundWrapper>
@@ -179,11 +181,11 @@ const StyledTouchableHighlight = styled.TouchableHighlight.attrs(({ theme }) => 
   width: THUMBNAIL_WIDTH,
 })
 
-const StyledTitleContainer = styled.View(({ theme }) => ({
-  marginHorizontal: theme.contentPage.marginHorizontal,
+const StyledTitleContainer = styled.View({
   flexDirection: 'row',
+  marginBottom: getSpacing(5),
   alignItems: 'center',
-}))
+})
 
 const StyledVideoMonoOfferTile = styled(VideoMonoOfferTile)({
   flexGrow: 1,

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent, useState } from 'react'
 import { LayoutChangeEvent, View } from 'react-native'
 import styled from 'styled-components/native'
 
+import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
 import { VideoMonoOfferTile } from 'features/home/components/modules/video/VideoMonoOfferTile'
 import { VideoMultiOfferPlaylist } from 'features/home/components/modules/video/VideoMultiOfferPlaylist'
 import { VideoModuleProps } from 'features/home/types'
@@ -30,9 +31,8 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
   return (
     <Container>
       <StyledTitleContainer>
-        <StyledTitleComponent>{props.title}</StyledTitleComponent>
+        <AccessibleTitle testID="playlistTitle" title={props.title} />
       </StyledTitleContainer>
-      <Spacer.Column numberOfSpaces={5} />
 
       <View testID="mobile-video-module">
         <StyledTouchableHighlight
@@ -91,13 +91,7 @@ const Container = styled.View(({ theme }) => ({
   paddingBottom: theme.home.spaceBetweenModules,
 }))
 
-const StyledTitleContainer = styled.View(({ theme }) => ({
-  marginHorizontal: theme.contentPage.marginHorizontal,
-}))
-
-const StyledTitleComponent = styled(Typo.Title3).attrs({
-  numberOfLines: 2,
-})({})
+const StyledTitleContainer = styled.View({ marginBottom: getSpacing(5), alignItems: 'center' })
 
 const StyledTouchableHighlight = styled.TouchableHighlight.attrs(({ theme }) => ({
   underlayColor: theme.colors.white,

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
@@ -99,7 +99,7 @@ export const VideoMonoOfferTile: FunctionComponent<Props> = ({
       <AttachedOfferCard offer={offer} />
     </StyledInternalTouchableLink>
   ) : (
-    <OfferInsert {...containerProps}>
+    <OfferInsert {...containerProps} testID="videoMonoOfferTile">
       <Row>
         <OfferImageContainer>
           <OfferImage

--- a/src/features/home/pages/GenericHome.tsx
+++ b/src/features/home/pages/GenericHome.tsx
@@ -309,7 +309,6 @@ const OnlineHome: FunctionComponent<GenericHomeProps> = ({
           </ScrollToTopContainer>
         ) : null}
       </HomeBodyLoadingContainer>
-      <Spacer.Column numberOfSpaces={6} />
       {statusBar ?? null}
     </Container>
   )
@@ -326,6 +325,7 @@ export const GenericHome: FunctionComponent<GenericHomeProps> = (props) => {
 const HomeBodyLoadingContainer = styled.View<{ hide: boolean }>(({ hide }) => ({
   height: hide ? 0 : '100%',
   overflow: 'hidden',
+  marginVertical: getSpacing(6),
 }))
 
 const Container = styled.View({

--- a/src/features/offer/components/MoviesScreeningCalendar/MoviesScreeningCalendar.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendar/MoviesScreeningCalendar.tsx
@@ -1,6 +1,5 @@
 import { useRoute } from '@react-navigation/native'
 import React, { FunctionComponent } from 'react'
-import styled from 'styled-components/native'
 
 import { SubcategoryIdEnum } from 'api/gen'
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
@@ -13,8 +12,7 @@ import { Offer } from 'shared/offer/types'
 import { PassPlaylist } from 'ui/components/PassPlaylist'
 import { CustomListRenderItem } from 'ui/components/Playlist'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
-import { LENGTH_M, RATIO_HOME_IMAGE, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { LENGTH_M, RATIO_HOME_IMAGE } from 'ui/theme'
 
 type Props = {
   venueOffers: VenueOffers
@@ -55,7 +53,6 @@ export const MoviesScreeningCalendar: FunctionComponent<Props> = ({ venueOffers 
           <PassPlaylist
             testID="offersModuleList"
             title="Les autres offres"
-            TitleComponent={PlaylistTitleText}
             data={nonScreeningOffers}
             itemHeight={LENGTH_M}
             itemWidth={LENGTH_M * RATIO_HOME_IMAGE}
@@ -67,5 +64,3 @@ export const MoviesScreeningCalendar: FunctionComponent<Props> = ({ venueOffers 
     </React.Fragment>
   )
 }
-
-const PlaylistTitleText = styled(Typo.Title3).attrs(getHeadingAttrs(2))``

--- a/src/features/venue/components/VenueOffers/VenueOffersList.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffersList.tsx
@@ -117,7 +117,6 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
       <PassPlaylist
         testID="offersModuleList"
         title="Toutes les offres"
-        TitleComponent={PlaylistTitleText}
         data={hits}
         itemHeight={LENGTH_M}
         itemWidth={LENGTH_M * RATIO_HOME_IMAGE}
@@ -149,8 +148,6 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
     </Container>
   )
 }
-
-const PlaylistTitleText = styled(Typo.Title3).attrs(getHeadingAttrs(2))``
 
 const Container = styled.View({ marginTop: getSpacing(6) })
 

--- a/src/ui/components/PassPlaylist.tsx
+++ b/src/ui/components/PassPlaylist.tsx
@@ -1,7 +1,8 @@
-import React, { ComponentProps, ComponentType, Ref, useCallback } from 'react'
+import React, { ComponentProps, Ref, useCallback } from 'react'
 import { FlatList } from 'react-native-gesture-handler'
 import styled, { useTheme } from 'styled-components/native'
 
+import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
 import { Playlist, RenderFooterItem } from 'ui/components/Playlist'
 import { SeeMore } from 'ui/components/SeeMore'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
@@ -27,7 +28,6 @@ type Props = Pick<
   noMarginBottom?: boolean
   title: string
   subtitle?: string
-  TitleComponent?: ComponentType<ComponentProps<typeof DefaultTitle>>
   onPressSeeMore?: () => void
   renderFooter?: RenderFooterItem
   titleSeeMoreLink?: InternalNavigationProps['navigateTo']
@@ -37,7 +37,6 @@ type Props = Pick<
 export const PassPlaylist = ({
   title,
   subtitle,
-  TitleComponent,
   onPressSeeMore,
   onEndReached,
   onViewableItemsChanged,
@@ -59,12 +58,6 @@ export const PassPlaylist = ({
 
   const showTitleSeeMore = !!onPressSeeMore && !isTouch
   const showFooterSeeMore = !!onPressSeeMore && isTouch
-
-  const StyledTitleComponent = styled(TitleComponent || DefaultTitle).attrs({
-    numberOfLines: 2,
-  })(({ theme }) => ({
-    marginHorizontal: theme.contentPage.marginHorizontal,
-  }))
 
   type SizeProps = {
     width: number
@@ -91,7 +84,7 @@ export const PassPlaylist = ({
     <StyledViewGap gap={4} noMarginBottom={noMarginBottom} {...props}>
       <ViewGap gap={1}>
         <StyledView>
-          <StyledTitleComponent testID="playlistTitle">{title}</StyledTitleComponent>
+          <AccessibleTitle TitleComponent={TitleLevel2} testID="playlistTitle" title={title} />
           {renderTitleSeeMore()}
         </StyledView>
         {subtitle ? <StyledSubtitle>{subtitle}</StyledSubtitle> : null}
@@ -121,7 +114,7 @@ const StyledViewGap = styled(ViewGap)<{ noMarginBottom?: boolean }>(
   })
 )
 
-const DefaultTitle = styled(Typo.Title3).attrs(getHeadingAttrs(2))``
+const TitleLevel2 = styled(Typo.Title3).attrs(getHeadingAttrs(2))``
 
 const StyledSubtitle = styled(Typo.BodyAccentXs).attrs({
   numberOfLines: 2,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34902

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
