### PR TITLE
(PC-35716) feat(search): add artists in search multi-query

### DIFF
--- a/src/features/search/api/useSearchResults/useSearchResults.native.test.ts
+++ b/src/features/search/api/useSearchResults/useSearchResults.native.test.ts
@@ -47,6 +47,7 @@ const mockDispatch = jest.fn()
 const mockFetchSearchResultsResponse = {
   offersResponse: { ...mockedAlgoliaResponse, nbHits: 0, userData: null },
   venuesResponse: mockedAlgoliaVenueResponse,
+  offerArtistsResponse: { ...mockedAlgoliaResponse, nbHits: 0, userData: null },
   facetsResponse: algoliaFacets,
   duplicatedOffersResponse: { ...mockedAlgoliaResponse, nbHits: 0, userData: null },
   redirectUrl: undefined,
@@ -122,6 +123,20 @@ describe('useSearchResults', () => {
             },
             query: '',
           },
+          {
+            indexName: 'algoliaOffersIndexName',
+            params: {
+              attributesToHighlight: [],
+              attributesToRetrieve: ['artists'],
+              clickAnalytics: true,
+              facetFilters: [['offer.isEducational:false']],
+              hitsPerPage: 100,
+              numericFilters: [['offer.prices: 0 TO 300']],
+              tagFilters: '["-is_future"]',
+              page: 0,
+            },
+            query: '',
+          },
         ])
       })
     })
@@ -133,6 +148,20 @@ describe('useSearchResults', () => {
       await waitFor(() => {
         expect(multipleQueries).toHaveBeenCalledTimes(1)
       })
+    })
+
+    it('should return artist list based on offers', async () => {
+      fetchSearchResultsSpy.mockResolvedValueOnce(mockFetchSearchResultsResponse)
+      const { result } = renderUseSearchResults()
+
+      await waitFor(() =>
+        expect(result.current.hits.artists).toStrictEqual([
+          { id: '1', name: 'Artist 1' },
+          { id: '2', name: 'Artist 2' },
+          { id: '3', name: 'Artist 3' },
+          { id: '4', name: 'Artist 4' },
+        ])
+      )
     })
 
     // because of an Algolia issue, sometimes nbHits is at 0 even when there is some hits, cf PC-28287

