### PR TITLE
(BSR) chore(ios): avoid CocoaPods warning

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -32,8 +32,7 @@ if [ "$(uname)" == "Darwin" ]; then
 	if [ ! -d ./ios/Pods/ ]; then
 		pushd ./ios/
 		bundle install
-		bundle exec pod install --repo-update
+		LANG='en_US.UTF-8' bundle exec pod install --repo-update
 		popd
 	fi
 fi
-


### PR DESCRIPTION
```txt
WARNING: CocoaPods requires your terminal to be using UTF-8 encoding.
    Consider adding the following to ~/.profile:

    export LANG=en_US.UTF-8
```

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
