### PR TITLE
(BSR) chore(ios): fix iOS CLI

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -17,6 +17,12 @@ use flake
 export DEVBOX_COREPACK_ENABLED=true
 eval "$(devbox generate direnv --print-envrc)"
 
+# recent Nix set variables
+# then DevBox set variables again
+# with this variables, XCode build don't find what he is looking for
+# https://github.com/NixOS/nixpkgs/issues/355486#issuecomment-2746182772
+unset DEVELOPER_DIR
+
 layout node
 
 source_env ./scripts/install_node_modules_when_not_installed.sh
@@ -36,4 +42,3 @@ if [ "$(uname)" == "Darwin" ]; then
 		popd
 	fi
 fi
-

--- a/.envrc
+++ b/.envrc
@@ -28,6 +28,15 @@ unset DEVELOPER_DIR
 # error: unable to find sdk: 'macosx'
 export PATH="$(echo "$PATH" | sed -E 's@/nix/store/[a-zA-Z0-9.-]+-xcrun/bin:@@')"
 
+# the following script use `-X` option of `cp`
+# node_modules/react-native/scripts/react_native_pods_utils/script_phases.sh
+# coreutils include `cp` where the `-X` option doesn't exists and is replaced by `--preserve`
+# remove coreutils from the `PATH` to use globally installed `cp`
+# avoid the following error when building iOS from CLI
+# cp: invalid option -- 'X'
+# Try 'cp --help' for more information.
+export PATH="$(echo "$PATH" | sed -E 's@/nix/store/[a-zA-Z0-9.-]+-coreutils[0-9.-]+/bin:@@')"
+
 layout node
 
 source_env ./scripts/install_node_modules_when_not_installed.sh

--- a/.envrc
+++ b/.envrc
@@ -23,6 +23,11 @@ eval "$(devbox generate direnv --print-envrc)"
 # https://github.com/NixOS/nixpkgs/issues/355486#issuecomment-2746182772
 unset DEVELOPER_DIR
 
+# avoid the following error when building iOS from CLI
+# Error: Command failed with exit code 255: xcrun xcdevice list
+# error: unable to find sdk: 'macosx'
+export PATH="$(echo "$PATH" | sed -E 's@/nix/store/[a-zA-Z0-9.-]+-xcrun/bin:@@')"
+
 layout node
 
 source_env ./scripts/install_node_modules_when_not_installed.sh

--- a/.envrc
+++ b/.envrc
@@ -32,7 +32,7 @@ if [ "$(uname)" == "Darwin" ]; then
 	if [ ! -d ./ios/Pods/ ]; then
 		pushd ./ios/
 		bundle install
-		bundle exec pod install --repo-update
+		LANG='en_US.UTF-8' bundle exec pod install --repo-update
 		popd
 	fi
 fi

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,5 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "devbox.autoShellOnTerminal": false,
-  "window.confirmBeforeClose": "keyboardOnly",
   "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/doc/installation/Android.md
+++ b/doc/installation/Android.md
@@ -44,6 +44,7 @@ SECRET_KEYTOOL_PASSWORD=THE_PASSWORD # replace THE_PASSWORD with the one from Ke
 then in your terminal run :
 
 ```sh
+sudo xcodebuild -license # read and accept Apple license to be abble to use git inside Android Studio
 ./scripts/install_certificate_java.sh # this script ask root password
 direnv reload
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
           packages = [
             pkgs.devbox
             pkgs.jdk17 # needed by Android
+            pkgs.ios-deploy # needed to run the app on real iPhone
             pkgs.jq # needed by some scripts run in the pipeline
             pkgs.python3 # needed by scripts/add_tracker.py
             pkgs.maestro # needed to run end to end test locally

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "generate:api:client:silicon": "SWAGGER_CODEGEN_CLI_VERSION=3.0.32 ./scripts/generate_api_client_silicon.sh",
     "generate:allure-report": "allure generate allure-results --clean -o allure-report",
     "preios": "./scripts/check_xcode_version.sh",
-    "ios": "yarn preios && react-native run-ios \"$@\" && yarn postios",
+    "ios": "yarn preios && CC=\"$(xcrun --find clang)\" CXX=\"$(xcrun --find clang++)\" react-native run-ios \"$@\" && yarn postios",
     "postios": "./scripts/add_certificate_to_ios_simulator.sh",
     "ios:prod": "yarn ios --scheme PassCulture-Production",
     "ios:staging": "yarn ios --scheme PassCulture-Staging",


### PR DESCRIPTION
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] `npx rn-game-over --all --no-install ; direnv deny`
- [x] `rm -rf .direnv .devbox .venv ios/Pods`
- [x] `direnv allow`
- [x] `yarn ios:staging`

[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

