### PR TITLE
(BSR) feat(ci): remove coverage logs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -76,6 +76,7 @@ module.exports = {
   ],
   coveragePathIgnorePatterns: ['\\.web\\.(test|spec)', '/node_modules/', '/src/environment'],
   collectCoverage: false,
+  coverageReporters: ['json'],
   // TODO(PC-20887): Investigate how to avoid timeouts in CI without increasing default timeout
   testTimeout: 10_000,
 }

--- a/jest.web.config.js
+++ b/jest.web.config.js
@@ -51,6 +51,7 @@ module.exports = {
       '|design-system' +
       ')',
   ],
+  coverageReporters: ['json'],
   verbose: true,
   globals: {
     __DEV__: true,


### PR DESCRIPTION
Les développeurs ont besoin de pas mal de scroll sur les ci de test à cause du rapport de coverage qui prend énormément de lignes.

Le coverage reste mais n'est plus loggé dans la console de ci