### PR TITLE
(PC-35306) feat(BookingDetails): add link to Offer page

### DIFF
--- a/src/features/bookings/components/BookingDetailsContent.tsx
+++ b/src/features/bookings/components/BookingDetailsContent.tsx
@@ -18,6 +18,7 @@ import { VenueBlockWithItinerary } from 'features/offer/components/OfferVenueBlo
 import { analytics } from 'libs/analytics/provider'
 import { useLocation } from 'libs/location'
 import { getDistance } from 'libs/location/getDistance'
+import { SubcategoriesMapping } from 'libs/subcategories/types'
 import { formatFullAddress } from 'shared/address/addressFormatter'
 import { theme } from 'theme'
 import { ErrorBanner } from 'ui/components/banners/ErrorBanner'
@@ -33,9 +34,11 @@ const VENUE_THUMBNAIL_SIZE = getSpacing(15)
 export const BookingDetailsContent = ({
   properties,
   booking,
+  mapping,
 }: {
   properties: BookingProperties
   booking: BookingReponse
+  mapping: SubcategoriesMapping
 }) => {
   const { address } = booking?.stock.offer ?? {}
   const { visible: cancelModalVisible, showModal: showCancelModal, hideModal } = useModal(false)
@@ -86,6 +89,8 @@ export const BookingDetailsContent = ({
         hour={hourLabel == '' ? undefined : hourLabel}
         day={dayLabel == '' ? undefined : dayLabel}
         isDuo={properties.isDuo}
+        offer={offer}
+        mapping={mapping}
         venueInfo={
           <VenueBlockWithItinerary
             shouldDisplayItineraryButton={shouldDisplayItineraryButton}

--- a/src/features/bookings/components/LinkToOffer.tsx
+++ b/src/features/bookings/components/LinkToOffer.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+import { BookingOfferResponse } from 'api/gen'
+import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
+import { SubcategoriesMapping } from 'libs/subcategories/types'
+import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
+import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
+import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
+import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
+
+export const LinkToOffer = ({
+  offer,
+  mapping,
+}: {
+  offer: BookingOfferResponse
+  mapping: SubcategoriesMapping
+}) => {
+  const netInfo = useNetInfoContext()
+  const prePopulateOffer = usePrePopulateOffer()
+  const { showErrorSnackBar } = useSnackBarContext()
+
+  const onNavigateToOfferPress = () => {
+    if (netInfo.isConnected) {
+      prePopulateOffer({
+        ...offer,
+        categoryId: mapping[offer.subcategoryId].categoryId,
+        thumbUrl: offer.image?.url,
+        name: offer.name,
+        offerId: offer.id,
+      })
+
+      triggerConsultOfferLog({ offerId: offer.id, from: 'bookings' })
+    } else {
+      showErrorSnackBar({
+        message:
+          'Impossible d’afficher le détail de l’offre. Connecte-toi à internet avant de réessayer.',
+        timeout: SNACK_BAR_TIME_OUT,
+      })
+    }
+  }
+  return (
+    <InternalTouchableLink
+      inline
+      justifyContent="flex-start"
+      enableNavigate={!!netInfo.isConnected}
+      as={ButtonTertiaryBlack}
+      wording="Voir l’offre"
+      navigateTo={{ screen: 'Offer', params: { id: offer.id, from: 'bookingdetails' } }}
+      onBeforeNavigate={onNavigateToOfferPress}
+      icon={PlainArrowNext}
+    />
+  )
+}

--- a/src/features/bookings/components/TicketCutout.native.test.tsx
+++ b/src/features/bookings/components/TicketCutout.native.test.tsx
@@ -1,37 +1,71 @@
 import React from 'react'
 
 import { TicketCutout } from 'features/bookings/components/TicketCutout'
+import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
+import { subcategoriesMappingSnap } from 'libs/subcategories/fixtures/mappings'
+import { SubcategoriesMapping } from 'libs/subcategories/types'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen } from 'tests/utils'
 import { Typo } from 'ui/theme'
 
 describe('TicketCutout', () => {
-  it('should display duo block if offer is duo', async () => {
-    render(
-      <TicketCutout title="Super spectacle" hour="18h56" day="20 mars 2025" isDuo>
-        <Typo.Body>Partie basse du ticket</Typo.Body>
-      </TicketCutout>
-    )
+  it('should display duo block when offer is duo', async () => {
+    renderTicketCutout({ isDuo: true })
 
     expect(screen.getByText('Pour deux personnes')).toBeOnTheScreen()
   })
 
-  it('should display day block if offer has a day', async () => {
-    render(
-      <TicketCutout title="Super spectacle" hour="18h56" day="20 mars 2025">
-        <Typo.Body>Partie basse du ticket</Typo.Body>
-      </TicketCutout>
-    )
+  it('should not display duo block when offer is not duo', async () => {
+    renderTicketCutout({})
+
+    expect(screen.queryByText('Pour deux personnes')).not.toBeOnTheScreen()
+  })
+
+  it('should display day block when offer has a day', async () => {
+    renderTicketCutout({ day: '20 mars 2025' })
 
     expect(screen.getByText('20 mars 2025')).toBeOnTheScreen()
   })
 
-  it('should display hour block if offer has an hour', async () => {
-    render(
-      <TicketCutout title="Super spectacle" hour="18h56" day="20 mars 2025">
-        <Typo.Body>Partie basse du ticket</Typo.Body>
-      </TicketCutout>
-    )
+  it('should not display day block when offer has no day', async () => {
+    renderTicketCutout({})
+
+    expect(screen.queryByText('20 mars 2025')).not.toBeOnTheScreen()
+  })
+
+  it('should display hour block when offer has an hour', async () => {
+    renderTicketCutout({ hour: '18h56' })
 
     expect(screen.getByText('18h56')).toBeOnTheScreen()
   })
+
+  it('should not display hour block when offer has no hour', async () => {
+    renderTicketCutout({})
+
+    expect(screen.queryByText('18h56')).not.toBeOnTheScreen()
+  })
 })
+
+const renderTicketCutout = ({
+  hour,
+  day,
+  isDuo,
+}: {
+  hour?: string
+  day?: string
+  isDuo?: boolean
+}) => {
+  return render(
+    reactQueryProviderHOC(
+      <TicketCutout
+        title="Super spectacle"
+        hour={hour}
+        day={day}
+        isDuo={isDuo}
+        offer={bookingsSnap.ongoing_bookings[0].stock.offer}
+        mapping={subcategoriesMappingSnap as SubcategoriesMapping}>
+        <Typo.Body>Partie basse du ticket</Typo.Body>
+      </TicketCutout>
+    )
+  )
+}

--- a/src/features/bookings/components/TicketCutout.tsx
+++ b/src/features/bookings/components/TicketCutout.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import { View } from 'react-native'
 import styled from 'styled-components/native'
 
+import { BookingOfferResponse } from 'api/gen'
+import { LinkToOffer } from 'features/bookings/components/LinkToOffer'
+import { SubcategoriesMapping } from 'libs/subcategories/types'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { CalendarS } from 'ui/svg/icons/CalendarS'
 import { ClockFilled } from 'ui/svg/icons/ClockFilled'
@@ -19,6 +22,8 @@ type Props = {
   children: React.JSX.Element
   infoBanner?: React.JSX.Element
   venueInfo?: React.JSX.Element
+  offer: BookingOfferResponse
+  mapping: SubcategoriesMapping
 }
 
 export const TicketCutout = ({
@@ -29,6 +34,8 @@ export const TicketCutout = ({
   infoBanner,
   children,
   venueInfo,
+  offer,
+  mapping,
 }: Props) => {
   return (
     <View testID="ticket-punched">
@@ -54,6 +61,9 @@ export const TicketCutout = ({
                 <Typo.Body>Pour deux personnes</Typo.Body>
               </Row>
             ) : null}
+            <Container>
+              <LinkToOffer offer={offer} mapping={mapping} />
+            </Container>
           </ViewGap>
           {venueInfo}
         </ViewGap>
@@ -96,7 +106,6 @@ const StyledClockFilled = styled(ClockFilled).attrs(({ theme }) => ({
 const StyledCalendarS = styled(CalendarS).attrs(({ theme }) => ({
   size: theme.icons.sizes.small,
 }))({})
-
 const StyledStock = styled(Stock).attrs(({ theme }) => ({
   size: theme.icons.sizes.small,
 }))({})
@@ -105,6 +114,7 @@ const Row = styled.View({
   flexDirection: 'row',
   gap: getSpacing(2),
   alignContent: 'center',
+  justifyContent: 'flex-start',
 })
 
 const ContentBlock = styled.View(({ theme }) => ({
@@ -133,4 +143,8 @@ const TopBlock = styled(ContentBlock)({
   borderTopLeftRadius: getSpacing(6),
   borderTopRightRadius: getSpacing(6),
   paddingTop: getSpacing(6),
+})
+
+const Container = styled(View)({
+  marginLeft: getSpacing(1),
 })

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.tsx
@@ -61,7 +61,7 @@ export const BookingDetails = () => {
     mapping[booking.stock.offer.subcategoryId].isEvent
   )
   return enableNewBookingPage && properties.isEvent === true ? (
-    <BookingDetailsContent properties={properties} booking={booking} />
+    <BookingDetailsContent properties={properties} booking={booking} mapping={mapping} />
   ) : (
     <OldBookingDetailsContent
       properties={properties}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35306

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              | <img width="245" alt="Screenshot 2025-04-04 at 17 46 16" src="https://github.com/user-attachments/assets/3c8927de-8d09-4b71-9110-dfbcff95605b" />|![Simulator Screenshot - iPhone SE (3rd generation) - 2025-04-04 at 18 07 31](https://github.com/user-attachments/assets/d49a6976-0f92-4006-9d1f-21ce643d1a0a)|


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
