### PR TITLE
(BSR) chore(gitignore): don't ignore templates_github_ci/.sentryclirc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ android/sentry.properties
 ios/sentry.properties
 sourcemaps/*
 .sentryclirc
+!templates_github_ci/.sentryclirc
 
 # Snyk extension
 .dccache


### PR DESCRIPTION
So that sentryclirc, an important config file for sentry's config (used by fastlane) appears in the results of VS Code by default