### PR TITLE
(PC-35427) feat(offer): use minLikesValue and maxLikesValue as params for getTagConfig to prepare remote config use

### DIFF
--- a/src/features/offer/components/InteractionTag/getTagConfig.test.ts
+++ b/src/features/offer/components/InteractionTag/getTagConfig.test.ts
@@ -3,43 +3,79 @@ import { theme } from 'theme'
 
 describe('getTagConfig', () => {
   it('should return null if no parameters are provided', () => {
-    expect(getTagConfig({ theme })).toEqual(null)
+    expect(getTagConfig({ theme, minLikesValue: 20, maxLikesValue: 50 })).toEqual(null)
   })
 
   it('should return the "Reco par les lieux" tag if headlineCount is set and chroniclesCount is not set', () => {
-    expect(getTagConfig({ theme, headlineCount: 1 })).toEqual({
+    expect(getTagConfig({ theme, headlineCount: 1, minLikesValue: 20, maxLikesValue: 50 })).toEqual(
+      {
+        label: 'Reco par les lieux',
+        backgroundColor: theme.colors.goldLight100,
+        Icon: expect.anything(),
+      }
+    )
+  })
+
+  it('should return the "Reco par les lieux" tag if headlineCount is set but likesCount is lower than minLikesValues', () => {
+    expect(
+      getTagConfig({
+        theme,
+        headlineCount: 1,
+        likesCount: 10,
+        minLikesValue: 20,
+        maxLikesValue: 50,
+      })
+    ).toEqual({
       label: 'Reco par les lieux',
       backgroundColor: theme.colors.goldLight100,
       Icon: expect.anything(),
     })
   })
 
-  it('should return the "Reco par les lieux" tag if headlineCount is set but likesCount is lower than MIN_LIKES_VALUE', () => {
-    expect(getTagConfig({ theme, headlineCount: 1, likesCount: 10 })).toEqual({
-      label: 'Reco par les lieux',
-      backgroundColor: theme.colors.goldLight100,
-      Icon: expect.anything(),
-    })
-  })
-
-  it('should return the "j’aime" tag if headlineCount is set and likesCount is >= MIN_LIKES_VALUE', () => {
-    expect(getTagConfig({ theme, headlineCount: 1, likesCount: 20 })).toEqual({
+  it('should return the "j’aime" tag if headlineCount is set and likesCount is >= minLikesValue', () => {
+    expect(
+      getTagConfig({
+        theme,
+        headlineCount: 1,
+        likesCount: 20,
+        minLikesValue: 20,
+        maxLikesValue: 50,
+      })
+    ).toEqual({
       label: '20 j’aime',
       backgroundColor: theme.colors.white,
       Icon: expect.anything(),
     })
   })
 
-  it('should return the "Reco du Book Club" tag if both headlineCount and chroniclesCount are set and likesCount is < MAX_LIKES_VALUE', () => {
-    expect(getTagConfig({ theme, headlineCount: 1, chroniclesCount: 1, likesCount: 40 })).toEqual({
+  it('should return the "Reco du Book Club" tag if both headlineCount and chroniclesCount are set and likesCount is < maxLikesValue', () => {
+    expect(
+      getTagConfig({
+        theme,
+        headlineCount: 1,
+        chroniclesCount: 1,
+        likesCount: 40,
+        minLikesValue: 20,
+        maxLikesValue: 50,
+      })
+    ).toEqual({
       label: 'Reco du Book Club',
       backgroundColor: theme.colors.skyBlueLight,
       Icon: expect.anything(),
     })
   })
 
-  it('should return the "j’aime" tag if both headlineCount and chroniclesCount are set and likesCount is >= MAX_LIKES_VALUE', () => {
-    expect(getTagConfig({ theme, headlineCount: 1, chroniclesCount: 1, likesCount: 50 })).toEqual({
+  it('should return the "j’aime" tag if both headlineCount and chroniclesCount are set and likesCount is >= maxLikesValue', () => {
+    expect(
+      getTagConfig({
+        theme,
+        headlineCount: 1,
+        chroniclesCount: 1,
+        likesCount: 50,
+        minLikesValue: 20,
+        maxLikesValue: 50,
+      })
+    ).toEqual({
       label: '50 j’aime',
       backgroundColor: theme.colors.white,
       Icon: expect.anything(),
@@ -47,7 +83,7 @@ describe('getTagConfig', () => {
   })
 
   it('should return the "j’aime" tag if likesCount is set without headlineCount or chroniclesCount', () => {
-    expect(getTagConfig({ theme, likesCount: 15 })).toEqual({
+    expect(getTagConfig({ theme, likesCount: 15, minLikesValue: 20, maxLikesValue: 50 })).toEqual({
       label: '15 j’aime',
       backgroundColor: theme.colors.white,
       Icon: expect.anything(),
@@ -55,7 +91,9 @@ describe('getTagConfig', () => {
   })
 
   it('should return the "Reco du Book Club" tag if chroniclesCount is set without headlineCount or likesCount', () => {
-    expect(getTagConfig({ theme, chroniclesCount: 1 })).toEqual({
+    expect(
+      getTagConfig({ theme, chroniclesCount: 1, minLikesValue: 20, maxLikesValue: 50 })
+    ).toEqual({
       label: 'Reco du Book Club',
       backgroundColor: theme.colors.skyBlueLight,
       Icon: expect.anything(),

--- a/src/features/offer/components/InteractionTag/getTagConfig.tsx
+++ b/src/features/offer/components/InteractionTag/getTagConfig.tsx
@@ -8,17 +8,17 @@ import { Star } from 'ui/svg/Star'
 
 type TagConfig = {
   theme: typeof theme
+  maxLikesValue: number
+  minLikesValue: number
   likesCount?: number
   chroniclesCount?: number
   headlineCount?: number
 }
 
-// TODO(PC-35427) handle logic values with remote config
-const MIN_LIKES_VALUE = 20
-const MAX_LIKES_VALUE = 50
-
 export function getTagConfig({
   theme,
+  maxLikesValue,
+  minLikesValue,
   likesCount,
   chroniclesCount,
   headlineCount,
@@ -44,11 +44,11 @@ export function getTagConfig({
   const hasLikes = !!likesCount
 
   if (hasHeadline && !hasChronicles) {
-    return likesCount && likesCount >= MIN_LIKES_VALUE ? likesTagConfig : headlineTagConfig
+    return likesCount && likesCount >= minLikesValue ? likesTagConfig : headlineTagConfig
   }
 
   if (hasHeadline && hasChronicles) {
-    return likesCount && likesCount >= MAX_LIKES_VALUE ? likesTagConfig : bookClubTagConfig
+    return likesCount && likesCount >= maxLikesValue ? likesTagConfig : bookClubTagConfig
   }
 
   if (hasLikes) return likesTagConfig

--- a/src/libs/firebase/remoteConfig/helpers/getRemoteConfigFromConfigValues.ts
+++ b/src/libs/firebase/remoteConfig/helpers/getRemoteConfigFromConfigValues.ts
@@ -30,6 +30,8 @@ export const getRemoteConfigFromConfigValues = (
   reactionFakeDoorCategories: JSON.parse(
     getConfigValue(parameters.reactionFakeDoorCategories).asString()
   ),
+  maxLikesValue: getConfigValue(parameters.maxLikesValue).asNumber(),
+  minLikesValue: getConfigValue(parameters.minLikesValue).asNumber(),
   sameAuthorPlaylist: getConfigValue(parameters.sameAuthorPlaylist).asString(),
   shouldDisplayReassuranceMention: getConfigValue(
     parameters.shouldDisplayReassuranceMention

--- a/src/libs/firebase/remoteConfig/remoteConfig.constants.ts
+++ b/src/libs/firebase/remoteConfig/remoteConfig.constants.ts
@@ -18,6 +18,8 @@ export const DEFAULT_REMOTE_CONFIG: CustomRemoteConfig = {
   homeEntryIdWithoutBooking_15_17: '',
   homeEntryId_18: '',
   homeEntryId_15_17: '',
+  maxLikesValue: 0,
+  minLikesValue: 0,
   reactionFakeDoorCategories: {
     categories: [],
   },

--- a/src/libs/firebase/remoteConfig/remoteConfig.types.ts
+++ b/src/libs/firebase/remoteConfig/remoteConfig.types.ts
@@ -15,6 +15,8 @@ export type CustomRemoteConfig = {
   homeEntryIdWithoutBooking_15_17: string
   homeEntryId_18: string
   homeEntryId_15_17: string
+  maxLikesValue: number
+  minLikesValue: number
   reactionFakeDoorCategories: Record<'categories', NativeCategoryIdEnumv2[]>
   sameAuthorPlaylist: string
   shouldDisplayReassuranceMention: boolean


### PR DESCRIPTION
Ce ticket prépare l'utilisation de remote config (pour pouvoir faire évoluer les compteurs plus facilement) quand la feature sera implémentée dans les items de playlist.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35427

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
