### PR TITLE
(BSR) feat(gitignore): add google-services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ vendor/
 
 # Google service
 google-services.json
+google-services*.json
 ios/GoogleService-Info.plist
 GoogleService-Info*.plist
 


### PR DESCRIPTION
To be able to keep several google-services for each env in the folder:
<img width="292" alt="image" src="https://github.com/user-attachments/assets/9705ad98-3400-4cfc-834c-b0c6a5514c62" />