--- a/src/features/search/components/SearchList/SearchList.native.test.tsx
+++ b/src/features/search/components/SearchList/SearchList.native.test.tsx
@@ -46,7 +46,7 @@ describe('<SearchList />', () => {
 
   const props: SearchListProps = {
     nbHits: mockNbHits,
-    hits: { offers: mockHits, venues: [], duplicatedOffers: mockHits },
+    hits: { offers: mockHits, venues: [], duplicatedOffers: mockHits, artists: [] },
     renderItem,
     autoScrollEnabled: true,
     refreshing: false,

--- a/src/features/search/components/SearchList/SearchList.web.test.tsx
+++ b/src/features/search/components/SearchList/SearchList.web.test.tsx
@@ -33,7 +33,7 @@ const renderItem = jest.fn()
 
 const props: SearchListProps = {
   nbHits: mockNbHits,
-  hits: { offers: mockHits, venues: [], duplicatedOffers: mockHits },
+  hits: { offers: mockHits, venues: [], duplicatedOffers: mockHits, artists: [] },
   renderItem,
   autoScrollEnabled: true,
   refreshing: false,

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/offerAttributesToRetrieve.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/offerAttributesToRetrieve.ts
@@ -16,6 +16,7 @@ export const offerAttributesToRetrieve = [
   'objectID',
   '_geoloc',
   'venue',
+  'artists',
   'offer.likes',
   'offer.chroniclesCount',
   'offer.headlineCount',

--- a/src/libs/algolia/fetchAlgolia/fetchSearchResults/fetchSearchResults.test.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchSearchResults/fetchSearchResults.test.ts
@@ -127,6 +127,20 @@ describe('fetchSearchResults', () => {
         },
         query: 'searched query',
       },
+      {
+        indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
+        params: {
+          attributesToHighlight: [],
+          attributesToRetrieve: ['artists'],
+          clickAnalytics: true,
+          facetFilters: [['offer.isEducational:false']],
+          numericFilters: [['offer.prices: 0 TO 300']],
+          tagFilters: '["-is_future"]',
+          page: 0,
+          hitsPerPage: 100,
+        },
+        query: 'searched query',
+      },
     ]
 
     expect(mockMultipleQueries).toHaveBeenCalledWith(expectedResult)
@@ -189,6 +203,20 @@ describe('fetchSearchResults', () => {
           tagFilters: '["-is_future"]',
           page: 0,
           typoTolerance: false,
+        },
+        query: 'searched query',
+      },
+      {
+        indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
+        params: {
+          attributesToHighlight: [],
+          attributesToRetrieve: ['artists'],
+          clickAnalytics: true,
+          facetFilters: [['offer.isEducational:false']],
+          numericFilters: [['offer.prices: 0 TO 300']],
+          tagFilters: '["-is_future"]',
+          page: 0,
+          hitsPerPage: 100,
         },
         query: 'searched query',
       },
@@ -265,6 +293,22 @@ describe('fetchSearchResults', () => {
           tagFilters: '["-is_future"]',
           page: 0,
           typoTolerance: false,
+        },
+        query: 'searched query',
+      },
+      {
+        indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
+        params: {
+          aroundLatLng: '42, 43',
+          aroundRadius: 'all',
+          attributesToHighlight: [],
+          attributesToRetrieve: ['artists'],
+          clickAnalytics: true,
+          facetFilters: [['offer.isEducational:false']],
+          numericFilters: [['offer.prices: 0 TO 300']],
+          tagFilters: '["-is_future"]',
+          page: 0,
+          hitsPerPage: 100,
         },
         query: 'searched query',
       },
@@ -345,6 +389,22 @@ describe('fetchSearchResults', () => {
         },
         query: 'searched query',
       },
+      {
+        indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
+        params: {
+          aroundLatLng: '42, 43',
+          aroundRadius: 100000,
+          attributesToHighlight: [],
+          attributesToRetrieve: ['artists'],
+          clickAnalytics: true,
+          facetFilters: [['offer.isEducational:false']],
+          numericFilters: [['offer.prices: 0 TO 300']],
+          tagFilters: '["-is_future"]',
+          page: 0,
+          hitsPerPage: 100,
+        },
+        query: 'searched query',
+      },
     ]
 
     expect(mockMultipleQueries).toHaveBeenCalledWith(expectedResult)
@@ -419,6 +479,22 @@ describe('fetchSearchResults', () => {
           tagFilters: '["-is_future"]',
           page: 0,
           typoTolerance: false,
+        },
+        query: 'searched query',
+      },
+      {
+        indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
+        params: {
+          aroundLatLng: '5.16176, -52.669726',
+          aroundRadius: 100000,
+          attributesToHighlight: [],
+          attributesToRetrieve: ['artists'],
+          clickAnalytics: true,
+          facetFilters: [['offer.isEducational:false']],
+          numericFilters: [['offer.prices: 0 TO 300']],
+          tagFilters: '["-is_future"]',
+          page: 0,
+          hitsPerPage: 100,
         },
         query: 'searched query',
       },
@@ -499,6 +575,22 @@ describe('fetchSearchResults', () => {
         },
         query: 'searched query',
       },
+      {
+        indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
+        params: {
+          aroundLatLng: '5.16176, -52.669726',
+          aroundRadius: 100000,
+          attributesToHighlight: [],
+          attributesToRetrieve: ['artists'],
+          clickAnalytics: true,
+          facetFilters: [['offer.isEducational:false']],
+          numericFilters: [['offer.prices: 0 TO 300']],
+          tagFilters: '["-is_future"]',
+          page: 0,
+          hitsPerPage: 100,
+        },
+        query: 'searched query',
+      },
     ]
 
     expect(mockMultipleQueries).toHaveBeenCalledWith(expectedResult)
@@ -573,6 +665,20 @@ describe('fetchSearchResults', () => {
         },
         query: 'searched query',
       },
+      {
+        indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
+        params: {
+          attributesToHighlight: [],
+          attributesToRetrieve: ['artists'],
+          clickAnalytics: true,
+          facetFilters: [['offer.isEducational:false'], ['venue.id:5543']],
+          numericFilters: [['offer.prices: 0 TO 300']],
+          tagFilters: '["-is_future"]',
+          page: 0,
+          hitsPerPage: 100,
+        },
+        query: 'searched query',
+      },
     ]
 
     expect(mockMultipleQueries).toHaveBeenCalledWith(expectedResult)
@@ -644,6 +750,20 @@ describe('fetchSearchResults', () => {
           tagFilters: '["-is_future"]',
           page: 0,
           typoTolerance: false,
+        },
+        query: 'searched query',
+      },
+      {
+        indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
+        params: {
+          attributesToHighlight: [],
+          attributesToRetrieve: ['artists'],
+          clickAnalytics: true,
+          facetFilters: [['offer.isEducational:false'], ['venue.id:5543']],
+          numericFilters: [['offer.prices: 0 TO 300']],
+          tagFilters: '["-is_future"]',
+          page: 0,
+          hitsPerPage: 100,
         },
         query: 'searched query',
       },
@@ -735,6 +855,24 @@ describe('fetchSearchResults', () => {
         },
         query: 'searched query',
       },
+      {
+        indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
+        params: {
+          attributesToHighlight: [],
+          attributesToRetrieve: ['artists'],
+          clickAnalytics: true,
+          facetFilters: [
+            ['offer.isEducational:false'],
+            ['venue.isAudioDisabilityCompliant:true'],
+            ['venue.isMentalDisabilityCompliant:true'],
+          ],
+          numericFilters: [['offer.prices: 0 TO 300']],
+          tagFilters: '["-is_future"]',
+          page: 0,
+          hitsPerPage: 100,
+        },
+        query: 'searched query',
+      },
     ]
 
     expect(mockMultipleQueries).toHaveBeenCalledWith(expectedResult)
