### PR TITLE
(PC-35361) feat(offer): add interaction tag to use it in playlist

### DIFF
--- a/src/features/offer/components/InteractionTag/InteractionTag.native.test.tsx
+++ b/src/features/offer/components/InteractionTag/InteractionTag.native.test.tsx
@@ -2,77 +2,20 @@ import React from 'react'
 
 import { InteractionTag } from 'features/offer/components/InteractionTag/InteractionTag'
 import { render, screen } from 'tests/utils'
+import { theme } from 'theme'
 
 describe('<InteractionTag />', () => {
-  it('should not return interaction tag when no counter defined', () => {
-    render(<InteractionTag />)
+  it('should display the correct label', () => {
+    render(<InteractionTag label="Recommended" backgroundColor={theme.colors.goldLight100} />)
 
-    expect(screen.toJSON()).toBeNull()
+    expect(screen.getByText('Recommended')).toBeOnTheScreen()
   })
 
-  it('should not return interaction tag when all counter defined at 0', () => {
-    render(<InteractionTag chroniclesCount={0} headlineCount={0} likesCount={0} />)
+  it('should apply the correct background color', () => {
+    render(<InteractionTag label="Book Club" backgroundColor={theme.colors.skyBlueLight} />)
 
-    expect(screen.toJSON()).toBeNull()
-  })
-
-  it('should return headline tag when headline counter defined and likes counter < 20', () => {
-    render(<InteractionTag headlineCount={10} likesCount={19} />)
-
-    expect(screen.getByText('Reco par les lieux')).toBeOnTheScreen()
-  })
-
-  it('should return likes tag when headline counter defined and likes counter = 20', () => {
-    render(<InteractionTag headlineCount={10} likesCount={20} />)
-
-    expect(screen.getByText('20 j’aime')).toBeOnTheScreen()
-  })
-
-  it('should return likes tag when headline counter defined and likes counter > 20', () => {
-    render(<InteractionTag headlineCount={10} likesCount={21} />)
-
-    expect(screen.getByText('21 j’aime')).toBeOnTheScreen()
-  })
-
-  it('should return book club tag when headline counter, chronicles counter defined and likes counter < 50', () => {
-    render(<InteractionTag headlineCount={10} chroniclesCount={10} likesCount={49} />)
-
-    expect(screen.getByText('Reco du Book Club')).toBeOnTheScreen()
-  })
-
-  it('should return likes tag when headline counter, chronicles counter defined and likes counter = 50', () => {
-    render(<InteractionTag headlineCount={10} chroniclesCount={10} likesCount={50} />)
-
-    expect(screen.getByText('50 j’aime')).toBeOnTheScreen()
-  })
-
-  it('should return likes tag when headline counter, chronicles counter defined and likes counter > 50', () => {
-    render(<InteractionTag headlineCount={10} chroniclesCount={10} likesCount={51} />)
-
-    expect(screen.getByText('51 j’aime')).toBeOnTheScreen()
-  })
-
-  it('should return likes tag when likes counter defined and counter > 0', () => {
-    render(<InteractionTag likesCount={18} />)
-
-    expect(screen.getByText('18 j’aime')).toBeOnTheScreen()
-  })
-
-  it('should return book club tag when book club counter defined and counter > 0', () => {
-    render(<InteractionTag chroniclesCount={5} />)
-
-    expect(screen.getByText('Reco du Book Club')).toBeOnTheScreen()
-  })
-
-  it('should return book club tag when book club and headline counters defined and counters > 0', () => {
-    render(<InteractionTag chroniclesCount={5} headlineCount={5} />)
-
-    expect(screen.getByText('Reco du Book Club')).toBeOnTheScreen()
-  })
-
-  it('should return headline tag when headline counter defined and counter > 0', () => {
-    render(<InteractionTag headlineCount={5} />)
-
-    expect(screen.getByText('Reco par les lieux')).toBeOnTheScreen()
+    expect(screen.getByTestId('interaction-tag')).toHaveStyle({
+      backgroundColor: theme.colors.skyBlueLight,
+    })
   })
 })

--- a/src/features/offer/components/InteractionTag/InteractionTag.native.test.tsx
+++ b/src/features/offer/components/InteractionTag/InteractionTag.native.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+
+import { InteractionTag } from 'features/offer/components/InteractionTag/InteractionTag'
+import { render, screen } from 'tests/utils'
+
+describe('<InteractionTag />', () => {
+  it('should not return interaction tag when no counter defined', () => {
+    render(<InteractionTag />)
+
+    expect(screen.toJSON()).toBeNull()
+  })
+
+  it('should not return interaction tag when all counter defined at 0', () => {
+    render(<InteractionTag chroniclesCount={0} headlineCount={0} likesCount={0} />)
+
+    expect(screen.toJSON()).toBeNull()
+  })
+
+  it('should return headline tag when headline counter defined and likes counter < 20', () => {
+    render(<InteractionTag headlineCount={10} likesCount={19} />)
+
+    expect(screen.getByText('Reco par les lieux')).toBeOnTheScreen()
+  })
+
+  it('should return likes tag when headline counter defined and likes counter = 20', () => {
+    render(<InteractionTag headlineCount={10} likesCount={20} />)
+
+    expect(screen.getByText('20 j’aime')).toBeOnTheScreen()
+  })
+
+  it('should return likes tag when headline counter defined and likes counter > 20', () => {
+    render(<InteractionTag headlineCount={10} likesCount={21} />)
+
+    expect(screen.getByText('21 j’aime')).toBeOnTheScreen()
+  })
+
+  it('should return book club tag when headline counter, chronicles counter defined and likes counter < 50', () => {
+    render(<InteractionTag headlineCount={10} chroniclesCount={10} likesCount={49} />)
+
+    expect(screen.getByText('Reco du Book Club')).toBeOnTheScreen()
+  })
+
+  it('should return likes tag when headline counter, chronicles counter defined and likes counter = 50', () => {
+    render(<InteractionTag headlineCount={10} chroniclesCount={10} likesCount={50} />)
+
+    expect(screen.getByText('50 j’aime')).toBeOnTheScreen()
+  })
+
+  it('should return likes tag when headline counter, chronicles counter defined and likes counter > 50', () => {
+    render(<InteractionTag headlineCount={10} chroniclesCount={10} likesCount={51} />)
+
+    expect(screen.getByText('51 j’aime')).toBeOnTheScreen()
+  })
+
+  it('should return likes tag when likes counter defined and counter > 0', () => {
+    render(<InteractionTag likesCount={18} />)
+
+    expect(screen.getByText('18 j’aime')).toBeOnTheScreen()
+  })
+
+  it('should return book club tag when book club counter defined and counter > 0', () => {
+    render(<InteractionTag chroniclesCount={5} />)
+
+    expect(screen.getByText('Reco du Book Club')).toBeOnTheScreen()
+  })
+
+  it('should return book club tag when book club and headline counters defined and counters > 0', () => {
+    render(<InteractionTag chroniclesCount={5} headlineCount={5} />)
+
+    expect(screen.getByText('Reco du Book Club')).toBeOnTheScreen()
+  })
+
+  it('should return headline tag when headline counter defined and counter > 0', () => {
+    render(<InteractionTag headlineCount={5} />)
+
+    expect(screen.getByText('Reco par les lieux')).toBeOnTheScreen()
+  })
+})

--- a/src/features/offer/components/InteractionTag/InteractionTag.tsx
+++ b/src/features/offer/components/InteractionTag/InteractionTag.tsx
@@ -1,84 +1,27 @@
 import React, { FunctionComponent } from 'react'
-import styled, { useTheme } from 'styled-components/native'
 
 import { Tag } from 'ui/components/Tag/Tag'
-import { BookClubCertification } from 'ui/svg/BookClubCertification'
-import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
-import { Star } from 'ui/svg/Star'
+import { AccessibleIcon, ColorsTypeLegacy } from 'ui/svg/icons/types'
 import { getSpacing } from 'ui/theme'
 
-type Props = {
-  likesCount?: number
-  chroniclesCount?: number
-  headlineCount?: number
+export type InteractionTagProps = {
+  label: string
+  backgroundColor?: ColorsTypeLegacy
+  Icon?: React.FunctionComponent<AccessibleIcon> | undefined
 }
 
-export const InteractionTag: FunctionComponent<Props> = ({
-  likesCount,
-  chroniclesCount,
-  headlineCount,
+export const InteractionTag: FunctionComponent<InteractionTagProps> = ({
+  label,
+  backgroundColor,
+  Icon,
 }) => {
-  const { colors } = useTheme()
-
-  const getTagConfig = (likesCount?: number, chroniclesCount?: number, headlineCount?: number) => {
-    const headlineTagConfig = {
-      label: 'Reco par les lieux',
-      backgroundColor: colors.goldLight100,
-      Icon: CustomStar,
-    }
-    const likesTagConfig = {
-      label: likesCount ? `${likesCount} j’aime` : '',
-      backgroundColor: colors.white,
-      Icon: CustomThumbUp,
-    }
-    const bookClubTagConfig = {
-      label: 'Reco du Book Club',
-      backgroundColor: colors.skyBlueLight,
-      Icon: CustomBookClub,
-    }
-
-    const hasHeadline = !!headlineCount
-    const hasChronicles = !!chroniclesCount
-    const hasLikes = !!likesCount
-
-    if (hasHeadline && !hasChronicles) {
-      return likesCount && likesCount >= 20 ? likesTagConfig : headlineTagConfig
-    }
-
-    if (hasHeadline && hasChronicles) {
-      return likesCount && likesCount >= 50 ? likesTagConfig : bookClubTagConfig
-    }
-
-    if (hasLikes) return likesTagConfig
-    if (hasChronicles) return bookClubTagConfig
-    if (hasHeadline) return headlineTagConfig
-
-    return null
-  }
-
-  const tagConfig = getTagConfig(likesCount, chroniclesCount, headlineCount)
-
-  if (!tagConfig) return null
-
   return (
     <Tag
-      label={tagConfig.label}
-      backgroundColor={tagConfig.backgroundColor}
-      Icon={tagConfig.Icon}
+      testID="interaction-tag"
+      label={label}
+      backgroundColor={backgroundColor}
+      Icon={Icon}
       paddingHorizontal={getSpacing(1)}
     />
   )
 }
-
-const CustomThumbUp = styled(ThumbUpFilled).attrs(({ theme }) => ({
-  size: theme.icons.sizes.extraSmall,
-  color: theme.colors.primary,
-}))``
-
-const CustomBookClub = styled(BookClubCertification).attrs(({ theme }) => ({
-  size: theme.icons.sizes.extraSmall,
-}))``
-
-const CustomStar = styled(Star).attrs(({ theme }) => ({
-  size: theme.icons.sizes.extraSmall,
-}))``

--- a/src/features/offer/components/InteractionTag/InteractionTag.tsx
+++ b/src/features/offer/components/InteractionTag/InteractionTag.tsx
@@ -5,6 +5,7 @@ import { Tag } from 'ui/components/Tag/Tag'
 import { BookClubCertification } from 'ui/svg/BookClubCertification'
 import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
 import { Star } from 'ui/svg/Star'
+import { getSpacing } from 'ui/theme'
 
 type Props = {
   likesCount?: number
@@ -64,6 +65,7 @@ export const InteractionTag: FunctionComponent<Props> = ({
       label={tagConfig.label}
       backgroundColor={tagConfig.backgroundColor}
       Icon={tagConfig.Icon}
+      paddingHorizontal={getSpacing(1)}
     />
   )
 }

--- a/src/features/offer/components/InteractionTag/InteractionTag.tsx
+++ b/src/features/offer/components/InteractionTag/InteractionTag.tsx
@@ -7,7 +7,7 @@ import { getSpacing } from 'ui/theme'
 export type InteractionTagProps = {
   label: string
   backgroundColor?: ColorsTypeLegacy
-  Icon?: React.FunctionComponent<AccessibleIcon> | undefined
+  Icon?: React.FunctionComponent<AccessibleIcon>
 }
 
 export const InteractionTag: FunctionComponent<InteractionTagProps> = ({

--- a/src/features/offer/components/InteractionTag/InteractionTag.tsx
+++ b/src/features/offer/components/InteractionTag/InteractionTag.tsx
@@ -1,0 +1,82 @@
+import React, { FunctionComponent } from 'react'
+import styled, { useTheme } from 'styled-components/native'
+
+import { Tag } from 'ui/components/Tag/Tag'
+import { BookClubCertification } from 'ui/svg/BookClubCertification'
+import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
+import { Star } from 'ui/svg/Star'
+
+type Props = {
+  likesCount?: number
+  chroniclesCount?: number
+  headlineCount?: number
+}
+
+export const InteractionTag: FunctionComponent<Props> = ({
+  likesCount,
+  chroniclesCount,
+  headlineCount,
+}) => {
+  const { colors } = useTheme()
+
+  const getTagConfig = (likesCount?: number, chroniclesCount?: number, headlineCount?: number) => {
+    const headlineTagConfig = {
+      label: 'Reco par les lieux',
+      backgroundColor: colors.goldLight100,
+      Icon: CustomStar,
+    }
+    const likesTagConfig = {
+      label: likesCount ? `${likesCount} j’aime` : '',
+      backgroundColor: colors.white,
+      Icon: CustomThumbUp,
+    }
+    const bookClubTagConfig = {
+      label: 'Reco du Book Club',
+      backgroundColor: colors.skyBlueLight,
+      Icon: CustomBookClub,
+    }
+
+    const hasHeadline = !!headlineCount
+    const hasChronicles = !!chroniclesCount
+    const hasLikes = !!likesCount
+
+    if (hasHeadline && !hasChronicles) {
+      return likesCount && likesCount >= 20 ? likesTagConfig : headlineTagConfig
+    }
+
+    if (hasHeadline && hasChronicles) {
+      return likesCount && likesCount >= 50 ? likesTagConfig : bookClubTagConfig
+    }
+
+    if (hasLikes) return likesTagConfig
+    if (hasChronicles) return bookClubTagConfig
+    if (hasHeadline) return headlineTagConfig
+
+    return null
+  }
+
+  const tagConfig = getTagConfig(likesCount, chroniclesCount, headlineCount)
+
+  if (!tagConfig) return null
+
+  return (
+    <Tag
+      label={tagConfig.label}
+      backgroundColor={tagConfig.backgroundColor}
+      Icon={tagConfig.Icon}
+    />
+  )
+}
+
+const CustomThumbUp = styled(ThumbUpFilled).attrs(({ theme }) => ({
+  size: theme.icons.sizes.extraSmall,
+  color: theme.colors.primary,
+}))``
+
+const CustomBookClub = styled(BookClubCertification).attrs(({ theme }) => ({
+  size: theme.icons.sizes.extraSmall,
+}))``
+
+const CustomStar = styled(Star).attrs(({ theme }) => ({
+  size: theme.icons.sizes.extraSmall,
+}))``

--- a/src/features/offer/components/InteractionTag/getTagConfig.test.ts
+++ b/src/features/offer/components/InteractionTag/getTagConfig.test.ts
@@ -1,0 +1,64 @@
+import { getTagConfig } from 'features/offer/components/InteractionTag/getTagConfig'
+import { theme } from 'theme'
+
+describe('getTagConfig', () => {
+  it('should return null if no parameters are provided', () => {
+    expect(getTagConfig({ theme })).toEqual(null)
+  })
+
+  it('should return the "Reco par les lieux" tag if headlineCount is set and chroniclesCount is absent', () => {
+    expect(getTagConfig({ theme, headlineCount: 1 })).toEqual({
+      label: 'Reco par les lieux',
+      backgroundColor: theme.colors.goldLight100,
+      Icon: expect.anything(),
+    })
+  })
+
+  it('should return the "Reco par les lieux" tag if headlineCount is set but likesCount is lower than MIN_LIKES_VALUE', () => {
+    expect(getTagConfig({ theme, headlineCount: 1, likesCount: 10 })).toEqual({
+      label: 'Reco par les lieux',
+      backgroundColor: theme.colors.goldLight100,
+      Icon: expect.anything(),
+    })
+  })
+
+  it('should return the "j’aime" tag if headlineCount is set and likesCount is >= MIN_LIKES_VALUE', () => {
+    expect(getTagConfig({ theme, headlineCount: 1, likesCount: 20 })).toEqual({
+      label: '20 j’aime',
+      backgroundColor: theme.colors.white,
+      Icon: expect.anything(),
+    })
+  })
+
+  it('should return the "Reco du Book Club" tag if both headlineCount and chroniclesCount are set and likesCount is < MAX_LIKES_VALUE', () => {
+    expect(getTagConfig({ theme, headlineCount: 1, chroniclesCount: 1, likesCount: 40 })).toEqual({
+      label: 'Reco du Book Club',
+      backgroundColor: theme.colors.skyBlueLight,
+      Icon: expect.anything(),
+    })
+  })
+
+  it('should return the "j’aime" tag if both headlineCount and chroniclesCount are set and likesCount is >= MAX_LIKES_VALUE', () => {
+    expect(getTagConfig({ theme, headlineCount: 1, chroniclesCount: 1, likesCount: 50 })).toEqual({
+      label: '50 j’aime',
+      backgroundColor: theme.colors.white,
+      Icon: expect.anything(),
+    })
+  })
+
+  it('should return the "j’aime" tag if likesCount is set without headlineCount or chroniclesCount', () => {
+    expect(getTagConfig({ theme, likesCount: 15 })).toEqual({
+      label: '15 j’aime',
+      backgroundColor: theme.colors.white,
+      Icon: expect.anything(),
+    })
+  })
+
+  it('should return the "Reco du Book Club" tag if chroniclesCount is set without headlineCount or likesCount', () => {
+    expect(getTagConfig({ theme, chroniclesCount: 1 })).toEqual({
+      label: 'Reco du Book Club',
+      backgroundColor: theme.colors.skyBlueLight,
+      Icon: expect.anything(),
+    })
+  })
+})

--- a/src/features/offer/components/InteractionTag/getTagConfig.test.ts
+++ b/src/features/offer/components/InteractionTag/getTagConfig.test.ts
@@ -6,7 +6,7 @@ describe('getTagConfig', () => {
     expect(getTagConfig({ theme })).toEqual(null)
   })
 
-  it('should return the "Reco par les lieux" tag if headlineCount is set and chroniclesCount is absent', () => {
+  it('should return the "Reco par les lieux" tag if headlineCount is set and chroniclesCount is not set', () => {
     expect(getTagConfig({ theme, headlineCount: 1 })).toEqual({
       label: 'Reco par les lieux',
       backgroundColor: theme.colors.goldLight100,

--- a/src/features/offer/components/InteractionTag/getTagConfig.tsx
+++ b/src/features/offer/components/InteractionTag/getTagConfig.tsx
@@ -13,7 +13,7 @@ type TagConfig = {
   headlineCount?: number
 }
 
-// TODO(PC-0000) handle logic values with remote config
+// TODO(PC-35427) handle logic values with remote config
 const MIN_LIKES_VALUE = 20
 const MAX_LIKES_VALUE = 50
 

--- a/src/features/offer/components/InteractionTag/getTagConfig.tsx
+++ b/src/features/offer/components/InteractionTag/getTagConfig.tsx
@@ -1,0 +1,72 @@
+import styled from 'styled-components/native'
+
+import { InteractionTagProps } from 'features/offer/components/InteractionTag/InteractionTag'
+import { theme } from 'theme'
+import { BookClubCertification } from 'ui/svg/BookClubCertification'
+import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
+import { Star } from 'ui/svg/Star'
+
+export type TagConfig = {
+  theme: typeof theme
+  likesCount?: number
+  chroniclesCount?: number
+  headlineCount?: number
+}
+
+// TODO(PC-0000) handle logic values with remote config
+const MIN_LIKES_VALUE = 20
+const MAX_LIKES_VALUE = 50
+
+export function getTagConfig({
+  theme,
+  likesCount,
+  chroniclesCount,
+  headlineCount,
+}: TagConfig): InteractionTagProps | null {
+  const headlineTagConfig = {
+    label: 'Reco par les lieux',
+    backgroundColor: theme.colors.goldLight100,
+    Icon: CustomStar,
+  }
+  const likesTagConfig = {
+    label: likesCount ? `${likesCount} j’aime` : '',
+    backgroundColor: theme.colors.white,
+    Icon: CustomThumbUp,
+  }
+  const bookClubTagConfig = {
+    label: 'Reco du Book Club',
+    backgroundColor: theme.colors.skyBlueLight,
+    Icon: CustomBookClub,
+  }
+
+  const hasHeadline = !!headlineCount
+  const hasChronicles = !!chroniclesCount
+  const hasLikes = !!likesCount
+
+  if (hasHeadline && !hasChronicles) {
+    return likesCount && likesCount >= MIN_LIKES_VALUE ? likesTagConfig : headlineTagConfig
+  }
+
+  if (hasHeadline && hasChronicles) {
+    return likesCount && likesCount >= MAX_LIKES_VALUE ? likesTagConfig : bookClubTagConfig
+  }
+
+  if (hasLikes) return likesTagConfig
+  if (hasChronicles) return bookClubTagConfig
+  if (hasHeadline) return headlineTagConfig
+
+  return null
+}
+
+const CustomThumbUp = styled(ThumbUpFilled).attrs(({ theme }) => ({
+  size: theme.icons.sizes.extraSmall,
+  color: theme.colors.primary,
+}))``
+
+const CustomBookClub = styled(BookClubCertification).attrs(({ theme }) => ({
+  size: theme.icons.sizes.extraSmall,
+}))``
+
+const CustomStar = styled(Star).attrs(({ theme }) => ({
+  size: theme.icons.sizes.extraSmall,
+}))``

--- a/src/features/offer/components/InteractionTag/getTagConfig.tsx
+++ b/src/features/offer/components/InteractionTag/getTagConfig.tsx
@@ -6,7 +6,7 @@ import { BookClubCertification } from 'ui/svg/BookClubCertification'
 import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
 import { Star } from 'ui/svg/Star'
 
-export type TagConfig = {
+type TagConfig = {
   theme: typeof theme
   likesCount?: number
   chroniclesCount?: number

--- a/src/features/offer/components/OfferTile/OfferTile.stories.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.stories.tsx
@@ -1,8 +1,12 @@
 import { NavigationContainer } from '@react-navigation/native'
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
+import styled from 'styled-components/native'
 
-import { CategoryIdEnum, SubcategoryIdEnum } from 'api/gen'
+import { Tag } from 'ui/components/Tag/Tag'
+import { BookClubCertification } from 'ui/svg/BookClubCertification'
+import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
+import { Star } from 'ui/svg/Star'
 
 import { OfferTile } from './OfferTile'
 
@@ -19,6 +23,24 @@ const meta: Meta<typeof OfferTile> = {
 }
 export default meta
 
+const LikeTag = styled(Tag).attrs(({ theme }) => ({
+  Icon: <ThumbUpFilled color={theme.colors.primary} size={16} />,
+}))(({ theme }) => ({
+  backgroundColor: theme.colors.greyLight,
+}))
+
+const HeadlineTag = styled(Tag).attrs(() => ({
+  Icon: <Star size={16} />,
+}))(({ theme }) => ({
+  backgroundColor: theme.colors.goldLight100,
+}))
+
+const ChronicleTag = styled(Tag).attrs(() => ({
+  Icon: <BookClubCertification size={16} />,
+}))(({ theme }) => ({
+  backgroundColor: theme.colors.skyBlueLight,
+}))
+
 type Story = StoryObj<typeof OfferTile>
 
 export const Default: Story = {
@@ -30,15 +52,11 @@ export const Default: Story = {
     width: 200,
     height: 300,
     offerLocation: { lat: 48.94374, lng: 2.48171 },
-    categoryId: CategoryIdEnum.CINEMA,
-    subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
-    offerId: 123456,
-    analyticsFrom: 'home',
   },
 }
 
-export const WithTags = {
-  name: 'WithTags',
+export const WithLikes = {
+  name: 'WithLikes',
   args: {
     date: 'le 18 juin 2024',
     name: 'The Fall Guy',
@@ -46,6 +64,35 @@ export const WithTags = {
     categoryLabel: 'Cinéma',
     width: 200,
     height: 300,
-    likes: 99,
+    interactionTag: <LikeTag label="100 j’aime" />,
+    offerLocation: { lat: 48.94374, lng: 2.48171 },
+  },
+}
+
+export const WithChronicles = {
+  name: 'WithChronicles',
+  args: {
+    date: 'le 18 juin 2024',
+    name: 'The Fall Guy',
+    price: 'dès 15,60\u00a0€',
+    categoryLabel: 'Cinéma',
+    width: 200,
+    height: 300,
+    interactionTag: <ChronicleTag label="Reco du Book Club" />,
+    offerLocation: { lat: 48.94374, lng: 2.48171 },
+  },
+}
+
+export const WithHeadlines = {
+  name: 'WithHeadlines',
+  args: {
+    date: 'le 18 juin 2024',
+    name: 'The Fall Guy',
+    price: 'dès 15,60\u00a0€',
+    categoryLabel: 'Cinéma',
+    width: 200,
+    height: 300,
+    interactionTag: <HeadlineTag label="Reco par les lieux" />,
+    offerLocation: { lat: 48.94374, lng: 2.48171 },
   },
 }

--- a/src/features/offer/components/OfferTile/OfferTile.stories.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.stories.tsx
@@ -1,9 +1,11 @@
 import { NavigationContainer } from '@react-navigation/native'
-import type { Meta, StoryObj } from '@storybook/react'
+import type { Meta } from '@storybook/react'
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { Tag } from 'ui/components/Tag/Tag'
+import { InteractionTag } from 'features/offer/components/InteractionTag/InteractionTag'
+import { theme } from 'theme'
+import { Variants, VariantsStory, VariantsTemplate } from 'ui/storybook/VariantsTemplate'
 import { BookClubCertification } from 'ui/svg/BookClubCertification'
 import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
 import { Star } from 'ui/svg/Star'
@@ -23,76 +25,77 @@ const meta: Meta<typeof OfferTile> = {
 }
 export default meta
 
-const LikeTag = styled(Tag).attrs(({ theme }) => ({
+const LikeTag = styled(InteractionTag).attrs(({ theme }) => ({
   Icon: <ThumbUpFilled color={theme.colors.primary} size={16} />,
-}))(({ theme }) => ({
   backgroundColor: theme.colors.greyLight,
-}))
+}))``
 
-const HeadlineTag = styled(Tag).attrs(() => ({
+const HeadlineTag = styled(InteractionTag).attrs(() => ({
   Icon: <Star size={16} />,
-}))(({ theme }) => ({
   backgroundColor: theme.colors.goldLight100,
-}))
+}))``
 
-const ChronicleTag = styled(Tag).attrs(() => ({
+const ChronicleTag = styled(InteractionTag).attrs(() => ({
   Icon: <BookClubCertification size={16} />,
-}))(({ theme }) => ({
   backgroundColor: theme.colors.skyBlueLight,
-}))
+}))``
 
-type Story = StoryObj<typeof OfferTile>
-
-export const Default: Story = {
-  args: {
-    date: 'le 18 juin 2024',
-    name: 'The Fall Guy',
-    price: 'dès 15,60\u00a0€',
-    categoryLabel: 'Cinéma',
-    width: 200,
-    height: 300,
-    offerLocation: { lat: 48.94374, lng: 2.48171 },
+const variantConfig: Variants<typeof OfferTile> = [
+  {
+    label: 'Default',
+    props: {
+      date: 'le 18 juin 2024',
+      name: 'The Fall Guy',
+      price: 'dès 15,60\u00a0€',
+      categoryLabel: 'Cinéma',
+      width: 200,
+      height: 300,
+      offerLocation: { lat: 48.94374, lng: 2.48171 },
+    },
   },
-}
-
-export const WithLikes = {
-  name: 'WithLikes',
-  args: {
-    date: 'le 18 juin 2024',
-    name: 'The Fall Guy',
-    price: 'dès 15,60\u00a0€',
-    categoryLabel: 'Cinéma',
-    width: 200,
-    height: 300,
-    interactionTag: <LikeTag label="100 j’aime" />,
-    offerLocation: { lat: 48.94374, lng: 2.48171 },
+  {
+    label: 'With Likes',
+    props: {
+      date: 'le 18 juin 2024',
+      name: 'The Fall Guy',
+      price: 'dès 15,60\u00a0€',
+      categoryLabel: 'Cinéma',
+      width: 200,
+      height: 300,
+      interactionTag: <LikeTag label="100 j’aime" />,
+      offerLocation: { lat: 48.94374, lng: 2.48171 },
+    },
   },
-}
-
-export const WithChronicles = {
-  name: 'WithChronicles',
-  args: {
-    date: 'le 18 juin 2024',
-    name: 'The Fall Guy',
-    price: 'dès 15,60\u00a0€',
-    categoryLabel: 'Cinéma',
-    width: 200,
-    height: 300,
-    interactionTag: <ChronicleTag label="Reco du Book Club" />,
-    offerLocation: { lat: 48.94374, lng: 2.48171 },
+  {
+    label: 'WithChronicles',
+    props: {
+      date: 'le 18 juin 2024',
+      name: 'The Fall Guy',
+      price: 'dès 15,60\u00a0€',
+      categoryLabel: 'Cinéma',
+      width: 200,
+      height: 300,
+      interactionTag: <ChronicleTag label="Reco du Book Club" />,
+      offerLocation: { lat: 48.94374, lng: 2.48171 },
+    },
   },
-}
-
-export const WithHeadlines = {
-  name: 'WithHeadlines',
-  args: {
-    date: 'le 18 juin 2024',
-    name: 'The Fall Guy',
-    price: 'dès 15,60\u00a0€',
-    categoryLabel: 'Cinéma',
-    width: 200,
-    height: 300,
-    interactionTag: <HeadlineTag label="Reco par les lieux" />,
-    offerLocation: { lat: 48.94374, lng: 2.48171 },
+  {
+    label: 'WithHeadlines',
+    props: {
+      date: 'le 18 juin 2024',
+      name: 'The Fall Guy',
+      price: 'dès 15,60\u00a0€',
+      categoryLabel: 'Cinéma',
+      width: 200,
+      height: 300,
+      interactionTag: <HeadlineTag label="Reco par les lieux" />,
+      offerLocation: { lat: 48.94374, lng: 2.48171 },
+    },
   },
-}
+]
+
+const Template: VariantsStory<typeof OfferTile> = (args) => (
+  <VariantsTemplate variants={variantConfig} Component={OfferTile} defaultProps={{ ...args }} />
+)
+
+export const AllVariants = Template.bind({})

--- a/src/features/offer/components/OfferTile/PlaylistCardOffer.tsx
+++ b/src/features/offer/components/OfferTile/PlaylistCardOffer.tsx
@@ -37,12 +37,10 @@ export const PlaylistCardOffer: FC<Props> = ({
   return (
     <Container maxWidth={width}>
       <NewOfferCaption name={name} date={date} price={price} categoryLabel={categoryLabel} />
+      {interactionTag ? interactionTag : null}
       <View>
         {distance ? <DistanceTag label={`à ${distance}`} /> : null}
         <ImageTile categoryId={categoryId} uri={thumbnailUrl} width={width} height={height} />
-        {interactionTag ? (
-          <InteractionTagContainer>{interactionTag}</InteractionTagContainer>
-        ) : null}
       </View>
     </Container>
   )
@@ -54,10 +52,6 @@ const Container = styled(ViewGap).attrs({
   flexDirection: 'column-reverse',
   maxWidth,
 }))
-
-const InteractionTagContainer = styled(View)({
-  marginTop: getSpacing(2),
-})
 
 const DistanceTag = styled(Tag).attrs(() => ({
   testID: 'DistanceId',

--- a/src/features/offer/components/OfferTile/PlaylistCardOffer.tsx
+++ b/src/features/offer/components/OfferTile/PlaylistCardOffer.tsx
@@ -37,7 +37,7 @@ export const PlaylistCardOffer: FC<Props> = ({
   return (
     <Container maxWidth={width}>
       <NewOfferCaption name={name} date={date} price={price} categoryLabel={categoryLabel} />
-      {interactionTag ? interactionTag : null}
+      {interactionTag ?? null}
       <View>
         {distance ? <DistanceTag label={`à ${distance}`} /> : null}
         <ImageTile categoryId={categoryId} uri={thumbnailUrl} width={width} height={height} />

--- a/src/features/offer/components/OfferTile/PlaylistCardOffer.tsx
+++ b/src/features/offer/components/OfferTile/PlaylistCardOffer.tsx
@@ -22,24 +22,6 @@ type Props = {
   interactionTag?: ReactNode
 }
 
-const renderTags = ({
-  distance = '',
-  interactionTag,
-}: {
-  distance?: string
-  interactionTag?: ReactNode
-}) => {
-  if (!distance && !interactionTag) {
-    return null
-  }
-  return (
-    <TagContainer>
-      {distance ? <DistanceTag label={`à ${distance}`} /> : null}
-      {interactionTag ?? null}
-    </TagContainer>
-  )
-}
-
 export const PlaylistCardOffer: FC<Props> = ({
   thumbnailUrl,
   categoryId,
@@ -56,8 +38,11 @@ export const PlaylistCardOffer: FC<Props> = ({
     <Container maxWidth={width}>
       <NewOfferCaption name={name} date={date} price={price} categoryLabel={categoryLabel} />
       <View>
-        {renderTags({ distance, interactionTag })}
+        {distance ? <DistanceTag label={`à ${distance}`} /> : null}
         <ImageTile categoryId={categoryId} uri={thumbnailUrl} width={width} height={height} />
+        {interactionTag ? (
+          <InteractionTagContainer>{interactionTag}</InteractionTagContainer>
+        ) : null}
       </View>
     </Container>
   )
@@ -70,19 +55,16 @@ const Container = styled(ViewGap).attrs({
   maxWidth,
 }))
 
-const TagContainer = styled.View({
-  position: 'absolute',
-  width: '100%',
-  padding: getSpacing(2),
-  columnGap: getSpacing(2),
-  top: 0,
-  left: 0,
-  zIndex: 1,
-  flexDirection: 'row',
+const InteractionTagContainer = styled(View)({
+  marginTop: getSpacing(2),
 })
 
 const DistanceTag = styled(Tag).attrs(() => ({
   testID: 'DistanceId',
 }))(({ theme }) => ({
+  position: 'absolute',
+  top: getSpacing(2),
+  left: getSpacing(2),
+  zIndex: 1,
   backgroundColor: theme.colors.white,
 }))

--- a/src/shared/typeguards/isReactElement.test.tsx
+++ b/src/shared/typeguards/isReactElement.test.tsx
@@ -1,0 +1,22 @@
+import React, { ReactElement } from 'react'
+import { Text, View } from 'react-native'
+
+import { isReactElement } from 'shared/typeguards/isReactElement'
+
+describe('isReactElement', () => {
+  it('should return true for valid React elements', () => {
+    const element: ReactElement = (
+      <View>
+        <Text>Test</Text>
+      </View>
+    )
+
+    expect(isReactElement(element)).toEqual(true)
+  })
+
+  it('should return false for non-React elements', () => {
+    const nonElement = { key: 'value' }
+
+    expect(isReactElement(nonElement)).toEqual(false)
+  })
+})

--- a/src/shared/typeguards/isReactElement.ts
+++ b/src/shared/typeguards/isReactElement.ts
@@ -1,0 +1,5 @@
+import { ReactElement, isValidElement } from 'react'
+
+export function isReactElement(Icon: unknown): Icon is ReactElement {
+  return isValidElement(Icon)
+}

--- a/src/shared/typeguards/isStyledComponent.test.tsx
+++ b/src/shared/typeguards/isStyledComponent.test.tsx
@@ -1,0 +1,36 @@
+import React, { FunctionComponent } from 'react'
+import { Text, View } from 'react-native'
+import styled from 'styled-components/native'
+
+import { isStyledComponent } from 'shared/typeguards/isStyledComponent'
+import { ArrowRight } from 'ui/svg/icons/ArrowRight'
+
+const StyledArrowRight = styled(ArrowRight).attrs(({ theme }) => ({
+  size: theme.icons.sizes.extraSmall,
+}))``
+
+describe('isStyledComponent', () => {
+  it('should return true for styled components', () => {
+    expect(isStyledComponent(StyledArrowRight)).toEqual(true)
+  })
+
+  it('should return false for non-styled components', () => {
+    const NonStyledComponent: FunctionComponent = () => (
+      <View>
+        <Text>Non-Styled Component</Text>
+      </View>
+    )
+
+    expect(isStyledComponent(NonStyledComponent)).toEqual(false)
+  })
+
+  it('should return false for regular React components', () => {
+    const RegularComponent: FunctionComponent = () => (
+      <View>
+        <Text>Regular Component</Text>
+      </View>
+    )
+
+    expect(isStyledComponent(RegularComponent)).toEqual(false)
+  })
+})

--- a/src/shared/typeguards/isStyledComponent.ts
+++ b/src/shared/typeguards/isStyledComponent.ts
@@ -1,0 +1,7 @@
+import { FunctionComponent } from 'react'
+
+import { AccessibleIcon } from 'ui/svg/icons/types'
+
+export function isStyledComponent(Icon: FunctionComponent<AccessibleIcon>): boolean {
+  return typeof Icon === 'object' && 'styledComponentId' in Icon
+}

--- a/src/ui/components/Tag/Tag.native.test.tsx
+++ b/src/ui/components/Tag/Tag.native.test.tsx
@@ -17,6 +17,12 @@ describe('<Tag />', () => {
     expect(screen.getByTestId('tagIcon')).toBeOnTheScreen()
   })
 
+  it('should display icon tag (JSX) when it is informed', () => {
+    render(<Tag label="1" Icon={<ArrowRight />} />)
+
+    expect(screen.getByTestId('tagIcon')).toBeOnTheScreen()
+  })
+
   it('should not display icon tag when it is not informed', () => {
     render(<Tag label="1" />)
 

--- a/src/ui/components/Tag/Tag.stories.tsx
+++ b/src/ui/components/Tag/Tag.stories.tsx
@@ -27,6 +27,10 @@ const variantConfig: Variants<typeof Tag> = [
     props: { label: '1,4km', backgroundColor: '#20C5E9' },
   },
   {
+    label: 'Tag with custom horizontal padding',
+    props: { label: '1,4km', paddingHorizontal: 8 },
+  },
+  {
     label: 'Tag with icon',
     props: { label: '1', Icon: StyledArrowRight },
   },

--- a/src/ui/components/Tag/Tag.stories.tsx
+++ b/src/ui/components/Tag/Tag.stories.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 
 import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
 import { ArrowRight } from 'ui/svg/icons/ArrowRight'
+import { Star } from 'ui/svg/Star'
 
 import { Tag } from './Tag'
 
@@ -33,6 +34,10 @@ const variantConfig: Variants<typeof Tag> = [
   {
     label: 'Tag with icon',
     props: { label: '1', Icon: StyledArrowRight },
+  },
+  {
+    label: 'Tag with JSX icon ',
+    props: { label: '1', Icon: <Star size={16} /> },
   },
 ]
 

--- a/src/ui/components/Tag/Tag.stories.tsx
+++ b/src/ui/components/Tag/Tag.stories.tsx
@@ -23,6 +23,10 @@ const variantConfig: Variants<typeof Tag> = [
     props: { label: '1,4km' },
   },
   {
+    label: 'Tag with custom background color',
+    props: { label: '1,4km', backgroundColor: '#20C5E9' },
+  },
+  {
     label: 'Tag with icon',
     props: { label: '1', Icon: StyledArrowRight },
   },

--- a/src/ui/components/Tag/Tag.tsx
+++ b/src/ui/components/Tag/Tag.tsx
@@ -8,6 +8,7 @@ import { getSpacing, getSpacingString, Typo } from 'ui/theme'
 type TagProps = ViewProps & {
   label: string
   Icon?: FunctionComponent<AccessibleIcon>
+  backgroundColor?: string
 }
 
 const PADDING_VERTICAL = getSpacing(1)
@@ -16,9 +17,9 @@ const LINE_HEIGHT = getSpacing(NUMBER_OF_SPACES_LINE_HEIGHT)
 
 export const TAG_HEIGHT = PADDING_VERTICAL + LINE_HEIGHT + PADDING_VERTICAL
 
-export const Tag: FunctionComponent<TagProps> = ({ label, Icon, ...props }) => {
+export const Tag: FunctionComponent<TagProps> = ({ label, Icon, backgroundColor, ...props }) => {
   return (
-    <Wrapper {...props}>
+    <Wrapper backgroundColor={backgroundColor} {...props}>
       {Icon ? (
         <IconContainer>
           <Icon testID="tagIcon" />
@@ -29,12 +30,12 @@ export const Tag: FunctionComponent<TagProps> = ({ label, Icon, ...props }) => {
   )
 }
 
-const Wrapper = styled(View)(({ theme }) => ({
+const Wrapper = styled(View)<{ backgroundColor?: string }>(({ theme, backgroundColor }) => ({
   flexDirection: 'row',
   alignItems: 'center',
   alignSelf: 'flex-start',
   borderRadius: 6,
-  backgroundColor: theme.colors.greyLight,
+  backgroundColor: backgroundColor ?? theme.colors.greyLight,
   paddingVertical: PADDING_VERTICAL,
   paddingHorizontal: getSpacing(2),
 }))

--- a/src/ui/components/Tag/Tag.tsx
+++ b/src/ui/components/Tag/Tag.tsx
@@ -9,6 +9,7 @@ type TagProps = ViewProps & {
   label: string
   Icon?: FunctionComponent<AccessibleIcon>
   backgroundColor?: string
+  paddingHorizontal?: number
 }
 
 const PADDING_VERTICAL = getSpacing(1)
@@ -17,9 +18,15 @@ const LINE_HEIGHT = getSpacing(NUMBER_OF_SPACES_LINE_HEIGHT)
 
 export const TAG_HEIGHT = PADDING_VERTICAL + LINE_HEIGHT + PADDING_VERTICAL
 
-export const Tag: FunctionComponent<TagProps> = ({ label, Icon, backgroundColor, ...props }) => {
+export const Tag: FunctionComponent<TagProps> = ({
+  label,
+  Icon,
+  backgroundColor,
+  paddingHorizontal,
+  ...props
+}) => {
   return (
-    <Wrapper backgroundColor={backgroundColor} {...props}>
+    <Wrapper backgroundColor={backgroundColor} paddingHorizontal={paddingHorizontal} {...props}>
       {Icon ? (
         <IconContainer>
           <Icon testID="tagIcon" />
@@ -30,15 +37,17 @@ export const Tag: FunctionComponent<TagProps> = ({ label, Icon, backgroundColor,
   )
 }
 
-const Wrapper = styled(View)<{ backgroundColor?: string }>(({ theme, backgroundColor }) => ({
-  flexDirection: 'row',
-  alignItems: 'center',
-  alignSelf: 'flex-start',
-  borderRadius: 6,
-  backgroundColor: backgroundColor ?? theme.colors.greyLight,
-  paddingVertical: PADDING_VERTICAL,
-  paddingHorizontal: getSpacing(2),
-}))
+const Wrapper = styled(View)<{ backgroundColor?: string; paddingHorizontal?: number }>(
+  ({ theme, backgroundColor, paddingHorizontal }) => ({
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    borderRadius: 6,
+    backgroundColor: backgroundColor ?? theme.colors.greyLight,
+    paddingVertical: PADDING_VERTICAL,
+    paddingHorizontal: paddingHorizontal ?? getSpacing(2),
+  })
+)
 
 const LabelText = styled(Typo.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.black,

--- a/src/ui/components/Tag/Tag.tsx
+++ b/src/ui/components/Tag/Tag.tsx
@@ -1,7 +1,9 @@
-import React, { FunctionComponent, ReactElement } from 'react'
+import React, { cloneElement, FunctionComponent, ReactElement } from 'react'
 import { View, ViewProps } from 'react-native'
 import styled from 'styled-components/native'
 
+import { isReactElement } from 'shared/typeguards/isReactElement'
+import { isStyledComponent } from 'shared/typeguards/isStyledComponent'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { getSpacing, getSpacingString, Typo } from 'ui/theme'
 
@@ -29,7 +31,11 @@ export const Tag: FunctionComponent<TagProps> = ({
     <Wrapper backgroundColor={backgroundColor} paddingHorizontal={paddingHorizontal} {...props}>
       {Icon ? (
         <IconContainer>
-          {typeof Icon === 'function' ? <Icon testID="tagIcon" /> : Icon}
+          {isReactElement(Icon) ? (
+            cloneElement(Icon, { testID: 'tagIcon' })
+          ) : isStyledComponent(Icon) ? (
+            <Icon testID="tagIcon" />
+          ) : null}
         </IconContainer>
       ) : null}
       <LabelText>{label}</LabelText>

--- a/src/ui/components/Tag/Tag.tsx
+++ b/src/ui/components/Tag/Tag.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, ReactElement } from 'react'
 import { View, ViewProps } from 'react-native'
 import styled from 'styled-components/native'
 
@@ -7,7 +7,7 @@ import { getSpacing, getSpacingString, Typo } from 'ui/theme'
 
 type TagProps = ViewProps & {
   label: string
-  Icon?: FunctionComponent<AccessibleIcon>
+  Icon?: FunctionComponent<AccessibleIcon> | ReactElement
   backgroundColor?: string
   paddingHorizontal?: number
 }
@@ -29,7 +29,7 @@ export const Tag: FunctionComponent<TagProps> = ({
     <Wrapper backgroundColor={backgroundColor} paddingHorizontal={paddingHorizontal} {...props}>
       {Icon ? (
         <IconContainer>
-          <Icon testID="tagIcon" />
+          {typeof Icon === 'function' ? <Icon testID="tagIcon" /> : Icon}
         </IconContainer>
       ) : null}
       <LabelText>{label}</LabelText>

--- a/src/ui/components/Tag/Tag.tsx
+++ b/src/ui/components/Tag/Tag.tsx
@@ -27,17 +27,22 @@ export const Tag: FunctionComponent<TagProps> = ({
   paddingHorizontal,
   ...props
 }) => {
+  const renderIcon = () => {
+    if (!Icon) return null
+
+    if (isReactElement(Icon)) {
+      return cloneElement(Icon, { testID: 'tagIcon' })
+    }
+    if (isStyledComponent(Icon)) {
+      return <Icon testID="tagIcon" />
+    }
+
+    return null
+  }
+
   return (
     <Wrapper backgroundColor={backgroundColor} paddingHorizontal={paddingHorizontal} {...props}>
-      {Icon ? (
-        <IconContainer>
-          {isReactElement(Icon) ? (
-            cloneElement(Icon, { testID: 'tagIcon' })
-          ) : isStyledComponent(Icon) ? (
-            <Icon testID="tagIcon" />
-          ) : null}
-        </IconContainer>
-      ) : null}
+      {Icon ? <IconContainer>{renderIcon()}</IconContainer> : null}
       <LabelText>{label}</LabelText>
     </Wrapper>
   )

--- a/src/ui/components/Tag/Tag.tsx
+++ b/src/ui/components/Tag/Tag.tsx
@@ -20,13 +20,7 @@ const LINE_HEIGHT = getSpacing(NUMBER_OF_SPACES_LINE_HEIGHT)
 
 export const TAG_HEIGHT = PADDING_VERTICAL + LINE_HEIGHT + PADDING_VERTICAL
 
-export const Tag: FunctionComponent<TagProps> = ({
-  label,
-  Icon,
-  backgroundColor,
-  paddingHorizontal,
-  ...props
-}) => {
+export const Tag: FunctionComponent<TagProps> = ({ label, Icon, ...props }) => {
   const renderIcon = () => {
     if (!Icon) return null
 
@@ -41,7 +35,7 @@ export const Tag: FunctionComponent<TagProps> = ({
   }
 
   return (
-    <Wrapper backgroundColor={backgroundColor} paddingHorizontal={paddingHorizontal} {...props}>
+    <Wrapper {...props}>
       {Icon ? <IconContainer>{renderIcon()}</IconContainer> : null}
       <LabelText>{label}</LabelText>
     </Wrapper>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35361

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |<img width="442" alt="Capture d’écran 2025-03-31 à 11 04 08" src="https://github.com/user-attachments/assets/2d8c5c35-7971-4d74-a083-15224e88d1db" /> <img width="442" alt="Capture d’écran 2025-03-31 à 11 04 48" src="https://github.com/user-attachments/assets/dcf3b51f-3e95-4592-9c5e-e866dfa6ed74" /> <img width="446" alt="Capture d’écran 2025-03-31 à 11 05 21" src="https://github.com/user-attachments/assets/e1a24916-fcaa-41e9-b8d5-1304b4854719" />|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
