### PR TITLE
add color scheme store

### DIFF
--- a/src/libs/styled/ThemeWrapper.tsx
+++ b/src/libs/styled/ThemeWrapper.tsx
@@ -1,17 +1,20 @@
 import React from 'react'
-import { useColorScheme, ColorSchemeName } from 'react-native'
+import { ColorSchemeName } from 'react-native'
 
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 
+import { useColorScheme } from './useColorScheme'
+
 type ThemeWrapperProps = {
   children: (colorScheme: ColorSchemeName) => React.ReactNode
 }
+const DISABLED_FF_COLOR_SCHEME = 'light'
 
 export const ThemeWrapper: React.FC<ThemeWrapperProps> = ({ children }) => {
   const enableDarkMode = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ENABLE_DARK_MODE)
   const systemColorScheme = useColorScheme()
-  const colorScheme = enableDarkMode ? systemColorScheme ?? 'light' : 'light'
+  const colorScheme = enableDarkMode ? systemColorScheme : DISABLED_FF_COLOR_SCHEME
 
   return <React.Fragment>{children(colorScheme)}</React.Fragment>
 }

--- a/src/libs/styled/useColorScheme.tsx
+++ b/src/libs/styled/useColorScheme.tsx
@@ -1,0 +1,31 @@
+import { ColorSchemeName, Appearance } from 'react-native'
+
+import { createStore } from 'libs/store/createStore'
+
+export type ColorScheme = 'dark' | 'light'
+
+type State = { colorScheme: ColorScheme }
+
+const DEFAULT_COLOR_SCHEME = 'light'
+
+const defaultState: State = { colorScheme: Appearance.getColorScheme() || DEFAULT_COLOR_SCHEME }
+
+const colorSchemeStore = createStore({
+  name: 'colorScheme',
+  defaultState,
+  actions: (set) => ({
+    setColorScheme: ({ colorScheme }: { colorScheme: ColorSchemeName }) => {
+      set({ colorScheme: colorScheme || DEFAULT_COLOR_SCHEME })
+    },
+  }),
+  selectors: {
+    selectColorScheme: () => (state) => state.colorScheme,
+  },
+  options: {
+    persist: true,
+  },
+})
+
+export const { useColorScheme } = colorSchemeStore.hooks
+
+Appearance.addChangeListener(colorSchemeStore.actions.setColorScheme)

--- a/src/libs/styled/useComputedTheme.ts
+++ b/src/libs/styled/useComputedTheme.ts
@@ -1,11 +1,12 @@
 import { useMemo } from 'react'
-import { ColorSchemeName, useWindowDimensions } from 'react-native'
+import { useWindowDimensions } from 'react-native'
 
 import { useMediaQuery } from 'libs/react-responsive/useMediaQuery'
+import { ColorScheme } from 'libs/styled/useColorScheme'
 import { BaseAppThemeType, AppThemeType } from 'theme'
 import { designTokensDark, designTokensLight } from 'theme/designTokens'
 
-export function useComputedTheme(theme: BaseAppThemeType, colorScheme: ColorSchemeName) {
+export function useComputedTheme(theme: BaseAppThemeType, colorScheme: ColorScheme) {
   const { width: windowWidth } = useWindowDimensions()
   const tabletMinWidth = theme.breakpoints.md
   const desktopMinWidth = theme.breakpoints.lg

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,7 +1,8 @@
-import { ColorSchemeName, Platform } from 'react-native'
+import { Platform } from 'react-native'
 
 // eslint-disable-next-line no-restricted-imports
 import { isMobileDeviceDetectOnWeb, isTabletDeviceDetectOnWeb } from 'libs/react-device-detect'
+import { ColorScheme } from 'libs/styled/useColorScheme'
 // eslint-disable-next-line no-restricted-imports
 import { ModalSpacing } from 'ui/components/modals/enum'
 import { getSpacing } from 'ui/theme'
@@ -514,7 +515,7 @@ export const theme = {
 
 export type BaseAppThemeType = typeof theme
 export type AppThemeType = BaseAppThemeType & {
-  colorScheme?: ColorSchemeName
+  colorScheme?: ColorScheme
   isMobileViewport?: boolean
   isTabletViewport?: boolean
   isDesktopViewport?: boolean

--- a/src/ui/components/BlurView.tsx
+++ b/src/ui/components/BlurView.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export const BlurView = ({ blurAmount = 8, blurType }: Props) => {
   const { colorScheme } = useTheme()
-  const computedBlurType = blurType || (colorScheme === 'dark' ? 'dark' : 'light')
+  const computedBlurType = blurType || colorScheme
 
   return <Blurred blurType={computedBlurType} blurAmount={blurAmount} />
 }

--- a/src/ui/components/headers/BlurHeader.tsx
+++ b/src/ui/components/headers/BlurHeader.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export const BlurHeader = ({ height, blurAmount = 8, blurType }: Props) => {
   const { colorScheme } = useTheme()
-  const computedBlurType = blurType || (colorScheme === 'dark' ? 'dark' : 'light')
+  const computedBlurType = blurType || colorScheme
   // There is an issue with the blur on Android: we chose not to render it and use a white background
   // https://github.com/Kureev/react-native-blur/issues/511
   if (Platform.OS === 'android') return null


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