@@ -810,6 +948,25 @@ describe('fetchSearchResults', () => {
         },
         query: 'searched query',
       },
+      {
+        indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
+        params: {
+          attributesToHighlight: [],
+          attributesToRetrieve: ['artists'],
+          clickAnalytics: true,
+          facetFilters: [['offer.isEducational:false']],
+          numericFilters: [['offer.prices: 0 TO 300']],
+          tagFilters: '["-is_future"]',
+          page: 0,
+          hitsPerPage: 100,
+          aroundPrecision: [
+            { from: 0, value: 1000 },
+            { from: 1000, value: 4000 },
+            { from: 5000, value: 10000 },
+          ],
+        },
+        query: 'searched query',
+      },
     ]
 
     expect(mockMultipleQueries).toHaveBeenCalledWith(expectedResult)
@@ -873,6 +1030,20 @@ describe('fetchSearchResults', () => {
           tagFilters: '["-is_future"]',
           page: 0,
           typoTolerance: false,
+        },
+        query: 'searched query',
+      },
+      {
+        indexName: 'algoliaOffersIndexName',
+        params: {
+          attributesToHighlight: [],
+          attributesToRetrieve: ['artists'],
+          clickAnalytics: true,
+          facetFilters: [['offer.isEducational:false']],
+          hitsPerPage: 100,
+          numericFilters: [['offer.prices: 0 TO 300']],
+          tagFilters: '["-is_future"]',
+          page: 0,
         },
         query: 'searched query',
       },

