### PR TITLE
(PC-33854) feat(SearchResults): add searchId to logExtendSearchRadiusClicked

### DIFF
--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -915,7 +915,7 @@ describe('SearchResultsContent component', () => {
       const cta = await screen.findByText('Élargir la zone de recherche')
       await user.press(cta)
 
-      expect(analytics.logExtendSearchRadiusClicked).toHaveBeenCalledWith()
+      expect(analytics.logExtendSearchRadiusClicked).toHaveBeenNthCalledWith(1, searchId)
     })
 
     it('should not log NoSearchResult when there is not search query execution', async () => {

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -413,7 +413,7 @@ export const SearchResultsContent: React.FC = () => {
           errorDescription="Élargis la zone de recherche pour plus de résultats."
           ctaWording="Élargir la zone de recherche"
           onPress={() => {
-            analytics.logExtendSearchRadiusClicked()
+            analytics.logExtendSearchRadiusClicked(searchState.searchId)
             onResetPlace()
             navigateToSearchResults({
               ...searchState,

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -317,8 +317,8 @@ export const logEventAnalytics = {
     moduleId: string
     homeEntryId?: string
   }) => analytics.logEvent({ firebase: AnalyticsEvent.EXCLUSIVITY_BLOCK_CLICKED }, params),
-  logExtendSearchRadiusClicked: () =>
-    analytics.logEvent({ firebase: AnalyticsEvent.EXTEND_SEARCH_RADIUS_CLICKED }),
+  logExtendSearchRadiusClicked: (searchId?: string) =>
+    analytics.logEvent({ firebase: AnalyticsEvent.EXTEND_SEARCH_RADIUS_CLICKED }, { searchId }),
   logGoToProfil: ({ from, offerId }: { from: string; offerId: number }) =>
     analytics.logEvent(
       { firebase: AnalyticsEvent.GO_TO_PROFIL },


### PR DESCRIPTION
Due to data demand, i am adding a  searchId parameter to the tracker logExtendSearchRadiusClicked