### PR TITLE
(BSR) refactor(ObjectType): strict type Object.keys

### DIFF
--- a/src/features/cookies/helpers/setMarketingParams.native.test.ts
+++ b/src/features/cookies/helpers/setMarketingParams.native.test.ts
@@ -24,8 +24,8 @@ const EXPECTED_STORAGE: { [key in StorageKey]?: string } = {
   campaign_date: UTM_PARAMS.campaign_date,
 }
 
-const storageKeys = Object.keys(EXPECTED_STORAGE) as StorageKey[]
-const storageKeysWithoutDate = (Object.keys(EXPECTED_STORAGE) as StorageKey[]).filter(
+const storageKeys = Object.keys(EXPECTED_STORAGE)
+const storageKeysWithoutDate = Object.keys(EXPECTED_STORAGE).filter(
   (key) => key !== 'campaign_date'
 )
 const { campaign_date: _campaign_date, ...EXPECTED_STORAGE_WITHOUT_DATE } = EXPECTED_STORAGE

--- a/src/features/internal/components/DeeplinksGeneratorForm.tsx
+++ b/src/features/internal/components/DeeplinksGeneratorForm.tsx
@@ -339,9 +339,7 @@ export const DeeplinksGeneratorForm = ({ onCreate }: Props) => {
         <StyledTitle4>Besoin d’un lien&nbsp;?</StyledTitle4>
         <Spacer.Column numberOfSpaces={6} />
         <Accordion title="Pages" defaultOpen>
-          {Object.keys(SCREENS_CONFIG).map((key) =>
-            renderScreenItem(key as ScreensUsedByMarketing)
-          )}
+          {Object.keys(SCREENS_CONFIG).map((key) => renderScreenItem(key))}
         </Accordion>
         {paramsCount > 0 ? (
           <Accordion title={'Paramètres applicatifs' + ` (${paramsCount})`} defaultOpen>

--- a/src/features/search/helpers/categoriesHelpers/mapping-tree.ts
+++ b/src/features/search/helpers/categoriesHelpers/mapping-tree.ts
@@ -127,8 +127,7 @@ export function createMappingTree(data: SubcategoriesResponseModelv2, facetsData
   return data.searchGroups
     .filter(
       (searchGroup) =>
-        Object.keys(availableCategories).includes(searchGroup.name) &&
-        Object.keys(CATEGORY_CRITERIA).includes(searchGroup.name)
+        searchGroup.name in availableCategories && searchGroup.name in CATEGORY_CRITERIA
     )
     .sort((a, b) => {
       const positionA: number = CATEGORY_CRITERIA[a.name]?.position ?? 0

--- a/src/features/share/helpers/getShareOffer.tsx
+++ b/src/features/share/helpers/getShareOffer.tsx
@@ -10,11 +10,9 @@ type Parameters = {
   utmMedium: string
 }
 
-const hasVenue = (offer: Offer) =>
-  Object.keys(offer).includes('venueName') || Object.keys(offer).includes('venue')
+const hasVenue = (offer: Offer) => 'venueName' in offer || 'venue' in offer
 
-const isFavoriteOffer = (offer: Offer): offer is FavoriteOfferResponse =>
-  !!Object.keys(offer).includes('venueName')
+const isFavoriteOffer = (offer: Offer): offer is FavoriteOfferResponse => 'venueName' in offer
 const getVenueName = (offer: Offer) => (isFavoriteOffer(offer) ? offer.venueName : offer.venue.name)
 
 const offerShareSubject = 'Je t’invite à découvrir une super offre sur le pass Culture\u00a0!'

--- a/src/features/venueMap/helpers/venueMapCluster/getClusterColorByDominantVenueType.ts
+++ b/src/features/venueMap/helpers/venueMapCluster/getClusterColorByDominantVenueType.ts
@@ -26,8 +26,10 @@ const getClusterColorFromVenueType = (venueType?: VenueTypeCode): ClusterImageCo
   }
 }
 
-export const getClusterColorByDominantVenueType = (types: VenueTypeCode[]) => {
-  const occurenceMap = types.reduce<Record<ClusterImageColorName, number> | Record<string, never>>(
+export const getClusterColorByDominantVenueType = (
+  types: VenueTypeCode[]
+): ClusterImageColorName | undefined => {
+  const occurenceMap = types.reduce(
     (previous, current) => {
       const color = getClusterColorFromVenueType(current)
       if (previous[color]) {
@@ -37,8 +39,9 @@ export const getClusterColorByDominantVenueType = (types: VenueTypeCode[]) => {
       }
       return previous
     },
-    {}
+    {} as Record<ClusterImageColorName, number>
   )
+
   const colorsInCluster = Object.keys(occurenceMap)
     .filter((color): color is ClusterImageColorName => !!color)
     .sort((a, b) => a.localeCompare(b))

--- a/src/libs/analytics/utils.ts
+++ b/src/libs/analytics/utils.ts
@@ -42,7 +42,7 @@ export const isCloseToBottom = ({
 // we just cast it to string.
 export const prepareLogEventParams = (params: Record<string, unknown>) =>
   Object.keys(params).reduce((acc: Record<string, unknown>, key) => {
-    acc[key] = typeof params[key] === 'number' ? (params[key] as number).toString() : params[key]
+    acc[key] = typeof params[key] === 'number' ? params[key]?.toString() : params[key]
     return acc
   }, {})
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 export {}
 
+type NotAny<T> = 0 extends 1 & T ? never : T
+
 type Enumerate<N extends number, Acc extends number[] = []> = Acc['length'] extends N
   ? Acc[number]
   : Enumerate<N, [...Acc, Acc['length']]>
@@ -13,6 +15,11 @@ declare global {
     getMonth(): NumberRange<0, 12>
 
     getDate(): NumberRange<0, 31>
+  }
+
+  interface ObjectConstructor {
+    keys<T extends object>(obj: NotAny<T>): (keyof T)[]
+    keys(obj: unknown): string[]
   }
 
   // Web only


### PR DESCRIPTION
Object.keys n'est nativement pas strictement typé, ce qui fait perdre le type dans des clés dans des objets inférés ou `as const`

Cette PR apporte un typage strict sur l'utilisation d'`Object.keys`