### PR TITLE
(BSR) fix(Home): add fallback for contenful categories

### DIFF
--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/getCategoriesFacetFilters.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/getCategoriesFacetFilters.ts
@@ -25,5 +25,6 @@ export const getCategoriesFacetFilters = (
   categoryLabel: ContentfulLabelCategories
 ): SearchGroupNameEnumv2 => {
   const searchGroup = CONTENTFUL_LABELS[categoryLabel]
-  return CATEGORY_CRITERIA[searchGroup].facetFilter
+
+  return CATEGORY_CRITERIA[searchGroup]?.facetFilter ?? SearchGroupNameEnumv2.NONE
 }


### PR DESCRIPTION
To prevent future bugs in case a deprecated category is selected on Contentful