### PR TITLE
(PC-35559) fix(allure): execute allure step even if a test failed

### DIFF
--- a/.github/workflows/dev_on_workflow_tester.yml
+++ b/.github/workflows/dev_on_workflow_tester.yml
@@ -145,12 +145,12 @@ jobs:
 
   allure-report:
     name: Update Allure report
-    if: github.ref == 'refs/heads/master'
+    if: ${{ always() && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
       contents: read
-    needs: yarn_test_native
+    needs: [yarn_test_native, yarn_test_web]
 
     steps:
       - name: Enable Corepack


### PR DESCRIPTION
## Contexte
Actuellement, le rapport Allure n'est pas généré lorsqu'au moins un des tests échoue. Cela empêche d'avoir une vue complète des tests flaky et des statistiques de test.

## Modifications
- Ajout de la condition `always()` dans le job `allure-report` pour qu'il s'exécute même en cas d'échec des tests
- Modification de la dépendance `needs` pour inclure à la fois `yarn_test_native` et `yarn_test_web`
- Le rapport Allure sera maintenant généré systématiquement sur la branche master, même si des tests échouent

## Impact
- Meilleure visibilité sur les tests flaky
- Statistiques de test plus complètes
- Rapport unifié incluant les tests web et natifs
- Conservation de l'historique des tests même en cas d'échec
