### PR TITLE
(PC-35529) fix(SearchFilter): revert move search filter

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1156,7 +1156,7 @@ SPEC CHECKSUMS:
   FirebaseCore: 5743c5785c074a794d35f2fff7ecc254a91e08b1
   FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
   FirebaseDynamicLinks: 1dc816ef789c5adac6fede0b46d11478175c70e4
-  FirebaseFirestore: cb361b7f8f225a225c9f11b8d42066baebb1630c
+  FirebaseFirestore: c3dadcf89ba4b89f493d1a34c37be94a4f9dd76e
   FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
   FirebasePerformance: 66eb58c3e3568a0501a9be271c8ff424dea0ff34
   FirebaseRemoteConfig: 2d6e2cfdb49af79535c8af8a80a4a5009038ec2b
@@ -1188,7 +1188,7 @@ SPEC CHECKSUMS:
   Permission-LocationWhenInUse: 02d8eff562bd0743762c59a7f0919ccc8acb6565
   Permission-Notifications: c5842ced07b9f181ed638193533eb11e35b5e947
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
+  RCT-Folly: 8dc08ca5a393b48b1c523ab6220dfdcc0fe000ad
   RCTRequired: b6cea797b684c6d8d82ba0107cef58cbb679afdb
   RCTTypeSafety: d2eb5e0e8af9181b24034f5171f9b659994b4678
   React: e5aafc4c18040e8fbe0870a1f6df890d35f5af1d

--- a/src/features/deeplinks/helpers/getScreenFromDeeplink.test.ts
+++ b/src/features/deeplinks/helpers/getScreenFromDeeplink.test.ts
@@ -68,12 +68,12 @@ describe('getScreenFromDeeplink()', () => {
     expect(params).toEqual({ screen: 'SearchStackNavigator', params: undefined })
   })
 
