### PR TITLE
(BSR) fix(allure): add always conditions for allure

### DIFF
--- a/.github/workflows/dev_on_workflow_tester.yml
+++ b/.github/workflows/dev_on_workflow_tester.yml
@@ -62,11 +62,11 @@ jobs:
       - run: yarn test:unit:web:ci --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
       - name: Rename allure reports folder
-        if: github.ref == 'refs/heads/master'
+        if: ${{ always() && github.ref == 'refs/heads/master' }}
         run: mv allure-results allure-results-web-${{matrix.shard}}
 
       - name: Cache the allure reports
-        if: github.ref == 'refs/heads/master'
+        if: ${{ always() && github.ref == 'refs/heads/master' }}
         id: allure-report-cache-web
         uses: pass-culture-github-actions/gcs-cache@v1.0.0
         with:
@@ -119,7 +119,7 @@ jobs:
       - run: mv coverage/coverage-final.json coverage/${{matrix.shard}}.json
 
       - name: Rename allure reports folder
-        if: github.ref == 'refs/heads/master'
+        if: ${{ always() && github.ref == 'refs/heads/master' }}
         run: mv allure-results allure-results-${{matrix.shard}}
 
       - name: Cache the coverage report
@@ -134,7 +134,7 @@ jobs:
           key: v1-coverage-dependency-cache-${{ runner.os }}-${{ github.sha }}-${{ matrix.shard }}
 
       - name: Cache the allure reports
-        if: github.ref == 'refs/heads/master'
+        if: ${{ always() && github.ref == 'refs/heads/master' }}
         id: allure-report-cache-native
         uses: pass-culture-github-actions/gcs-cache@v1.0.0
         with:


### PR DESCRIPTION
# 📝 Description

Amélioration de la génération des rapports Allure en s'assurant qu'ils sont toujours générés, même en cas d'échec des tests.

## 🔄 Changements

Modification des conditions d'exécution des étapes Allure pour qu'elles s'exécutent systématiquement sur la branche master, même en cas d'échec des tests précédents :

```yaml
# Avant
if: github.ref == 'refs/heads/master'

# Après
if: ${{ always() && github.ref == 'refs/heads/master' }}
```

Ces modifications ont été appliquées aux étapes suivantes :
- Renommage du dossier des rapports Allure pour les tests web
- Mise en cache des rapports Allure pour les tests web
- Renommage du dossier des rapports Allure pour les tests natifs
- Mise en cache des rapports Allure pour les tests natifs

## 🎯 Objectif

Garantir que nous disposons toujours des rapports de test Allure sur la branche master, même lorsque les tests échouent. Cela permettra :
- Une meilleure visibilité sur les échecs de tests
- Un historique complet des exécutions de tests
- Une analyse post-mortem facilitée en cas d'échec
