### PR TITLE
(PC-33854) feat(Search): add tracker on no result cta

### DIFF
--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -893,7 +893,7 @@ describe('SearchResultsContent component', () => {
       })
     })
 
-    it('should log ExtendSearchRadius when `Élargir la zone de recherche` cta is pressed', async () => {
+    it('should log ExtendSearchRadiusClicked when `Élargir la zone de recherche` cta is pressed', async () => {
       const query = 'cinéma'
       const newSearchState = {
         ...mockSearchState,
@@ -915,7 +915,7 @@ describe('SearchResultsContent component', () => {
       const cta = await screen.findByText('Élargir la zone de recherche')
       await user.press(cta)
 
-      expect(analytics.logExtendSearchRadius).toHaveBeenCalledWith()
+      expect(analytics.logExtendSearchRadiusClicked).toHaveBeenCalledWith()
     })
 
     it('should not log NoSearchResult when there is not search query execution', async () => {

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -893,6 +893,31 @@ describe('SearchResultsContent component', () => {
       })
     })
 
+    it('should log ExtendSearchRadius when `Élargir la zone de recherche` cta is pressed', async () => {
+      const query = 'cinéma'
+      const newSearchState = {
+        ...mockSearchState,
+        locationFilter: {
+          locationType: LocationMode.AROUND_ME,
+          aroundRadius: MAX_RADIUS,
+          place: mockedPlace,
+        },
+        query,
+      }
+
+      mockUseSearch.mockReturnValueOnce({
+        searchState: newSearchState,
+        dispatch: mockDispatch,
+      })
+
+      render(<SearchResultsContent />)
+
+      const cta = await screen.findByText('Élargir la zone de recherche')
+      await user.press(cta)
+
+      expect(analytics.logExtendSearchRadius).toHaveBeenCalledWith()
+    })
+
     it('should not log NoSearchResult when there is not search query execution', async () => {
       render(<SearchResultsContent />)
       await screen.findByText('Lieu culturel')

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -413,6 +413,7 @@ export const SearchResultsContent: React.FC = () => {
           errorDescription="Élargis la zone de recherche pour plus de résultats."
           ctaWording="Élargir la zone de recherche"
           onPress={() => {
+            analytics.logExtendSearchRadius()
             onResetPlace()
             navigateToSearchResults({
               ...searchState,

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -413,7 +413,7 @@ export const SearchResultsContent: React.FC = () => {
           errorDescription="Élargis la zone de recherche pour plus de résultats."
           ctaWording="Élargir la zone de recherche"
           onPress={() => {
-            analytics.logExtendSearchRadius()
+            analytics.logExtendSearchRadiusClicked()
             onResetPlace()
             navigateToSearchResults({
               ...searchState,

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -83,7 +83,7 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logEmailValidated: jest.fn(),
   logErrorSavingNewEmail: jest.fn(),
   logExclusivityBlockClicked: jest.fn(),
-  logExtendSearchRadius: jest.fn(),
+  logExtendSearchRadiusClicked: jest.fn(),
   logGoToProfil: jest.fn(),
   logGoToUbble: jest.fn(),
   logHasAcceptedAllCookies: jest.fn(),

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -83,6 +83,7 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logEmailValidated: jest.fn(),
   logErrorSavingNewEmail: jest.fn(),
   logExclusivityBlockClicked: jest.fn(),
+  logExtendSearchRadius: jest.fn(),
   logGoToProfil: jest.fn(),
   logGoToUbble: jest.fn(),
   logHasAcceptedAllCookies: jest.fn(),

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -317,8 +317,8 @@ export const logEventAnalytics = {
     moduleId: string
     homeEntryId?: string
   }) => analytics.logEvent({ firebase: AnalyticsEvent.EXCLUSIVITY_BLOCK_CLICKED }, params),
-  logExtendSearchRadius: () =>
-    analytics.logEvent({ firebase: AnalyticsEvent.EXTEND_SEARCH_RADIUS }),
+  logExtendSearchRadiusClicked: () =>
+    analytics.logEvent({ firebase: AnalyticsEvent.EXTEND_SEARCH_RADIUS_CLICKED }),
   logGoToProfil: ({ from, offerId }: { from: string; offerId: number }) =>
     analytics.logEvent(
       { firebase: AnalyticsEvent.GO_TO_PROFIL },

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -317,6 +317,8 @@ export const logEventAnalytics = {
     moduleId: string
     homeEntryId?: string
   }) => analytics.logEvent({ firebase: AnalyticsEvent.EXCLUSIVITY_BLOCK_CLICKED }, params),
+  logExtendSearchRadius: () =>
+    analytics.logEvent({ firebase: AnalyticsEvent.EXTEND_SEARCH_RADIUS }),
   logGoToProfil: ({ from, offerId }: { from: string; offerId: number }) =>
     analytics.logEvent(
       { firebase: AnalyticsEvent.GO_TO_PROFIL },

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -78,7 +78,7 @@ export enum AnalyticsEvent {
   DISPLAY_FORCED_LOGIN_HELP_MESSAGE = 'DisplayForcedLoginHelpMessage',
   ERROR_SAVING_NEW_EMAIL = 'ErrorSavingNewMail',
   EXCLUSIVITY_BLOCK_CLICKED = 'ExclusivityBlockClicked',
-  EXTEND_SEARCH_RADIUS = 'ExtendSearchRadius',
+  EXTEND_SEARCH_RADIUS_CLICKED = 'ExtendSearchRadiusClicked',
   GO_TO_PARENTS_FAQ = 'GoToParentsFAQ',
   GO_TO_PROFIL = 'GoToProfil',
   HAS_ACCEPTED_ALL_COOKIES = 'HasAcceptedAllCookies',

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -78,6 +78,7 @@ export enum AnalyticsEvent {
   DISPLAY_FORCED_LOGIN_HELP_MESSAGE = 'DisplayForcedLoginHelpMessage',
   ERROR_SAVING_NEW_EMAIL = 'ErrorSavingNewMail',
   EXCLUSIVITY_BLOCK_CLICKED = 'ExclusivityBlockClicked',
+  EXTEND_SEARCH_RADIUS = 'ExtendSearchRadius',
   GO_TO_PARENTS_FAQ = 'GoToParentsFAQ',
   GO_TO_PROFIL = 'GoToProfil',
   HAS_ACCEPTED_ALL_COOKIES = 'HasAcceptedAllCookies',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33854

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |               | <img width="512" alt="Capture d’écran 2025-04-04 à 16 46 22" src="https://github.com/user-attachments/assets/2f5bfe01-778b-4783-8776-3799d8dfc92b" /> |
| Desktop - Chrome |               | <video src="https://github.com/user-attachments/assets/80b10909-303a-471a-bc80-6e438156bce5" /> |


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
