### PR TITLE
(BSR) fix(Typescript): match typescript vscode version with package.json version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,5 +31,6 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "devbox.autoShellOnTerminal": false,
-  "window.confirmBeforeClose": "keyboardOnly"
+  "window.confirmBeforeClose": "keyboardOnly",
+  "typescript.enablePromptUseWorkspaceTsdk": true
 }


### PR DESCRIPTION
Certains développeurs se sont récemment plaint d'une disparité entre les résultats de la commande yarn:test:types et les erreurs Typescript indiquées dans l'IDE

Actuellement la version Typescript utilisée dans l'IDE est celle définie dans l'IDE par le développeur, l'ajout de cette ligne dans le `settings.json` palie à cela en autorisant l'apparition d'une popup (bloquée par défaut) proposant l'utilisation de la version Typescript du package.json dans l'IDE