-  it('should return SearchStackNavigator when url = /recherche/filter', () => {
-    const url = getFullUrl(getScreenPath(...getSearchStackConfig('SearchFilter')))
+  it('should return SearchFilter when url = /recherche/filter', () => {
+    const url = getFullUrl(getScreenPath('SearchFilter', undefined))
     const { screen, params } = getScreenFromDeeplink(url)
 
-    expect(screen).toEqual('TabNavigator')
-    expect(params).toEqual({ screen: 'SearchStackNavigator', params: undefined })
+    expect(screen).toEqual('SearchFilter')
+    expect(params).toEqual(undefined)
   })
 
   it('should return SearchStackNavigator when url = /recherche/thematic', () => {

--- a/src/features/navigation/RootNavigator/rootRoutes.ts
+++ b/src/features/navigation/RootNavigator/rootRoutes.ts
@@ -34,12 +34,13 @@ import { subscriptionRoutes } from 'features/navigation/RootNavigator/subscripti
 import { SuspenseAchievements } from 'features/navigation/RootNavigator/SuspenseAchievements'
 import { trustedDeviceRoutes } from 'features/navigation/RootNavigator/trustedDeviceRoutes'
 import { tutorialRoutes } from 'features/navigation/RootNavigator/tutorialRoutes'
-import { screenParamsParser } from 'features/navigation/screenParamsUtils'
+import { screenParamsParser, screenParamsStringifier } from 'features/navigation/screenParamsUtils'
 import { tabNavigatorPathConfig } from 'features/navigation/TabBar/tabBarRoutes'
 import { TabNavigator } from 'features/navigation/TabBar/TabNavigator'
 import { Offer } from 'features/offer/pages/Offer/Offer'
 import { OfferPreview } from 'features/offer/pages/OfferPreview/OfferPreview'
 import { ChangeEmailExpiredLink } from 'features/profile/pages/ChangeEmail/ChangeEmailExpiredLink'
+import { SearchFilter } from 'features/search/pages/SearchFilter/SearchFilter'
 import { OnboardingSubscription } from 'features/subscription/page/OnboardingSubscription'
 import { ProfileTutorialAgeInformation } from 'features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation'
 import { Venue } from 'features/venue/pages/Venue/Venue'
@@ -237,6 +238,17 @@ export const rootRoutes: RootRoute[] = [
     options: { title: 'Email création de compte expiré' },
   },
   { name: 'TabNavigator', component: TabNavigator, pathConfig: tabNavigatorPathConfig },
+  // SearchFilter could have been in TabNavigator > SearchStackNavigator but we don't want a tabBar on this screen
+  {
+    name: 'SearchFilter',
+    component: SearchFilter,
+    pathConfig: {
+      path: 'recherche/filtres',
+      parse: screenParamsParser['SearchFilter'],
+      stringify: screenParamsStringifier['SearchFilter'],
+    },
+    options: { title: 'Filtres de recherche' },
+  },
   {
     name: 'ProfileStackNavigator',
     component: SuspenseProfileStackNavigator,

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -3,6 +3,7 @@ import { StackNavigationProp } from '@react-navigation/stack'
 import { ComponentType } from 'react'
 
 import { CulturalSurveyQuestionEnum } from 'api/gen/api'
+import { DisabilitiesProperties } from 'features/accessibility/types'
 import { BookingsTab } from 'features/bookings/enum'
 import { CheatcodesStackParamList } from 'features/navigation/CheatcodesStackNavigator/types'
 import {
@@ -11,6 +12,7 @@ import {
 } from 'features/navigation/ProfileStackNavigator/ProfileStack'
 import { SearchStackParamList } from 'features/navigation/SearchStackNavigator/types'
 import { PlaylistType } from 'features/offer/enums'
+import { SearchState } from 'features/search/types'
 import { TutorialType } from 'features/tutorial/types'
 import { Venue } from 'features/venue/types'
 import { ContentfulLabelCategories } from 'libs/contentful/types'
@@ -259,6 +261,7 @@ export type RootStackParamList = {
   }
   ResetPasswordEmailSent: { email: string }
   ResetPasswordExpiredLink: { email: string }
+  SearchFilter?: Partial<SearchState & { accessibilityFilter: Partial<DisabilitiesProperties> }>
   SignupConfirmationEmailSent: { email: string }
   SignupConfirmationExpiredLink: { email: string }
   SignupForm:

--- a/src/features/navigation/SearchStackNavigator/SearchStackNavigator.tsx
+++ b/src/features/navigation/SearchStackNavigator/SearchStackNavigator.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 import { SEARCH_STACK_NAVIGATOR_SCREEN_OPTIONS } from 'features/navigation/SearchStackNavigator/searchStackNavigationOptions'
 import { SearchStack } from 'features/navigation/SearchStackNavigator/Stack'
-import { SearchFilter } from 'features/search/pages/SearchFilter/SearchFilter'
 import { SearchLanding } from 'features/search/pages/SearchLanding/SearchLanding'
 import { SearchResults } from 'features/search/pages/SearchResults/SearchResults'
 import { ThematicSearch } from 'features/search/pages/ThematicSearch/ThematicSearch'
@@ -16,7 +15,6 @@ export const SearchStackNavigator = () => {
       <SearchStack.Screen name={SearchView.Landing} component={SearchLanding} />
       <SearchStack.Screen name={SearchView.Results} component={SearchResults} />
       <SearchStack.Screen name={SearchView.Thematic} component={ThematicSearch} />
-      <SearchStack.Screen name={SearchView.Filter} component={SearchFilter} />
     </SearchStack.Navigator>
   )
 }

--- a/src/features/navigation/SearchStackNavigator/searchRoutes.ts
+++ b/src/features/navigation/SearchStackNavigator/searchRoutes.ts
@@ -41,16 +41,6 @@ const searchRoutes: SearchStackRoute[] = [
     },
     options: { title: 'recherche dans les sous-catégories' },
   },
-  {
-    name: SearchView.Filter,
-    component: ComponentForPathConfig,
-    pathConfig: {
-      path: 'recherche/filtres',
-      parse: screenParamsParser[SearchView.Filter],
-      stringify: screenParamsStringifier[SearchView.Filter],
-    },
-    options: { title: 'Filtres de recherche' },
-  },
 ]
 
 const { screensConfig: searchScreensConfig } = getScreensAndConfig(searchRoutes, SearchStack.Screen)

--- a/src/features/navigation/SearchStackNavigator/types.ts
+++ b/src/features/navigation/SearchStackNavigator/types.ts
@@ -25,7 +25,6 @@ export type SearchStackParamList = {
       accessibilityFilter: Partial<DisabilitiesProperties>
     }
   >
-  SearchFilter?: Partial<SearchState & { accessibilityFilter: Partial<DisabilitiesProperties> }>
 }
 
 export type SearchStackScreenNames = keyof SearchStackParamList

--- a/src/features/search/components/Buttons/FilterButton/FilterButton.native.test.tsx
+++ b/src/features/search/components/Buttons/FilterButton/FilterButton.native.test.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { getSearchNavConfig } from 'features/navigation/SearchStackNavigator/searchStackHelpers'
-import { SearchView } from 'features/search/types'
 import { userEvent, render, screen } from 'tests/utils'
 
 import { FilterButton } from './FilterButton'
@@ -12,32 +10,29 @@ jest.useFakeTimers()
 
 describe('FilterButton', () => {
   it('should contains the number of active filters', () => {
-    render(<FilterButton activeFilters={2} navigateTo={getSearchNavConfig(SearchView.Filter)} />)
+    render(<FilterButton activeFilters={2} navigateTo={{ screen: 'SearchFilter' }} />)
 
     expect(screen.getByText('2')).toBeOnTheScreen()
   })
 
   it('should not display badge when there are no active filters', () => {
-    render(<FilterButton activeFilters={0} navigateTo={getSearchNavConfig(SearchView.Filter)} />)
+    render(<FilterButton activeFilters={0} navigateTo={{ screen: 'SearchFilter' }} />)
 
     expect(screen.queryByTestId('searchFilterBadge')).not.toBeOnTheScreen()
   })
 
   it('should navigate with undefined params when pressing filter button', async () => {
-    render(<FilterButton activeFilters={1} navigateTo={getSearchNavConfig(SearchView.Filter)} />)
+    render(<FilterButton activeFilters={1} navigateTo={{ screen: 'SearchFilter' }} />)
 
     const filterButton = screen.getByTestId('searchFilterBadge')
     await user.press(filterButton)
 
-    expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-      params: { params: undefined, screen: 'SearchFilter' },
-      screen: 'SearchStackNavigator',
-    })
+    expect(navigate).toHaveBeenCalledWith('SearchFilter', undefined)
   })
 
   describe('Accessibility', () => {
     it('should have an accessible label with the number of active filters', () => {
-      render(<FilterButton activeFilters={2} navigateTo={getSearchNavConfig(SearchView.Filter)} />)
+      render(<FilterButton activeFilters={2} navigateTo={{ screen: 'SearchFilter' }} />)
 
       expect(
         screen.getByLabelText('Voir tous les filtres\u00a0: 2 filtres actifs')
@@ -45,13 +40,13 @@ describe('FilterButton', () => {
     })
 
     it('should have an accessible label with one active filter', () => {
-      render(<FilterButton activeFilters={1} navigateTo={getSearchNavConfig(SearchView.Filter)} />)
+      render(<FilterButton activeFilters={1} navigateTo={{ screen: 'SearchFilter' }} />)
 
       expect(screen.getByLabelText('Voir tous les filtres\u00a0: 1 filtre actif')).toBeOnTheScreen()
     })
 
     it('should have an accessible label without active filter', () => {
-      render(<FilterButton activeFilters={0} navigateTo={getSearchNavConfig(SearchView.Filter)} />)
+      render(<FilterButton activeFilters={0} navigateTo={{ screen: 'SearchFilter' }} />)
 
       expect(screen.getByLabelText('Voir tous les filtres')).toBeOnTheScreen()
     })

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -856,10 +856,7 @@ describe('SearchResultsContent component', () => {
       const cta = await screen.findByText('Modifier mes filtres')
       await user.press(cta)
 
-      expect(navigate).toHaveBeenNthCalledWith(1, 'TabNavigator', {
-        screen: 'SearchStackNavigator',
-        params: { screen: 'SearchFilter', params: newSearchState },
-      })
+      expect(navigate).toHaveBeenNthCalledWith(1, 'SearchFilter', newSearchState)
     })
 
     it('should navigate to SearchResults when location is not EVERYWHERE', async () => {

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -9,7 +9,6 @@ import { AccessibilityFiltersModal } from 'features/accessibility/components/Acc
 import { useAccessibilityFiltersContext } from 'features/accessibility/context/AccessibilityFiltersWrapper'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { VenueMapLocationModal } from 'features/location/components/VenueMapLocationModal'
-import { getSearchNavConfig } from 'features/navigation/SearchStackNavigator/searchStackHelpers'
 import { PlaylistType } from 'features/offer/enums'
 import { useSearchResults } from 'features/search/api/useSearchResults/useSearchResults'
 import { AutoScrollSwitch } from 'features/search/components/AutoScrollSwitch/AutoScrollSwitch'
@@ -33,7 +32,6 @@ import { DatesHoursModal } from 'features/search/pages/modals/DatesHoursModal/Da
 import { OfferDuoModal } from 'features/search/pages/modals/OfferDuoModal/OfferDuoModal'
 import { PriceModal } from 'features/search/pages/modals/PriceModal/PriceModal'
 import { VenueModal } from 'features/search/pages/modals/VenueModal/VenueModal'
-import { SearchView } from 'features/search/types'
 import { TabLayout } from 'features/venue/components/TabLayout/TabLayout'
 import { GeolocatedVenue } from 'features/venueMap/components/VenueMapView/types'
 import { VenueMapViewContainer } from 'features/venueMap/components/VenueMapView/VenueMapViewContainer'
@@ -450,7 +448,7 @@ export const SearchResultsContent: React.FC = () => {
             <StyledLi>
               <FilterButton
                 activeFilters={activeFiltersCount}
-                navigateTo={getSearchNavConfig(SearchView.Filter)}
+                navigateTo={{ screen: 'SearchFilter' }}
               />
             </StyledLi>
             <StyledLi>

--- a/src/features/search/helpers/useNavigateToSearchFilter/useNavigateToSearchFilter.ts
+++ b/src/features/search/helpers/useNavigateToSearchFilter/useNavigateToSearchFilter.ts
@@ -1,14 +1,13 @@
 import { useNavigation } from '@react-navigation/native'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/searchStackHelpers'
-import { SearchState, SearchView } from 'features/search/types'
+import { SearchState } from 'features/search/types'
 
 export const useNavigateToSearchFilter = () => {
   const { navigate } = useNavigation<UseNavigationType>()
 
   const navigateToSearchFilter = (newSearchState: SearchState): void => {
-    navigate(...getSearchStackConfig(SearchView.Filter, newSearchState))
+    navigate('SearchFilter', newSearchState)
   }
   return { navigateToSearchFilter }
 }

--- a/src/features/search/pages/SearchFilter/SearchFilter.tsx
+++ b/src/features/search/pages/SearchFilter/SearchFilter.tsx
@@ -15,7 +15,7 @@ import { useSearch } from 'features/search/context/SearchWrapper'
 import { FilterBehaviour } from 'features/search/enums'
 import { useNavigateToSearch } from 'features/search/helpers/useNavigateToSearch/useNavigateToSearch'
 import { useSync } from 'features/search/helpers/useSync/useSync'
-import { LocationFilter, SearchView } from 'features/search/types'
+import { LocationFilter } from 'features/search/types'
 import { analytics } from 'libs/analytics/provider'
 import { useFunctionOnce } from 'libs/hooks'
 import { useLocation } from 'libs/location'
@@ -36,7 +36,7 @@ export const SearchFilter: React.FC = () => {
   const { disabilities, setDisabilities } = useAccessibilityFiltersContext()
   const routes = useNavigationState((state) => state?.routes)
   const currentRoute = routes?.[routes?.length - 1]?.name
-  useSync(currentRoute === SearchView.Filter)
+  useSync(currentRoute === 'SearchFilter')
 
   const { searchState, dispatch } = useSearch()
   const { navigateToSearch } = useNavigateToSearch('SearchResults')

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -31,7 +31,6 @@ export enum SearchView {
   Landing = 'SearchLanding',
   Results = 'SearchResults',
   Thematic = 'ThematicSearch',
-  Filter = 'SearchFilter',
 }
 
 export type OfferGenreType = { key: GenreType } & GenreTypeContentModel


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35529

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
