### PR TITLE
(BSR) fix(pipeline): revert to fix the main branch

### DIFF
--- a/doc/decision-records/DR003 - queries.md
+++ b/doc/decision-records/DR003 - queries.md
@@ -31,15 +31,7 @@
 - useCookiesChoiceByCategory => ça commence par "use" mais ça n'appelle aucun hook
 - useUserHasBookingsQuery => select
 - src/features/favorites/hooks/useFavorite.ts => select + à déplacer dans les select communs
-- src/features/home/queries/useVideoOffersQuery => extraire query + déplacer les logiques dans des selects + tester + simplifier la logique
-- src/features/home/queries/useGetOffersDataQuery => extraire query + déplacer les logiques dans des selects + tester
 
 ### Devrait utiliser react-query
 
 - getCookiesLastUpdate => useIsCookiesListUpToDate est plus complexe que nécessaire
-
-## Propositions
-
-### Queries invalidées au changement de localisation
-
-Tester un POC de mise en place d'une logique pour l'invalidation des queries au changement de la localisation.

--- a/src/features/home/api/useActivationBanner.native.test.ts
+++ b/src/features/home/api/useActivationBanner.native.test.ts
@@ -15,8 +15,8 @@ import { renderHook, act } from 'tests/utils'
 import { useActivationBanner } from './useActivationBanner'
 
 const mockBannerName = BannerName.activation_banner
