### PR TITLE
(PC-35715) refactor(AvatarList): add avatar config prop

### DIFF
--- a/src/features/venue/components/VenueOffers/VenueOffersList.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffersList.tsx
@@ -25,7 +25,7 @@ import {
 import { CategoryHomeLabelMapping, CategoryIdMapping } from 'libs/subcategories/types'
 import { Currency } from 'shared/currency/useGetCurrencyToDisplay'
 import { Offer } from 'shared/offer/types'
-import { AvatarsList } from 'ui/components/Avatar/AvatarList'
+import { AvatarList } from 'ui/components/Avatar/AvatarList'
 import { PassPlaylist } from 'ui/components/PassPlaylist'
 import { CustomListRenderItem, RenderFooterItem } from 'ui/components/Playlist'
 import { SeeMore } from 'ui/components/SeeMore'
@@ -138,7 +138,7 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
       {shouldDisplayArtistsPlaylist ? (
         <ArtistsPlaylistContainer gap={2}>
           <ArtistsPlaylistTitleText>Les artistes disponibles dans ce lieu</ArtistsPlaylistTitleText>
-          <AvatarsList data={artists} onItemPress={handleArtistsPlaylistPress} />
+          <AvatarList data={artists} onItemPress={handleArtistsPlaylistPress} />
         </ArtistsPlaylistContainer>
       ) : null}
       {playlists.length

--- a/src/ui/components/Avatar/Avatar.tsx
+++ b/src/ui/components/Avatar/Avatar.tsx
@@ -37,6 +37,7 @@ export const Avatar = ({
       <Container
         rounded={rounded}
         size={size}
+        testID="Avatar"
         borderWidth={borderWidth}
         borderColor={borderColor}
         borderRadius={borderRadius}>

--- a/src/ui/components/Avatar/AvatarList.native.test.tsx
+++ b/src/ui/components/Avatar/AvatarList.native.test.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { render, screen, userEvent } from 'tests/utils'
-import { AvatarsList } from 'ui/components/Avatar/AvatarList'
+import { AvatarList } from 'ui/components/Avatar/AvatarList'
+import { AVATAR_LARGE, AVATAR_SMALL } from 'ui/theme/constants'
 
 const avatarsData = [
   { id: '1', image: 'url1', name: 'Oda' },
@@ -16,28 +17,56 @@ describe('<AvatarsList />', () => {
   jest.useFakeTimers()
 
   it('should display all items in the list', () => {
-    render(<AvatarsList data={avatarsData} onItemPress={jest.fn()} />)
+    render(<AvatarList data={avatarsData} onItemPress={jest.fn()} />)
 
     expect(screen.getByText('Oda')).toBeOnTheScreen()
     expect(screen.getByText('MMMM')).toBeOnTheScreen()
     expect(screen.getByText('Lolo')).toBeOnTheScreen()
+
+    expect(screen.getAllByTestId('Avatar').at(0)).toHaveProp('size', AVATAR_LARGE)
+    expect(screen.getAllByTestId('Avatar').at(0)).toHaveProp('borderColor', 'white')
+  })
+
+  it('should display items with custom avatar config', () => {
+    render(
+      <AvatarList
+        data={avatarsData}
+        onItemPress={jest.fn()}
+        avatarConfig={{ size: AVATAR_SMALL, borderColor: 'pink' }}
+      />
+    )
+
+    expect(screen.getByText('Oda')).toBeOnTheScreen()
+    expect(screen.getByText('MMMM')).toBeOnTheScreen()
+    expect(screen.getByText('Lolo')).toBeOnTheScreen()
+
+    expect(screen.getAllByTestId('Avatar').at(0)).toHaveProp('size', AVATAR_SMALL)
+    expect(screen.getAllByTestId('Avatar').at(0)).toHaveProp('borderColor', 'pink')
+  })
+
+  it('should force default avatar size to AVATAR_LARGE', () => {
+    render(
+      <AvatarList data={avatarsData} onItemPress={jest.fn()} avatarConfig={{ size: undefined }} />
+    )
+
+    expect(screen.getAllByTestId('Avatar').at(0)).toHaveProp('size', AVATAR_LARGE)
   })
 
   it('should display custom images for avatars', () => {
-    render(<AvatarsList data={avatarsData} onItemPress={jest.fn()} />)
+    render(<AvatarList data={avatarsData} onItemPress={jest.fn()} />)
 
     expect(screen.getByLabelText('Avatar de lʼartiste Oda')).toBeOnTheScreen()
     expect(screen.getByLabelText('Avatar de lʼartiste MMMM')).toBeOnTheScreen()
   })
 
   it('should handle missing images gracefully', () => {
-    render(<AvatarsList data={avatarsData} onItemPress={jest.fn()} />)
+    render(<AvatarList data={avatarsData} onItemPress={jest.fn()} />)
 
     expect(screen.getByTestId('BicolorProfile')).toBeOnTheScreen()
   })
 
   it('should navigate to the artist when clicking on avatar tile', async () => {
-    render(<AvatarsList data={avatarsData} onItemPress={jest.fn()} />)
+    render(<AvatarList data={avatarsData} onItemPress={jest.fn()} />)
 
     await user.press(screen.getByText('Oda'))
 

--- a/src/ui/components/Avatar/AvatarList.tsx
+++ b/src/ui/components/Avatar/AvatarList.tsx
@@ -1,40 +1,56 @@
-import React, { FunctionComponent } from 'react'
+import { mergeWith } from 'lodash'
+import React, { FunctionComponent, useCallback } from 'react'
 import { FlatList } from 'react-native-gesture-handler'
 
 import { Artist } from 'features/venue/types'
-import { theme } from 'theme'
+import { AvatarProps } from 'ui/components/Avatar/Avatar'
 import { AvatarListItem, AvatarListItemProps } from 'ui/components/Avatar/AvatarListItem'
 import { Playlist } from 'ui/components/Playlist'
-import { getSpacing } from 'ui/theme'
 import { AVATAR_LARGE } from 'ui/theme/constants'
 
-type AvatarsListProps = {
+type AvatarListProps = {
   data: Artist[]
+  avatarConfig?: AvatarProps
   onItemPress: (artistName: string) => void
 }
 
-const GAP = getSpacing(2)
-const PLAYLIST_ITEM_HEIGHT =
-  AVATAR_LARGE + parseFloat(theme.designSystem.typography.title4.fontSize) + GAP
-const PLAYLIST_ITEM_WIDTH = AVATAR_LARGE
+const AVATAR_DEFAULT_CONFIG = {
+  size: AVATAR_LARGE,
+  rounded: true,
+} satisfies AvatarProps
 
-export const AvatarsList: FunctionComponent<AvatarsListProps> = ({ data, onItemPress }) => {
-  const renderAvatar = ({ item }: { item: AvatarListItemProps }) => (
-    <AvatarListItem
-      id={item.id}
-      image={item.image}
-      name={item.name}
-      width={PLAYLIST_ITEM_WIDTH}
-      onItemPress={onItemPress}
-    />
+export const AvatarList: FunctionComponent<AvatarListProps> = ({
+  data,
+  onItemPress,
+  avatarConfig = {},
+}) => {
+  const mergedAvatarConfig = mergeWith(
+    avatarConfig,
+    AVATAR_DEFAULT_CONFIG,
+    (value, srcValue) => value ?? srcValue
   )
+  const renderAvatar = useCallback(
+    ({ item }: { item: AvatarListItemProps }) => (
+      <AvatarListItem
+        id={item.id}
+        image={item.image}
+        name={item.name}
+        onItemPress={onItemPress}
+        {...mergedAvatarConfig}
+      />
+    ),
+    [onItemPress, mergedAvatarConfig]
+  )
+
+  const size = mergedAvatarConfig.size
+
   return (
     <Playlist
       data={data}
       keyExtractor={(item) => item.id}
       renderItem={renderAvatar}
-      itemHeight={PLAYLIST_ITEM_HEIGHT}
-      itemWidth={PLAYLIST_ITEM_WIDTH}
+      itemHeight={size}
+      itemWidth={size}
       FlatListComponent={FlatList}
     />
   )

--- a/src/ui/components/Avatar/AvatarListItem.native.test.tsx
+++ b/src/ui/components/Avatar/AvatarListItem.native.test.tsx
@@ -4,20 +4,15 @@ import { render, screen } from 'tests/utils'
 import { AvatarListItem } from 'ui/components/Avatar/AvatarListItem'
 
 describe('<AvatarListItem />', () => {
-  it('should display artist avatar name', () => {
-    render(<AvatarListItem id={1} name="Oda" width={100} onItemPress={jest.fn()} />)
+  it('should display artist avatar name + image', () => {
+    render(<AvatarListItem id={1} name="Oda" image="url" onItemPress={jest.fn()} />)
 
     expect(screen.getByText('Oda')).toBeOnTheScreen()
-  })
-
-  it('should display image avatar', () => {
-    render(<AvatarListItem id={1} name="Oda" image="url" width={100} onItemPress={jest.fn()} />)
-
     expect(screen.getByLabelText('Avatar de lʼartiste Oda')).toBeOnTheScreen()
   })
 
   it('should display default image avatar', () => {
-    render(<AvatarListItem id={1} name="Oda" width={100} onItemPress={jest.fn()} />)
+    render(<AvatarListItem id={1} name="Oda" onItemPress={jest.fn()} />)
 
     expect(screen.queryByLabelText('Avatar de lʼartiste')).not.toBeOnTheScreen()
     expect(screen.getByTestId('BicolorProfile')).toBeOnTheScreen()

--- a/src/ui/components/Avatar/AvatarListItem.tsx
+++ b/src/ui/components/Avatar/AvatarListItem.tsx
@@ -8,12 +8,10 @@ import { DefaultAvatar } from 'ui/components/Avatar/DefaultAvatar'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { getSpacing, Typo } from 'ui/theme'
-import { AVATAR_LARGE } from 'ui/theme/constants'
 
 export type AvatarListItemProps = {
   id: number
   name: string
-  width: number
   onItemPress: (artistName: string) => void
   image?: string
 } & AvatarProps
@@ -22,7 +20,7 @@ export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
   id,
   image,
   name,
-  width,
+  size,
   onItemPress,
   ...props
 }) => {
@@ -36,7 +34,7 @@ export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
       }}
       onBeforeNavigate={() => onItemPress(name)}>
       <StyledView gap={2}>
-        <Avatar borderWidth={6} size={AVATAR_LARGE} {...props}>
+        <Avatar borderWidth={6} size={size} {...props}>
           {image ? (
             <StyledImage
               url={image}
@@ -48,7 +46,7 @@ export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
           )}
         </Avatar>
 
-        <ArtistName numberOfLines={2} maxWidth={width}>
+        <ArtistName numberOfLines={2} maxWidth={size ?? 0}>
           {name}
         </ArtistName>
       </StyledView>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35715

Ajout d'un prop `avatarConfig` au composant `AvatarList` pour plus de flexibilité dans la configuration des avatars

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
