### PR TITLE
(PC-35813) refactor(test): replace fireEvent.press by userEvent.press

### DIFF
--- a/src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx
+++ b/src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx
@@ -7,7 +7,7 @@ import { ChangeEmailExpiredLink } from 'features/profile/pages/ChangeEmail/Chang
 import { nonBeneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics/provider'
 import { mockAuthContextWithoutUser, mockAuthContextWithUser } from 'tests/AuthContextUtils'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('features/navigation/helpers/navigateToHome')
 jest.mock('features/navigation/navigationRef')
@@ -21,6 +21,10 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+
+jest.useFakeTimers()
 
 describe('<ChangeEmailExpiredLink />', () => {
   beforeEach(() => {
@@ -40,10 +44,10 @@ describe('<ChangeEmailExpiredLink />', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should redirect to home page when go back to home button is clicked', () => {
+  it('should redirect to home page when go back to home button is clicked', async () => {
     render(<ChangeEmailExpiredLink />)
 
-    fireEvent.press(screen.getByText(`Retourner à l’accueil`))
+    await user.press(screen.getByText(`Retourner à l’accueil`))
 
     expect(navigateFromRef).toHaveBeenCalledWith(
       navigateToHomeConfig.screen,
@@ -51,11 +55,11 @@ describe('<ChangeEmailExpiredLink />', () => {
     )
   })
 
-  it('should navigate when clicking on resend email button', () => {
+  it('should navigate when clicking on resend email button', async () => {
     render(<ChangeEmailExpiredLink />)
 
     const resendEmailButton = screen.getByText('Faire une nouvelle demande')
-    fireEvent.press(resendEmailButton)
+    await user.press(resendEmailButton)
 
     expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
       params: undefined,
@@ -63,26 +67,26 @@ describe('<ChangeEmailExpiredLink />', () => {
     })
   })
 
-  it('should log event when clicking on resend email button', () => {
+  it('should log event when clicking on resend email button', async () => {
     render(<ChangeEmailExpiredLink />)
 
     const resendEmailButton = screen.getByText('Faire une nouvelle demande')
-    fireEvent.press(resendEmailButton)
+    await user.press(resendEmailButton)
 
     expect(analytics.logSendActivationMailAgain).toHaveBeenCalledWith(1)
 
-    fireEvent.press(resendEmailButton)
+    await user.press(resendEmailButton)
 
     expect(analytics.logSendActivationMailAgain).toHaveBeenCalledWith(2)
   })
 
-  it('should navigate when clicking on resend email button when logged out', () => {
+  it('should navigate when clicking on resend email button when logged out', async () => {
     mockAuthContextWithoutUser()
 
     render(<ChangeEmailExpiredLink />)
 
     const resendEmailButton = screen.getByText('Se connecter')
-    fireEvent.press(resendEmailButton)
+    await user.press(resendEmailButton)
 
     expect(navigate).toHaveBeenCalledWith('Login')
   })

--- a/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx
+++ b/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx
@@ -6,7 +6,7 @@ import { EmptyResponse } from 'libs/fetch'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { act, fireEvent, render, screen, userEvent } from 'tests/utils'
 import * as SnackBarContextModule from 'ui/components/snackBar/SnackBarContext'
 
 const mockShowSuccessSnackBar = jest.fn()
@@ -27,6 +27,10 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+
+jest.useFakeTimers()
 
 describe('<ChangeEmailSetPassword />', () => {
   it('should match snapshot', async () => {
@@ -98,8 +102,9 @@ describe('<ChangeEmailSetPassword />', () => {
     await act(async () => {
       fireEvent.changeText(passwordInput, 'user@AZERTY123')
       fireEvent.changeText(confirmationInput, 'user@AZERTY123')
-      fireEvent.press(await screen.findByLabelText('Créer mon mot de passe'))
     })
+
+    await user.press(screen.getByLabelText('Créer mon mot de passe'))
 
     expect(replace).toHaveBeenCalledWith('ProfileStackNavigator', {
       params: {
@@ -124,8 +129,9 @@ describe('<ChangeEmailSetPassword />', () => {
     await act(async () => {
       fireEvent.changeText(passwordInput, 'user@AZERTY123')
       fireEvent.changeText(confirmationInput, 'user@AZERTY123')
-      fireEvent.press(await screen.findByLabelText('Créer mon mot de passe'))
     })
+
+    await user.press(screen.getByLabelText('Créer mon mot de passe'))
 
     expect(mockShowSuccessSnackBar).toHaveBeenCalledWith({
       message: 'Ton mot de passe a bien été créé.',
@@ -154,8 +160,9 @@ describe('<ChangeEmailSetPassword />', () => {
     await act(async () => {
       fireEvent.changeText(passwordInput, 'user@AZERTY123')
       fireEvent.changeText(confirmationInput, 'user@AZERTY123')
-      fireEvent.press(await screen.findByLabelText('Créer mon mot de passe'))
     })
+
+    await user.press(screen.getByLabelText('Créer mon mot de passe'))
 
     expect(mockShowSuccessSnackBar).not.toHaveBeenCalledWith({
       message: 'Ton mot de passe a bien été créé.',
@@ -180,8 +187,9 @@ describe('<ChangeEmailSetPassword />', () => {
     await act(async () => {
       fireEvent.changeText(passwordInput, 'user@AZERTY123')
       fireEvent.changeText(confirmationInput, 'user@AZERTY123')
-      fireEvent.press(await screen.findByLabelText('Créer mon mot de passe'))
     })
+
+    await user.press(screen.getByLabelText('Créer mon mot de passe'))
 
     expect(mockShowErrorSnackBar).toHaveBeenCalledWith({
       message: 'Une erreur s’est produite lors de la création du mot de passe. Réessaie plus tard.',

--- a/src/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx
+++ b/src/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx
@@ -6,7 +6,7 @@ import { analytics } from 'libs/analytics/provider'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { act, fireEvent, render, screen, userEvent, waitFor } from 'tests/utils'
 import { showSuccessSnackBar } from 'ui/components/snackBar/__mocks__/SnackBarContext'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 
@@ -35,6 +35,10 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+
+jest.useFakeTimers()
 
 describe('ChangePassword', () => {
   it('should render correctly', async () => {
@@ -115,9 +119,7 @@ describe('ChangePassword', () => {
       fireEvent.changeText(confirmationInput, 'user@AZERTY123')
     })
 
-    await act(async () => {
-      fireEvent.press(screen.getByTestId('Enregistrer les modifications'))
-    })
+    await user.press(screen.getByTestId('Enregistrer les modifications'))
 
     expect(mockShowSuccessSnackBar).toHaveBeenCalledWith({
       message: 'Ton mot de passe est modifié',
@@ -150,9 +152,7 @@ describe('ChangePassword', () => {
     })
 
     const continueButton = screen.getByTestId('Enregistrer les modifications')
-    await act(async () => {
-      fireEvent.press(continueButton)
-    })
+    await user.press(continueButton)
 
     await waitFor(() => {
       expect(screen.getByText('Mot de passe incorrect')).toBeOnTheScreen()

--- a/src/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx
+++ b/src/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx
@@ -11,7 +11,7 @@ import * as PackageJson from 'libs/packageJson'
 import { storage } from 'libs/storage'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 
@@ -54,7 +54,15 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+
+jest.useFakeTimers()
+
 describe('<ConsentSettings/>', () => {
+  beforeEach(() => {
+    mockdate.set(Today)
+  })
+
   it('should render correctly', async () => {
     renderConsentSettings()
 
@@ -71,10 +79,10 @@ describe('<ConsentSettings/>', () => {
     const performanceSwitch = screen.getByTestId(
       'Interrupteur Enregistrer des statistiques de navigation'
     )
-    fireEvent.press(performanceSwitch)
+    await user.press(performanceSwitch)
 
     const saveChoice = screen.getByText('Enregistrer mes choix')
-    fireEvent.press(saveChoice)
+    await user.press(saveChoice)
 
     const storageContent = {
       buildVersion,
@@ -86,9 +94,8 @@ describe('<ConsentSettings/>', () => {
         refused: [...COOKIES_BY_CATEGORY.customization, ...COOKIES_BY_CATEGORY.marketing],
       },
     }
-    await waitFor(async () => {
-      expect(await storage.readObject(COOKIES_CONSENT_KEY)).toEqual(storageContent)
-    })
+
+    expect(await storage.readObject(COOKIES_CONSENT_KEY)).toEqual(storageContent)
   })
 
   it('should call startTrackingAcceptedCookies with empty array if user refuses all cookies', async () => {
@@ -97,9 +104,7 @@ describe('<ConsentSettings/>', () => {
     renderConsentSettings()
 
     const saveChoice = screen.getByText('Enregistrer mes choix')
-    await act(async () => {
-      fireEvent.press(saveChoice)
-    })
+    await user.press(saveChoice)
 
     expect(mockStartTrackingAcceptedCookies).toHaveBeenCalledWith([])
   })
@@ -112,14 +117,10 @@ describe('<ConsentSettings/>', () => {
     const performanceSwitch = screen.getByTestId(
       'Interrupteur Enregistrer des statistiques de navigation'
     )
-    await act(async () => {
-      fireEvent.press(performanceSwitch)
-    })
+    await user.press(performanceSwitch)
 
     const saveChoice = screen.getByText('Enregistrer mes choix')
-    await act(async () => {
-      fireEvent.press(saveChoice)
-    })
+    await user.press(saveChoice)
 
     expect(mockStartTrackingAcceptedCookies).toHaveBeenCalledWith(COOKIES_BY_CATEGORY.performance)
   })
@@ -132,14 +133,10 @@ describe('<ConsentSettings/>', () => {
     const performanceSwitch = screen.getByTestId(
       'Interrupteur Enregistrer des statistiques de navigation'
     )
-    await act(async () => {
-      fireEvent.press(performanceSwitch)
-    })
+    await user.press(performanceSwitch)
 
     const saveChoice = screen.getByText('Enregistrer mes choix')
-    await act(async () => {
-      fireEvent.press(saveChoice)
-    })
+    await user.press(saveChoice)
 
     expect(analytics.logHasMadeAChoiceForCookies).toHaveBeenCalledWith({
       from: 'ConsentSettings',
@@ -153,9 +150,7 @@ describe('<ConsentSettings/>', () => {
     renderConsentSettings()
 
     const saveChoice = screen.getByText('Enregistrer mes choix')
-    await act(async () => {
-      fireEvent.press(saveChoice)
-    })
+    await user.press(saveChoice)
 
     expect(mockShowSuccessSnackBar).toHaveBeenCalledWith({
       message: 'Ton choix a bien été enregistré.',

--- a/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx
@@ -7,7 +7,7 @@ import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 
 import { ConfirmDeleteProfile } from './ConfirmDeleteProfile'
@@ -38,6 +38,10 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+
+jest.useFakeTimers()
+
 describe('ConfirmDeleteProfile component', () => {
   it('should render confirm delete profile', () => {
     renderConfirmDeleteProfile()
@@ -49,7 +53,7 @@ describe('ConfirmDeleteProfile component', () => {
     mockServer.postApi('/v1/account/suspend', {})
     renderConfirmDeleteProfile()
 
-    await act(async () => fireEvent.press(screen.getByText('Supprimer mon compte')))
+    await user.press(screen.getByText('Supprimer mon compte'))
 
     expect(reset).toHaveBeenCalledWith({
       index: 0,
@@ -73,7 +77,7 @@ describe('ConfirmDeleteProfile component', () => {
     mockServer.postApi('/v1/account/suspend', { responseOptions: { statusCode: 400 } })
     renderConfirmDeleteProfile()
 
-    await act(async () => fireEvent.press(screen.getByText('Supprimer mon compte')))
+    await user.press(screen.getByText('Supprimer mon compte'))
 
     expect(mockShowErrorSnackBar).toHaveBeenCalledWith({
       message: 'Une erreur s’est produite pendant le chargement.',
@@ -84,26 +88,24 @@ describe('ConfirmDeleteProfile component', () => {
   it('should log analytics and redirect to FAQ when clicking on FAQ link', async () => {
     renderConfirmDeleteProfile()
 
-    fireEvent.press(screen.getByText('Consulter l’article d’aide'))
+    await user.press(screen.getByText('Consulter l’article d’aide'))
 
-    await waitFor(() => {
-      expect(analytics.logConsultArticleAccountDeletion).toHaveBeenCalledTimes(1)
-      expect(openUrl).toHaveBeenCalledWith(env.FAQ_LINK_DELETE_ACCOUNT, undefined, true)
-    })
+    expect(analytics.logConsultArticleAccountDeletion).toHaveBeenCalledTimes(1)
+    expect(openUrl).toHaveBeenCalledWith(env.FAQ_LINK_DELETE_ACCOUNT, undefined, true)
   })
 
-  it('should go back when clicking on go back button', () => {
+  it('should go back when clicking on go back button', async () => {
     renderConfirmDeleteProfile()
 
-    fireEvent.press(screen.getByTestId('Revenir en arrière'))
+    await user.press(screen.getByTestId('Revenir en arrière'))
 
     expect(mockGoBack).toHaveBeenCalledTimes(1)
   })
 
-  it('should open CGU when clicking on "conditions générales d’utilisation"', () => {
+  it('should open CGU when clicking on "conditions générales d’utilisation"', async () => {
     renderConfirmDeleteProfile()
 
-    fireEvent.press(screen.getByLabelText('conditions générales d’utilisation'))
+    await user.press(screen.getByLabelText('conditions générales d’utilisation'))
 
     expect(openUrl).toHaveBeenNthCalledWith(1, env.CGU_LINK, undefined, true)
   })

--- a/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx
@@ -7,7 +7,7 @@ import { DeleteProfileReason } from 'features/profile/pages/DeleteProfileReason/
 import { beneficiaryUser, nonBeneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics/provider'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('features/navigation/helpers/navigateToHome')
 jest.mock('features/navigation/navigationRef')
@@ -24,6 +24,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 })
 
 jest.mock('features/auth/context/AuthContext')
+
+const user = userEvent.setup()
 
 jest.useFakeTimers()
 
@@ -44,17 +46,15 @@ describe('<DeleteProfileReason />', () => {
     mockAuthContextWithUser(nonBeneficiaryUser)
     render(<DeleteProfileReason />)
 
-    fireEvent.press(
+    await user.press(
       screen.getByText('J’aimerais créer un compte avec une adresse e-mail différente')
     )
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
-        params: {
-          showModal: true,
-        },
-        screen: 'ChangeEmail',
-      })
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: {
+        showModal: true,
+      },
+      screen: 'ChangeEmail',
     })
   })
 
@@ -62,21 +62,19 @@ describe('<DeleteProfileReason />', () => {
     mockAuthContextWithUser(nonBeneficiaryUser)
     render(<DeleteProfileReason />)
 
-    fireEvent.press(screen.getByText('Autre'))
+    await user.press(screen.getByText('Autre'))
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
-        params: undefined,
-        screen: 'DeleteProfileContactSupport',
-      })
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'DeleteProfileContactSupport',
     })
   })
 
-  it('should log analytics when clicking on reasonButton', () => {
+  it('should log analytics when clicking on reasonButton', async () => {
     mockAuthContextWithUser(nonBeneficiaryUser)
     render(<DeleteProfileReason />)
 
-    fireEvent.press(screen.getByText('Autre'))
+    await user.press(screen.getByText('Autre'))
 
     expect(analytics.logSelectDeletionReason).toHaveBeenNthCalledWith(1, 'other')
   })
@@ -92,13 +90,11 @@ describe('<DeleteProfileReason />', () => {
       mockAuthContextWithUser(nonBeneficiaryUser)
       render(<DeleteProfileReason />)
 
-      fireEvent.press(screen.getByText(reason))
+      await user.press(screen.getByText(reason))
 
-      await waitFor(() => {
-        expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
-          params: undefined,
-          screen: 'DeleteProfileConfirmation',
-        })
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+        params: undefined,
+        screen: 'DeleteProfileConfirmation',
       })
     }
   )
@@ -115,13 +111,11 @@ describe('<DeleteProfileReason />', () => {
         mockAuthContextWithUser(beneficiaryUser)
         render(<DeleteProfileReason />)
 
-        fireEvent.press(screen.getByText(reason))
+        await user.press(screen.getByText(reason))
 
-        await waitFor(() => {
-          expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
-            params: undefined,
-            screen: 'DeleteProfileAccountNotDeletable',
-          })
+        expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+          params: undefined,
+          screen: 'DeleteProfileAccountNotDeletable',
         })
       }
     )
@@ -141,13 +135,11 @@ describe('<DeleteProfileReason />', () => {
           mockAuthContextWithUser({ ...beneficiaryUser, birthDate })
           render(<DeleteProfileReason />)
 
-          fireEvent.press(screen.getByText('Je n’utilise plus l’application'))
+          await user.press(screen.getByText('Je n’utilise plus l’application'))
 
-          await waitFor(() => {
-            expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
-              params: undefined,
-              screen: expectedRedirect,
-            })
+          expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+            params: undefined,
+            screen: expectedRedirect,
           })
         }
       )

--- a/src/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx
+++ b/src/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx
@@ -6,7 +6,7 @@ import { EmptyResponse } from 'libs/fetch'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { act, fireEvent, render, screen, userEvent } from 'tests/utils'
 import { SUGGESTION_DELAY_IN_MS } from 'ui/components/inputs/EmailInputWithSpellingHelp/useEmailSpellingHelp'
 import * as SnackBarContextModule from 'ui/components/snackBar/SnackBarContext'
 
@@ -29,6 +29,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
 
 describe('<NewEmailSelection />', () => {
   it('should match snapshot', () => {
@@ -66,8 +68,9 @@ describe('<NewEmailSelection />', () => {
     const emailInput = screen.getByPlaceholderText('email@exemple.com')
     await act(async () => {
       fireEvent.changeText(emailInput, 'john.doe@gmail.com')
-      fireEvent.press(await screen.findByLabelText('Modifier mon adresse e-mail'))
     })
+
+    await user.press(screen.getByLabelText('Modifier mon adresse e-mail'))
 
     expect(replace).toHaveBeenCalledWith('ProfileStackNavigator', {
       params: undefined,
@@ -86,8 +89,9 @@ describe('<NewEmailSelection />', () => {
     const emailInput = screen.getByPlaceholderText('email@exemple.com')
     await act(async () => {
       fireEvent.changeText(emailInput, 'john.doe@gmail.com')
-      fireEvent.press(await screen.findByLabelText('Modifier mon adresse e-mail'))
     })
+
+    await user.press(screen.getByLabelText('Modifier mon adresse e-mail'))
 
     expect(mockShowSuccessSnackBar).toHaveBeenCalledWith({
       message:
@@ -111,8 +115,9 @@ describe('<NewEmailSelection />', () => {
     const emailInput = screen.getByPlaceholderText('email@exemple.com')
     await act(async () => {
       fireEvent.changeText(emailInput, 'john.doe@gmail.com')
-      fireEvent.press(await screen.findByLabelText('Modifier mon adresse e-mail'))
     })
+
+    await user.press(screen.getByLabelText('Modifier mon adresse e-mail'))
 
     expect(mockShowSuccessSnackBar).not.toHaveBeenCalledWith({
       message:
@@ -135,8 +140,9 @@ describe('<NewEmailSelection />', () => {
     const emailInput = screen.getByPlaceholderText('email@exemple.com')
     await act(async () => {
       fireEvent.changeText(emailInput, 'john.doe@gmail.com')
-      fireEvent.press(await screen.findByLabelText('Modifier mon adresse e-mail'))
     })
+
+    await user.press(screen.getByLabelText('Modifier mon adresse e-mail'))
 
     expect(mockShowErrorSnackBar).toHaveBeenCalledWith({
       message: 'Une erreur s’est produite lors du choix de l’adresse e-mail. Réessaie plus tard.',

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
@@ -10,7 +10,7 @@ import { analytics } from 'libs/analytics/provider'
 import { mockAuthContextWithoutUser, mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 
 import { NotificationsSettings } from './NotificationsSettings'
@@ -49,6 +49,10 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+
+jest.useFakeTimers()
+
 describe('NotificationsSettings', () => {
   it('should render correctly when user is logged in', () => {
     render(reactQueryProviderHOC(<NotificationsSettings />))
@@ -78,13 +82,13 @@ describe('NotificationsSettings', () => {
     expect(screen.getByText('Enregistrer')).toBeDisabled()
   })
 
-  it('should enable save button when user has changed a parameter', () => {
+  it('should enable save button when user has changed a parameter', async () => {
     render(reactQueryProviderHOC(<NotificationsSettings />))
 
     const toggleSwitch = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-    fireEvent.press(toggleSwitch)
+    await user.press(toggleSwitch)
     const cinemaSwitch = screen.getByTestId('Interrupteur Cinéma')
-    fireEvent.press(cinemaSwitch)
+    await user.press(cinemaSwitch)
 
     expect(screen.getByText('Enregistrer')).toBeEnabled()
   })
@@ -118,10 +122,10 @@ describe('NotificationsSettings', () => {
     render(reactQueryProviderHOC(<NotificationsSettings />))
 
     const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-    fireEvent.press(toggleEmail)
+    await user.press(toggleEmail)
 
     const toggleSwitch = screen.getByTestId('Interrupteur Suivre tous les thèmes')
-    fireEvent.press(toggleSwitch)
+    await user.press(toggleSwitch)
 
     expect(screen.getByTestId('Interrupteur Cinéma')).toHaveAccessibilityState({ checked: true })
     expect(screen.getByTestId('Interrupteur Lecture')).toHaveAccessibilityState({ checked: true })
@@ -141,11 +145,11 @@ describe('NotificationsSettings', () => {
     render(reactQueryProviderHOC(<NotificationsSettings />))
 
     const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-    fireEvent.press(toggleEmail)
+    await user.press(toggleEmail)
 
     const toggleSwitch = screen.getByTestId('Interrupteur Suivre tous les thèmes')
-    fireEvent.press(toggleSwitch)
-    fireEvent.press(toggleSwitch)
+    await user.press(toggleSwitch)
+    await user.press(toggleSwitch)
 
     expect(screen.getByTestId('Interrupteur Cinéma')).toHaveAccessibilityState({ checked: false })
     expect(screen.getByTestId('Interrupteur Lecture')).toHaveAccessibilityState({ checked: false })
@@ -165,10 +169,10 @@ describe('NotificationsSettings', () => {
     render(reactQueryProviderHOC(<NotificationsSettings />))
 
     const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-    fireEvent.press(toggleEmail)
+    await user.press(toggleEmail)
 
     const toggleSwitch = screen.getByTestId('Interrupteur Cinéma')
-    fireEvent.press(toggleSwitch)
+    await user.press(toggleSwitch)
 
     expect(screen.getByTestId('Interrupteur Cinéma')).toHaveAccessibilityState({ checked: true })
   })
@@ -184,14 +188,14 @@ describe('NotificationsSettings', () => {
     expect(screen.getByTestId('Interrupteur Activités créatives')).toBeDisabled()
   })
 
-  it('should switch off thematic toggle when disabling email and push toggle at the same time', () => {
+  it('should switch off thematic toggle when disabling email and push toggle at the same time', async () => {
     render(reactQueryProviderHOC(<NotificationsSettings />))
 
     const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-    fireEvent.press(toggleEmail)
+    await user.press(toggleEmail)
     const toggleSwitch = screen.getByTestId('Interrupteur Cinéma')
-    fireEvent.press(toggleSwitch)
-    fireEvent.press(toggleEmail)
+    await user.press(toggleSwitch)
+    await user.press(toggleEmail)
 
     expect(screen.getByTestId('Interrupteur Cinéma')).toHaveAccessibilityState({ checked: false })
   })
@@ -216,11 +220,11 @@ describe('NotificationsSettings', () => {
     ).toBeOnTheScreen()
   })
 
-  it('should not display info banner when at least email or push toggles is active', () => {
+  it('should not display info banner when at least email or push toggles is active', async () => {
     render(reactQueryProviderHOC(<NotificationsSettings />))
 
     const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-    fireEvent.press(toggleEmail)
+    await user.press(toggleEmail)
 
     expect(
       screen.queryByText(
@@ -250,20 +254,18 @@ describe('NotificationsSettings', () => {
       render(reactQueryProviderHOC(<NotificationsSettings />))
 
       const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-      await act(async () => fireEvent.press(toggleEmail))
+      await user.press(toggleEmail)
 
       const saveButton = screen.getByText('Enregistrer')
-      await act(async () => fireEvent.press(saveButton))
+      await user.press(saveButton)
 
-      await waitFor(() => {
-        expect(patchProfileSpy).toHaveBeenCalledWith({
-          subscriptions: {
-            marketingEmail: true,
-            marketingPush: false,
-            subscribedThemes: [],
-          },
-          origin: 'ProfileNotificationsSettings',
-        })
+      expect(patchProfileSpy).toHaveBeenCalledWith({
+        subscriptions: {
+          marketingEmail: true,
+          marketingPush: false,
+          subscribedThemes: [],
+        },
+        origin: 'ProfileNotificationsSettings',
       })
     })
 
@@ -273,10 +275,10 @@ describe('NotificationsSettings', () => {
       render(reactQueryProviderHOC(<NotificationsSettings />))
 
       const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-      fireEvent.press(toggleEmail)
+      await user.press(toggleEmail)
 
       const saveButton = screen.getByText('Enregistrer')
-      await act(async () => fireEvent.press(saveButton))
+      await user.press(saveButton)
 
       expect(mockShowSuccessSnackBar).toHaveBeenCalledWith({
         message: 'Tes modifications ont été enregistrées\u00a0!',
@@ -292,10 +294,10 @@ describe('NotificationsSettings', () => {
       render(reactQueryProviderHOC(<NotificationsSettings />))
 
       const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-      fireEvent.press(toggleEmail)
+      await user.press(toggleEmail)
 
       const saveButton = screen.getByText('Enregistrer')
-      await act(async () => fireEvent.press(saveButton))
+      await user.press(saveButton)
 
       expect(mockShowErrorSnackBar).toHaveBeenCalledWith({
         message: 'Une erreur est survenue',
@@ -311,17 +313,17 @@ describe('NotificationsSettings', () => {
       render(reactQueryProviderHOC(<NotificationsSettings />))
 
       const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-      fireEvent.press(toggleEmail)
+      await user.press(toggleEmail)
 
       const saveButton = screen.getByText('Enregistrer')
-      await act(async () => fireEvent.press(saveButton))
+      await user.press(saveButton)
 
       expect(toggleEmail).toHaveAccessibilityState({ checked: false })
     })
   })
 
   describe('The behavior of the push switch', () => {
-    it('should open the push notification modal when the push toggle is pressed and the permission is not granted', () => {
+    it('should open the push notification modal when the push toggle is pressed and the permission is not granted', async () => {
       usePushPermissionSpy.mockReturnValueOnce({
         pushPermission: 'blocked',
         refreshPermission: jest.fn(),
@@ -329,7 +331,7 @@ describe('NotificationsSettings', () => {
       render(reactQueryProviderHOC(<NotificationsSettings />))
 
       const toggleSwitch = screen.getByTestId('Interrupteur Autoriser les notifications')
-      fireEvent.press(toggleSwitch)
+      await user.press(toggleSwitch)
 
       expect(screen.getByText('Paramètres de notifications')).toBeOnTheScreen()
     })
@@ -342,10 +344,10 @@ describe('NotificationsSettings', () => {
       render(reactQueryProviderHOC(<NotificationsSettings />))
 
       const toggleSwitch = screen.getByTestId('Interrupteur Autoriser les notifications')
-      fireEvent.press(toggleSwitch)
+      await user.press(toggleSwitch)
 
       const openSettingsButton = await screen.findByLabelText('Autoriser les notifications')
-      fireEvent.press(openSettingsButton)
+      await user.press(openSettingsButton)
 
       expect(Linking.openSettings).toHaveBeenCalledTimes(1)
     })
@@ -358,7 +360,7 @@ describe('NotificationsSettings', () => {
       render(reactQueryProviderHOC(<NotificationsSettings />))
 
       const toggleSwitch = screen.getByTestId('Interrupteur Autoriser les notifications')
-      fireEvent.press(toggleSwitch)
+      await user.press(toggleSwitch)
 
       expect(toggleSwitch).toHaveAccessibilityState({ checked: true })
     })
@@ -369,10 +371,10 @@ describe('NotificationsSettings', () => {
       render(reactQueryProviderHOC(<NotificationsSettings />))
 
       const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-      fireEvent.press(toggleEmail)
+      await user.press(toggleEmail)
 
       const goBackButton = screen.getByTestId('Revenir en arrière')
-      fireEvent.press(goBackButton)
+      await user.press(goBackButton)
 
       expect(screen.getByText('Quitter sans enregistrer')).toBeOnTheScreen()
     })
@@ -384,19 +386,18 @@ describe('NotificationsSettings', () => {
       render(reactQueryProviderHOC(<NotificationsSettings />))
 
       const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-      await act(async () => fireEvent.press(toggleEmail))
+      await user.press(toggleEmail)
 
       const toggleSwitch = screen.getByTestId('Interrupteur Cinéma')
-      fireEvent.press(toggleSwitch)
+      await user.press(toggleSwitch)
 
       const saveButton = screen.getByText('Enregistrer')
 
-      fireEvent.press(saveButton)
-      await waitFor(() => {
-        expect(analytics.logSubscriptionUpdate).toHaveBeenCalledWith({
-          type: 'update',
-          from: 'profile',
-        })
+      await user.press(saveButton)
+
+      expect(analytics.logSubscriptionUpdate).toHaveBeenCalledWith({
+        type: 'update',
+        from: 'profile',
       })
     })
 
@@ -405,14 +406,12 @@ describe('NotificationsSettings', () => {
       render(reactQueryProviderHOC(<NotificationsSettings />))
 
       const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-      await act(async () => fireEvent.press(toggleEmail))
+      await user.press(toggleEmail)
 
       const saveButton = screen.getByText('Enregistrer')
-      fireEvent.press(saveButton)
+      await user.press(saveButton)
 
-      await waitFor(() => {
-        expect(analytics.logNotificationToggle).toHaveBeenCalledWith(true, false)
-      })
+      expect(analytics.logNotificationToggle).toHaveBeenCalledWith(true, false)
     })
 
     it('should log notification toggle update when user changes their settings from save modal', async () => {
@@ -420,17 +419,15 @@ describe('NotificationsSettings', () => {
       render(reactQueryProviderHOC(<NotificationsSettings />))
 
       const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-      await act(async () => fireEvent.press(toggleEmail))
+      await user.press(toggleEmail)
 
       const goBackButton = screen.getByTestId('Revenir en arrière')
-      await act(async () => fireEvent.press(goBackButton))
+      await user.press(goBackButton)
 
       const saveButton = screen.getByText('Enregistrer mes modifications')
-      await act(async () => fireEvent.press(saveButton))
+      await user.press(saveButton)
 
-      await waitFor(() => {
-        expect(analytics.logNotificationToggle).toHaveBeenCalledWith(true, false)
-      })
+      expect(analytics.logNotificationToggle).toHaveBeenCalledWith(true, false)
     })
 
     it('should not log subscription update when user only changes their notifications settings', async () => {
@@ -438,10 +435,10 @@ describe('NotificationsSettings', () => {
       render(reactQueryProviderHOC(<NotificationsSettings />))
 
       const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-      await act(async () => fireEvent.press(toggleEmail))
+      await user.press(toggleEmail)
 
       const saveButton = screen.getByText('Enregistrer')
-      await act(async () => fireEvent.press(saveButton))
+      await user.press(saveButton)
 
       expect(analytics.logSubscriptionUpdate).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35813

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