-jest.mock('features/home/queries/useBannerQuery', () => ({
-  useBannerQuery: jest.fn(() => ({
+jest.mock('features/home/api/useBanner', () => ({
+  useBanner: jest.fn(() => ({
     data: {
       banner: {
         title: 'API - Débloque tes 150\u00a0€',

--- a/src/features/home/api/useActivationBanner.ts
+++ b/src/features/home/api/useActivationBanner.ts
@@ -1,6 +1,6 @@
 import { CurrencyEnum } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { useBannerQuery } from 'features/home/queries/useBannerQuery'
+import { useBanner } from 'features/home/api/useBanner'
 import { useGetStepperInfo } from 'features/identityCheck/api/useGetStepperInfo'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags as featureFlags } from 'libs/firebase/firestore/types'
@@ -25,7 +25,7 @@ export function useActivationBanner() {
   const isUserInRelevantLocation = isUserLocated || isUserRegisteredInPacificFrancRegion
 
   const isGeolocated = permissionState === GeolocPermissionState.GRANTED
-  const { data } = useBannerQuery(isGeolocated)
+  const { data } = useBanner(isGeolocated)
 
   if (enablePacificFrancCurrency) {
     if (isActivationProcessEnable || isUserInRelevantLocation) {

--- a/src/features/home/api/useAlgoliaRecommendedOffers.native.test.ts
+++ b/src/features/home/api/useAlgoliaRecommendedOffers.native.test.ts
@@ -1,0 +1,91 @@
+import { useAlgoliaRecommendedOffers } from 'features/home/api/useAlgoliaRecommendedOffers'
+import * as fetchOffersByIdsAPI from 'libs/algolia/fetchAlgolia/fetchOffersByIds'
+import * as filterOfferHitWithImageAPI from 'libs/algolia/fetchAlgolia/transformOfferHit'
+import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
+import * as getSimilarOrRecoOffersInOrder from 'shared/offer/getSimilarOrRecoOffersInOrder'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { act, renderHook, waitFor } from 'tests/utils'
+
+const getSimilarOffersInOrderSpy = jest.spyOn(
+  getSimilarOrRecoOffersInOrder,
+  'getSimilarOrRecoOffersInOrder'
+)
+
+const ids = ['102280', '102272', '102249', '102310']
+
+jest.mock('libs/firebase/analytics/analytics')
+
+describe('useAlgoliaRecommendedOffers', () => {
+  const mockFetchAlgoliaHits = jest.fn().mockResolvedValue(mockedAlgoliaResponse.hits)
+  const fetchAlgoliaHitsSpy = jest
+    .spyOn(fetchOffersByIdsAPI, 'fetchOffersByIds')
+    .mockImplementation(mockFetchAlgoliaHits)
+
+  const filterAlgoliaHitSpy = jest
+    .spyOn(filterOfferHitWithImageAPI, 'filterOfferHitWithImage')
+    .mockImplementation(jest.fn())
+
+  it('should fetch algolia when ids are provided', async () => {
+    renderHook(() => useAlgoliaRecommendedOffers(ids, 'abcd'), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+    await waitFor(() => {
+      expect(fetchAlgoliaHitsSpy).toHaveBeenCalledWith({ objectIds: ids, isUserUnderage: false })
+    })
+  })
+
+  it('should filter algolia hits', async () => {
+    renderHook(() => useAlgoliaRecommendedOffers(ids, 'abcd'), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+    await waitFor(() => {
+      expect(filterAlgoliaHitSpy).toHaveBeenCalledTimes(mockedAlgoliaResponse.hits.length)
+    })
+  })
+
+  it('should return undefined when algolia does not return any hit', async () => {
+    jest.spyOn(fetchOffersByIdsAPI, 'fetchOffersByIds').mockResolvedValueOnce([])
+    const { result } = renderHook(() => useAlgoliaRecommendedOffers(ids, 'abcd'), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+    await waitFor(() => {
+      expect(result.current).toBeUndefined()
+      expect(filterAlgoliaHitSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  it('should return undefined when ids are not provided', async () => {
+    const { result } = renderHook(() => useAlgoliaRecommendedOffers([], 'abcd'), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+
+    expect(result.current).toBeUndefined()
+  })
+
+  it('should call function to preserve ids offer order when shouldPreserveIdsOrder is true', async () => {
+    renderHook(() => useAlgoliaRecommendedOffers(ids, 'abcd', true), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+    await act(async () => {})
+
+    expect(getSimilarOffersInOrderSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not call function to preserve ids offer order when shouldPreserveIdsOrder is undefined', async () => {
+    renderHook(() => useAlgoliaRecommendedOffers(ids, 'abcd'), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+    await act(async () => {})
+
+    expect(getSimilarOffersInOrderSpy).not.toHaveBeenCalled()
+  })
+
+  it('should not call function to preserve ids offer order when shouldPreserveIdsOrder is false', async () => {
+    renderHook(() => useAlgoliaRecommendedOffers(ids, 'abcd', false), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+    await act(async () => {})
+
+    expect(getSimilarOffersInOrderSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/home/api/useAlgoliaRecommendedOffers.ts
+++ b/src/features/home/api/useAlgoliaRecommendedOffers.ts
@@ -1,0 +1,15 @@
+import { useAlgoliaSimilarOffers } from 'features/offer/api/useAlgoliaSimilarOffers'
+import { QueryKeys } from 'libs/queryKeys'
+import { Offer } from 'shared/offer/types'
+
+export const useAlgoliaRecommendedOffers = (
+  ids: string[],
+  moduleId: string,
+  shouldPreserveIdsOrder?: boolean
+): Offer[] | undefined => {
+  return useAlgoliaSimilarOffers(ids, shouldPreserveIdsOrder, [
+    QueryKeys.RECOMMENDATION_HITS,
+    moduleId,
+    ids,
+  ])
+}

--- a/src/features/home/api/useBanner.ts
+++ b/src/features/home/api/useBanner.ts
@@ -5,7 +5,7 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { QueryKeys } from 'libs/queryKeys'
 
-export const useBannerQuery = (hasGeolocPosition: boolean) => {
+export function useBanner(hasGeolocPosition: boolean) {
   const { isLoggedIn } = useAuthContext()
 
   return useQuery(

--- a/src/features/home/api/useExcluOffer.ts
+++ b/src/features/home/api/useExcluOffer.ts
@@ -3,7 +3,7 @@ import { useQuery } from 'react-query'
 import { api } from 'api/api'
 import { QueryKeys } from 'libs/queryKeys'
 
-export const useExcluOfferQuery = (id: number) => {
+export const useExcluOffer = (id: number) => {
   return useQuery(
     [QueryKeys.OFFER, id],
     async () => {

--- a/src/features/home/api/useGetOffersData.ts
+++ b/src/features/home/api/useGetOffersData.ts
@@ -18,7 +18,7 @@ const isPlaylistOffersParamsArrayWithoutUndefined = (
   params: unknown
 ): params is PlaylistOffersParams[] => params !== undefined
 
-export const useGetOffersDataQuery = (modules: OffersModule[]) => {
+export const useGetOffersData = (modules: OffersModule[]) => {
   const { userLocation } = useLocation()
   const transformHits = useTransformOfferHits()
 
@@ -33,7 +33,7 @@ export const useGetOffersDataQuery = (modules: OffersModule[]) => {
       .filter(isPlaylistOffersParameters)
     offersModuleIds.push(module.id)
     return {
-      adaptedPlaylistParameters,
+      adaptedPlaylistParameters: adaptedPlaylistParameters,
       moduleId: module.id,
     } as OfferModuleParamsInfo
   })
@@ -47,8 +47,9 @@ export const useGetOffersDataQuery = (modules: OffersModule[]) => {
       paramsList: offersAdaptedPlaylistParametersWithoutUndefined,
       isUserUnderage,
     })
+    const searchResponseResult = result.filter(searchResponsePredicate)
 
-    return result.filter(searchResponsePredicate)
+    return searchResponseResult
   }
 
   const offersResultList = useQuery({
@@ -65,11 +66,11 @@ export const useGetOffersDataQuery = (modules: OffersModule[]) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userLocation?.latitude, userLocation?.longitude])
 
-  return offersResultList.data
-    ? mapOffersDataAndModules({
-        data: offersResultList.data,
-        modulesParams: offersParameters,
-        transformHits,
-      })
-    : []
+  const offersModulesData = mapOffersDataAndModules({
+    results: offersResultList,
+    modulesParams: offersParameters,
+    transformHits,
+  })
+
+  return { offersModulesData }
 }

--- a/src/features/home/api/useHomeRecommendedOffers.ts
+++ b/src/features/home/api/useHomeRecommendedOffers.ts
@@ -4,14 +4,14 @@ import { PlaylistRequestBody, RecommendationApiParams, SubcategoryIdEnumv2 } fro
 import { buildRecommendationOfferTypesList } from 'features/home/api/helpers/buildRecommendationOfferTypesList'
 import { computeBeginningAndEndingDatetimes } from 'features/home/api/helpers/computeBeginningAndEndingDatetimes'
 import { RecommendedOffersModule } from 'features/home/types'
-import { useAlgoliaSimilarOffers } from 'features/offer/api/useAlgoliaSimilarOffers'
 import { useSubcategoryIdsFromSearchGroups } from 'features/search/helpers/categoriesHelpers/categoriesHelpers'
 import { getCategoriesFacetFilters } from 'libs/algolia/fetchAlgolia/buildAlgoliaParameters/getCategoriesFacetFilters'
 import { Position } from 'libs/location'
-import { QueryKeys } from 'libs/queryKeys'
 import { useHomeRecommendedIdsQuery } from 'libs/recommendation/useHomeRecommendedIdsQuery'
 import { useSubcategoryLabelMapping } from 'libs/subcategories/mappings'
 import { Offer } from 'shared/offer/types'
+
+import { useAlgoliaRecommendedOffers } from './useAlgoliaRecommendedOffers'
 
 export function getRecommendationParameters(
   parameters: RecommendedOffersModule['recommendationParameters'] | undefined,
@@ -83,10 +83,9 @@ export const useHomeRecommendedOffers = (
     userId,
   })
 
-  const ids = data?.playlistRecommendedOffers ?? []
   return {
     offers:
-      useAlgoliaSimilarOffers(ids, true, [QueryKeys.RECOMMENDATION_HITS, moduleId, ids]) || [],
+      useAlgoliaRecommendedOffers(data?.playlistRecommendedOffers ?? [], moduleId, true) || [],
     recommendationApiParams: data?.params,
   }
 }

--- a/src/features/home/api/useVideoOffers.native.test.ts
+++ b/src/features/home/api/useVideoOffers.native.test.ts
@@ -1,5 +1,5 @@
 import { SubcategoriesResponseModelv2 } from 'api/gen'
-import { useVideoOffersQuery } from 'features/home/queries/useVideoOffersQuery'
+import { useVideoOffers } from 'features/home/api/useVideoOffers'
 import { OffersModuleParameters } from 'features/home/types'
 import { fetchMultipleOffers } from 'libs/algolia/fetchAlgolia/fetchMultipleOffers/fetchMultipleOffers'
 import { fetchOffersByEan } from 'libs/algolia/fetchAlgolia/fetchOffersByEan'
@@ -32,7 +32,7 @@ const mockOffers = mockedAlgoliaResponse.hits
 
 jest.mock('libs/firebase/analytics/analytics')
 
-describe('useVideoOffersQuery', () => {
+describe('useVideoOffers', () => {
   beforeEach(() => {
     mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', subcategoriesDataTest)
   })
@@ -41,8 +41,7 @@ describe('useVideoOffersQuery', () => {
     mockfetchOffersByIds.mockResolvedValueOnce([mockOffers[0], mockOffers[1]])
 
     const { result } = renderHook(
-      () =>
-        useVideoOffersQuery([{}] as OffersModuleParameters[], 'moduleId', ['offerId1', 'offerId2']),
+      () => useVideoOffers([{}] as OffersModuleParameters[], 'moduleId', ['offerId1', 'offerId2']),
       {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
       }
@@ -58,10 +57,7 @@ describe('useVideoOffersQuery', () => {
 
     const { result } = renderHook(
       () =>
-        useVideoOffersQuery([{}] as OffersModuleParameters[], 'moduleId', undefined, [
-          'ean1',
-          'ean2',
-        ]),
+        useVideoOffers([{}] as OffersModuleParameters[], 'moduleId', undefined, ['ean1', 'ean2']),
       {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
       }
@@ -77,7 +73,7 @@ describe('useVideoOffersQuery', () => {
     mockFetchMultipleOffers.mockResolvedValueOnce([{ hits: mockOffers, nbHits: 6 }])
 
     const { result } = renderHook(
-      () => useVideoOffersQuery([{}] as OffersModuleParameters[], 'moduleId', undefined, undefined),
+      () => useVideoOffers([{}] as OffersModuleParameters[], 'moduleId', undefined, undefined),
       {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
       }

--- a/src/features/home/components/modules/HomeModule.native.test.tsx
+++ b/src/features/home/components/modules/HomeModule.native.test.tsx
@@ -4,6 +4,7 @@ import { InViewProps } from 'react-native-intersection-observer'
 
 import { SubcategoriesResponseModelv2 } from 'api/gen'
 import { useHighlightOffer } from 'features/home/api/useHighlightOffer'
+import { useVideoOffers } from 'features/home/api/useVideoOffers'
 import { highlightOfferModuleFixture } from 'features/home/fixtures/highlightOfferModule.fixture'
 import {
   formattedBusinessModule,
@@ -16,7 +17,6 @@ import {
   formattedVenuesModule,
 } from 'features/home/fixtures/homepage.fixture'
 import { videoModuleFixture } from 'features/home/fixtures/videoModule.fixture'
-import { useVideoOffersQuery } from 'features/home/queries/useVideoOffersQuery'
 import { HomepageModule, ModuleData } from 'features/home/types'
 import { SimilarOffersResponse } from 'features/offer/types'
 import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
@@ -75,8 +75,8 @@ jest.mock('features/home/api/useAlgoliaRecommendedOffers', () => ({
   useAlgoliaRecommendedOffers: jest.fn(() => mockedAlgoliaResponse.hits),
 }))
 
-jest.mock('features/home/queries/useVideoOffersQuery')
-const mockuseVideoOffersQuery = useVideoOffersQuery as jest.Mock
+jest.mock('features/home/api/useVideoOffers')
+const mockUseVideoOffers = useVideoOffers as jest.Mock
 
 const offerFixture = [
   {
@@ -244,8 +244,8 @@ describe('<HomeModule />', () => {
   })
 
   it('should display VideoModule', async () => {
-    mockuseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture[0]] })
-    mockuseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture[1]] })
+    mockUseVideoOffers.mockReturnValueOnce({ offers: [offerFixture[0]] })
+    mockUseVideoOffers.mockReturnValueOnce({ offers: [offerFixture[1]] })
 
     renderHomeModule(videoModuleFixture)
 

--- a/src/features/home/components/modules/exclusivity/ExclusivityModule.native.test.tsx
+++ b/src/features/home/components/modules/exclusivity/ExclusivityModule.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { UseQueryResult } from 'react-query'
 
 import { OfferResponseV2 } from 'api/gen'
-import * as excluOfferAPI from 'features/home/queries/useExcluOfferQuery'
+import * as excluOfferAPI from 'features/home/api/useExcluOffer'
 import { offerResponseSnap as mockOffer } from 'features/offer/fixtures/offerResponse'
 import { render, screen } from 'tests/utils'
 
@@ -12,7 +12,7 @@ jest.mock('features/search/helpers/useMaxPrice/useMaxPrice', () => ({
   useMaxPrice: jest.fn(() => 300_00),
 }))
 
-const excluOfferAPISpy = jest.spyOn(excluOfferAPI, 'useExcluOfferQuery')
+const excluOfferAPISpy = jest.spyOn(excluOfferAPI, 'useExcluOffer')
 excluOfferAPISpy.mockImplementation(() => {
   return {
     isLoading: false,

--- a/src/features/home/components/modules/exclusivity/ExclusivityOffer.native.test.tsx
+++ b/src/features/home/components/modules/exclusivity/ExclusivityOffer.native.test.tsx
@@ -3,7 +3,7 @@ import { UseQueryResult } from 'react-query'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { OfferResponseV2 } from 'api/gen'
-import * as excluOfferAPI from 'features/home/queries/useExcluOfferQuery'
+import * as excluOfferAPI from 'features/home/api/useExcluOffer'
 import { ExclusivityOffer } from 'features/home/components/modules/exclusivity/ExclusivityOffer'
 import { offerResponseSnap as mockOffer } from 'features/offer/fixtures/offerResponse'
 import { analytics } from 'libs/analytics/provider'
@@ -30,7 +30,7 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('ExclusivityModule component', () => {
-  const excluOfferAPISpy = jest.spyOn(excluOfferAPI, 'useExcluOfferQuery')
+  const excluOfferAPISpy = jest.spyOn(excluOfferAPI, 'useExcluOffer')
 
   beforeEach(() => {
     excluOfferAPISpy.mockImplementation(() => {

--- a/src/features/home/components/modules/exclusivity/helpers/useShouldDisplayExcluOffer.native.test.ts
+++ b/src/features/home/components/modules/exclusivity/helpers/useShouldDisplayExcluOffer.native.test.ts
@@ -1,7 +1,7 @@
 import { UseQueryResult } from 'react-query'
 
 import { OfferResponseV2 } from 'api/gen'
-import * as excluOfferAPI from 'features/home/queries/useExcluOfferQuery'
+import * as excluOfferAPI from 'features/home/api/useExcluOffer'
 import { useShouldDisplayExcluOffer } from 'features/home/components/modules/exclusivity/helpers/useShouldDisplayExcluOffer'
 import { ExclusivityModule } from 'features/home/types'
 import { offerResponseSnap as mockOffer } from 'features/offer/fixtures/offerResponse'
@@ -26,7 +26,7 @@ const mockedUseMaxPrice = jest.mocked(useMaxPrice)
 mockedUseMaxPrice.mockReturnValue(300_00)
 
 const offerId = 116656
-const excluOfferAPISpy = jest.spyOn(excluOfferAPI, 'useExcluOfferQuery')
+const excluOfferAPISpy = jest.spyOn(excluOfferAPI, 'useExcluOffer')
 excluOfferAPISpy.mockReturnValue({
   isLoading: false,
   data: mockOffer,

--- a/src/features/home/components/modules/exclusivity/helpers/useShouldDisplayExcluOffer.ts
+++ b/src/features/home/components/modules/exclusivity/helpers/useShouldDisplayExcluOffer.ts
@@ -1,4 +1,4 @@
-import { useExcluOfferQuery } from 'features/home/queries/useExcluOfferQuery'
+import { useExcluOffer } from 'features/home/api/useExcluOffer'
 import { ExclusivityModule } from 'features/home/types'
 import { getOfferPrice } from 'features/offer/helpers/getOfferPrice/getOfferPrice'
 import { useMaxPrice } from 'features/search/helpers/useMaxPrice/useMaxPrice'
@@ -12,7 +12,7 @@ export function useShouldDisplayExcluOffer(
   const { userLocation } = useLocation()
 
   const maxPrice = useMaxPrice()
-  const { data: offer } = useExcluOfferQuery(offerId)
+  const { data: offer } = useExcluOffer(offerId)
 
   if (!offer) return false
 

--- a/src/features/home/components/modules/video/VideoModule.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoModule.native.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
 import { SubcategoriesResponseModelv2 } from 'api/gen'
+import { useVideoOffers } from 'features/home/api/useVideoOffers'
 import { VideoModule } from 'features/home/components/modules/video/VideoModule'
 import { videoModuleFixture } from 'features/home/fixtures/videoModule.fixture'
-import { useVideoOffersQuery } from 'features/home/queries/useVideoOffersQuery'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
@@ -20,8 +20,8 @@ jest.mock('ui/components/modals/useModal', () => ({
   }),
 }))
 
-jest.mock('features/home/queries/useVideoOffersQuery')
-const mockUseVideoOffersQuery = useVideoOffersQuery as jest.Mock
+jest.mock('features/home/api/useVideoOffers')
+const mockUseVideoOffers = useVideoOffers as jest.Mock
 
 jest.mock('libs/firebase/analytics/analytics')
 
@@ -35,14 +35,14 @@ describe('VideoModule', () => {
   })
 
   it('should render properly', async () => {
-    mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture] })
+    mockUseVideoOffers.mockReturnValueOnce({ offers: [offerFixture] })
     renderVideoModule()
 
     expect(await screen.findByText(offerFixture.offer.name)).toBeOnTheScreen()
   })
 
   it('should show modal when pressing video thumbnail', async () => {
-    mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture] })
+    mockUseVideoOffers.mockReturnValueOnce({ offers: [offerFixture] })
     renderVideoModule()
 
     const button = screen.getByTestId('video-thumbnail')
@@ -53,7 +53,7 @@ describe('VideoModule', () => {
   })
 
   it('should log ModuleDisplayedOnHomePage event when seeing the module', async () => {
-    mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture] })
+    mockUseVideoOffers.mockReturnValueOnce({ offers: [offerFixture] })
     renderVideoModule()
 
     await screen.findByText(offerFixture.offer.name)
@@ -68,14 +68,14 @@ describe('VideoModule', () => {
   })
 
   it('should not log ModuleDisplayedOnHomePage event when module is not rendered', async () => {
-    mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [] })
+    mockUseVideoOffers.mockReturnValueOnce({ offers: [] })
     renderVideoModule()
 
     expect(analytics.logModuleDisplayedOnHomepage).not.toHaveBeenCalled()
   })
 
   it('should render multi offer component if multiples offers', async () => {
-    mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture, offerFixture2] })
+    mockUseVideoOffers.mockReturnValueOnce({ offers: [offerFixture, offerFixture2] })
     renderVideoModule()
 
     const multiOfferList = screen.getByTestId('video-multi-offers-module-list')
@@ -86,14 +86,14 @@ describe('VideoModule', () => {
   })
 
   it('should render one offer component when one offer', async () => {
-    mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture] })
+    mockUseVideoOffers.mockReturnValueOnce({ offers: [offerFixture] })
     renderVideoModule()
 
     expect(await screen.findByTestId('videoMonoOfferTile')).toBeOnTheScreen()
   })
 
   it('should render mobile design if mobile viewport', async () => {
-    mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture] })
+    mockUseVideoOffers.mockReturnValueOnce({ offers: [offerFixture] })
     renderVideoModule()
 
     const multiOfferList = screen.getByTestId('mobile-video-module')
@@ -104,7 +104,7 @@ describe('VideoModule', () => {
   })
 
   it('should render desktop design if desktop viewport', async () => {
-    mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture] })
+    mockUseVideoOffers.mockReturnValueOnce({ offers: [offerFixture] })
     renderVideoModule(true)
 
     const multiOfferList = screen.getByTestId('desktop-video-module')
@@ -115,7 +115,7 @@ describe('VideoModule', () => {
   })
 
   it('should show SeeMore button when is multiples offers and more than three offers', async () => {
-    mockUseVideoOffersQuery.mockReturnValueOnce({
+    mockUseVideoOffers.mockReturnValueOnce({
       offers: [offerFixture, offerFixture2, offerFixture3, offerFixture4],
     })
     renderVideoModule(true)
@@ -128,7 +128,7 @@ describe('VideoModule', () => {
   })
 
   it('should not show SeeMore button when is multiples offers and less than three offers', async () => {
-    mockUseVideoOffersQuery.mockReturnValueOnce({
+    mockUseVideoOffers.mockReturnValueOnce({
       offers: [offerFixture, offerFixture2],
     })
     renderVideoModule(true)

--- a/src/features/home/components/modules/video/VideoModule.tsx
+++ b/src/features/home/components/modules/video/VideoModule.tsx
@@ -1,12 +1,12 @@
 import React, { FunctionComponent, useEffect } from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
+import { useVideoOffers } from 'features/home/api/useVideoOffers'
 import { OldVideoModuleDesktop } from 'features/home/components/modules/video/OldVideoModuleDesktop'
 import { OldVideoModuleMobile } from 'features/home/components/modules/video/OldVideoModuleMobile'
 import { VideoModal } from 'features/home/components/modules/video/VideoModal'
 import { VideoModuleDesktop } from 'features/home/components/modules/video/VideoModuleDesktop'
 import { VideoModuleMobile } from 'features/home/components/modules/video/VideoModuleMobile'
-import { useVideoOffersQuery } from 'features/home/queries/useVideoOffersQuery'
 import { VideoModuleProps, VideoModule as VideoModuleType } from 'features/home/types'
 import { analytics } from 'libs/analytics/provider'
 import { OfferAnalyticsParams } from 'libs/analytics/types'
@@ -51,7 +51,7 @@ export const VideoModule: FunctionComponent<VideoModuleBaseProps> = (props) => {
     hideModal: hideVideoModal,
   } = useModal(props.shouldShowModal)
 
-  const { offers } = useVideoOffersQuery(
+  const { offers } = useVideoOffers(
     props.offersModuleParameters,
     props.id,
     props.offerIds,

--- a/src/features/home/pages/GenericHome.tsx
+++ b/src/features/home/pages/GenericHome.tsx
@@ -16,6 +16,7 @@ import {
 import styled, { useTheme } from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
+import { useGetOffersData } from 'features/home/api/useGetOffersData'
 import { useGetVenuesData } from 'features/home/api/useGetVenuesData'
 import { useShowSkeleton } from 'features/home/api/useShowSkeleton'
 import { HomeBodyPlaceholder } from 'features/home/components/HomeBodyPlaceholder'
@@ -23,7 +24,6 @@ import { HomeModule } from 'features/home/components/modules/HomeModule'
 import { OffersModuleProps } from 'features/home/components/modules/OffersModule'
 import { VideoCarouselModule } from 'features/home/components/modules/video/VideoCarouselModule'
 import { useOnScroll } from 'features/home/pages/helpers/useOnScroll'
-import { useGetOffersDataQuery } from 'features/home/queries/useGetOffersDataQuery'
 import {
   HomepageModule,
   HomepageModuleType,
@@ -151,7 +151,7 @@ const OnlineHome: FunctionComponent<GenericHomeProps> = ({
   videoModuleId,
   statusBar,
 }) => {
-  const offersModulesData = useGetOffersDataQuery(modules.filter(isOffersModule))
+  const { offersModulesData } = useGetOffersData(modules.filter(isOffersModule))
   const { venuesModulesData } = useGetVenuesData(modules.filter(isVenuesModule))
   const logHasSeenAllModules = useFunctionOnce(async () =>
     analytics.logAllModulesSeen(modules.length)


### PR DESCRIPTION
Revert "(PC-35599) refactor(react-query): use react-query in home (#7993)"

This reverts commit e54ca3f0ab612fc9ebc0ca3de224404cfd0f3407.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
