### PR TITLE
(PC-35834) feat(search): add calendar modal

### DIFF
--- a/src/features/search/helpers/getMarkedDates/getMarkedDates.test.ts
+++ b/src/features/search/helpers/getMarkedDates/getMarkedDates.test.ts
@@ -1,6 +1,7 @@
 import { getMarkedDates } from 'features/search/helpers/getMarkedDates/getMarkedDates'
+import { MarkedDatesColors } from 'features/search/types'
 
-const colors = { primary: 'blue', white: 'white' }
+const colors: MarkedDatesColors = { backgroundColor: '#ffffff', textColor: '#cbcdd2' }
 
 describe('getMarkedDates', () => {
   it('should return an empty object if no start date', () => {
@@ -15,8 +16,8 @@ describe('getMarkedDates', () => {
       '2025-04-28': {
         startingDay: true,
         endingDay: true,
-        color: 'blue',
-        textColor: 'white',
+        color: '#ffffff',
+        textColor: '#cbcdd2',
       },
     })
   })
@@ -31,20 +32,20 @@ describe('getMarkedDates', () => {
       '2025-04-28': {
         startingDay: true,
         endingDay: false,
-        color: 'blue',
-        textColor: 'white',
+        color: '#ffffff',
+        textColor: '#cbcdd2',
       },
       '2025-04-29': {
         startingDay: false,
         endingDay: false,
-        color: 'blue',
-        textColor: 'white',
+        color: '#ffffff',
+        textColor: '#cbcdd2',
       },
       '2025-04-30': {
         startingDay: false,
         endingDay: true,
-        color: 'blue',
-        textColor: 'white',
+        color: '#ffffff',
+        textColor: '#cbcdd2',
       },
     })
   })

--- a/src/features/search/helpers/getMarkedDates/getMarkedDates.test.ts
+++ b/src/features/search/helpers/getMarkedDates/getMarkedDates.test.ts
@@ -1,0 +1,51 @@
+import { getMarkedDates } from 'features/search/helpers/getMarkedDates/getMarkedDates'
+
+const colors = { primary: 'blue', white: 'white' }
+
+describe('getMarkedDates', () => {
+  it('should return an empty object if no start date', () => {
+    expect(getMarkedDates(undefined, undefined, colors)).toEqual(undefined)
+  })
+
+  it('should return single day marked if only start date', () => {
+    const startDate = new Date('2025-04-28')
+    const result = getMarkedDates(startDate, undefined, colors)
+
+    expect(result).toEqual({
+      '2025-04-28': {
+        startingDay: true,
+        endingDay: true,
+        color: 'blue',
+        textColor: 'white',
+      },
+    })
+  })
+
+  it('should return correct range when start and end date are provided', () => {
+    const startDate = new Date('2025-04-28')
+    const endDate = new Date('2025-04-30')
+
+    const result = getMarkedDates(startDate, endDate, colors)
+
+    expect(result).toEqual({
+      '2025-04-28': {
+        startingDay: true,
+        endingDay: false,
+        color: 'blue',
+        textColor: 'white',
+      },
+      '2025-04-29': {
+        startingDay: false,
+        endingDay: false,
+        color: 'blue',
+        textColor: 'white',
+      },
+      '2025-04-30': {
+        startingDay: false,
+        endingDay: true,
+        color: 'blue',
+        textColor: 'white',
+      },
+    })
+  })
+})

--- a/src/features/search/helpers/getMarkedDates/getMarkedDates.ts
+++ b/src/features/search/helpers/getMarkedDates/getMarkedDates.ts
@@ -1,0 +1,44 @@
+import { addDays, differenceInCalendarDays, format } from 'date-fns'
+import { MarkingProps } from 'react-native-calendars/src/calendar/day/marking'
+
+type Colors = { primary: string; white: string }
+
+const formatDate = (date: Date) => format(date, 'yyyy-MM-dd')
+
+export function getMarkedDates(
+  selectedStartDate: Date | undefined,
+  selectedEndDate: Date | undefined,
+  colors: Colors
+): Record<string, MarkingProps> | undefined {
+  if (!selectedStartDate) return undefined
+
+  if (!selectedEndDate) {
+    return {
+      [formatDate(selectedStartDate)]: {
+        startingDay: true,
+        endingDay: true,
+        color: colors.primary,
+        textColor: colors.white,
+      },
+    }
+  }
+
+  // +1 to include end date
+  const dayCount = differenceInCalendarDays(selectedEndDate, selectedStartDate) + 1
+
+  const marked: Record<string, MarkingProps> = {}
+
+  Array.from({ length: dayCount }).forEach((_, index) => {
+    const date = addDays(selectedStartDate, index)
+    const dateString = formatDate(date)
+
+    marked[dateString] = {
+      color: colors.primary,
+      textColor: colors.white,
+      startingDay: index === 0,
+      endingDay: index === dayCount - 1,
+    }
+  })
+
+  return marked
+}

