### PR TITLE
(PC-35379) fix(tabbar): profile subscreens issue

### DIFF
--- a/__snapshots__/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx.native-snap
@@ -199,14 +199,11 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
           "navigateTo": {
             "params": {
               "params": {
-                "params": {
-                  "showModal": true,
-                },
-                "screen": "ChangeEmail",
+                "showModal": true,
               },
-              "screen": "ProfileStackNavigator",
+              "screen": "ChangeEmail",
             },
-            "screen": "TabNavigator",
+            "screen": "ProfileStackNavigator",
           },
           "wording": "J’aimerais créer un compte avec une adresse e-mail différente",
         },
@@ -214,13 +211,10 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
           "analyticsReason": "noLongerUsed",
           "navigateTo": {
             "params": {
-              "params": {
-                "params": undefined,
-                "screen": "DeleteProfileConfirmation",
-              },
-              "screen": "ProfileStackNavigator",
+              "params": undefined,
+              "screen": "DeleteProfileConfirmation",
             },
-            "screen": "TabNavigator",
+            "screen": "ProfileStackNavigator",
           },
           "wording": "Je n’utilise plus l’application",
         },
@@ -228,13 +222,10 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
           "analyticsReason": "noMoreCredit",
           "navigateTo": {
             "params": {
-              "params": {
-                "params": undefined,
-                "screen": "DeleteProfileConfirmation",
-              },
-              "screen": "ProfileStackNavigator",
+              "params": undefined,
+              "screen": "DeleteProfileConfirmation",
             },
-            "screen": "TabNavigator",
+            "screen": "ProfileStackNavigator",
           },
           "wording": "Je n’ai plus de crédit ou très peu de crédit restant",
         },
@@ -242,13 +233,10 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
           "analyticsReason": "dataDeletion",
           "navigateTo": {
             "params": {
-              "params": {
-                "params": undefined,
-                "screen": "DeleteProfileConfirmation",
-              },
-              "screen": "ProfileStackNavigator",
+              "params": undefined,
+              "screen": "DeleteProfileConfirmation",
             },
-            "screen": "TabNavigator",
+            "screen": "ProfileStackNavigator",
           },
           "wording": "Je souhaite supprimer mes données personnelles",
         },
@@ -256,13 +244,10 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
           "analyticsReason": "hackedAccount",
           "navigateTo": {
             "params": {
-              "params": {
-                "params": undefined,
-                "screen": "DeleteProfileAccountHacked",
-              },
-              "screen": "ProfileStackNavigator",
+              "params": undefined,
+              "screen": "DeleteProfileAccountHacked",
             },
-            "screen": "TabNavigator",
+            "screen": "ProfileStackNavigator",
           },
           "wording": "Je pense que quelqu’un d’autre a accès à mon compte",
         },
@@ -270,13 +255,10 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
           "analyticsReason": "other",
           "navigateTo": {
             "params": {
-              "params": {
-                "params": undefined,
-                "screen": "DeleteProfileContactSupport",
-              },
-              "screen": "ProfileStackNavigator",
+              "params": undefined,
+              "screen": "DeleteProfileContactSupport",
             },
-            "screen": "TabNavigator",
+            "screen": "ProfileStackNavigator",
           },
           "wording": "Autre",
         },

--- a/src/features/auth/pages/signup/SignupForm.tsx
+++ b/src/features/auth/pages/signup/SignupForm.tsx
@@ -12,8 +12,8 @@ import { useGoogleSignupMutation } from 'features/auth/queries/signup/useGoogleS
 import { DEFAULT_STEP_CONFIG, SSO_STEP_CONFIG } from 'features/auth/stepConfig'
 import { SignupData } from 'features/auth/types'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { useDeviceInfo } from 'features/trustedDevice/helpers/useDeviceInfo'
 import { analytics } from 'libs/analytics/provider'
