### PR TITLE
(PC-35325) chore(offer): offer playlist view tracking store

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -318,6 +318,7 @@ module.exports = {
           ['libs', './src/libs'],
           ['queries', './src/queries'],
           ['shared', './src/shared'],
+          ['store', './src/store'],
           ['tests', './src/tests'],
           ['theme', './src/theme'],
           ['types', './src/types'],

--- a/babel.config.js
+++ b/babel.config.js
@@ -18,6 +18,7 @@ module.exports = {
           libs: './src/libs',
           queries: './src/queries',
           shared: './src/shared',
+          store: './src/store',
           tests: './src/tests',
           theme: './src/theme',
           types: './src/types',

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
     '^libs(.*)$': '<rootDir>/src/libs$1',
     '^queries(.*)$': '<rootDir>/src/queries$1',
     '^shared(.*)$': '<rootDir>/src/shared$1',
+    '^store(.*)$': '<rootDir>/src/store$1',
     '^tests(.*)$': '<rootDir>/src/tests$1',
     '^theme(.*)$': '<rootDir>/src/theme$1',
     '^types(.*)$': '<rootDir>/src/types$1',

--- a/src/store/tracking/offerPlaylistTrackingStore.test.ts
+++ b/src/store/tracking/offerPlaylistTrackingStore.test.ts
@@ -1,0 +1,116 @@
+import { PageTrackingInfo } from 'store/tracking/types'
+import { act, renderHook } from 'tests/utils'
+
+import {
+  resetPageTrackingInfo,
+  setPageTrackingInfo,
+  setPlaylistTrackingInfo,
+  useOfferPlaylistTrackingStore,
+} from './offerPlaylistTrackingStore'
+
+const PAGE_TRACKING_INFO = {
+  pageId: 'abcd',
+  pageLocation: 'home',
+  playlists: [],
+} satisfies PageTrackingInfo
+
+describe('offerTileViewTrackingStore', () => {
+  it('should return default State', () => {
+    const { result } = renderHook(() => useOfferPlaylistTrackingStore())
+
+    expect(result.current).toMatchObject({
+      pageId: '',
+      pageLocation: '',
+      playlists: [],
+    })
+  })
+
+  it('should set new page tracking info', async () => {
+    const { result } = renderHook(() => useOfferPlaylistTrackingStore())
+
+    act(() => {
+      setPageTrackingInfo(PAGE_TRACKING_INFO)
+    })
+
+    expect(result.current).toMatchObject(PAGE_TRACKING_INFO)
+  })
+
+  it('should set playlist', async () => {
+    const { result } = renderHook(() => useOfferPlaylistTrackingStore())
+
+    const NEW_PLAYLIST = {
+      playlistId: 'az344',
+      callId: 'sdfdkjLKJ',
+      index: 1,
+      offerIds: ['777', '999'],
+    }
+
+    act(() => {
+      setPageTrackingInfo(PAGE_TRACKING_INFO)
+      setPlaylistTrackingInfo(NEW_PLAYLIST)
+    })
+
+    expect(result.current.playlists).toHaveLength(1)
+    expect(result.current.playlists[0]).toMatchObject(NEW_PLAYLIST)
+  })
+
+  it('should update playlist', async () => {
+    const { result } = renderHook(() => useOfferPlaylistTrackingStore())
+
+    const NEW_PLAYLIST = {
+      playlistId: 'az344',
+      callId: 'sdfdkjLKJ',
+      index: 1,
+      offerIds: ['777', '999'],
+    }
+
+    const SECOND_PLAYLIST = {
+      playlistId: '797tyu',
+      callId: 'sdfkjhOPL',
+      index: 2,
+      offerIds: ['888', '111'],
+    }
+
+    act(() => {
+      setPageTrackingInfo(PAGE_TRACKING_INFO)
+      setPlaylistTrackingInfo(NEW_PLAYLIST)
+      setPlaylistTrackingInfo(SECOND_PLAYLIST)
+      setPlaylistTrackingInfo({ ...NEW_PLAYLIST, offerIds: ['777', '333', '555'] })
+    })
+
+    expect(result.current.playlists).toHaveLength(2)
+    expect(
+      result.current.playlists.find((playlist) => playlist.playlistId === NEW_PLAYLIST.playlistId)
+    ).toMatchObject({
+      ...NEW_PLAYLIST,
+      offerIds: ['777', '999', '333', '555'],
+    })
+  })
+})
+
+it('should reset store to default state', async () => {
+  const { result } = renderHook(() => useOfferPlaylistTrackingStore())
+
+  act(() => {
+    setPageTrackingInfo(PAGE_TRACKING_INFO)
+    setPlaylistTrackingInfo({ playlistId: 'yolo' })
+    resetPageTrackingInfo()
+  })
+
+  expect(result.current).toMatchObject({
+    pageId: '',
+    pageLocation: '',
+    playlists: [],
+  })
+})
+
+it('should not set playlist tracking info', async () => {
+  const { result } = renderHook(() => useOfferPlaylistTrackingStore())
+
+  act(() => {
+    setPageTrackingInfo(PAGE_TRACKING_INFO)
+    setPlaylistTrackingInfo({})
+  })
+
+  expect(result.current).toMatchObject(PAGE_TRACKING_INFO)
+})

--- a/src/store/tracking/offerPlaylistTrackingStore.ts
+++ b/src/store/tracking/offerPlaylistTrackingStore.ts
@@ -1,0 +1,65 @@
+// eslint-disable-next-line no-restricted-imports
+import { create } from 'zustand'
+
+import { PageTrackingInfo, PlaylistTrackingInfo } from 'store/tracking/types'
+
+const mergeUniqueValues = (source: string[], target: string[]) =>
+  Array.from(new Set([...source, ...target]))
+
+const DEFAULT_STATE = {
+  pageId: '',
+  pageLocation: '',
+  playlists: [],
+}
+
+const updatePlaylistInfo = (
+  playlist: PlaylistTrackingInfo,
+  data: Partial<PlaylistTrackingInfo>
+) => {
+  return {
+    ...playlist,
+    offerIds: mergeUniqueValues(playlist.offerIds, data?.offerIds ?? []),
+    callId: data.callId ?? playlist.callId,
+    index: data.index === undefined || data.index === -1 ? playlist.index : data.index,
+  }
+}
+
+export const useOfferPlaylistTrackingStore = create<PageTrackingInfo>()(() => DEFAULT_STATE)
+
+// Set page information
+export const setPageTrackingInfo = ({ pageId, pageLocation, playlists = [] }: PageTrackingInfo) =>
+  useOfferPlaylistTrackingStore.setState({ pageId, pageLocation, playlists })
+
+// Set playlist informations
+export const setPlaylistTrackingInfo = ({
+  playlistId,
+  callId = '',
+  offerIds = [],
+  index = -1,
+}: Partial<PlaylistTrackingInfo>) => {
+  if (!playlistId) {
+    return
+  }
+
+  const state = useOfferPlaylistTrackingStore.getState()
+
+  const playlist = state.playlists.find((item) => item.playlistId === playlistId) ?? {
+    playlistId,
+    callId,
+    offerIds,
+    index,
+  }
+  const updatedPlaylist = updatePlaylistInfo(playlist, { callId, offerIds, index })
+
+  const playlists = [
+    ...state.playlists.filter((item) => item.playlistId !== playlist.playlistId),
+    updatedPlaylist,
+  ]
+
+  useOfferPlaylistTrackingStore.setState({ playlists })
+}
+
+// Reset store to default state
+export const resetPageTrackingInfo = () => {
+  useOfferPlaylistTrackingStore.setState(DEFAULT_STATE)
+}

--- a/src/store/tracking/types.ts
+++ b/src/store/tracking/types.ts
@@ -1,0 +1,12 @@
+export type PlaylistTrackingInfo = {
+  playlistId: string
+  callId: string
+  index: number
+  offerIds: string[]
+}
+
+export type PageTrackingInfo = {
+  pageLocation: string
+  pageId: string
+  playlists: PlaylistTrackingInfo[]
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35325

Création d'un store pour permettre de stocker les informations sur les offres vues sur une page afin de pouvoir ensuite les tracker.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