--- a/src/features/search/helpers/getMarkedDates/getMarkedDates.ts
+++ b/src/features/search/helpers/getMarkedDates/getMarkedDates.ts
@@ -1,14 +1,14 @@
 import { addDays, differenceInCalendarDays, format } from 'date-fns'
 import { MarkingProps } from 'react-native-calendars/src/calendar/day/marking'
 
-type Colors = { primary: string; white: string }
+import { MarkedDatesColors } from 'features/search/types'
 
 const formatDate = (date: Date) => format(date, 'yyyy-MM-dd')
 
 export function getMarkedDates(
   selectedStartDate: Date | undefined,
   selectedEndDate: Date | undefined,
-  colors: Colors
+  colors: MarkedDatesColors
 ): Record<string, MarkingProps> | undefined {
   if (!selectedStartDate) return undefined
 
@@ -17,8 +17,8 @@ export function getMarkedDates(
       [formatDate(selectedStartDate)]: {
         startingDay: true,
         endingDay: true,
-        color: colors.primary,
-        textColor: colors.white,
+        color: colors.backgroundColor,
+        textColor: colors.textColor,
       },
     }
   }
@@ -26,19 +26,22 @@ export function getMarkedDates(
   // +1 to include end date
   const dayCount = differenceInCalendarDays(selectedEndDate, selectedStartDate) + 1
 
-  const marked: Record<string, MarkingProps> = {}
+  const marked = Array.from({ length: dayCount }).reduce<Record<string, MarkingProps>>(
+    (acc, _, index) => {
+      const date = addDays(selectedStartDate, index)
+      const dateString = formatDate(date)
 
-  Array.from({ length: dayCount }).forEach((_, index) => {
-    const date = addDays(selectedStartDate, index)
-    const dateString = formatDate(date)
+      acc[dateString] = {
+        color: colors.backgroundColor,
+        textColor: colors.textColor,
+        startingDay: index === 0,
+        endingDay: index === dayCount - 1,
+      }
 
-    marked[dateString] = {
-      color: colors.primary,
-      textColor: colors.white,
-      startingDay: index === 0,
-      endingDay: index === dayCount - 1,
-    }
-  })
+      return acc
+    },
+    {}
+  )
 
   return marked
 }

--- a/src/features/search/helpers/getPastScrollRange/getPastScrollRange.test.ts
+++ b/src/features/search/helpers/getPastScrollRange/getPastScrollRange.test.ts
@@ -1,0 +1,38 @@
+import { getPastScrollRange } from 'features/search/helpers/getPastScrollRange/getPastScrollRange'
+
+describe('getPastScrollRange', () => {
+  it('should return 0 if from and to are the same month', () => {
+    const from = new Date(2024, 3, 15) // 15 April 2024
+    const to = new Date(2024, 3, 1) // 1 April 2024
+
+    expect(getPastScrollRange(from, to)).toEqual(0)
+  })
+
+  it('should return positive difference in months if from is after to', () => {
+    const from = new Date(2024, 3, 1) // 1 April 2024
+    const to = new Date(2024, 0, 10) // 10 Jan 2024
+
+    expect(getPastScrollRange(from, to)).toEqual(3)
+  })
+
+  it('should return 0 if from is before to', () => {
+    const from = new Date(2024, 3, 1) // 1 April 2024
+    const to = new Date(2024, 5, 10) // 10 June 2024
+
+    expect(getPastScrollRange(from, to)).toEqual(0)
+  })
+
+  it('should return correct diff when from is on the last day of a month', () => {
+    const from = new Date(2024, 3, 1) // 1 April 2024
+    const to = new Date(2024, 1, 29) // 29 Feb 2024
+
+    expect(getPastScrollRange(from, to)).toEqual(2)
+  })
+
+  it('should return correct diff when years are different', () => {
+    const from = new Date(2024, 3, 1) // 1 April 2024
+    const to = new Date(2023, 10, 1) // 1 Nov 2023
+
+    expect(getPastScrollRange(from, to)).toEqual(5)
+  })
+})

--- a/src/features/search/helpers/getPastScrollRange/getPastScrollRange.ts
+++ b/src/features/search/helpers/getPastScrollRange/getPastScrollRange.ts
@@ -1,0 +1,5 @@
+import { differenceInMonths, startOfMonth } from 'date-fns'
+
+export function getPastScrollRange(from: Date, to: Date): number {
+  return Math.max(0, differenceInMonths(startOfMonth(from), startOfMonth(to)))
+}

