### PR TITLE
(PC-35391) fix(Analytics): fix missing logSelectAge

### DIFF
--- a/src/features/tutorial/enums.ts
+++ b/src/features/tutorial/enums.ts
@@ -8,6 +8,7 @@ export enum NonEligible {
   UNDER_15 = 'under_15',
   UNDER_17 = 'under_17', // For credit V3
   OVER_18 = 'over_18',
+  OTHER = 'other',
 }
 
 export enum UserOnboardingRole {

--- a/src/features/tutorial/pages/AgeSelectionFork.native.test.tsx
+++ b/src/features/tutorial/pages/AgeSelectionFork.native.test.tsx
@@ -7,6 +7,7 @@ import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome
 import { TutorialRootStackParamList } from 'features/navigation/RootNavigator/types'
 import { TutorialTypes, NonEligible } from 'features/tutorial/enums'
 import { AgeSelectionFork } from 'features/tutorial/pages/AgeSelectionFork'
+import { analytics } from 'libs/analytics/__mocks__/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { storage } from 'libs/storage'
 import { render, screen, userEvent } from 'tests/utils'
@@ -191,6 +192,15 @@ describe('AgeSelectionFork', () => {
           age: 18,
           type: TutorialTypes.ONBOARDING,
         })
+      })
+
+      it('should call logSelectAge', async () => {
+        renderAgeSelectionFork({ type: TutorialTypes.ONBOARDING })
+
+        const button = screen.getByLabelText('J’ai 19 ans ou plus')
+        await user.press(button)
+
+        expect(analytics.logSelectAge).toHaveBeenCalledWith({ age: 'over_18', from: 'onboarding' })
       })
     })
   })

--- a/src/features/tutorial/pages/AgeSelectionOther.native.test.tsx
+++ b/src/features/tutorial/pages/AgeSelectionOther.native.test.tsx
@@ -2,6 +2,7 @@ import { StackScreenProps } from '@react-navigation/stack'
 import React from 'react'
 
 import { reset } from '__mocks__/@react-navigation/native'
+import { setSettings } from 'features/auth/tests/setSettings'
 import { TutorialRootStackParamList } from 'features/navigation/RootNavigator/types'
 import { homeNavConfig } from 'features/navigation/TabBar/helpers'
 import * as useGoBack from 'features/navigation/useGoBack'
@@ -41,6 +42,7 @@ jest.useFakeTimers()
 describe('AgeSelectionOther', () => {
   beforeEach(async () => {
     setFeatureFlags()
+    setSettings({ wipEnableCreditV3: true })
     await storage.clear('user_age')
   })
 

--- a/src/features/tutorial/pages/EligibleUserAgeSelection.tsx
+++ b/src/features/tutorial/pages/EligibleUserAgeSelection.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 
 import { TutorialRootStackParamList } from 'features/navigation/RootNavigator/types'
 import { AgeButton } from 'features/tutorial/components/AgeButton'
-import { TutorialTypes } from 'features/tutorial/enums'
+import { NonEligible, TutorialTypes } from 'features/tutorial/enums'
 import { TutorialPage } from 'features/tutorial/pages/TutorialPage'
 import { EligibleAges } from 'features/tutorial/types'
 import { analytics } from 'libs/analytics/provider'
@@ -18,8 +18,6 @@ import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
 
 type Props = StackScreenProps<TutorialRootStackParamList, 'EligibleUserAgeSelection'>
 
-const OTHER = 'other'
-
 const ageButtons: { age?: EligibleAges }[] = [
   { age: 15 },
   { age: 16 },
@@ -29,7 +27,7 @@ const ageButtons: { age?: EligibleAges }[] = [
 ]
 
 const onBeforeNavigate = async (type: TutorialTypes, age?: EligibleAges) => {
-  analytics.logSelectAge({ age: age ?? OTHER, from: type })
+  analytics.logSelectAge({ age: age ?? NonEligible.OTHER, from: type })
   age && (await storage.saveObject('user_age', age))
 }
 
@@ -62,24 +60,24 @@ export const EligibleUserAgeSelection: FunctionComponent<Props> = ({ route }: Pr
     }
     if (isPassForAllEnabled) {
       return null
-    } else {
-      return (
-        <AgeButton
-          key="other"
-          dense
-          onBeforeNavigate={async () => onBeforeNavigate(type)}
-          navigateTo={{ screen: 'AgeSelectionOther', params: { type } }}
-          accessibilityLabel={`${startButtonTitle} moins de 15 ans ou plus de 18 ans`}>
-          <StyledTitle4>Autre</StyledTitle4>
-          <React.Fragment>
-            <Spacer.Column numberOfSpaces={1} />
-            <StyledBodyAccentXs numberOfLines={2}>
-              {startButtonTitle} moins de 15 ans ou plus de 18 ans
-            </StyledBodyAccentXs>
-          </React.Fragment>
-        </AgeButton>
-      )
     }
+
+    return (
+      <AgeButton
+        key="other"
+        dense
+        onBeforeNavigate={async () => onBeforeNavigate(type)}
+        navigateTo={{ screen: 'AgeSelectionOther', params: { type } }}
+        accessibilityLabel={`${startButtonTitle} moins de 15 ans ou plus de 18 ans`}>
+        <StyledTitle4>Autre</StyledTitle4>
+        <React.Fragment>
+          <Spacer.Column numberOfSpaces={1} />
+          <StyledBodyAccentXs numberOfLines={2}>
+            {startButtonTitle} moins de 15 ans ou plus de 18 ans
+          </StyledBodyAccentXs>
+        </React.Fragment>
+      </AgeButton>
+    )
   })
 
   const title =

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -31,7 +31,8 @@ import {
 import { SearchState } from 'features/search/types'
 import { ShareAppModalType } from 'features/share/types'
 import { SubscriptionAnalyticsParams } from 'features/subscription/types'
-import { TutorialTypes } from 'features/tutorial/enums'
+import { NonEligible, TutorialTypes } from 'features/tutorial/enums'
+import { EligibleAges } from 'features/tutorial/types'
 import { AmplitudeEvent } from 'libs/amplitude/events'
 import { buildPerformSearchState, urlWithValueMaxLength } from 'libs/analytics'
 import { analytics } from 'libs/analytics/provider'
@@ -602,7 +603,7 @@ export const logEventAnalytics = {
     analytics.logEvent({ firebase: AnalyticsEvent.SEARCH_SCROLL_TO_PAGE }, { page, searchId }),
   logSeeMyBooking: (offerId: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.SEE_MY_BOOKING }, { offerId }),
-  logSelectAge: ({ age, from }: { age: number | string; from: TutorialTypes }) =>
+  logSelectAge: ({ age, from }: { age: EligibleAges | NonEligible; from: TutorialTypes }) =>
     analytics.logEvent(
       {
         amplitude: AmplitudeEvent.ONBOARDING_AGE_SELECTION_CLICKED,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35391

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
