### PR TITLE
Bsr poc orientation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
       android:screenOrientation="portrait"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
       android:launchMode="singleTask"
+      android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
       android:windowSoftInputMode="adjustResize"
       android:exported="true">
       <intent-filter>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,10 +20,8 @@
     <activity
       android:name=".MainActivity"
       android:label="@string/app_name"
-      android:screenOrientation="portrait"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
       android:launchMode="singleTask"
-      android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
       android:windowSoftInputMode="adjustResize"
       android:exported="true">
       <intent-filter>

--- a/android/app/src/main/java/com/passculture/MainActivity.java
+++ b/android/app/src/main/java/com/passculture/MainActivity.java
@@ -7,7 +7,9 @@ import com.facebook.react.ReactActivityDelegate; //@react-navigation
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
 import com.facebook.react.defaults.DefaultReactActivityDelegate;
 import android.content.Intent;
+import android.content.res.Configuration;
 import com.batch.android.Batch;
+import org.wonday.orientation.OrientationActivityLifecycle;
 
 public class MainActivity extends ReactActivity {
     /**
@@ -24,6 +26,7 @@ public class MainActivity extends ReactActivity {
     protected void onCreate(Bundle savedInstanceState) {
         SplashScreen.show(this, R.id.lottie);
         SplashScreen.setAnimationFinished(true); // We want the animation dialog to be forced to close when hide is called, so we use this
+        registerActivityLifecycleCallbacks(OrientationActivityLifecycle.getInstance());
         super.onCreate(null); // known fix for react-native-screens: https://github.com/software-mansion/react-native-screens#android
     }
 
@@ -46,4 +49,13 @@ public class MainActivity extends ReactActivity {
                 // If you opted-in for the New Architecture, we enable the Fabric Renderer.
                 DefaultNewArchitectureEntryPoint.getFabricEnabled());
     }
+
+    // react-native-orientation-locker
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+       super.onConfigurationChanged(newConfig);
+       Intent intent = new Intent("onConfigurationChanged");
+       intent.putExtra("newConfig", newConfig);
+       this.sendBroadcast(intent);
+   }
 }

--- a/ios/PassCulture/AppDelegate.mm
+++ b/ios/PassCulture/AppDelegate.mm
@@ -1,3 +1,5 @@
+#import "Orientation.h"
+
 #import "AppDelegate.h"
 
 #import <React/RCTBundleURLProvider.h>
@@ -95,6 +97,10 @@
 #else
   return [CodePush bundleURL]; // @codepush
 #endif
+}
+
+- (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {
+  return [Orientation getOrientation];
 }
 
 @end

--- a/ios/PassCulture/Info.plist
+++ b/ios/PassCulture/Info.plist
@@ -140,10 +140,6 @@
 	</array>
 	<key>UIRequiresFullScreen</key>
 	<true/>
-	<key>UISupportedInterfaceOrientations</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -601,6 +601,8 @@ PODS:
     - React-Core
   - react-native-netinfo (9.0.0):
     - React-Core
+  - react-native-orientation-locker (1.7.0):
+    - React-Core
   - react-native-safe-area-context (3.4.1):
     - React-Core
   - react-native-tracking-transparency (0.1.2):
@@ -868,6 +870,7 @@ DEPENDENCIES:
   - react-native-lottie-splash-screen (from `../node_modules/react-native-lottie-splash-screen`)
   - react-native-maps (from `../node_modules/react-native-maps`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
+  - react-native-orientation-locker (from `../node_modules/react-native-orientation-locker`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-tracking-transparency (from `../node_modules/react-native-tracking-transparency`)
   - react-native-webview (from `../node_modules/react-native-webview`)
@@ -1044,6 +1047,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-maps"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
+  react-native-orientation-locker:
+    :path: "../node_modules/react-native-orientation-locker"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-tracking-transparency:
@@ -1216,6 +1221,7 @@ SPEC CHECKSUMS:
   react-native-lottie-splash-screen: 2d84b1c81c176981d3e5e17df14da5a99a2f5082
   react-native-maps: a7783e616e0c3f2ee109ae315a15fb3c8608b1c3
   react-native-netinfo: 8fa5cbcb4a8e69e265ff685b9e54c175ef2bbd40
+  react-native-orientation-locker: cc6f357b289a2e0dd2210fea0c52cb8e0727fdaa
   react-native-safe-area-context: 667324e20fb3dd9c39c12d6036675ed90099bcd5
   react-native-tracking-transparency: 15eb319f2b982070eb9831582af27d87badfa624
   react-native-webview: ec195db71ebf55705d7b46a7da5f1b1746bb7efd

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "react-native-map-clustering": "^3.4.2",
     "react-native-maps": "^1.11.3",
     "react-native-modal": "^13.0.0",
+    "react-native-orientation-locker": "^1.7.0",
     "react-native-permissions": "^3.8.0",
     "react-native-qrcode-svg": "^6.1.2",
     "react-native-reanimated": "3.6.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import { ReactQueryClientProvider } from 'libs/react-query/ReactQueryClientProvi
 import { SplashScreenProvider } from 'libs/splashscreen'
 import { ThemeProvider } from 'libs/styled'
 import { ThemeWrapper } from 'libs/styled/ThemeWrapper'
+import { useOrientationLocked } from 'shared/hook/useOrientationLocked'
 import { theme } from 'theme'
 import { SnackBarProvider } from 'ui/components/snackBar/SnackBarContext'
 
@@ -57,6 +58,8 @@ LogBox.ignoreLogs([
 ])
 
 const App: FunctionComponent = function () {
+  useOrientationLocked()
+
   useEffect(() => {
     StatusBar.setBarStyle('dark-content')
     if (Platform.OS === 'android') {

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -1,6 +1,7 @@
 import { useFocusEffect } from '@react-navigation/native'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { NativeScrollEvent, Platform, ScrollView, View } from 'react-native'
+import Orientation from 'react-native-orientation-locker'
 import styled from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -144,6 +145,13 @@ const OnlineProfile: React.FC = () => {
     shareApp('profile_banner')
   }, [])
 
+  const [isOrientationLocked, setIsOrientationLocked] = useState(Orientation.isLocked())
+
+  useEffect(() => {
+    Orientation.addLockListener(() => setIsOrientationLocked(Orientation.isLocked()))
+    return () => Orientation.removeAllListeners()
+  }, [])
+
   return (
     <Page>
       <ScrollView
@@ -185,6 +193,19 @@ const OnlineProfile: React.FC = () => {
                     />
                   </Li>
                   <LiWithMarginVertical>
+                    <SectionWithSwitch
+                      icon={LocationPointer}
+                      iconSize={SECTION_ROW_ICON_SIZE}
+                      title="Permettre l’orientation"
+                      active={!isOrientationLocked}
+                      accessibilityDescribedBy={locationActivationErrorId}
+                      toggle={() => {
+                        Orientation.isLocked()
+                          ? Orientation.unlockAllOrientations()
+                          : Orientation.lockToPortrait()
+                      }}
+                      toggleLabel="Changer l’orientation"
+                    />
                     <SectionWithSwitch
                       icon={LocationPointer}
                       iconSize={SECTION_ROW_ICON_SIZE}

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -1,7 +1,6 @@
 import { useFocusEffect } from '@react-navigation/native'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { NativeScrollEvent, Platform, ScrollView, View } from 'react-native'
-import Orientation from 'react-native-orientation-locker'
 import styled from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -27,6 +26,7 @@ import { GeolocPermissionState, useLocation } from 'libs/location'
 import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { OfflinePage } from 'libs/network/OfflinePage'
 import { AccessibilityFooter } from 'shared/AccessibilityFooter/AccessibilityFooter'
+import { useOrientationLocked } from 'shared/hook/useOrientationLocked'
 import { getAge } from 'shared/user/getAge'
 import { InputError } from 'ui/components/inputs/InputError'
 import { Li } from 'ui/components/Li'
@@ -62,6 +62,7 @@ const OnlineProfile: React.FC = () => {
   const disableActivation = useFeatureFlag(RemoteStoreFeatureFlags.DISABLE_ACTIVATION)
   const enablePassForAll = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_PASS_FOR_ALL)
 
+  const [isOrientationLocked, toggleIsOrientationLocked] = useOrientationLocked()
   const { dispatch: favoritesDispatch } = useFavoritesState()
   const { isLoggedIn, user } = useAuthContext()
   const signOut = useLogoutRoutine()
@@ -145,13 +146,6 @@ const OnlineProfile: React.FC = () => {
     shareApp('profile_banner')
   }, [])
 
-  const [isOrientationLocked, setIsOrientationLocked] = useState(Orientation.isLocked())
-
-  useEffect(() => {
-    Orientation.addLockListener(() => setIsOrientationLocked(Orientation.isLocked()))
-    return () => Orientation.removeAllListeners()
-  }, [])
-
   return (
     <Page>
       <ScrollView
@@ -199,11 +193,7 @@ const OnlineProfile: React.FC = () => {
                       title="Permettre l’orientation"
                       active={!isOrientationLocked}
                       accessibilityDescribedBy={locationActivationErrorId}
-                      toggle={() => {
-                        Orientation.isLocked()
-                          ? Orientation.unlockAllOrientations()
-                          : Orientation.lockToPortrait()
-                      }}
+                      toggle={() => toggleIsOrientationLocked()}
                       toggleLabel="Changer l’orientation"
                     />
                     <SectionWithSwitch

--- a/src/shared/hook/useOrientationLocked.ts
+++ b/src/shared/hook/useOrientationLocked.ts
@@ -1,0 +1,26 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useCallback, useEffect, useState } from 'react'
+import Orientation from 'react-native-orientation-locker'
+
+export const useOrientationLocked = () => {
+  const [isOrientationLocked, setIsOrientationLocked] = useState(Orientation.isLocked())
+
+  const fetchOrientationLocked = useCallback(async () => {
+    const storedValue = await AsyncStorage.getItem('orientationLocked')
+    if (storedValue !== null) setIsOrientationLocked(Boolean(storedValue))
+    if (isOrientationLocked) Orientation.lockToPortrait()
+  }, [isOrientationLocked])
+
+  useEffect(() => {
+    void fetchOrientationLocked()
+    Orientation.addLockListener(() => setIsOrientationLocked(Orientation.isLocked()))
+    return () => Orientation.removeAllListeners()
+  }, [fetchOrientationLocked])
+
+  const toggleOrientationLocked = useCallback(async () => {
+    await AsyncStorage.setItem('orientationLocked', (!Orientation.isLocked()).toString())
+    Orientation.isLocked() ? Orientation.unlockAllOrientations() : Orientation.lockToPortrait()
+  }, [])
+
+  return [isOrientationLocked, toggleOrientationLocked] as const
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11060,6 +11060,7 @@ __metadata:
     react-native-map-clustering: ^3.4.2
     react-native-maps: ^1.11.3
     react-native-modal: ^13.0.0
+    react-native-orientation-locker: ^1.7.0
     react-native-permissions: ^3.8.0
     react-native-qrcode-svg: ^6.1.2
     react-native-reanimated: 3.6.3
@@ -25018,6 +25019,20 @@ __metadata:
     react: "*"
     react-native: ">=0.65.0"
   checksum: 0eac02e67a1c00a68b1537346b6a1abea234d56ea713e83af4673fda6b27841d8646339b4a64c2772a697f3f208ab74e1aabe7967e87b52d4e2db4ee3fc6166d
+  languageName: node
+  linkType: hard
+
+"react-native-orientation-locker@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "react-native-orientation-locker@npm:1.7.0"
+  peerDependencies:
+    react: ">=16.13.1"
+    react-native: ">=0.63.2"
+    react-native-windows: ">=0.63.3"
+  peerDependenciesMeta:
+    react-native-windows:
+      optional: true
+  checksum: 495010b3150adcbc1dcb24e0ca5c13838f02dbcee7c6ec391fe07bd47f9b75ac57b0ec1144aaab5d6ed62e7a354497e9fa5399359d896099ecbea439908817cf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Co-authored-by: Xavier De Koninck <XavierDK@users.noreply.github.com>

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