--- a/src/features/search/helpers/schema/calendarSchema/calendarSchema.test.ts
+++ b/src/features/search/helpers/schema/calendarSchema/calendarSchema.test.ts
@@ -1,0 +1,72 @@
+import { calendarSchema } from 'features/search/helpers/schema/calendarSchema/calendarSchema'
+
+describe('calendarSchema', () => {
+  const now = new Date()
+
+  it('should pass when selectedStartDate is today and selectedEndDate is after start', async () => {
+    const validData = {
+      selectedStartDate: new Date(now),
+      selectedEndDate: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+    }
+
+    await expect(calendarSchema.validate(validData)).resolves.toEqual(validData)
+  })
+
+  it('should pass when selectedStartDate is in the future and selectedEndDate is after start', async () => {
+    const validData = {
+      selectedStartDate: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+      selectedEndDate: new Date(now.getTime() + 48 * 60 * 60 * 1000),
+    }
+
+    await expect(calendarSchema.validate(validData)).resolves.toEqual(validData)
+  })
+
+  it('should fail when selectedStartDate is in the past', async () => {
+    const pastDate = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+
+    const invalidData = {
+      selectedStartDate: pastDate,
+      selectedEndDate: new Date(now),
+    }
+
+    await expect(calendarSchema.validate(invalidData)).rejects.toThrow(
+      'La date de début ne peut pas être dans le passé'
+    )
+  })
+
+  it('should pass when only selectedStartDate is provided and it is today', async () => {
+    const validData = {
+      selectedStartDate: new Date(now),
+    }
+
+    await expect(calendarSchema.validate(validData)).resolves.toEqual({
+      ...validData,
+      selectedEndDate: undefined,
+    })
+  })
+
+  it('should pass when only selectedStartDate is provided and it is future', async () => {
+    const validData = {
+      selectedStartDate: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+    }
+
+    await expect(calendarSchema.validate(validData)).resolves.toEqual({
+      ...validData,
+      selectedEndDate: undefined,
+    })
+  })
+
+  it('should fail when selectedEndDate is before selectedStartDate', async () => {
+    const today = new Date(now)
+    const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000)
+
+    const invalidData = {
+      selectedStartDate: tomorrow,
+      selectedEndDate: today,
+    }
+
+    await expect(calendarSchema.validate(invalidData)).rejects.toThrow(
+      'La date de fin ne peut pas être avant la date de début'
+    )
+  })
+})