@@ -57,7 +57,7 @@ export const SignupForm: FunctionComponent = () => {
       ? `Continuer vers l’étape ${nextStep.accessibilityTitle}`
       : undefined
 
-  const { goBack: goBackAndLeaveSignup } = useGoBack(...getProfileStackConfig('Profile'))
+  const { goBack: goBackAndLeaveSignup } = useGoBack(...getTabNavConfig('Profile'))
 
   const goToPreviousStep = () => {
     if (isFirstStep) {

--- a/src/features/deeplinks/helpers/getScreenFromDeeplink.test.ts
+++ b/src/features/deeplinks/helpers/getScreenFromDeeplink.test.ts
@@ -1,8 +1,7 @@
 import { getScreenFromDeeplink } from 'features/deeplinks/helpers'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { getScreenPath } from 'features/navigation/RootNavigator/linking/getScreenPath'
 import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/searchStackHelpers'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabNavConfig, homeNavConfig } from 'features/navigation/TabBar/helpers'
 import { WEBAPP_V2_URL } from 'libs/environment/useWebAppUrl'
 
 jest.mock('libs/firebase/analytics/analytics')
@@ -46,7 +45,7 @@ describe('getScreenFromDeeplink()', () => {
   })
 
   it('should return ProfileStackNavigator when url = /profil', () => {
-    const url = getFullUrl(getScreenPath(...getProfileStackConfig('Profile')))
+    const url = getFullUrl(getScreenPath(...getTabNavConfig('Profile')))
     const { screen, params } = getScreenFromDeeplink(url)
 
     expect(screen).toEqual('TabNavigator')

--- a/src/features/deeplinks/helpers/getScreenFromDeeplink.test.ts
+++ b/src/features/deeplinks/helpers/getScreenFromDeeplink.test.ts
@@ -49,7 +49,7 @@ describe('getScreenFromDeeplink()', () => {
     const { screen, params } = getScreenFromDeeplink(url)
 
     expect(screen).toEqual('TabNavigator')
-    expect(params).toEqual({ screen: 'ProfileStackNavigator', params: undefined })
+    expect(params).toEqual({ screen: 'Profile', params: undefined })
   })
 
   it('should return SearchStackNavigator when url = /recherche/resultats', () => {

--- a/src/features/internal/components/DeeplinksGeneratorForm.tsx
+++ b/src/features/internal/components/DeeplinksGeneratorForm.tsx
@@ -19,8 +19,6 @@ import {
   SCREENS_CONFIG,
   ScreensUsedByMarketing,
 } from 'features/internal/config/deeplinksExportConfig'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
-import { isProfileStackScreen } from 'features/navigation/ProfileStackNavigator/profileRoutes'
 import { getScreenPath } from 'features/navigation/RootNavigator/linking/getScreenPath'
 import { isSearchStackScreen } from 'features/navigation/SearchStackNavigator/searchRoutes'
 import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/searchStackHelpers'
@@ -311,11 +309,6 @@ export const DeeplinksGeneratorForm = ({ onCreate }: Props) => {
     if (isSearchStackScreen(selectedScreen)) {
       const searchStackConfig = getSearchStackConfig(selectedScreen, appAndMarketingParams)
       screenPath = getScreenPath(...searchStackConfig)
-    }
-
-    if (isProfileStackScreen(selectedScreen)) {
-      const profileStackConfig = getProfileStackConfig(selectedScreen, appAndMarketingParams)
-      screenPath = getScreenPath(...profileStackConfig)
     }
 
     let universalLink = `https://${env.WEBAPP_V2_DOMAIN}${screenPath}`

--- a/src/features/navigation/ProfileStackNavigator/ProfileStack.ts
+++ b/src/features/navigation/ProfileStackNavigator/ProfileStack.ts
@@ -6,7 +6,7 @@ import {
 } from 'features/navigation/RootNavigator/types'
 
 export type ProfileStackParamList = {
-  NotificationsSettings?: Record<string, unknown> // I had to put type Record<string, unknown> so that getProfileStackConfig in DeeplinksGeneratorForm can take appAndMarketingParams, otherwise I would have just put undefined.
+  NotificationsSettings: undefined
   DeleteProfileAccountHacked: undefined
   DeleteProfileAccountNotDeletable: undefined
   DeleteProfileConfirmation: undefined

--- a/src/features/navigation/ProfileStackNavigator/ProfileStack.ts
+++ b/src/features/navigation/ProfileStackNavigator/ProfileStack.ts
@@ -7,32 +7,32 @@ import {
 
 export type ProfileStackParamList = {
   NotificationsSettings?: Record<string, unknown> // I had to put type Record<string, unknown> so that getProfileStackConfig in DeeplinksGeneratorForm can take appAndMarketingParams, otherwise I would have just put undefined.
-  DeleteProfileAccountHacked?: undefined
-  DeleteProfileAccountNotDeletable?: undefined
-  DeleteProfileConfirmation?: undefined
-  DeleteProfileContactSupport?: undefined
-  DeleteProfileEmailHacked?: undefined
-  DeleteProfileReason?: undefined
-  DeleteProfileSuccess?: undefined
-  ConfirmDeleteProfile?: undefined
-  DeactivateProfileSuccess?: undefined
-  SuspendAccountConfirmationWithoutAuthentication?: undefined
-  ChangeStatus?: undefined
-  ChangeCity?: undefined
-  ChangeEmail?: { showModal?: boolean } | undefined
-  TrackEmailChange?: undefined
-  LegalNotices?: undefined
-  PersonalData?: undefined
-  ValidateEmailChange?: { token?: string } | undefined
-  ChangePassword?: undefined
-  SuspendAccountConfirmation?: { token?: string } | undefined
-  FeedbackInApp?: undefined
-  ConsentSettings?: { onGoBack?: () => void } | undefined
-  ConfirmChangeEmail?: { token: string; expiration_timestamp?: number } | undefined
-  ChangeEmailSetPassword?:
-    | { token?: string | null | undefined; emailSelectionToken?: string | null | undefined }
+  DeleteProfileAccountHacked: undefined
+  DeleteProfileAccountNotDeletable: undefined
+  DeleteProfileConfirmation: undefined
+  DeleteProfileContactSupport: undefined
+  DeleteProfileEmailHacked: undefined
+  DeleteProfileReason: undefined
+  DeleteProfileSuccess: undefined
+  ConfirmDeleteProfile: undefined
+  DeactivateProfileSuccess: undefined
+  SuspendAccountConfirmationWithoutAuthentication: undefined
+  ChangeStatus: undefined
+  ChangeCity: undefined
+  ChangeEmail: { showModal: boolean } | undefined
+  TrackEmailChange: undefined
+  LegalNotices: undefined
+  PersonalData: undefined
+  ValidateEmailChange: { token: string } | undefined
+  ChangePassword: undefined
+  SuspendAccountConfirmation: { token: string } | undefined
+  FeedbackInApp: undefined
+  ConsentSettings: { onGoBack?: () => void } | undefined
+  ConfirmChangeEmail: { token: string; expiration_timestamp: number } | undefined
+  ChangeEmailSetPassword:
+    | { token: string | null | undefined; emailSelectionToken: string | null | undefined }
     | undefined
-  NewEmailSelection?: { token: string | null | undefined } | undefined
+  NewEmailSelection: { token: string | null | undefined } | undefined
 } & AccessibilityRootStackParamList
 
 export type ProfileStackRouteName = keyof ProfileStackParamList

--- a/src/features/navigation/ProfileStackNavigator/ProfileStack.ts
+++ b/src/features/navigation/ProfileStackNavigator/ProfileStack.ts
@@ -6,34 +6,33 @@ import {
 } from 'features/navigation/RootNavigator/types'
 
 export type ProfileStackParamList = {
-  Profile?: Record<string, unknown> // I had to put type Record<string, unknown> so that getProfileStackConfig in DeeplinksGeneratorForm can take appAndMarketingParams, otherwise I would have just put undefined.
-  NotificationsSettings: undefined
-  DeleteProfileAccountHacked: undefined
-  DeleteProfileAccountNotDeletable: undefined
-  DeleteProfileConfirmation: undefined
-  DeleteProfileContactSupport: undefined
-  DeleteProfileEmailHacked: undefined
-  DeleteProfileReason: undefined
-  DeleteProfileSuccess: undefined
-  ConfirmDeleteProfile: undefined
-  DeactivateProfileSuccess: undefined
-  SuspendAccountConfirmationWithoutAuthentication: undefined
-  ChangeStatus: undefined
-  ChangeCity: undefined
-  ChangeEmail: { showModal: boolean } | undefined
-  TrackEmailChange: undefined
-  LegalNotices: undefined
-  PersonalData: undefined
-  ValidateEmailChange: { token: string } | undefined
-  ChangePassword: undefined
-  SuspendAccountConfirmation: { token: string } | undefined
-  FeedbackInApp: undefined
-  ConsentSettings: { onGoBack?: () => void } | undefined
-  ConfirmChangeEmail: { token: string; expiration_timestamp: number } | undefined
-  ChangeEmailSetPassword:
-    | { token: string | null | undefined; emailSelectionToken: string | null | undefined }
+  NotificationsSettings?: Record<string, unknown> // I had to put type Record<string, unknown> so that getProfileStackConfig in DeeplinksGeneratorForm can take appAndMarketingParams, otherwise I would have just put undefined.
+  DeleteProfileAccountHacked?: undefined
+  DeleteProfileAccountNotDeletable?: undefined
+  DeleteProfileConfirmation?: undefined
+  DeleteProfileContactSupport?: undefined
+  DeleteProfileEmailHacked?: undefined
+  DeleteProfileReason?: undefined
+  DeleteProfileSuccess?: undefined
+  ConfirmDeleteProfile?: undefined
+  DeactivateProfileSuccess?: undefined
+  SuspendAccountConfirmationWithoutAuthentication?: undefined
+  ChangeStatus?: undefined
+  ChangeCity?: undefined
+  ChangeEmail?: { showModal?: boolean } | undefined
+  TrackEmailChange?: undefined
+  LegalNotices?: undefined
+  PersonalData?: undefined
+  ValidateEmailChange?: { token?: string } | undefined
+  ChangePassword?: undefined
+  SuspendAccountConfirmation?: { token?: string } | undefined
+  FeedbackInApp?: undefined
+  ConsentSettings?: { onGoBack?: () => void } | undefined
+  ConfirmChangeEmail?: { token: string; expiration_timestamp?: number } | undefined
+  ChangeEmailSetPassword?:
+    | { token?: string | null | undefined; emailSelectionToken?: string | null | undefined }
     | undefined
-  NewEmailSelection: { token: string | null | undefined } | undefined
+  NewEmailSelection?: { token: string | null | undefined } | undefined
 } & AccessibilityRootStackParamList
 
 export type ProfileStackRouteName = keyof ProfileStackParamList

--- a/src/features/navigation/ProfileStackNavigator/ProfileStackNavigator.tsx
+++ b/src/features/navigation/ProfileStackNavigator/ProfileStackNavigator.tsx
@@ -30,14 +30,14 @@ import { LegalNotices } from 'features/profile/pages/LegalNotices/LegalNotices'
 import { NewEmailSelection } from 'features/profile/pages/NewEmailSelection/NewEmailSelection'
 import { NotificationsSettings } from 'features/profile/pages/NotificationSettings/NotificationsSettings'
 import { PersonalData } from 'features/profile/pages/PersonalData/PersonalData'
-import { Profile } from 'features/profile/pages/Profile'
 import { SuspendAccountConfirmation } from 'features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation'
 import { TrackEmailChange } from 'features/profile/pages/TrackEmailChange/TrackEmailChange'
 import { ValidateEmailChange } from 'features/profile/pages/ValidateEmailChange/ValidateEmailChange'
 
 export const ProfileStackNavigator = () => (
-  <ProfileStack.Navigator initialRouteName="Profile" screenOptions={ROOT_NAVIGATOR_SCREEN_OPTIONS}>
-    <ProfileStack.Screen name="Profile" component={Profile} options={{ title: 'Mon profil' }} />
+  <ProfileStack.Navigator
+    initialRouteName="Accessibility"
+    screenOptions={ROOT_NAVIGATOR_SCREEN_OPTIONS}>
     <ProfileStack.Screen
       name="Accessibility"
       component={Accessibility}

--- a/src/features/navigation/ProfileStackNavigator/getProfileNavConfig.ts
+++ b/src/features/navigation/ProfileStackNavigator/getProfileNavConfig.ts
@@ -7,14 +7,14 @@ export function getProfileNavConfig<Screen extends ProfileStackRouteName>(
   screen: Screen,
   params?: ProfileStackParamList[Screen]
 ): {
-  screen: 'TabNavigator'
+  screen: 'ProfileStackNavigator'
   params: {
-    screen: 'ProfileStackNavigator'
-    params: { screen: Screen; params: ProfileStackParamList[Screen] }
+    screen: Screen
+    params: ProfileStackParamList[Screen]
   }
 } {
   return {
-    screen: 'TabNavigator',
-    params: { screen: 'ProfileStackNavigator', params: { screen, params } },
+    screen: 'ProfileStackNavigator',
+    params: { screen, params },
   }
 }

--- a/src/features/navigation/ProfileStackNavigator/getProfileNavConfig.ts
+++ b/src/features/navigation/ProfileStackNavigator/getProfileNavConfig.ts
@@ -8,9 +8,9 @@ export function getProfileNavConfig<Screen extends ProfileStackRouteName>(
   params?: ProfileStackParamList[Screen]
 ): {
   screen: 'ProfileStackNavigator'
-  params: {
+  params?: {
     screen: Screen
-    params: ProfileStackParamList[Screen]
+    params?: ProfileStackParamList[Screen]
   }
 } {
   return {

--- a/src/features/navigation/ProfileStackNavigator/getProfileStackConfig.ts
+++ b/src/features/navigation/ProfileStackNavigator/getProfileStackConfig.ts
@@ -7,11 +7,11 @@ export function getProfileStackConfig<Screen extends ProfileStackRouteName>(
   screen: Screen,
   params?: ProfileStackParamList[Screen]
 ): [
-  'TabNavigator',
+  'ProfileStackNavigator',
   {
-    screen: 'ProfileStackNavigator'
-    params: { screen: Screen; params: ProfileStackParamList[Screen] }
+    screen: Screen
+    params: ProfileStackParamList[Screen]
   },
 ] {
-  return ['TabNavigator', { screen: 'ProfileStackNavigator', params: { screen, params } }]
+  return ['ProfileStackNavigator', { screen, params }]
 }

--- a/src/features/navigation/ProfileStackNavigator/profileNavigatorPathConfig.ts
+++ b/src/features/navigation/ProfileStackNavigator/profileNavigatorPathConfig.ts
@@ -10,6 +10,6 @@ import { getScreensAndConfig } from 'features/navigation/RootNavigator/linking/g
 const { screensConfig } = getScreensAndConfig(profileRoutes, ProfileStack.Screen)
 
 export const profileNavigatorPathConfig: LinkingOptions<ProfileStackParamList>['config'] = {
-  initialRouteName: 'Profile',
+  initialRouteName: 'Accessibility',
   screens: screensConfig,
 }

--- a/src/features/navigation/ProfileStackNavigator/profileRoutes.ts
+++ b/src/features/navigation/ProfileStackNavigator/profileRoutes.ts
@@ -1,9 +1,6 @@
 import { ComponentForPathConfig } from 'features/navigation/ComponentForPathConfig'
 import { accessibilityRoutes } from 'features/navigation/ProfileStackNavigator/accessibilityRoutes'
-import {
-  ProfileStackRoute,
-  ProfileStackRouteName,
-} from 'features/navigation/ProfileStackNavigator/ProfileStack'
+import { ProfileStackRoute } from 'features/navigation/ProfileStackNavigator/ProfileStack'
 
 export const profileRoutes: ProfileStackRoute[] = [
   ...accessibilityRoutes,
@@ -133,8 +130,3 @@ export const profileRoutes: ProfileStackRoute[] = [
     path: 'profil/nouvelle-adresse-email',
   },
 ]
-
-export function isProfileStackScreen(screen: string): screen is ProfileStackRouteName {
-  const profileStackRouteNames = profileRoutes.map((route): string => route.name)
-  return profileStackRouteNames.includes(screen)
-}

--- a/src/features/navigation/ProfileStackNavigator/profileRoutes.ts
+++ b/src/features/navigation/ProfileStackNavigator/profileRoutes.ts
@@ -8,11 +8,6 @@ import {
 export const profileRoutes: ProfileStackRoute[] = [
   ...accessibilityRoutes,
   {
-    name: 'Profile',
-    component: ComponentForPathConfig,
-    path: 'profil',
-  },
-  {
     name: 'NotificationsSettings',
     component: ComponentForPathConfig,
     path: 'profil/notifications',

--- a/src/features/navigation/RootNavigator/Header/Header.web.test.tsx
+++ b/src/features/navigation/RootNavigator/Header/Header.web.test.tsx
@@ -109,12 +109,9 @@ describe('Header', () => {
   it('should identify one tab as current page', () => {
     renderHeader({ isLoggedIn: true, isBeneficiary: true })
 
-    const tabs = [
-      'SearchStackNavigator tab',
-      'Bookings tab',
-      'Favorites tab',
-      'ProfileStackNavigator tab',
-    ].map((tabId) => screen.getByTestId(tabId))
+    const tabs = ['SearchStackNavigator tab', 'Bookings tab', 'Favorites tab', 'Profile tab'].map(
+      (tabId) => screen.getByTestId(tabId)
+    )
 
     expect(screen.getByTestId('Home tab').getAttribute('aria-current')).toEqual('page')
 

--- a/src/features/navigation/RootNavigator/Header/Nav.native.test.tsx
+++ b/src/features/navigation/RootNavigator/Header/Nav.native.test.tsx
@@ -98,7 +98,7 @@ describe('Nav', () => {
       'SearchStackNavigator tab',
       'Bookings tab',
       'Favorites tab',
-      'ProfileStackNavigator tab',
+      'Profile tab',
     ]
 
     expectedTabsTestIds.forEach((tab) => {

--- a/src/features/navigation/RootNavigator/linking/getScreenPath.test.ts
+++ b/src/features/navigation/RootNavigator/linking/getScreenPath.test.ts
@@ -5,11 +5,6 @@ jest.mock('libs/firebase/analytics/analytics')
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
 describe('getScreenPath()', () => {
-  const ProfileStack = {
-    screen: 'ProfileStackNavigator',
-    params: { screen: 'Profile', params: undefined },
-  }
-
   const SearchStack = {
     screen: 'SearchStackNavigator',
     params: { screen: 'SearchLanding', params: undefined },
@@ -18,7 +13,7 @@ describe('getScreenPath()', () => {
   it.each`
     screen             | params                        | expectedPath
     ${'TabNavigator'}  | ${{ screen: 'Home' }}         | ${'/accueil'}
-    ${'TabNavigator'}  | ${ProfileStack}               | ${'/profil'}
+    ${'TabNavigator'}  | ${{ screen: 'Profile' }}      | ${'/profil'}
     ${'TabNavigator'}  | ${SearchStack}                | ${'/recherche/accueil'}
     ${'Offer'}         | ${{ id: 666, from: 'offer' }} | ${'/offre/666?from=offer'}
     ${'UnknownScreen'} | ${undefined}                  | ${'/UnknownScreen'}

--- a/src/features/navigation/RootNavigator/linking/getScreenPath.ts
+++ b/src/features/navigation/RootNavigator/linking/getScreenPath.ts
@@ -6,7 +6,7 @@ type NavigationState = Parameters<typeof linking.getPathFromState>[0]
 
 export function getScreenPath<RouteName extends keyof AllNavParamList>(
   screen: RouteName,
-  params?: AllNavParamList[RouteName]
+  params: AllNavParamList[RouteName]
 ) {
   let state: NavigationState = { routes: [{ name: screen, params }] }
   if (isScreen('TabNavigator', screen, params)) {

--- a/src/features/navigation/RootNavigator/linking/getScreenPath.ts
+++ b/src/features/navigation/RootNavigator/linking/getScreenPath.ts
@@ -6,44 +6,41 @@ type NavigationState = Parameters<typeof linking.getPathFromState>[0]
 
 export function getScreenPath<RouteName extends keyof AllNavParamList>(
   screen: RouteName,
-  params: AllNavParamList[RouteName]
+  params?: AllNavParamList[RouteName]
 ) {
   let state: NavigationState = { routes: [{ name: screen, params }] }
   if (isScreen('TabNavigator', screen, params)) {
-    const { screen: tabNavigatorScreen, params: tabNavigatorParams } = params
-    const nestedRoutes = [{ name: tabNavigatorScreen, params: tabNavigatorParams }]
+    const { screen: nestedScreen, params: nestedParams } = params
+    const nestedRoutes = [{ name: nestedScreen, params: nestedParams }]
     state = { routes: [{ name: screen, state: { routes: nestedRoutes } }] }
 
-    if (
-      isScreen('SearchStackNavigator', tabNavigatorScreen, tabNavigatorParams) &&
-      tabNavigatorParams
-    ) {
-      const { screen: searchStackScreen, params: searchStackParams } = tabNavigatorParams
-      const nestedNestedRoutes = [{ name: searchStackScreen, params: searchStackParams }]
+    if (isScreen('SearchStackNavigator', nestedScreen, nestedParams) && nestedParams) {
+      const { screen: searchStackScreen, params: searchStackParams } = nestedParams
+      const nestedRoutes = [{ name: searchStackScreen, params: searchStackParams }]
       state = {
         routes: [
           {
             name: screen,
-            state: { routes: [{ name: params.screen, state: { routes: nestedNestedRoutes } }] },
+            state: { routes: [{ name: params.screen, state: { routes: nestedRoutes } }] },
           },
         ],
       }
     }
-    if (isScreen('ProfileStackNavigator', tabNavigatorScreen, tabNavigatorParams)) {
-      const nestedNestedRoutes = [
+  }
+  if (isScreen('ProfileStackNavigator', screen, params)) {
+    const nestedRoutes = [
+      {
+        name: screen,
+        params: params,
+      },
+    ]
+    state = {
+      routes: [
         {
-          name: tabNavigatorParams ? tabNavigatorParams.screen : tabNavigatorScreen,
-          params: tabNavigatorParams?.params,
+          name: screen,
+          state: { routes: nestedRoutes },
         },
-      ]
-      state = {
-        routes: [
-          {
-            name: screen,
-            state: { routes: [{ name: params.screen, state: { routes: nestedNestedRoutes } }] },
-          },
-        ],
-      }
+      ],
     }
   }
 

--- a/src/features/navigation/RootNavigator/rootRoutes.ts
+++ b/src/features/navigation/RootNavigator/rootRoutes.ts
@@ -27,6 +27,8 @@ import { ThematicHome } from 'features/home/pages/ThematicHome'
 import { DeeplinksGenerator } from 'features/internal/pages/DeeplinksGenerator'
 import { UTMParameters } from 'features/internal/pages/UTMParameters'
 import { PageNotFound } from 'features/navigation/pages/PageNotFound'
+import { profileNavigatorPathConfig } from 'features/navigation/ProfileStackNavigator/profileNavigatorPathConfig'
+import { SuspenseProfileStackNavigator } from 'features/navigation/ProfileStackNavigator/SuspenseProfileStackNavigator'
 import { culturalSurveyRoutes } from 'features/navigation/RootNavigator/culturalSurveyRoutes'
 import { subscriptionRoutes } from 'features/navigation/RootNavigator/subscriptionRoutes'
 import { SuspenseAchievements } from 'features/navigation/RootNavigator/SuspenseAchievements'
@@ -235,6 +237,11 @@ export const rootRoutes: RootRoute[] = [
     options: { title: 'Email création de compte expiré' },
   },
   { name: 'TabNavigator', component: TabNavigator, pathConfig: tabNavigatorPathConfig },
+  {
+    name: 'ProfileStackNavigator',
+    component: SuspenseProfileStackNavigator,
+    pathConfig: profileNavigatorPathConfig,
+  },
   {
     name: 'VerifyEligibility',
     component: VerifyEligibility,

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -5,7 +5,10 @@ import { ComponentType } from 'react'
 import { CulturalSurveyQuestionEnum } from 'api/gen/api'
 import { BookingsTab } from 'features/bookings/enum'
 import { CheatcodesStackParamList } from 'features/navigation/CheatcodesStackNavigator/types'
-import { ProfileStackParamList } from 'features/navigation/ProfileStackNavigator/ProfileStack'
+import {
+  ProfileStackParamList,
+  ProfileStackRouteName,
+} from 'features/navigation/ProfileStackNavigator/ProfileStack'
 import { SearchStackParamList } from 'features/navigation/SearchStackNavigator/types'
 import { PlaylistType } from 'features/offer/enums'
 import { TutorialType } from 'features/tutorial/types'
@@ -241,6 +244,10 @@ export type RootStackParamList = {
   OfferPreview: { id: number; defaultIndex?: number }
   OnboardingSubscription: undefined
   PageNotFound: undefined
+  ProfileStackNavigator?: {
+    screen: ProfileStackRouteName
+    params: ProfileStackParamList[ProfileStackRouteName]
+  }
   RecreditBirthdayNotification: undefined
   ReinitializePassword: {
     email: string

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -69,12 +69,12 @@ export type ThematicHomeParams = BaseThematicHome &
   (OtherThematicBlockHome | CategoryBlockThematicHome | HighlightThematicBlockThematicHome)
 
 export type AccessibilityRootStackParamList = {
-  Accessibility: undefined
-  AccessibilityActionPlan: undefined
-  AccessibilityDeclarationMobile: undefined
-  AccessibilityDeclarationWeb: undefined
-  AccessibilityEngagement: undefined
-  RecommendedPaths: undefined
+  Accessibility?: Record<string, unknown> // I had to put type Record<string, unknown> so that getProfileStackConfig in DeeplinksGeneratorForm can take appAndMarketingParams, otherwise I would have just put undefined.
+  AccessibilityActionPlan?: undefined
+  AccessibilityDeclarationMobile?: undefined
+  AccessibilityDeclarationWeb?: undefined
+  AccessibilityEngagement?: undefined
+  RecommendedPaths?: undefined
 }
 
 export type CulturalSurveyRootStackParamList = {
@@ -244,6 +244,7 @@ export type RootStackParamList = {
   OfferPreview: { id: number; defaultIndex?: number }
   OnboardingSubscription: undefined
   PageNotFound: undefined
+  Profile: undefined
   ProfileStackNavigator?: {
     screen: ProfileStackRouteName
     params: ProfileStackParamList[ProfileStackRouteName]
@@ -348,7 +349,7 @@ export type GenericRoute<
   options?: { title?: string }
   secure?: boolean
 }
-export type RootRoute = GenericRoute<RootStackParamList, TabParamList>
+export type RootRoute = GenericRoute<RootStackParamList, TabParamList & ProfileStackParamList>
 
 // Typeguard for screen params
 export function isScreen<Screen extends AllNavigateParams[0]>(

--- a/src/features/navigation/TabBar/TabBar.native.test.tsx
+++ b/src/features/navigation/TabBar/TabBar.native.test.tsx
@@ -208,7 +208,7 @@ describe('TabBar', () => {
       setTabNavigationState: jest.fn(),
       tabRoutes: DEFAULT_TAB_ROUTES.map((route) => ({
         ...route,
-        isSelected: route.name === 'ProfileStackNavigator',
+        isSelected: route.name === 'Profile',
       })),
     })
     renderTabBar(mockTabNavigationState)
@@ -275,7 +275,7 @@ describe('TabBar', () => {
     await user.press(profileTab)
 
     expect(navigation.navigate).toHaveBeenCalledWith('TabNavigator', {
-      screen: 'ProfileStackNavigator',
+      screen: 'Profile',
       params: undefined,
     })
   })

--- a/src/features/navigation/TabBar/TabBar.tsx
+++ b/src/features/navigation/TabBar/TabBar.tsx
@@ -65,7 +65,7 @@ export const TabBar: React.FC<Props> = ({ navigation, state }) => {
               break
             case 'Bookings':
             case 'Favorites':
-            case 'ProfileStackNavigator':
+            case 'Profile':
               break
           }
           navigation.navigate('TabNavigator', navigateParams)

--- a/src/features/navigation/TabBar/TabNavigationStateContext.tsx
+++ b/src/features/navigation/TabBar/TabNavigationStateContext.tsx
@@ -11,7 +11,7 @@ export const DEFAULT_TAB_ROUTES: TabStateRoute[] = [
   { name: 'SearchStackNavigator', key: 'search-initial' },
   { name: 'Bookings', key: 'bookings-initial' },
   { name: 'Favorites', key: 'favorites-initial' },
-  { name: 'ProfileStackNavigator', key: 'profile-initial' },
+  { name: 'Profile', key: 'profile-initial' },
 ]
 const DEFAULT_TAB_NAVIGATION_STATE: TabNavigationStateType = {
   history: [],

--- a/src/features/navigation/TabBar/__mocks__/tabBarRoutes.ts
+++ b/src/features/navigation/TabBar/__mocks__/tabBarRoutes.ts
@@ -1,20 +1,10 @@
 import { LinkingOptions } from '@react-navigation/native'
 
-import { ProfileStackParamList } from 'features/navigation/ProfileStackNavigator/ProfileStack'
 import { ScreenNames } from 'features/navigation/RootNavigator/types'
 import { screenParamsParser } from 'features/navigation/screenParamsUtils'
 import { searchNavigatorPathConfig } from 'features/navigation/SearchStackNavigator/__mocks__/searchRoutes'
 
 import { TabParamList, TabRoute, TabRouteName } from '../types'
-
-const profileNavigatorPathConfig: LinkingOptions<ProfileStackParamList>['config'] = {
-  initialRouteName: 'Profile',
-  screens: {
-    Profile: {
-      path: 'profil',
-    },
-  },
-}
 
 export const tabNavigatorPathConfig: LinkingOptions<TabParamList>['config'] = {
   initialRouteName: 'Home',

--- a/src/features/navigation/TabBar/__mocks__/tabBarRoutes.ts
+++ b/src/features/navigation/TabBar/__mocks__/tabBarRoutes.ts
@@ -1,4 +1,4 @@
-import { LinkingOptions, PathConfig } from '@react-navigation/native'
+import { LinkingOptions } from '@react-navigation/native'
 
 import { ProfileStackParamList } from 'features/navigation/ProfileStackNavigator/ProfileStack'
 import { ScreenNames } from 'features/navigation/RootNavigator/types'
@@ -30,7 +30,9 @@ export const tabNavigatorPathConfig: LinkingOptions<TabParamList>['config'] = {
     Favorites: {
       path: 'favoris',
     },
-    ProfileStackNavigator: profileNavigatorPathConfig as PathConfig<ProfileStackParamList>, // without this, TS considers profileNavigatorPathConfig as invalid.
+    Profile: {
+      path: 'profil',
+    },
   },
 }
 const MockComponent = () => null
@@ -56,9 +58,9 @@ export const tabBarRoutes: Array<TabRoute> = [
     path: 'favoris',
   },
   {
-    name: 'ProfileStackNavigator',
+    name: 'Profile',
     component: MockComponent,
-    pathConfig: profileNavigatorPathConfig,
+    path: 'profil',
   },
 ]
 

--- a/src/features/navigation/TabBar/mapTabRouteToBicolorIcon.ts
+++ b/src/features/navigation/TabBar/mapTabRouteToBicolorIcon.ts
@@ -29,7 +29,7 @@ export function mapTabRouteToBicolorIcon({
       return BicolorBookingsIcon
     case 'Favorites':
       return BicolorFavorite
-    case 'ProfileStackNavigator':
+    case 'Profile':
       return BicolorTabBarProfile
     default:
       return BicolorLogo

--- a/src/features/navigation/TabBar/menu.ts
+++ b/src/features/navigation/TabBar/menu.ts
@@ -8,5 +8,5 @@ export const menu: Record<TabRouteName, { displayName: string; accessibilityLabe
   SearchStackNavigator: { displayName: 'Recherche', accessibilityLabel: 'Rechercher des offres' },
   Bookings: { displayName: 'Réservations', accessibilityLabel: 'Mes réservations' },
   Favorites: { displayName: 'Favoris', accessibilityLabel: isWeb ? undefined : 'Mes favoris' },
-  ProfileStackNavigator: { displayName: 'Profil', accessibilityLabel: 'Mon profil' },
+  Profile: { displayName: 'Profil', accessibilityLabel: 'Mon profil' },
 }

--- a/src/features/navigation/TabBar/tabBarRoutes.ts
+++ b/src/features/navigation/TabBar/tabBarRoutes.ts
@@ -4,12 +4,11 @@ import { Bookings } from 'features/bookings/pages/Bookings/Bookings'
 import { withAsyncErrorBoundary } from 'features/errors/hocs/withAsyncErrorBoundary'
 import { Favorites } from 'features/favorites/pages/Favorites'
 import { Home as HomeComponent } from 'features/home/pages/Home'
-import { profileNavigatorPathConfig } from 'features/navigation/ProfileStackNavigator/profileNavigatorPathConfig'
-import { SuspenseProfileStackNavigator } from 'features/navigation/ProfileStackNavigator/SuspenseProfileStackNavigator'
 import { getScreensAndConfig } from 'features/navigation/RootNavigator/linking/getScreensConfig'
 import { screenParamsParser } from 'features/navigation/screenParamsUtils'
 import { searchNavigatorPathConfig } from 'features/navigation/SearchStackNavigator/searchRoutes'
 import { SuspenseSearchStackNavigator } from 'features/navigation/SearchStackNavigator/SuspenseSearchStackNavigator'
+import { Profile } from 'features/profile/pages/Profile'
 
 import { TabStack } from './Stack'
 import { TabParamList, TabRoute, TabRouteName } from './types'
@@ -45,9 +44,10 @@ const tabBarRoutes: TabRoute[] = [
     options: { title: 'Mes favoris' },
   },
   {
-    name: 'ProfileStackNavigator',
-    component: SuspenseProfileStackNavigator,
-    pathConfig: profileNavigatorPathConfig,
+    name: 'Profile',
+    component: Profile,
+    path: 'profil',
+    options: { title: 'Mon profil' },
   },
 ]
 

--- a/src/features/navigation/TabBar/types.ts
+++ b/src/features/navigation/TabBar/types.ts
@@ -1,10 +1,6 @@
 import { TabNavigationState } from '@react-navigation/native'
 
 import { BookingsTab } from 'features/bookings/enum'
-import {
-  ProfileStackParamList,
-  ProfileStackRouteName,
-} from 'features/navigation/ProfileStackNavigator/ProfileStack'
 import { GenericRoute } from 'features/navigation/RootNavigator/types'
 import {
   SearchStackParamList,
@@ -23,10 +19,7 @@ export type TabParamList = {
   }
   Bookings: { activeTab?: BookingsTab } | undefined
   Favorites: undefined
-  ProfileStackNavigator?: {
-    screen: ProfileStackRouteName
-    params: ProfileStackParamList[ProfileStackRouteName]
-  }
+  Profile: undefined
 }
 
 export type TabNavigationStateType = TabNavigationState<TabParamList>

--- a/src/features/profile/api/useFeedback.ts
+++ b/src/features/profile/api/useFeedback.ts
@@ -3,13 +3,13 @@ import { useMutation } from 'react-query'
 
 import { api } from 'api/api'
 import { PostFeedbackBody } from 'api/gen'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 
 export const useFeedback = () => {
   const { navigate } = useNavigation<UseNavigationType>()
-  const navigateToProfile = () => navigate(...getProfileStackConfig('Profile'))
+  const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
   const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()
 
   return useMutation((body: PostFeedbackBody) => api.postNativeV1Feedback(body), {

--- a/src/features/profile/helpers/useChangeEmailMutation.native.test.ts
+++ b/src/features/profile/helpers/useChangeEmailMutation.native.test.ts
@@ -42,9 +42,9 @@ describe('useChangeEmailMutation', () => {
 
     await act(async () => changeEmail())
 
-    expect(replace).toHaveBeenCalledWith('TabNavigator', {
-      params: { params: undefined, screen: 'TrackEmailChange' },
-      screen: 'ProfileStackNavigator',
+    expect(replace).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'TrackEmailChange',
     })
   })
 

--- a/src/features/profile/pages/Accessibility/Accessibility.native.test.tsx
+++ b/src/features/profile/pages/Accessibility/Accessibility.native.test.tsx
@@ -35,9 +35,9 @@ describe('Accessibility', () => {
     const row = screen.getByText(title)
     await user.press(row)
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: { params: undefined, screen: route },
-      screen: 'ProfileStackNavigator',
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: route,
     })
   })
 })

--- a/src/features/profile/pages/Accessibility/Accessibility.tsx
+++ b/src/features/profile/pages/Accessibility/Accessibility.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { useGoBack } from 'features/navigation/useGoBack'
 import { AccessibleUnorderedList } from 'ui/components/accessibility/AccessibleUnorderedList'
 import { SectionRow } from 'ui/components/SectionRow'
 import { Separator } from 'ui/components/Separator'
@@ -48,8 +50,10 @@ const sections = [
 ]
 
 export function Accessibility() {
+  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+
   return (
-    <SecondaryPageWithBlurHeader title="Accessibilité" enableMaxWidth={false}>
+    <SecondaryPageWithBlurHeader title="Accessibilité" enableMaxWidth={false} onGoBack={goBack}>
       <AccessibleUnorderedList items={sections} Separator={<Separator.Horizontal />} />
     </SecondaryPageWithBlurHeader>
   )

--- a/src/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx
+++ b/src/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx
@@ -97,9 +97,9 @@ describe('ChangeCity', () => {
     })
 
     await waitFor(async () => {
-      expect(navigate).toHaveBeenNthCalledWith(1, 'TabNavigator', {
-        params: { params: undefined, screen: 'PersonalData' },
-        screen: 'ProfileStackNavigator',
+      expect(navigate).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
+        params: undefined,
+        screen: 'PersonalData',
       })
     })
   })

--- a/src/features/profile/pages/ChangeEmail/ChangeEmail.web.test.tsx
+++ b/src/features/profile/pages/ChangeEmail/ChangeEmail.web.test.tsx
@@ -54,14 +54,11 @@ describe('<ChangeEmail/>', () => {
       fireEvent.click(closeButton)
 
       await waitFor(() => {
-        expect(replace).toHaveBeenNthCalledWith(1, 'TabNavigator', {
+        expect(replace).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
           params: {
-            params: {
-              showModal: false,
-            },
-            screen: 'ChangeEmail',
+            showModal: false,
           },
-          screen: 'ProfileStackNavigator',
+          screen: 'ChangeEmail',
         })
       })
     })

--- a/src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx
+++ b/src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx
@@ -57,9 +57,9 @@ describe('<ChangeEmailExpiredLink />', () => {
     const resendEmailButton = screen.getByText('Faire une nouvelle demande')
     fireEvent.press(resendEmailButton)
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: { params: undefined, screen: 'ChangeEmail' },
-      screen: 'ProfileStackNavigator',
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'ChangeEmail',
     })
   })
 

--- a/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx
+++ b/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx
@@ -101,14 +101,11 @@ describe('<ChangeEmailSetPassword />', () => {
       fireEvent.press(await screen.findByLabelText('Créer mon mot de passe'))
     })
 
-    expect(replace).toHaveBeenCalledWith('TabNavigator', {
+    expect(replace).toHaveBeenCalledWith('ProfileStackNavigator', {
       params: {
-        params: {
-          token: 'email_selection_token',
-        },
-        screen: 'NewEmailSelection',
+        token: 'email_selection_token',
       },
-      screen: 'ProfileStackNavigator',
+      screen: 'NewEmailSelection',
     })
   })
 

--- a/src/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx
+++ b/src/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx
@@ -123,13 +123,7 @@ describe('ChangePassword', () => {
       message: 'Ton mot de passe est modifié',
       timeout: SNACK_BAR_TIME_OUT,
     })
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: {
-        params: undefined,
-        screen: 'Profile',
-      },
-      screen: 'ProfileStackNavigator',
-    })
+    expect(navigate).toHaveBeenCalledWith('TabNavigator', { screen: 'Profile' })
     expect(analytics.logHasChangedPassword).toHaveBeenCalledWith({
       from: 'personaldata',
       reason: 'changePassword',

--- a/src/features/profile/pages/ChangePassword/ChangePassword.tsx
+++ b/src/features/profile/pages/ChangePassword/ChangePassword.tsx
@@ -9,8 +9,8 @@ import { ApiError } from 'api/ApiError'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useChangePasswordMutation } from 'features/auth/queries/useChangePasswordMutation'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { changePasswordSchema } from 'features/profile/pages/ChangePassword/schema/changePasswordSchema'
 import { analytics } from 'libs/analytics/provider'
 import { eventMonitoring } from 'libs/monitoring/services'
@@ -81,7 +81,7 @@ export function ChangePassword() {
               message: 'Ton mot de passe est modifié',
               timeout: SNACK_BAR_TIME_OUT,
             })
-            navigate(...getProfileStackConfig('Profile'))
+            navigate(...getTabNavConfig('Profile'))
             analytics.logHasChangedPassword({ from: 'personaldata', reason: 'changePassword' })
             resolve()
           },

--- a/src/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx
+++ b/src/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx
@@ -84,9 +84,9 @@ describe('<ConfirmChangeEmail />', () => {
 
     await act(async () => userEvent.press(screen.getByText('Confirmer la demande')))
 
-    expect(replace).toHaveBeenCalledWith('TabNavigator', {
-      params: { params: { token: 'token' }, screen: 'NewEmailSelection' },
-      screen: 'ProfileStackNavigator',
+    expect(replace).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: { token: 'token' },
+      screen: 'NewEmailSelection',
     })
   })
 
@@ -101,12 +101,9 @@ describe('<ConfirmChangeEmail />', () => {
 
     await act(async () => userEvent.press(screen.getByText('Confirmer la demande')))
 
-    expect(replace).toHaveBeenCalledWith('TabNavigator', {
-      params: {
-        params: { token: 'reset_password_token', emailSelectionToken: 'token' },
-        screen: 'ChangeEmailSetPassword',
-      },
-      screen: 'ProfileStackNavigator',
+    expect(replace).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: { token: 'reset_password_token', emailSelectionToken: 'token' },
+      screen: 'ChangeEmailSetPassword',
     })
   })
 

--- a/src/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx
+++ b/src/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx
@@ -161,13 +161,7 @@ describe('<ConsentSettings/>', () => {
       message: 'Ton choix a bien été enregistré.',
       timeout: SNACK_BAR_TIME_OUT,
     })
-    expect(mockNavigate).toHaveBeenCalledWith('TabNavigator', {
-      params: {
-        params: undefined,
-        screen: 'Profile',
-      },
-      screen: 'ProfileStackNavigator',
-    })
+    expect(mockNavigate).toHaveBeenCalledWith('TabNavigator', { screen: 'Profile' })
   })
 })
 

--- a/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
+++ b/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
@@ -10,6 +10,7 @@ import { useCookies } from 'features/cookies/helpers/useCookies'
 import { CookiesChoiceByCategory } from 'features/cookies/types'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { useGoBack } from 'features/navigation/useGoBack'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
@@ -23,6 +24,8 @@ import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const ConsentSettings = () => {
   const { navigate } = useNavigation<UseNavigationType>()
+  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+
   const { showSuccessSnackBar } = useSnackBarContext()
   const { setCookiesConsent } = useCookies()
   const [settingsCookiesChoice, setSettingsCookiesChoice] = useState<CookiesChoiceByCategory>({
@@ -51,7 +54,7 @@ export const ConsentSettings = () => {
   }, [navigate, setCookiesConsent, settingsCookiesChoice, showSuccessSnackBar])
 
   return (
-    <SecondaryPageWithBlurHeader title="Paramètres de confidentialité" scrollable>
+    <SecondaryPageWithBlurHeader onGoBack={goBack} title="Paramètres de confidentialité" scrollable>
       <Typo.Body>
         L’application pass Culture utilise des outils et traceurs appelés cookies pour améliorer ton
         expérience de navigation.

--- a/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
+++ b/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
@@ -8,8 +8,8 @@ import { getCookiesChoiceFromCategories } from 'features/cookies/helpers/getCook
 import { startTrackingAcceptedCookies } from 'features/cookies/helpers/startTrackingAcceptedCookies'
 import { useCookies } from 'features/cookies/helpers/useCookies'
 import { CookiesChoiceByCategory } from 'features/cookies/types'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
@@ -47,7 +47,7 @@ export const ConsentSettings = () => {
       message: 'Ton choix a bien été enregistré.',
       timeout: SNACK_BAR_TIME_OUT,
     })
-    navigate(...getProfileStackConfig('Profile'))
+    navigate(...getTabNavConfig('Profile'))
   }, [navigate, setCookiesConsent, settingsCookiesChoice, showSuccessSnackBar])
 
   return (

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx
@@ -29,13 +29,7 @@ describe('DeleteProfileAccountHacked', () => {
 
     await user.press(button)
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: {
-        params: undefined,
-        screen: 'Profile',
-      },
-      screen: 'ProfileStackNavigator',
-    })
+    expect(navigate).toHaveBeenCalledWith('TabNavigator', { params: undefined, screen: 'Profile' })
   })
 
   it('should navigate to confirm delete profile on press Susprendre mon compte', async () => {

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx
@@ -38,12 +38,9 @@ describe('DeleteProfileAccountHacked', () => {
 
     await user.press(button)
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: {
-        params: undefined,
-        screen: 'SuspendAccountConfirmationWithoutAuthentication',
-      },
-      screen: 'ProfileStackNavigator',
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'SuspendAccountConfirmationWithoutAuthentication',
     })
   })
 })

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react'
 
 import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { InfoBanner } from 'ui/components/banners/InfoBanner'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
@@ -14,7 +15,7 @@ import { Typo } from 'ui/theme'
 export const DeleteProfileAccountHacked: FC = () => {
   const { navigate } = useNavigation<UseNavigationType>()
 
-  const navigateToProfile = () => navigate(...getProfileStackConfig('Profile'))
+  const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
 
   const navigateToSuspendAccount = () => {
     navigate(...getProfileStackConfig('SuspendAccountConfirmationWithoutAuthentication'))

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx
@@ -32,13 +32,7 @@ describe('DeleteProfileAccountNotDeletable', () => {
     const button = screen.getByText('Retourner sur mon profil')
     await user.press(button)
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: {
-        params: undefined,
-        screen: 'Profile',
-      },
-      screen: 'ProfileStackNavigator',
-    })
+    expect(navigate).toHaveBeenCalledWith('TabNavigator', { params: undefined, screen: 'Profile' })
   })
 
   it('should navigate to notifications settings on press Désactiver mes notifications', async () => {

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx
@@ -41,9 +41,9 @@ describe('DeleteProfileAccountNotDeletable', () => {
     const button = screen.getByText('Désactiver mes notifications')
     await user.press(button)
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: { params: undefined, screen: 'NotificationsSettings' },
-      screen: 'ProfileStackNavigator',
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'NotificationsSettings',
     })
   })
 

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 
 import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { env } from 'libs/environment/env'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
@@ -18,7 +19,7 @@ import { SPACE } from 'ui/theme/constants'
 export const DeleteProfileAccountNotDeletable: FC = () => {
   const { navigate } = useNavigation<UseNavigationType>()
 
-  const navigateToProfile = () => navigate(...getProfileStackConfig('Profile'))
+  const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
   const navigateToNotifications = () => navigate(...getProfileStackConfig('NotificationsSettings'))
 
   return (

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx
@@ -81,9 +81,9 @@ describe('DeleteProfileConfirmation', () => {
 
     fireEvent.press(screen.getByText('Annuler'))
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: { params: undefined, screen: 'DeleteProfileReason' },
-      screen: 'ProfileStackNavigator',
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'DeleteProfileReason',
     })
   })
 
@@ -94,9 +94,9 @@ describe('DeleteProfileConfirmation', () => {
     whenAnonymizeAccount()
 
     await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-        params: { params: undefined, screen: 'DeleteProfileSuccess' },
-        screen: 'ProfileStackNavigator',
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+        params: undefined,
+        screen: 'DeleteProfileSuccess',
       })
     })
   })

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.tsx
@@ -3,8 +3,8 @@ import React, { FC } from 'react'
 import { Platform } from 'react-native'
 import styled from 'styled-components/native'
 
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
 import { BicolorEmailSent } from 'ui/svg/icons/BicolorEmailSent'
@@ -23,7 +23,7 @@ export const DeleteProfileContactSupport: FC = () => {
   const { requestSendMail } = useContactSupportForDeletionProfile({ emailProvider })
   const { navigate } = useNavigation<UseNavigationType>()
 
-  const navigateToProfile = () => navigate(...getProfileStackConfig('Profile'))
+  const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
   return (
     <GenericInfoPageWhite
       withGoBack

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx
@@ -38,9 +38,9 @@ describe('DeleteProfileEmailHacked', () => {
 
     await user.press(button)
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: { params: undefined, screen: 'ChangeEmail' },
-      screen: 'ProfileStackNavigator',
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'ChangeEmail',
     })
   })
 
@@ -50,12 +50,9 @@ describe('DeleteProfileEmailHacked', () => {
 
     await user.press(button)
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: {
-        params: undefined,
-        screen: 'SuspendAccountConfirmationWithoutAuthentication',
-      },
-      screen: 'ProfileStackNavigator',
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'SuspendAccountConfirmationWithoutAuthentication',
     })
   })
 })

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx
@@ -29,13 +29,7 @@ describe('DeleteProfileEmailHacked', () => {
 
     await user.press(button)
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: {
-        params: undefined,
-        screen: 'Profile',
-      },
-      screen: 'ProfileStackNavigator',
-    })
+    expect(navigate).toHaveBeenCalledWith('TabNavigator', { params: undefined, screen: 'Profile' })
   })
 
   it('should navigate to change email on press Modifier mon adresse e-mail', async () => {

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react'
 
 import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
 import { Clear } from 'ui/svg/icons/Clear'
@@ -12,7 +13,7 @@ import { Typo } from 'ui/theme'
 export const DeleteProfileEmailHacked: FC = () => {
   const { navigate } = useNavigation<UseNavigationType>()
 
-  const navigateToProfile = () => navigate(...getProfileStackConfig('Profile'))
+  const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
 
   const navigateToChangeEmail = () => navigate(...getProfileStackConfig('ChangeEmail'))
 

--- a/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx
@@ -49,14 +49,11 @@ describe('<DeleteProfileReason />', () => {
     )
 
     await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
         params: {
-          params: {
-            showModal: true,
-          },
-          screen: 'ChangeEmail',
+          showModal: true,
         },
-        screen: 'ProfileStackNavigator',
+        screen: 'ChangeEmail',
       })
     })
   })
@@ -68,9 +65,9 @@ describe('<DeleteProfileReason />', () => {
     fireEvent.press(screen.getByText('Autre'))
 
     await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-        params: { params: undefined, screen: 'DeleteProfileContactSupport' },
-        screen: 'ProfileStackNavigator',
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+        params: undefined,
+        screen: 'DeleteProfileContactSupport',
       })
     })
   })
@@ -98,9 +95,9 @@ describe('<DeleteProfileReason />', () => {
       fireEvent.press(screen.getByText(reason))
 
       await waitFor(() => {
-        expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-          params: { params: undefined, screen: 'DeleteProfileConfirmation' },
-          screen: 'ProfileStackNavigator',
+        expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+          params: undefined,
+          screen: 'DeleteProfileConfirmation',
         })
       })
     }
@@ -121,9 +118,9 @@ describe('<DeleteProfileReason />', () => {
         fireEvent.press(screen.getByText(reason))
 
         await waitFor(() => {
-          expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-            params: { params: undefined, screen: 'DeleteProfileAccountNotDeletable' },
-            screen: 'ProfileStackNavigator',
+          expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+            params: undefined,
+            screen: 'DeleteProfileAccountNotDeletable',
           })
         })
       }
@@ -147,9 +144,9 @@ describe('<DeleteProfileReason />', () => {
           fireEvent.press(screen.getByText('Je n’utilise plus l’application'))
 
           await waitFor(() => {
-            expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-              params: { params: undefined, screen: expectedRedirect },
-              screen: 'ProfileStackNavigator',
+            expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+              params: undefined,
+              screen: expectedRedirect,
             })
           })
         }

--- a/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.tsx
+++ b/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { useOnViewableItemsChanged } from 'features/subscription/helpers/useOnViewableItemsChanged'
 import { analytics } from 'libs/analytics/provider'
@@ -92,7 +92,7 @@ export function DeleteProfileReason() {
   const canDeleteProfile = !user?.isBeneficiary || userIsDefinedAndAbove21
   const reasons = reasonButtons(!!canDeleteProfile)
   const { onViewableItemsChanged } = useOnViewableItemsChanged(gradientRef, reasons)
-  const { goBack } = useGoBack(...getProfileStackConfig('Profile'))
+  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
 
   return (
     <React.Fragment>

--- a/src/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx
+++ b/src/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx
@@ -68,11 +68,7 @@ describe('<FeedbackInApp/>', () => {
 
       await waitFor(async () => {
         expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-          params: {
-            params: undefined,
-            screen: 'Profile',
-          },
-          screen: 'ProfileStackNavigator',
+          screen: 'Profile',
         })
       })
     })

--- a/src/features/profile/pages/FeedbackInApp/FeedbackInApp.tsx
+++ b/src/features/profile/pages/FeedbackInApp/FeedbackInApp.tsx
@@ -5,6 +5,8 @@ import styled from 'styled-components/native'
 
 import { contactSupport } from 'features/auth/helpers/contactSupport'
 import { PageWithHeader } from 'features/identityCheck/components/layout/PageWithHeader'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { useGoBack } from 'features/navigation/useGoBack'
 import { useFeedback } from 'features/profile/api/useFeedback'
 import {
   FEEDBACK_IN_APP_VALUE_MAX_LENGTH,
@@ -40,9 +42,12 @@ export const FeedbackInApp = () => {
     sendFeedback({ feedback })
   }
 
+  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+
   return (
     <PageWithHeader
       title="Faire une suggestion"
+      onGoBack={goBack}
       scrollChildren={
         <React.Fragment>
           <Typo.Title3 {...getHeadingAttrs(1)}>

--- a/src/features/profile/pages/LegalNotices/LegalNotices.tsx
+++ b/src/features/profile/pages/LegalNotices/LegalNotices.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { contactSupport } from 'features/auth/helpers/contactSupport'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { useGoBack } from 'features/navigation/useGoBack'
 import { env } from 'libs/environment/env'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
 import { SectionRow } from 'ui/components/SectionRow'
@@ -16,8 +18,10 @@ import { LINE_BREAK, SECTION_ROW_ICON_SIZE } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export function LegalNotices() {
+  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+
   return (
-    <SecondaryPageWithBlurHeader title="Informations légales" scrollable>
+    <SecondaryPageWithBlurHeader title="Informations légales" onGoBack={goBack} scrollable>
       <TitleText>Mentions légales</TitleText>
       <Spacer.Column numberOfSpaces={4} />
       <Typo.Body>

--- a/src/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx
+++ b/src/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx
@@ -69,9 +69,9 @@ describe('<NewEmailSelection />', () => {
       fireEvent.press(await screen.findByLabelText('Modifier mon adresse e-mail'))
     })
 
-    expect(replace).toHaveBeenCalledWith('TabNavigator', {
-      params: { params: undefined, screen: 'TrackEmailChange' },
-      screen: 'ProfileStackNavigator',
+    expect(replace).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'TrackEmailChange',
     })
   })
 

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -4,7 +4,7 @@ import { PermissionStatus } from 'react-native-permissions'
 import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { PushNotificationsModal } from 'features/notifications/pages/PushNotificationsModal'
 import { usePatchProfile } from 'features/profile/api/usePatchProfile'
@@ -139,7 +139,7 @@ export const NotificationsSettings = () => {
     }
   }
 
-  const { goBack } = useGoBack(...getProfileStackConfig('Profile'))
+  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
 
   return (
     <SecondaryPageWithBlurHeader

--- a/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.tsx
+++ b/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
@@ -21,9 +21,7 @@ export const UnsavedSettingsModal: FunctionComponent<Props> = ({
   dismissModal,
   onPressSaveChanges,
 }) => {
-  const { goBack: goBackAndLeaveNotificationsSettings } = useGoBack(
-    ...getProfileStackConfig('Profile')
-  )
+  const { goBack: goBackAndLeaveNotificationsSettings } = useGoBack(...getTabNavConfig('Profile'))
 
   return (
     <AppModal

--- a/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
@@ -171,9 +171,9 @@ describe('PersonalData', () => {
 
     fireEvent.press(await screen.findByTestId('Modifier la ville de résidence'))
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: { params: undefined, screen: 'ChangeCity' },
-      screen: 'ProfileStackNavigator',
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'ChangeCity',
     })
   })
 

--- a/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
@@ -156,9 +156,9 @@ describe('PersonalData', () => {
 
     fireEvent.press(await screen.findByTestId('Modifier mot de passe'))
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: { params: undefined, screen: 'ChangePassword' },
-      screen: 'ProfileStackNavigator',
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'ChangePassword',
     })
   })
 
@@ -192,9 +192,9 @@ describe('PersonalData', () => {
 
     await waitFor(() => {
       expect(analytics.logAccountDeletion).toHaveBeenCalledTimes(1)
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-        params: { params: undefined, screen: 'DeleteProfileReason' },
-        screen: 'ProfileStackNavigator',
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+        params: undefined,
+        screen: 'DeleteProfileReason',
       })
     })
   })

--- a/src/features/profile/pages/PersonalData/PersonalData.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.tsx
@@ -5,6 +5,8 @@ import { ActivityIdEnum } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
 import { ProfileNavigateParams } from 'features/navigation/RootNavigator/types'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { useGoBack } from 'features/navigation/useGoBack'
 import { EditButton } from 'features/profile/components/Buttons/EditButton/EditButton'
 import { useCheckHasCurrentEmailChange } from 'features/profile/helpers/useCheckHasCurrentEmailChange'
 import { analytics } from 'libs/analytics/provider'
@@ -38,6 +40,8 @@ const ACTIVITIES: Record<ActivityIdEnum, string> = {
 
 export function PersonalData() {
   const { user } = useAuthContext()
+  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+
   const fullname = String(user?.firstName + ' ' + user?.lastName).trim()
   const hasCity = user?.postalCode && user?.city
   const city = hasCity && user?.postalCode && user?.city ? `${user.postalCode}, ${user.city}` : ''
@@ -50,7 +54,7 @@ export function PersonalData() {
   }, [hasCurrentEmailChange])
 
   return (
-    <SecondaryPageWithBlurHeader title="Informations personnelles">
+    <SecondaryPageWithBlurHeader onGoBack={goBack} title="Informations personnelles">
       {user?.isBeneficiary ? (
         <React.Fragment>
           <CaptionNeutralInfo>Prénom et nom</CaptionNeutralInfo>

--- a/src/features/profile/pages/Profile.native.test.tsx
+++ b/src/features/profile/pages/Profile.native.test.tsx
@@ -211,9 +211,9 @@ describe('Profile component', () => {
       const row = screen.getByText('Informations personnelles')
       await user.press(row)
 
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-        params: { params: undefined, screen: 'PersonalData' },
-        screen: 'ProfileStackNavigator',
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+        params: undefined,
+        screen: 'PersonalData',
       })
     })
 
@@ -302,9 +302,9 @@ describe('Profile component', () => {
       const notificationsButton = screen.getByText('Notifications')
       await user.press(notificationsButton)
 
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-        params: { params: undefined, screen: 'NotificationsSettings' },
-        screen: 'ProfileStackNavigator',
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+        params: undefined,
+        screen: 'NotificationsSettings',
       })
     })
   })
@@ -386,9 +386,9 @@ describe('Profile component', () => {
       const accessibilityButton = screen.getByText('Accessibilité')
       await user.press(accessibilityButton)
 
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-        params: { params: undefined, screen: 'Accessibility' },
-        screen: 'ProfileStackNavigator',
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+        params: undefined,
+        screen: 'Accessibility',
       })
     })
 
@@ -398,9 +398,9 @@ describe('Profile component', () => {
       const legalNoticesButton = screen.getByText('Informations légales')
       await user.press(legalNoticesButton)
 
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-        params: { params: undefined, screen: 'LegalNotices' },
-        screen: 'ProfileStackNavigator',
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+        params: undefined,
+        screen: 'LegalNotices',
       })
     })
 
@@ -410,9 +410,9 @@ describe('Profile component', () => {
       const legalNoticesButton = screen.getByText('Faire une suggestion')
       await user.press(legalNoticesButton)
 
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-        params: { params: undefined, screen: 'FeedbackInApp' },
-        screen: 'ProfileStackNavigator',
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+        params: undefined,
+        screen: 'FeedbackInApp',
       })
     })
 
@@ -422,9 +422,9 @@ describe('Profile component', () => {
       const confidentialityButton = screen.getByText('Confidentialité')
       await user.press(confidentialityButton)
 
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-        params: { params: undefined, screen: 'ConsentSettings' },
-        screen: 'ProfileStackNavigator',
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+        params: undefined,
+        screen: 'ConsentSettings',
       })
     })
   })

--- a/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.native.test.tsx
+++ b/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.native.test.tsx
@@ -123,9 +123,9 @@ describe('<SuspendAccountConfirmation />', () => {
     fireEvent.press(screen.getByText('Oui, suspendre mon compte'))
 
     await waitFor(() => {
-      expect(navigation.navigate).toHaveBeenNthCalledWith(1, 'TabNavigator', {
-        params: { params: undefined, screen: 'TrackEmailChange' },
-        screen: 'ProfileStackNavigator',
+      expect(navigation.navigate).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
+        params: undefined,
+        screen: 'TrackEmailChange',
       })
     })
   })

--- a/src/features/profile/pages/TrackEmailChange/TrackEmailChange.tsx
+++ b/src/features/profile/pages/TrackEmailChange/TrackEmailChange.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Platform, ScrollView } from 'react-native'
 import styled from 'styled-components/native'
 
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { TrackEmailChangeContent } from 'features/profile/pages/TrackEmailChange/TrackEmailChangeContent'
 import { BackButton } from 'ui/components/headers/BackButton'
@@ -13,7 +13,7 @@ const HEADER_HEIGHT = getSpacing(8)
 
 export function TrackEmailChange() {
   const { top } = useCustomSafeInsets()
-  const { goBack } = useGoBack(...getProfileStackConfig('Profile'))
+  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
 
   return (
     <StyledScrollViewContainer>

--- a/src/features/profile/pages/TrackEmailChange/TrackEmailChangeContent.native.test.tsx
+++ b/src/features/profile/pages/TrackEmailChange/TrackEmailChangeContent.native.test.tsx
@@ -57,14 +57,11 @@ describe('TrackEmailChangeContent', () => {
 
     fireEvent.press(await screen.findByText('Choisis ta nouvelle adresse e-mail'))
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
       params: {
-        params: {
-          token: 'new_email_selection_token',
-        },
-        screen: 'NewEmailSelection',
+        token: 'new_email_selection_token',
       },
-      screen: 'ProfileStackNavigator',
+      screen: 'NewEmailSelection',
     })
   })
 
@@ -126,15 +123,12 @@ describe('TrackEmailChangeContent', () => {
 
       fireEvent.press(await screen.findByText('Crée ton mot de passe'))
 
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
         params: {
-          params: {
-            emailSelectionToken: 'new_email_selection_token',
-            token: 'reset_password_token',
-          },
-          screen: 'ChangeEmailSetPassword',
+          emailSelectionToken: 'new_email_selection_token',
+          token: 'reset_password_token',
         },
-        screen: 'ProfileStackNavigator',
+        screen: 'ChangeEmailSetPassword',
       })
     })
   })

--- a/src/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx
+++ b/src/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx
@@ -42,9 +42,9 @@ describe('<SubscriptionSuccessModal />', () => {
     fireEvent.press(screen.getByText('Voir mes préférences'))
 
     await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-        params: { params: undefined, screen: 'NotificationsSettings' },
-        screen: 'ProfileStackNavigator',
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+        params: undefined,
+        screen: 'NotificationsSettings',
       })
     })
   })

--- a/src/shared/AccessibilityFooter/AccessibilityFooter.web.test.tsx
+++ b/src/shared/AccessibilityFooter/AccessibilityFooter.web.test.tsx
@@ -35,9 +35,9 @@ describe('AccessibilityFooter', () => {
 
     fireEvent.click(passCultureButton)
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: { params: undefined, screen: 'Accessibility' },
-      screen: 'ProfileStackNavigator',
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'Accessibility',
     })
   })
 
@@ -47,9 +47,9 @@ describe('AccessibilityFooter', () => {
 
     fireEvent.click(passCultureButton)
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: { params: undefined, screen: 'LegalNotices' },
-      screen: 'ProfileStackNavigator',
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'LegalNotices',
     })
   })
 })

--- a/src/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx
+++ b/src/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx
@@ -38,13 +38,7 @@ describe('<ErrorApplicationModal />', () => {
     await user.press(screen.getByLabelText('Aller vers la section profil'))
 
     expect(hideModal).toHaveBeenCalledTimes(1)
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: {
-        params: undefined,
-        screen: 'Profile',
-      },
-      screen: 'ProfileStackNavigator',
-    })
+    expect(navigate).toHaveBeenCalledWith('TabNavigator', { screen: 'Profile' })
   })
 
   it('should log analytics when clicking on close button with label "Aller vers la section profil', async () => {

--- a/src/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.tsx
+++ b/src/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.tsx
@@ -2,8 +2,8 @@ import { useNavigation } from '@react-navigation/native'
 import React, { FunctionComponent, useCallback } from 'react'
 import styled from 'styled-components/native'
 
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { Referrals, UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { AddToFavoritesButton } from 'features/offer/components/AddToFavoritesButton/AddToFavoritesButton'
 import { analytics } from 'libs/analytics/provider'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
@@ -36,7 +36,7 @@ export const ErrorApplicationModal: FunctionComponent<Props> = ({
   const navigateToProfile = () => {
     analytics.logGoToProfil({ from: 'ErrorApplicationModal', offerId })
     hideModal()
-    navigate(...getProfileStackConfig('Profile'))
+    navigate(...getTabNavConfig('Profile'))
   }
 
   return (


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35379

We had a tabbar at the bottom of subscreen of the Profile since a dedicated Profile stack was created and placed in the TabNavigator.
To fix this we moved the ProfileStack to the RootNavigator, took the Profile screen out of the the ProfileStack and put it back in the TabNavigator directly.
As a side-effect of the fix, some of the goBacks of the subscreens of Profile would navigate to the Home. We added custom goBacks in those cases.
Now there are no longer tabbars at the bottom of subscreens of the Profile

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
