### PR TITLE
(PC-35727) feat(DS): add color scheme store

### DIFF
--- a/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
@@ -531,6 +531,7 @@ exports[`NotEligibleEduConnect should render correctly 1`] = `
               },
               "size": 24,
             },
+            "colorScheme": "light",
             "colors": {
               "accent": "#0066ff",
               "aquamarine": "#27DCA8",

--- a/src/libs/styled/ThemeWrapper.tsx
+++ b/src/libs/styled/ThemeWrapper.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 
-import { ColorScheme, useColorScheme } from './useColorScheme'
+import { ColorScheme, colorSchemeActions, useColorScheme } from './useColorScheme'
 
 type ThemeWrapperProps = {
   children: (colorScheme: ColorScheme) => React.ReactNode
@@ -12,6 +12,7 @@ const DISABLED_FF_COLOR_SCHEME = 'light'
 
 export const ThemeWrapper: React.FC<ThemeWrapperProps> = ({ children }) => {
   const enableDarkMode = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ENABLE_DARK_MODE)
+  colorSchemeActions.init()
   const systemColorScheme = useColorScheme()
   const colorScheme = enableDarkMode ? systemColorScheme : DISABLED_FF_COLOR_SCHEME
 

--- a/src/libs/styled/ThemeWrapper.tsx
+++ b/src/libs/styled/ThemeWrapper.tsx
@@ -1,17 +1,19 @@
 import React from 'react'
-import { useColorScheme, ColorSchemeName } from 'react-native'
 
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 
+import { ColorScheme, useColorScheme } from './useColorScheme'
+
 type ThemeWrapperProps = {
-  children: (colorScheme: ColorSchemeName) => React.ReactNode
+  children: (colorScheme: ColorScheme) => React.ReactNode
 }
+const DISABLED_FF_COLOR_SCHEME = 'light'
 
 export const ThemeWrapper: React.FC<ThemeWrapperProps> = ({ children }) => {
   const enableDarkMode = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ENABLE_DARK_MODE)
   const systemColorScheme = useColorScheme()
-  const colorScheme = enableDarkMode ? systemColorScheme ?? 'light' : 'light'
+  const colorScheme = enableDarkMode ? systemColorScheme : DISABLED_FF_COLOR_SCHEME
 
   return <React.Fragment>{children(colorScheme)}</React.Fragment>
 }

--- a/src/libs/styled/native/ThemeProvider.tsx
+++ b/src/libs/styled/native/ThemeProvider.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
-import { ColorSchemeName } from 'react-native'
 import { ThemeProvider as DefaultThemeProvider } from 'styled-components/native'
 
+import { ColorScheme } from 'libs/styled/useColorScheme'
 import { BaseAppThemeType } from 'theme'
 
 import { useComputedTheme } from '../useComputedTheme'
@@ -9,7 +9,7 @@ import { useComputedTheme } from '../useComputedTheme'
 export type ThemeProviderProps = {
   theme: BaseAppThemeType
   children: React.ReactNode
-  colorScheme: ColorSchemeName
+  colorScheme: ColorScheme
 }
 
 export const ThemeProvider: FunctionComponent<ThemeProviderProps> = ({

--- a/src/libs/styled/useColorScheme.native.test.ts
+++ b/src/libs/styled/useColorScheme.native.test.ts
@@ -1,0 +1,71 @@
+import { Appearance, ColorSchemeName } from 'react-native'
+
+import { useColorScheme } from 'libs/styled/useColorScheme'
+import { act, renderHook } from 'tests/utils'
+
+const mockCurrentColorScheme = jest.fn((): ColorSchemeName => 'light')
+
+jest.mock('react-native/Libraries/Utilities/Appearance', () => {
+  let mockListenerColorScheme = jest.fn()
+  return {
+    getColorScheme: jest.fn(() => mockCurrentColorScheme()),
+    addChangeListener: (listener) => {
+      mockListenerColorScheme = listener
+    },
+    setColorScheme: (colorScheme) => {
+      mockCurrentColorScheme.mockReturnValue(colorScheme)
+      mockListenerColorScheme({ colorScheme })
+    },
+  }
+})
+
+describe('colorSchemeStore', () => {
+  beforeEach(() => {
+    mockCurrentColorScheme.mockReset()
+  })
+
+  it('should initialize with system colorScheme when is available', () => {
+    mockCurrentColorScheme.mockReturnValueOnce('dark')
+    const { result } = renderHook(() => useColorScheme())
+
+    expect(result.current).toBe('dark')
+  })
+
+  it.each([null, undefined])(
+    'should default to light theme if no color scheme is detected (%s)',
+    (value) => {
+      mockCurrentColorScheme.mockReturnValueOnce(value)
+
+      const { result } = renderHook(() => useColorScheme())
+
+      expect(result.current).toBe('light')
+    }
+  )
+
+  it('should react to system color scheme change from light to dark', async () => {
+    const { result } = renderHook(() => useColorScheme())
+
+    expect(result.current).toBe('light')
+
+    await act(async () => {
+      Appearance.setColorScheme('dark')
+    })
+
+    expect(result.current).toBe('dark')
+  })
+
+  it.each([null, undefined])(
+    'should keep light theme when system color scheme becomes unavailable (%s)',
+    async (value) => {
+      const { result } = renderHook(() => useColorScheme())
+
+      expect(result.current).toBe('light')
+
+      await act(async () => {
+        Appearance.setColorScheme(value)
+      })
+
+      expect(result.current).toBe('light')
+    }
+  )
+})

--- a/src/libs/styled/useColorScheme.native.test.ts
+++ b/src/libs/styled/useColorScheme.native.test.ts
@@ -42,7 +42,7 @@ describe('colorSchemeStore', () => {
     }
   )
 
-  it('should react to system color scheme change from light to dark', async () => {
+  it('should react to system color scheme change', async () => {
     const { result } = renderHook(() => useColorScheme())
 
     expect(result.current).toBe('light')
@@ -55,7 +55,7 @@ describe('colorSchemeStore', () => {
   })
 
   it.each([null, undefined])(
-    'should keep light theme when system color scheme becomes unavailable (%s)',
+    'should default to light theme when system color scheme becomes unavailable (%s)',
     async (value) => {
       const { result } = renderHook(() => useColorScheme())
 

--- a/src/libs/styled/useColorScheme.native.test.ts
+++ b/src/libs/styled/useColorScheme.native.test.ts
@@ -1,6 +1,6 @@
 import { Appearance, ColorSchemeName } from 'react-native'
 
-import { useColorScheme } from 'libs/styled/useColorScheme'
+import { colorSchemeActions, useColorScheme } from 'libs/styled/useColorScheme'
 import { act, renderHook } from 'tests/utils'
 
 const mockCurrentColorScheme = jest.fn((): ColorSchemeName => 'light')
@@ -24,8 +24,15 @@ describe('colorSchemeStore', () => {
     mockCurrentColorScheme.mockReset()
   })
 
+  it('should initialize with system colorScheme default (light)', () => {
+    const { result } = renderHook(() => useColorScheme())
+
+    expect(result.current).toBe('light')
+  })
+
   it('should initialize with system colorScheme when is available', () => {
     mockCurrentColorScheme.mockReturnValueOnce('dark')
+    colorSchemeActions.init()
     const { result } = renderHook(() => useColorScheme())
 
     expect(result.current).toBe('dark')
@@ -35,7 +42,7 @@ describe('colorSchemeStore', () => {
     'should default to light theme if no color scheme is detected (%s)',
     (value) => {
       mockCurrentColorScheme.mockReturnValueOnce(value)
-
+      colorSchemeActions.init()
       const { result } = renderHook(() => useColorScheme())
 
       expect(result.current).toBe('light')
@@ -43,6 +50,7 @@ describe('colorSchemeStore', () => {
   )
 
   it('should react to system color scheme change', async () => {
+    colorSchemeActions.init()
     const { result } = renderHook(() => useColorScheme())
 
     expect(result.current).toBe('light')
@@ -57,6 +65,7 @@ describe('colorSchemeStore', () => {
   it.each([null, undefined])(
     'should default to light theme when system color scheme becomes unavailable (%s)',
     async (value) => {
+      colorSchemeActions.init()
       const { result } = renderHook(() => useColorScheme())
 
       expect(result.current).toBe('light')

--- a/src/libs/styled/useColorScheme.tsx
+++ b/src/libs/styled/useColorScheme.tsx
@@ -4,22 +4,27 @@ import { createStore } from 'libs/store/createStore'
 
 export type ColorScheme = 'dark' | 'light'
 
-type State = { colorScheme: ColorScheme }
+type State = { colorScheme: () => ColorScheme }
 
 const DEFAULT_COLOR_SCHEME = 'light'
 
-const defaultState: State = { colorScheme: Appearance.getColorScheme() || DEFAULT_COLOR_SCHEME }
+const defaultState: State = {
+  colorScheme: () => Appearance.getColorScheme() || DEFAULT_COLOR_SCHEME,
+}
 
 const colorSchemeStore = createStore({
   name: 'colorScheme',
   defaultState,
   actions: (set) => ({
     setColorScheme: ({ colorScheme }: { colorScheme: ColorSchemeName }) => {
-      set({ colorScheme: colorScheme || DEFAULT_COLOR_SCHEME })
+      set({ colorScheme: () => colorScheme || DEFAULT_COLOR_SCHEME })
     },
   }),
   selectors: {
-    selectColorScheme: () => (state) => state.colorScheme,
+    selectColorScheme:
+      () =>
+      (state): ColorScheme =>
+        state.colorScheme(),
   },
   options: {
     persist: true,

--- a/src/libs/styled/useColorScheme.tsx
+++ b/src/libs/styled/useColorScheme.tsx
@@ -4,33 +4,35 @@ import { createStore } from 'libs/store/createStore'
 
 export type ColorScheme = 'dark' | 'light'
 
-type State = { colorScheme: () => ColorScheme }
+type State = { colorScheme: ColorScheme }
 
 const DEFAULT_COLOR_SCHEME = 'light'
 
 const defaultState: State = {
-  colorScheme: () => Appearance.getColorScheme() || DEFAULT_COLOR_SCHEME,
+  colorScheme: DEFAULT_COLOR_SCHEME,
 }
 
 const colorSchemeStore = createStore({
   name: 'colorScheme',
   defaultState,
   actions: (set) => ({
+    init: () => set({ colorScheme: Appearance.getColorScheme() || DEFAULT_COLOR_SCHEME }),
     setColorScheme: ({ colorScheme }: { colorScheme: ColorSchemeName }) => {
-      set({ colorScheme: () => colorScheme || DEFAULT_COLOR_SCHEME })
+      set({ colorScheme: colorScheme || DEFAULT_COLOR_SCHEME })
     },
   }),
   selectors: {
     selectColorScheme:
       () =>
       (state): ColorScheme =>
-        state.colorScheme(),
+        state.colorScheme,
   },
   options: {
     persist: true,
   },
 })
 
+export const colorSchemeActions = colorSchemeStore.actions
 export const { useColorScheme } = colorSchemeStore.hooks
 
 Appearance.addChangeListener(colorSchemeStore.actions.setColorScheme)

--- a/src/libs/styled/useColorScheme.tsx
+++ b/src/libs/styled/useColorScheme.tsx
@@ -1,0 +1,31 @@
+import { ColorSchemeName, Appearance } from 'react-native'
+
+import { createStore } from 'libs/store/createStore'
+
+export type ColorScheme = 'dark' | 'light'
+
+type State = { colorScheme: ColorScheme }
+
+const DEFAULT_COLOR_SCHEME = 'light'
+
+const defaultState: State = { colorScheme: Appearance.getColorScheme() || DEFAULT_COLOR_SCHEME }
+
+const colorSchemeStore = createStore({
+  name: 'colorScheme',
+  defaultState,
+  actions: (set) => ({
+    setColorScheme: ({ colorScheme }: { colorScheme: ColorSchemeName }) => {
+      set({ colorScheme: colorScheme || DEFAULT_COLOR_SCHEME })
+    },
+  }),
+  selectors: {
+    selectColorScheme: () => (state) => state.colorScheme,
+  },
+  options: {
+    persist: true,
+  },
+})
+
+export const { useColorScheme } = colorSchemeStore.hooks
+
+Appearance.addChangeListener(colorSchemeStore.actions.setColorScheme)

--- a/src/libs/styled/useComputedTheme.ts
+++ b/src/libs/styled/useComputedTheme.ts
@@ -1,11 +1,12 @@
 import { useMemo } from 'react'
-import { ColorSchemeName, useWindowDimensions } from 'react-native'
+import { useWindowDimensions } from 'react-native'
 
 import { useMediaQuery } from 'libs/react-responsive/useMediaQuery'
+import { ColorScheme } from 'libs/styled/useColorScheme'
 import { BaseAppThemeType, AppThemeType } from 'theme'
 import { designTokensDark, designTokensLight } from 'theme/designTokens'
 
-export function useComputedTheme(theme: BaseAppThemeType, colorScheme: ColorSchemeName) {
+export function useComputedTheme(theme: BaseAppThemeType, colorScheme: ColorScheme) {
   const { width: windowWidth } = useWindowDimensions()
   const tabletMinWidth = theme.breakpoints.md
   const desktopMinWidth = theme.breakpoints.lg

--- a/src/tests/computedTheme.tsx
+++ b/src/tests/computedTheme.tsx
@@ -2,6 +2,7 @@ import { AppThemeType, theme } from 'theme'
 
 export const computedTheme: Readonly<AppThemeType> = {
   ...theme,
+  colorScheme: 'light',
   isMobileViewport: true,
   isTabletViewport: false,
   isDesktopViewport: false,

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,7 +1,8 @@
-import { ColorSchemeName, Platform } from 'react-native'
+import { Platform } from 'react-native'
 
 // eslint-disable-next-line no-restricted-imports
 import { isMobileDeviceDetectOnWeb, isTabletDeviceDetectOnWeb } from 'libs/react-device-detect'
+import { ColorScheme } from 'libs/styled/useColorScheme'
 // eslint-disable-next-line no-restricted-imports
 import { ModalSpacing } from 'ui/components/modals/enum'
 import { getSpacing } from 'ui/theme'
@@ -514,7 +515,7 @@ export const theme = {
 
 export type BaseAppThemeType = typeof theme
 export type AppThemeType = BaseAppThemeType & {
-  colorScheme?: ColorSchemeName
+  colorScheme?: ColorScheme
   isMobileViewport?: boolean
   isTabletViewport?: boolean
   isDesktopViewport?: boolean

--- a/src/ui/components/BlurView.tsx
+++ b/src/ui/components/BlurView.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export const BlurView = ({ blurAmount = 8, blurType }: Props) => {
   const { colorScheme } = useTheme()
-  const computedBlurType = blurType || (colorScheme === 'dark' ? 'dark' : 'light')
+  const computedBlurType = blurType || colorScheme
 
   return <Blurred blurType={computedBlurType} blurAmount={blurAmount} />
 }

--- a/src/ui/components/headers/BlurHeader.tsx
+++ b/src/ui/components/headers/BlurHeader.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export const BlurHeader = ({ height, blurAmount = 8, blurType }: Props) => {
   const { colorScheme } = useTheme()
-  const computedBlurType = blurType || (colorScheme === 'dark' ? 'dark' : 'light')
+  const computedBlurType = blurType || colorScheme
   // There is an issue with the blur on Android: we chose not to render it and use a white background
   // https://github.com/Kureev/react-native-blur/issues/511
   if (Platform.OS === 'android') return null


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35727

Description : En vue de la préparation et de la réfactorisation du theme pour le dark mode. 
Dans un premier temps réaliser un store de colorScheme afin de pouvoir récupérer et set la valeur du theme partout dans l'app en ajoutant cette option de persistance dans l'app. 

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