--- a/src/libs/algolia/fixtures/algoliaFixtures.ts
+++ b/src/libs/algolia/fixtures/algoliaFixtures.ts
@@ -29,6 +29,7 @@ export const mockedAlgoliaResponse = toMutable({
         postalCode: '75000',
         city: 'Paris',
       },
+      artists: [{ id: '1', name: 'Artist 1' }],
     },
     {
       offer: {
@@ -51,6 +52,10 @@ export const mockedAlgoliaResponse = toMutable({
         postalCode: '75000',
         city: 'Paris',
       },
+      artists: [
+        { id: '2', name: 'Artist 2' },
+        { id: '3', name: 'Artist 3' },
+      ],
     },
     {
       offer: {
@@ -95,6 +100,10 @@ export const mockedAlgoliaResponse = toMutable({
         postalCode: '75000',
         city: 'Paris',
       },
+      artists: [
+        { id: '4', name: 'Artist 4' },
+        { id: '5', name: 'Artist 4' },
+      ],
     },
   ],
   nbHits: 4,

--- a/src/shared/offer/getSimilarOrRecoOffersInOrder.test.ts
+++ b/src/shared/offer/getSimilarOrRecoOffersInOrder.test.ts
@@ -1,4 +1,3 @@
-import { SubcategoryIdEnum } from 'api/gen'
 import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
 import { getSimilarOrRecoOffersInOrder } from 'shared/offer/getSimilarOrRecoOffersInOrder'
 
@@ -6,99 +5,12 @@ describe('getSimilarOffersInOrder', () => {
   const ids = ['102310', '102249', '102272', '102280']
   const offers = mockedAlgoliaResponse.hits
 
+  const getOfferById = (id: string) => offers.find((offer) => offer.objectID === id)
+
   it('should return offers in ids array order', () => {
     const similarOffersInOrder = getSimilarOrRecoOffersInOrder(ids, offers)
 
-    expect(similarOffersInOrder).toEqual([
-      {
-        offer: {
-          dates: [],
-          isDigital: false,
-          isDuo: false,
-          name: 'I want something more',
-          prices: [28.0],
-          subcategoryId: SubcategoryIdEnum.CONCERT,
-          thumbUrl:
-            'https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/CDZQ',
-        },
-        _geoloc: { lat: 4.90339, lng: -52.31663 },
-        objectID: '102310',
-        venue: {
-          id: 4,
-          name: 'Lieu 4',
-          publicName: 'Lieu 4',
-          address: '4 rue de la paix',
-          postalCode: '75000',
-          city: 'Paris',
-        },
-      },
-      {
-        offer: {
-          dates: [1605643200.0],
-          isDigital: false,
-          isDuo: true,
-          name: 'Un lit sous une rivière',
-          prices: [34.0],
-          subcategoryId: SubcategoryIdEnum.CONCERT,
-          thumbUrl:
-            'https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/CDBA',
-        },
-        _geoloc: { lat: 4.90339, lng: -52.31663 },
-        objectID: '102249',
-        venue: {
-          id: 3,
-          name: 'Lieu 3',
-          publicName: 'Lieu 3',
-          address: '3 rue de la paix',
-          postalCode: '75000',
-          city: 'Paris',
-        },
-      },
-      {
-        offer: {
-          dates: [],
-          isDigital: false,
-          isDuo: false,
-          name: 'I want something more',
-          prices: [23.0],
-          subcategoryId: SubcategoryIdEnum.CONCERT,
-          thumbUrl:
-            'https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/CDKQ',
-        },
-        _geoloc: { lat: 48.91265, lng: 2.4513 },
-        objectID: '102272',
-        venue: {
-          id: 2,
-          name: 'Lieu 2',
-          publicName: 'Lieu 2',
-          address: '2 rue de la paix',
-          postalCode: '75000',
-          city: 'Paris',
-        },
-      },
-      {
-        offer: {
-          dates: [],
-          isDigital: false,
-          isDuo: false,
-          name: 'La nuit des temps',
-          prices: [28.0],
-          subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
-          thumbUrl:
-            'https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/CDNQ',
-        },
-        _geoloc: { lat: 48.94374, lng: 2.48171 },
-        objectID: '102280',
-        venue: {
-          id: 1,
-          name: 'Lieu 1',
-          publicName: 'Lieu 1',
-          address: '1 rue de la paix',
-          postalCode: '75000',
-          city: 'Paris',
-        },
-      },
-    ])
+    expect(similarOffersInOrder).toEqual(ids.map((id) => getOfferById(id)))
   })
 
   it('should not return offers in offers array order', () => {

--- a/src/shared/offer/offer.fixture.ts
+++ b/src/shared/offer/offer.fixture.ts
@@ -26,6 +26,7 @@ export const offersFixture = toMutable([
       postalCode: '75000',
       city: 'Paris',
     },
+    artists: [{ id: '1', name: 'Artist 1' }],
   },
   {
     offer: {
@@ -48,6 +49,10 @@ export const offersFixture = toMutable([
       postalCode: '75000',
       city: 'Paris',
     },
+    artists: [
+      { id: '2', name: 'Artist 2' },
+      { id: '3', name: 'Artist 3' },
+    ],
   },
   {
     offer: {
@@ -92,5 +97,9 @@ export const offersFixture = toMutable([
       postalCode: '75000',
       city: 'Paris',
     },
+    artists: [
+      { id: '4', name: 'Artist 4' },
+      { id: '5', name: 'Artist 4' },
+    ],
   },
 ] as const satisfies ReadonlyDeep<Offer[]>)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35716

Prise en compte des artistes dans les résultats de recherche.

EDIT : Après discussion, on oublie la multi-query Algolia, à la place on crée une liste d'artistes à partir des offres récupérées.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