--- a/src/features/search/helpers/schema/calendarSchema/calendarSchema.test.ts
+++ b/src/features/search/helpers/schema/calendarSchema/calendarSchema.test.ts
@@ -1,3 +1,5 @@
+import { startOfDay } from 'date-fns'
+
 import { calendarSchema } from 'features/search/helpers/schema/calendarSchema/calendarSchema'
 
 describe('calendarSchema', () => {
@@ -37,6 +39,17 @@ describe('calendarSchema', () => {
   it('should pass when only selectedStartDate is provided and it is today', async () => {
     const validData = {
       selectedStartDate: new Date(now),
+    }
+
+    await expect(calendarSchema.validate(validData)).resolves.toEqual({
+      ...validData,
+      selectedEndDate: undefined,
+    })
+  })
+
+  it('should pass when only selectedStartDate is provided and it is today at midnight', async () => {
+    const validData = {
+      selectedStartDate: startOfDay(new Date()),
     }
 
     await expect(calendarSchema.validate(validData)).resolves.toEqual({

--- a/src/features/search/helpers/schema/calendarSchema/calendarSchema.ts
+++ b/src/features/search/helpers/schema/calendarSchema/calendarSchema.ts
@@ -1,0 +1,14 @@
+import { date, object } from 'yup'
+
+export const calendarSchema = object().shape({
+  selectedStartDate: date()
+    .optional()
+    .min(new Date(), 'La date de début ne peut pas être dans le passé'),
+  selectedEndDate: date()
+    .optional()
+    .when('selectedStartDate', (selectedStartDate, schema) =>
+      selectedStartDate
+        ? schema.min(selectedStartDate, 'La date de fin ne peut pas être avant la date de début')
+        : schema
+    ),
+})

--- a/src/features/search/helpers/schema/calendarSchema/calendarSchema.ts
+++ b/src/features/search/helpers/schema/calendarSchema/calendarSchema.ts
@@ -1,9 +1,10 @@
+import { startOfDay } from 'date-fns'
 import { date, object } from 'yup'
 
 export const calendarSchema = object().shape({
   selectedStartDate: date()
     .optional()
-    .min(new Date(), 'La date de début ne peut pas être dans le passé'),
+    .min(startOfDay(new Date()), 'La date de début ne peut pas être dans le passé'),
   selectedEndDate: date()
     .optional()
     .when('selectedStartDate', (selectedStartDate, schema) =>

--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.native.test.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.native.test.tsx
@@ -1,0 +1,127 @@
+import mockdate from 'mockdate'
+import React from 'react'
+
+import { initialSearchState } from 'features/search/context/reducer'
+import { ISearchContext } from 'features/search/context/SearchWrapper'
+import { FilterBehaviour } from 'features/search/enums'
+import {
+  CalendarModal,
+  CalendarModalProps,
+} from 'features/search/pages/modals/CalendarModal/CalendarModal'
+import { act, render, screen, userEvent } from 'tests/utils'
+
+const mockDispatch = jest.fn()
+
+const initialMockUseSearch = {
+  searchState: initialSearchState,
+  dispatch: mockDispatch,
+}
+const mockUseSearch: jest.Mock<Partial<ISearchContext>> = jest.fn(() => initialMockUseSearch)
+jest.mock('features/search/context/SearchWrapper', () => ({
+  useSearch: () => mockUseSearch(),
+}))
+
+const TODAY = new Date(2025, 3, 28)
+
+const mockHideModal = jest.fn()
+const mockOnClose = jest.fn()
+
+const user = userEvent.setup()
+
+jest.useFakeTimers()
+
+describe('CalendarModal', () => {
+  beforeEach(() => {
+    mockUseSearch.mockReturnValueOnce(initialMockUseSearch)
+  })
+
+  beforeAll(() => {
+    mockdate.set(TODAY)
+  })
+
+  it('should display modal with title', async () => {
+    renderCalendarModal()
+
+    await act(() => {
+      expect(screen.getByText('Dates')).toBeOnTheScreen()
+    })
+  })
+
+  it('should close the modal when pressing close button', async () => {
+    renderCalendarModal()
+
+    await user.press(screen.getByLabelText('Fermer'))
+
+    expect(mockOnClose).toHaveBeenCalledWith()
+  })
+
+  it('should hide the modal when pressing close button', async () => {
+    renderCalendarModal()
+
+    await user.press(screen.getByLabelText('Fermer'))
+
+    expect(mockHideModal).toHaveBeenCalledWith()
+  })
+
+  it('should reset dates when pressing reset button and execute search after', async () => {
+    mockUseSearch.mockReturnValueOnce({
+      ...initialMockUseSearch,
+      searchState: {
+        ...initialSearchState,
+        beginningDatetime: '2025-05-01',
+        endingDatetime: '2025-05-05',
+      },
+    })
+
+    renderCalendarModal()
+
+    await user.press(screen.getByText('Réinitialiser'))
+
+    await user.press(screen.getByText('Rechercher'))
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'SET_STATE',
+        payload: expect.objectContaining({
+          beginningDatetime: undefined,
+          endingDatetime: undefined,
+        }),
+      })
+    )
+  })
+
+  it('should execute search with selected dates and close the modal when pressing search button', async () => {
+    renderCalendarModal()
+
+    await user.press(screen.getByLabelText(' Saturday 14 June 2025 '))
+    await user.press(screen.getByLabelText(' Tuesday 17 June 2025 '))
+
+    await user.press(screen.getByText('Rechercher'))
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'SET_STATE',
+        payload: expect.objectContaining({
+          beginningDatetime: '2025-06-14T00:00:00.000Z',
+          endingDatetime: '2025-06-17T00:00:00.000Z',
+        }),
+      })
+    )
+    expect(mockHideModal).toHaveBeenCalledWith()
+  })
+})
+
+function renderCalendarModal({
+  filterBehaviour = FilterBehaviour.SEARCH,
+}: Partial<CalendarModalProps> = {}) {
+  return render(
+    <CalendarModal
+      title="Dates"
+      accessibilityLabel="Ne pas filtrer sur les dates"
+      isVisible
+      hideModal={mockHideModal}
+      filterBehaviour={filterBehaviour}
+      onClose={mockOnClose}
+    />
+  )
+}

--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
@@ -1,0 +1,187 @@
+import { yupResolver } from '@hookform/resolvers/yup'
+import { addYears, format } from 'date-fns'
+import React, { FunctionComponent, useCallback, useEffect, useMemo } from 'react'
+import { SetValueConfig, useForm } from 'react-hook-form'
+import { CalendarList, DateData } from 'react-native-calendars'
+import { useTheme } from 'styled-components/native'
+import { v4 as uuidv4 } from 'uuid'
+
+import { SearchCustomModalHeader } from 'features/search/components/SearchCustomModalHeader'
+import { SearchFixedModalBottom } from 'features/search/components/SearchFixedModalBottom'
+import { useSearch } from 'features/search/context/SearchWrapper'
+import { FilterBehaviour } from 'features/search/enums'
+import { getMarkedDates } from 'features/search/helpers/getMarkedDates/getMarkedDates'
+import { calendarSchema } from 'features/search/helpers/schema/calendarSchema/calendarSchema'
+import { SearchState } from 'features/search/types'
+import { AppModal } from 'ui/components/modals/AppModal'
+import { Close } from 'ui/svg/icons/Close'
+
+type CalendarModalFormData = {
+  selectedStartDate?: Date
+  selectedEndDate?: Date
+}
+
+export type CalendarModalProps = {
+  title: string
+  accessibilityLabel: string
+  isVisible: boolean
+  hideModal: () => void
+  filterBehaviour: FilterBehaviour
+  onClose?: VoidFunction
+}
+
+const titleId = uuidv4()
+const today = new Date()
+const twoYearsLater = addYears(today, 2)
+
+export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
+  title,
+  accessibilityLabel,
+  isVisible,
+  hideModal,
+  filterBehaviour,
+  onClose,
+}) => {
+  const { modal, colors } = useTheme()
+  const { searchState, dispatch } = useSearch()
+
+  const defaultValues = useMemo(() => {
+    return {
+      selectedStartDate: searchState.beginningDatetime
+        ? new Date(searchState.beginningDatetime)
+        : undefined,
+      selectedEndDate: searchState.endingDatetime
+        ? new Date(searchState.endingDatetime)
+        : undefined,
+    }
+  }, [searchState.beginningDatetime, searchState.endingDatetime])
+
+  const {
+    handleSubmit,
+    reset,
+    setValue,
+    formState: { isSubmitting, isValid },
+    watch,
+  } = useForm<CalendarModalFormData>({
+    mode: 'onChange',
+    resolver: yupResolver(calendarSchema),
+    defaultValues,
+  })
+  const { selectedStartDate, selectedEndDate } = watch()
+
+  const markedDates = useMemo(
+    () =>
+      getMarkedDates(selectedStartDate, selectedEndDate, {
+        primary: colors.primary,
+        white: colors.white,
+      }),
+    [colors.primary, colors.white, selectedEndDate, selectedStartDate]
+  )
+
+  useEffect(() => {
+    reset(defaultValues)
+  }, [defaultValues, reset])
+
+  const closeModal = useCallback(() => {
+    reset(defaultValues)
+    hideModal()
+  }, [defaultValues, hideModal, reset])
+
+  const handleClose = useCallback(() => {
+    closeModal()
+    onClose?.()
+  }, [closeModal, onClose])
+
+  const onResetPress = useCallback(() => {
+    reset({
+      selectedStartDate: undefined,
+      selectedEndDate: undefined,
+    })
+  }, [reset])
+
+  const search = useCallback(
+    ({ selectedStartDate, selectedEndDate }: CalendarModalFormData) => {
+      const additionalSearchState: SearchState = {
+        ...searchState,
+        beginningDatetime: selectedStartDate ? selectedStartDate.toISOString() : undefined,
+        endingDatetime: selectedEndDate ? selectedEndDate.toISOString() : undefined,
+      }
+
+      dispatch({ type: 'SET_STATE', payload: additionalSearchState })
+      hideModal()
+    },
+    [hideModal, searchState, dispatch]
+  )
+
+  const onSubmit = handleSubmit(search)
+
+  /**
+   * Helper to avoid using `setValue(x, y, { shouldValidate: true })`
+   * since it's repetitive.
+   */
+  const setValueWithValidation = useCallback(
+    <FieldName extends keyof CalendarModalFormData>(
+      fieldName: FieldName,
+      value: CalendarModalFormData[FieldName],
+      options?: Omit<SetValueConfig, 'shouldValidate'>
+    ) => {
+      setValue(fieldName, value as never, { shouldValidate: true, ...options })
+    },
+    [setValue]
+  )
+
+  const onDayPress = (date: DateData) => {
+    const selectedDate = new Date(date.dateString)
+
+    if (!selectedStartDate || selectedEndDate || selectedDate < selectedStartDate) {
+      setValueWithValidation('selectedStartDate', selectedDate)
+      setValueWithValidation('selectedEndDate', undefined)
+    } else {
+      setValueWithValidation('selectedEndDate', selectedDate)
+    }
+  }
+
+  const disabled = !isValid || isSubmitting
+  const shouldDisplayBackButton = filterBehaviour === FilterBehaviour.APPLY_WITHOUT_SEARCHING
+
+  return (
+    <AppModal
+      visible={isVisible}
+      customModalHeader={
+        <SearchCustomModalHeader
+          titleId={titleId}
+          title={title}
+          onGoBack={closeModal}
+          onClose={handleClose}
+          shouldDisplayBackButton={shouldDisplayBackButton}
+          shouldDisplayCloseButton
+        />
+      }
+      title={title}
+      isUpToStatusBar
+      noPadding
+      modalSpacing={modal.spacing.MD}
+      rightIconAccessibilityLabel={accessibilityLabel}
+      rightIcon={Close}
+      onRightIconPress={closeModal}
+      fixedModalBottom={
+        <SearchFixedModalBottom
+          onSearchPress={onSubmit}
+          onResetPress={onResetPress}
+          isSearchDisabled={disabled}
+          filterBehaviour={filterBehaviour}
+        />
+      }
+      scrollEnabled={false}>
+      <CalendarList
+        minDate={format(today, 'yyyy-MM-dd')}
+        maxDate={format(twoYearsLater, 'yyyy-MM-dd')}
+        pastScrollRange={0} // month before today not visible
+        futureScrollRange={24} // 24 months to have scrolling
+        markingType="period" // to have visible period
+        onDayPress={onDayPress}
+        markedDates={markedDates}
+      />
+    </AppModal>
+  )
+}

--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
@@ -43,7 +43,7 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
   filterBehaviour,
   onClose,
 }) => {
-  const { modal, colors } = useTheme()
+  const { modal, designSystem } = useTheme()
   const { searchState, dispatch } = useSearch()
 
   const defaultValues = useMemo(() => {
@@ -73,10 +73,15 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
   const markedDates = useMemo(
     () =>
       getMarkedDates(selectedStartDate, selectedEndDate, {
-        primary: colors.primary,
-        white: colors.white,
+        backgroundColor: designSystem.color.background.brandPrimary,
+        textColor: designSystem.color.text.locked,
       }),
-    [colors.primary, colors.white, selectedEndDate, selectedStartDate]
+    [
+      designSystem.color.background.brandPrimary,
+      designSystem.color.text.locked,
+      selectedEndDate,
+      selectedStartDate,
+    ]
   )
 
   useEffect(() => {

--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
@@ -11,6 +11,7 @@ import { SearchFixedModalBottom } from 'features/search/components/SearchFixedMo
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { FilterBehaviour } from 'features/search/enums'
 import { getMarkedDates } from 'features/search/helpers/getMarkedDates/getMarkedDates'
+import { getPastScrollRange } from 'features/search/helpers/getPastScrollRange/getPastScrollRange'
 import { calendarSchema } from 'features/search/helpers/schema/calendarSchema/calendarSchema'
 import { SearchState } from 'features/search/types'
 import { AppModal } from 'ui/components/modals/AppModal'
@@ -174,10 +175,19 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
       }
       scrollEnabled={false}>
       <CalendarList
+        current={
+          searchState.beginningDatetime
+            ? format(new Date(searchState.beginningDatetime), 'yyyy-MM-dd')
+            : undefined
+        }
         minDate={format(today, 'yyyy-MM-dd')}
         maxDate={format(twoYearsLater, 'yyyy-MM-dd')}
-        pastScrollRange={0} // month before today not visible
         futureScrollRange={24} // 24 months to have scrolling
+        pastScrollRange={
+          searchState.beginningDatetime
+            ? getPastScrollRange(new Date(searchState.beginningDatetime), today)
+            : 0
+        }
         markingType="period" // to have visible period
         onDayPress={onDayPress}
         markedDates={markedDates}

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -17,6 +17,7 @@ import { LocationMode } from 'libs/location/types'
 import { SuggestedPlace } from 'libs/place/types'
 import { Range } from 'libs/typesUtils/typeHelpers'
 import { Offer } from 'shared/offer/types'
+import { ColorsType } from 'theme/types'
 interface SelectedDate {
   option: DATE_FILTER_OPTIONS
   selectedDate: string
@@ -130,3 +131,5 @@ export enum BooksNativeCategoriesEnum {
 }
 
 export type NativeCategoryEnum = NativeCategoryIdEnumv2 | BooksNativeCategoriesEnum
+
+export type MarkedDatesColors = { backgroundColor: ColorsType; textColor: ColorsType }

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildNumericFilters.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildNumericFilters.ts
@@ -4,33 +4,36 @@ import {
   buildOfferLast30DaysBookings,
   buildOfferPriceRangePredicate,
 } from 'libs/algolia/fetchAlgolia/buildAlgoliaParameters/helpers/buildNumericFiltersHelpers/buildNumericFiltersHelpers'
-import { SearchQueryParameters, FiltersArray } from 'libs/algolia/types'
+import { FiltersArray, SearchQueryParameters } from 'libs/algolia/types'
 
-export const buildNumericFilters = ({
-  date,
-  beginningDatetime,
-  endingDatetime,
-  offerIsFree,
-  priceRange,
-  timeRange,
-  minPrice,
-  maxPrice,
-  maxPossiblePrice,
-  minBookingsThreshold,
-}: Pick<
-  SearchQueryParameters,
-  | 'beginningDatetime'
-  | 'endingDatetime'
-  | 'date'
-  | 'offerIsFree'
-  | 'priceRange'
-  | 'timeRange'
-  | 'minPrice'
-  | 'maxPrice'
-  | 'maxPossiblePrice'
-  | 'minBookingsThreshold'
-  | 'isHeadline'
->): null | {
+export const buildNumericFilters = (
+  {
+    date,
+    beginningDatetime,
+    endingDatetime,
+    offerIsFree,
+    priceRange,
+    timeRange,
+    minPrice,
+    maxPrice,
+    maxPossiblePrice,
+    minBookingsThreshold,
+  }: Pick<
+    SearchQueryParameters,
+    | 'beginningDatetime'
+    | 'endingDatetime'
+    | 'date'
+    | 'offerIsFree'
+    | 'priceRange'
+    | 'timeRange'
+    | 'minPrice'
+    | 'maxPrice'
+    | 'maxPossiblePrice'
+    | 'minBookingsThreshold'
+    | 'isHeadline'
+  >,
+  isUsedFromSearch?: boolean
+): null | {
   numericFilters: FiltersArray
 } => {
   const priceRangePredicate = buildOfferPriceRangePredicate({
@@ -41,7 +44,13 @@ export const buildNumericFilters = ({
     maxPossiblePrice,
   })
   const datePredicate = buildDatePredicate({ date, timeRange })
-  const homepageDatePredicate = buildHomepageDatePredicate({ beginningDatetime, endingDatetime })
+  const homepageDatePredicate = buildHomepageDatePredicate(
+    {
+      beginningDatetime,
+      endingDatetime,
+    },
+    isUsedFromSearch
+  )
   const last30DaysBookingsPredicate = buildOfferLast30DaysBookings(minBookingsThreshold)
   const numericFilters: FiltersArray = []
 

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildOfferSearchParameters.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildOfferSearchParameters.ts
@@ -51,7 +51,8 @@ export const buildOfferSearchParameters = (
   }: Parameters,
   buildLocationParameterParams: BuildLocationParameterParams,
   isUserUnderage: boolean,
-  disabilitiesProperties: DisabilitiesProperties = defaultDisabilitiesProperties
+  disabilitiesProperties: DisabilitiesProperties = defaultDisabilitiesProperties,
+  isUsedFromSearch?: boolean
 ) => {
   const locationParameter =
     venue || isFullyDigitalOffersCategory
@@ -78,19 +79,22 @@ export const buildOfferSearchParameters = (
       disabilitiesProperties,
       isHeadline,
     }),
-    ...buildNumericFilters({
-      beginningDatetime,
-      date,
-      endingDatetime,
-      maxPossiblePrice,
-      maxPrice,
-      minBookingsThreshold,
-      minPrice,
-      offerIsFree,
-      priceRange,
-      timeRange,
-      isHeadline,
-    }),
+    ...buildNumericFilters(
+      {
+        beginningDatetime,
+        date,
+        endingDatetime,
+        maxPossiblePrice,
+        maxPrice,
+        minBookingsThreshold,
+        minPrice,
+        offerIsFree,
+        priceRange,
+        timeRange,
+        isHeadline,
+      },
+      isUsedFromSearch
+    ),
     ...locationParameter,
     ...buildFilters({ excludedObjectIds }),
     ...buildTagFilters({ shouldExcludeFutureOffers }),

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/helpers/buildNumericFiltersHelpers/buildNumericFiltersHelpers.test.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/helpers/buildNumericFiltersHelpers/buildNumericFiltersHelpers.test.ts
@@ -159,13 +159,25 @@ describe('buildHomepageDatePredicate', () => {
     expect(homepageDatePredicate).toEqual(undefined)
   })
 
-  it('should return an homepage date predicate with only beginning date when beginning date defined and ending date not defined', () => {
+  it('should return an homepage date predicate from beginning date when beginning date defined and ending date not defined', () => {
     const homepageDatePredicate = buildHomepageDatePredicate({
       ...defaultBuildHomepageDatePredicate,
       beginningDatetime: new Date('2023-04-20').toISOString(),
     })
 
     expect(homepageDatePredicate).toEqual(['offer.dates >= 1681948800'])
+  })
+
+  it('should return an homepage date predicate with only beginning date when beginning date defined, ending date not defined and used from search', () => {
+    const homepageDatePredicate = buildHomepageDatePredicate(
+      {
+        ...defaultBuildHomepageDatePredicate,
+        beginningDatetime: new Date('2023-04-20').toISOString(),
+      },
+      true
+    )
+
+    expect(homepageDatePredicate).toEqual(['offer.dates: 1681948800 TO 1682035199'])
   })
 
   it('should return an homepage date predicate with only ending date when ending date defined and beginning date not defined', () => {

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/helpers/buildNumericFiltersHelpers/buildNumericFiltersHelpers.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/helpers/buildNumericFiltersHelpers/buildNumericFiltersHelpers.ts
@@ -51,19 +51,23 @@ export const buildDatePredicate = ({
   return undefined
 }
 
-export const buildHomepageDatePredicate = ({
-  beginningDatetime,
-  endingDatetime,
-}: Pick<SearchQueryParameters, 'beginningDatetime' | 'endingDatetime'>):
-  | undefined
-  | FiltersArray[0] => {
+export const buildHomepageDatePredicate = (
+  {
+    beginningDatetime,
+    endingDatetime,
+  }: Pick<SearchQueryParameters, 'beginningDatetime' | 'endingDatetime'>,
+  isUsedFromSearch?: boolean
+): undefined | FiltersArray[0] => {
   if (!(beginningDatetime || endingDatetime)) return undefined
   const formattedBeginningDatetime = beginningDatetime ? new Date(beginningDatetime) : undefined
   const formattedEndingDatetime = endingDatetime ? new Date(endingDatetime) : undefined
 
   if (formattedBeginningDatetime && !formattedEndingDatetime) {
     const beginningTimestamp = TIMESTAMP.getFromDate(formattedBeginningDatetime)
-    return [`${NUMERIC_FILTERS_ENUM.OFFER_DATES} >= ${beginningTimestamp}`]
+    const endOfBeginningTimestamp = TIMESTAMP.getLastOfDate(formattedBeginningDatetime)
+    return isUsedFromSearch
+      ? [`${NUMERIC_FILTERS_ENUM.OFFER_DATES}: ${beginningTimestamp} TO ${endOfBeginningTimestamp}`]
+      : [`${NUMERIC_FILTERS_ENUM.OFFER_DATES} >= ${beginningTimestamp}`]
   }
 
   if (!formattedBeginningDatetime && formattedEndingDatetime) {

--- a/src/libs/algolia/fetchAlgolia/fetchSearchResults/fetchSearchResults.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchSearchResults/fetchSearchResults.ts
@@ -64,7 +64,8 @@ export const fetchSearchResults = async ({
         parameters,
         buildLocationParameterParams,
         isUserUnderage,
-        disabilitiesProperties
+        disabilitiesProperties,
+        true
       ),
       attributesToRetrieve: offerAttributesToRetrieve,
       attributesToHighlight: [], // We disable highlighting because we don't need it
@@ -116,7 +117,8 @@ export const fetchSearchResults = async ({
           },
           buildLocationParameterParams,
           isUserUnderage,
-          disabilitiesProperties
+          disabilitiesProperties,
+          true
         ),
       },
       facets: [


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35834

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |![Capture d’écran 2025-04-29 à 11 19 09](https://github.com/user-attachments/assets/090e65c6-d7c4-4740-bf8d-00ca2a811554)|<img width="421" alt="Capture d’écran 2025-04-28 à 15 35 42" src="https://github.com/user-attachments/assets/52220002-41b3-4758-a552-e70261d9d7b9" />|
| Android          |               |<img width="431" alt="Capture d’écran 2025-04-28 à 15 35 32" src="https://github.com/user-attachments/assets/90a0516f-e9c1-4d58-8f6a-ca59b6fabffa" />|
| Phone - Chrome   |               |![Capture d’écran 2025-04-28 à 15 37 06](https://github.com/user-attachments/assets/17e7df39-1e8b-4c52-b917-84436c4bbb17)|
| Desktop - Chrome |               |![Capture d’écran 2025-04-28 à 15 37 32](https://github.com/user-attachments/assets/a9b084df-d5f6-4584-b0c7-8309b423be07)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
