### PR TITLE
(PC-35835) feat(search): use calendar modal in dates filter when wipTimeFilterV2 FF activated

### DIFF
--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -358,6 +358,146 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                       ]
                     }
                   >
+                    Dates & heures
+                  </Text>
+                </View>
+              </View>
+              <View
+                accessibilityLabel="Affiner la recherche"
+                height={20}
+                width={20}
+              >
+                <Text>
+                  undefined-SVG-Mock
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityRole="none"
+            isFirstSectionItem={false}
+            style={
+              [
+                {
+                  "display": "flex",
+                  "marginBottom": 24,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "backgroundColor": "#F1F1F4",
+                    "height": 2,
+                    "marginBottom": 24,
+                    "width": "100%",
+                  },
+                ]
+              }
+            />
+            <View
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  [
+                    {
+                      "userSelect": "auto",
+                    },
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ],
+                  {
+                    "opacity": 1,
+                  },
+                ]
+              }
+              testID="FilterRow"
+            >
+              <View
+                style={
+                  [
+                    {
+                      "marginRight": 16,
+                    },
+                  ]
+                }
+              >
+                <View
+                  fill="#161617"
+                  height={24}
+                  width={24}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "flex-start",
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                      "marginRight": 16,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    numberOfLines={2}
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "flexShrink": 1,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        },
+                      ]
+                    }
+                  >
                     Catégorie
                   </Text>
                 </View>
@@ -655,146 +795,6 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                     }
                   >
                     Prix
-                  </Text>
-                </View>
-              </View>
-              <View
-                accessibilityLabel="Affiner la recherche"
-                height={20}
-                width={20}
-              >
-                <Text>
-                  undefined-SVG-Mock
-                </Text>
-              </View>
-            </View>
-          </View>
-          <View
-            accessibilityRole="none"
-            isFirstSectionItem={false}
-            style={
-              [
-                {
-                  "display": "flex",
-                  "marginBottom": 24,
-                },
-              ]
-            }
-          >
-            <View
-              style={
-                [
-                  {
-                    "backgroundColor": "#F1F1F4",
-                    "height": 2,
-                    "marginBottom": 24,
-                    "width": "100%",
-                  },
-                ]
-              }
-            />
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": undefined,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
-              }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                [
-                  [
-                    {
-                      "userSelect": "auto",
-                    },
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                    },
-                  ],
-                  {
-                    "opacity": 1,
-                  },
-                ]
-              }
-              testID="FilterRow"
-            >
-              <View
-                style={
-                  [
-                    {
-                      "marginRight": 16,
-                    },
-                  ]
-                }
-              >
-                <View
-                  fill="#161617"
-                  height={24}
-                  width={24}
-                >
-                  <Text>
-                    undefined-SVG-Mock
-                  </Text>
-                </View>
-              </View>
-              <View
-                style={
-                  [
-                    {
-                      "alignItems": "flex-start",
-                      "flexBasis": 0,
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                      "marginRight": 16,
-                    },
-                  ]
-                }
-              >
-                <View
-                  style={
-                    [
-                      {
-                        "flexDirection": "row",
-                      },
-                    ]
-                  }
-                >
-                  <Text
-                    numberOfLines={2}
-                    style={
-                      [
-                        {
-                          "color": "#161617",
-                          "flexShrink": 1,
-                          "fontFamily": "Montserrat-SemiBold",
-                          "fontSize": 16,
-                          "lineHeight": 25.6,
-                        },
-                      ]
-                    }
-                  >
-                    Dates & heures
                   </Text>
                 </View>
               </View>

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -246,24 +246,17 @@ exports[`<SearchFilter/> should render correctly 1`] = `
         >
           <View
             accessibilityRole="none"
+            isFirstSectionItem={true}
             style={
               [
                 {
                   "display": "flex",
+                  "marginBottom": 24,
+                  "marginTop": 24,
                 },
               ]
             }
           >
-            <View
-              numberOfSpaces={6}
-              style={
-                [
-                  {
-                    "height": 24,
-                  },
-                ]
-              }
-            />
             <View
               accessibilityRole="button"
               accessibilityState={
@@ -395,23 +388,15 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={6}
-              style={
-                [
-                  {
-                    "height": 24,
-                  },
-                ]
-              }
-            />
           </View>
           <View
             accessibilityRole="none"
+            isFirstSectionItem={false}
             style={
               [
                 {
                   "display": "flex",
+                  "marginBottom": 24,
                 },
               ]
             }
@@ -422,17 +407,8 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                   {
                     "backgroundColor": "#F1F1F4",
                     "height": 2,
+                    "marginBottom": 24,
                     "width": "100%",
-                  },
-                ]
-              }
-            />
-            <View
-              numberOfSpaces={6}
-              style={
-                [
-                  {
-                    "height": 24,
                   },
                 ]
               }
@@ -552,23 +528,15 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={6}
-              style={
-                [
-                  {
-                    "height": 24,
-                  },
-                ]
-              }
-            />
           </View>
           <View
             accessibilityRole="none"
+            isFirstSectionItem={false}
             style={
               [
                 {
                   "display": "flex",
+                  "marginBottom": 24,
                 },
               ]
             }
@@ -579,17 +547,8 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                   {
                     "backgroundColor": "#F1F1F4",
                     "height": 2,
+                    "marginBottom": 24,
                     "width": "100%",
-                  },
-                ]
-              }
-            />
-            <View
-              numberOfSpaces={6}
-              style={
-                [
-                  {
-                    "height": 24,
                   },
                 ]
               }
@@ -709,23 +668,15 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={6}
-              style={
-                [
-                  {
-                    "height": 24,
-                  },
-                ]
-              }
-            />
           </View>
           <View
             accessibilityRole="none"
+            isFirstSectionItem={false}
             style={
               [
                 {
                   "display": "flex",
+                  "marginBottom": 24,
                 },
               ]
             }
@@ -736,17 +687,8 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                   {
                     "backgroundColor": "#F1F1F4",
                     "height": 2,
+                    "marginBottom": 24,
                     "width": "100%",
-                  },
-                ]
-              }
-            />
-            <View
-              numberOfSpaces={6}
-              style={
-                [
-                  {
-                    "height": 24,
                   },
                 ]
               }
@@ -866,23 +808,15 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={6}
-              style={
-                [
-                  {
-                    "height": 24,
-                  },
-                ]
-              }
-            />
           </View>
           <View
             accessibilityRole="none"
+            isFirstSectionItem={false}
             style={
               [
                 {
                   "display": "flex",
+                  "marginBottom": 24,
                 },
               ]
             }
@@ -893,17 +827,8 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                   {
                     "backgroundColor": "#F1F1F4",
                     "height": 2,
+                    "marginBottom": 24,
                     "width": "100%",
-                  },
-                ]
-              }
-            />
-            <View
-              numberOfSpaces={6}
-              style={
-                [
-                  {
-                    "height": 24,
                   },
                 ]
               }
@@ -1022,16 +947,6 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={6}
-              style={
-                [
-                  {
-                    "height": 24,
-                  },
-                ]
-              }
-            />
           </View>
         </View>
       </View>
@@ -1072,16 +987,6 @@ exports[`<SearchFilter/> should render correctly 1`] = `
       />
     </View>
   </View>
-  <View
-    numberOfSpaces={4}
-    style={
-      [
-        {
-          "height": 16,
-        },
-      ]
-    }
-  />
   <View
     isModal={false}
     style={

--- a/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -300,24 +300,22 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
       <RCTScrollView
         horizontal={true}
         showsHorizontalScrollIndicator={false}
+        style={
+          [
+            {
+              "marginBottom": 8,
+            },
+          ]
+        }
       >
         <View>
-          <View
-            numberOfSpaces={5}
-            style={
-              [
-                {
-                  "width": 20,
-                },
-              ]
-            }
-          />
           <View
             accessibilityRole="list"
             style={
               [
                 {
                   "flexDirection": "row",
+                  "marginHorizontal": 20,
                   "paddingLeft": 0,
                 },
               ]
@@ -925,28 +923,8 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
               </View>
             </View>
           </View>
-          <View
-            numberOfSpaces={5}
-            style={
-              [
-                {
-                  "width": 20,
-                },
-              ]
-            }
-          />
         </View>
       </RCTScrollView>
-      <View
-        numberOfSpaces={2}
-        style={
-          [
-            {
-              "height": 8,
-            },
-          ]
-        }
-      />
     </View>
     <View
       style={

--- a/knip.ts
+++ b/knip.ts
@@ -36,10 +36,6 @@ const productionConfig: KnipConfig = {
   ignore: [
     ...(defaultConfig.ignore || []),
     'src/features/bookings/components/Ticket/ControlComponent.tsx',
-    'src/features/search/helpers/getMarkedDates/getMarkedDates.ts',
-    'src/features/search/helpers/getPastScrollRange/getPastScrollRange.ts',
-    'src/features/search/helpers/schema/calendarSchema/calendarSchema.ts',
-    'src/features/search/pages/modals/CalendarModal/CalendarModal.tsx',
     'src/libs/tick.ts', // only used in a codepush button appearing in cheatcodes, should be deleted soon
   ],
   rules: {

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -1168,4 +1168,30 @@ describe('SearchResultsContent component', () => {
       })
     })
   })
+
+  describe('When calendar filter feature flag activated', () => {
+    beforeEach(() => {
+      mockUseSearchResults.mockReturnValue({
+        ...initialSearchResults,
+        hits: mockedAlgoliaResponse.hits,
+        nbHits: mockedAlgoliaResponse.nbHits,
+      })
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_TIME_FILTER_V2])
+      mockUseLocation.mockReturnValue(aroundMeUseLocation)
+    })
+
+    it('should display Dates in button filter', async () => {
+      render(<SearchResultsContent />)
+
+      expect(await screen.findByText('Dates')).toBeOnTheScreen()
+    })
+
+    it('should open calendar modal', async () => {
+      render(<SearchResultsContent />)
+
+      await user.press(await screen.findByText('Dates'))
+
+      expect(screen.getByTestId('calendar')).toBeOnTheScreen()
+    })
+  })
 })

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -442,9 +442,8 @@ export const SearchResultsContent: React.FC = () => {
         toggle={() => setAutoScrollEnabled((autoScroll) => !autoScroll)}
       />
       <View>
-        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-          <Spacer.Row numberOfSpaces={5} />
-          <Ul>
+        <FiltersScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <StyledUl>
             <StyledLi>
               <FilterButton
                 activeFilters={activeFiltersCount}
@@ -505,10 +504,8 @@ export const SearchResultsContent: React.FC = () => {
                 isSelected={appliedFilters.includes(FILTER_TYPES.ACCESSIBILITY)}
               />
             </StyledLastLi>
-          </Ul>
-          <Spacer.Row numberOfSpaces={5} />
-        </ScrollView>
-        <Spacer.Column numberOfSpaces={2} />
+          </StyledUl>
+        </FiltersScrollView>
       </View>
       <Container testID="searchResults">{renderSearchList()}</Container>
       {shouldRenderScrollToTopButton ? (
@@ -621,6 +618,14 @@ const ScrollToTopContainer = styled.View(({ theme }) => ({
   bottom: theme.tabBar.height + getSpacing(6),
   zIndex: theme.zIndex.floatingButton,
 }))
+
+const StyledUl = styled(Ul)({
+  marginHorizontal: getSpacing(5),
+})
+
+const FiltersScrollView = styled(ScrollView)({
+  marginBottom: getSpacing(2),
+})
 
 const FAVORITE_LIST_PLACEHOLDER = Array.from({ length: 20 }).map((_, index) => ({
   key: index.toString(),

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -2,7 +2,7 @@ import { useFocusEffect, useIsFocused } from '@react-navigation/native'
 import { FlashList } from '@shopify/flash-list'
 import { debounce } from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { FlatList, Platform, ScrollView, View, useWindowDimensions } from 'react-native'
+import { FlatList, Platform, ScrollView, useWindowDimensions, View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { AccessibilityFiltersModal } from 'features/accessibility/components/AccessibilityFiltersModal'
@@ -27,6 +27,7 @@ import { useFilterCount } from 'features/search/helpers/useFilterCount/useFilter
 import { useNavigateToSearch } from 'features/search/helpers/useNavigateToSearch/useNavigateToSearch'
 import { useNavigateToSearchFilter } from 'features/search/helpers/useNavigateToSearchFilter/useNavigateToSearchFilter'
 import { usePrevious } from 'features/search/helpers/usePrevious'
+import { CalendarModal } from 'features/search/pages/modals/CalendarModal/CalendarModal'
 import { CategoriesModal } from 'features/search/pages/modals/CategoriesModal/CategoriesModal'
 import { DatesHoursModal } from 'features/search/pages/modals/DatesHoursModal/DatesHoursModal'
 import { OfferDuoModal } from 'features/search/pages/modals/OfferDuoModal/OfferDuoModal'
@@ -111,6 +112,7 @@ export const SearchResultsContent: React.FC = () => {
   const shouldDisplayVenueMapInSearch = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_VENUE_MAP_IN_SEARCH
   )
+  const shouldDisplayCalendarModal = useFeatureFlag(RemoteStoreFeatureFlags.WIP_TIME_FILTER_V2)
 
   const [isSearchListTab, setIsSearchListTab] = useState(true)
   const [defaultTab, setDefaultTab] = useState(Tab.SEARCHLIST)
@@ -207,6 +209,11 @@ export const SearchResultsContent: React.FC = () => {
     visible: venueMapLocationModalVisible,
     showModal: showVenueMapLocationModal,
     hideModal: hideVenueMapLocationModal,
+  } = useModal(false)
+  const {
+    visible: calendarModalVisible,
+    showModal: showCalendarModal,
+    hideModal: hideCalendarModal,
   } = useModal(false)
 
   const activeFiltersCount = useFilterCount(searchState)
@@ -452,9 +459,9 @@ export const SearchResultsContent: React.FC = () => {
             </StyledLi>
             <StyledLi>
               <StyledSingleFilterButton
-                label="Dates & heures"
+                label={shouldDisplayCalendarModal ? 'Dates' : 'Dates & heures'}
                 testID="datesHoursButton"
-                onPress={showDatesHoursModal}
+                onPress={shouldDisplayCalendarModal ? showCalendarModal : showDatesHoursModal}
                 isSelected={appliedFilters.includes(FILTER_TYPES.DATES_HOURS)}
               />
             </StyledLi>
@@ -546,6 +553,13 @@ export const SearchResultsContent: React.FC = () => {
         accessibilityLabel="Ne pas filtrer sur les dates et heures puis retourner aux résultats"
         isVisible={datesHoursModalVisible}
         hideModal={hideDatesHoursModal}
+        filterBehaviour={FilterBehaviour.SEARCH}
+      />
+      <CalendarModal
+        title="Dates"
+        accessibilityLabel="Ne pas filtrer sur les dates puis retourner aux résultats"
+        isVisible={calendarModalVisible}
+        hideModal={hideCalendarModal}
         filterBehaviour={FilterBehaviour.SEARCH}
       />
       <AccessibilityFiltersModal

--- a/src/features/search/components/sections/CalendarFilter/CalendarFilter.native.test.tsx
+++ b/src/features/search/components/sections/CalendarFilter/CalendarFilter.native.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+
+import { CalendarFilter } from 'features/search/components/sections/CalendarFilter/CalendarFilter'
+import { initialSearchState } from 'features/search/context/reducer'
+import { SearchState } from 'features/search/types'
+import { render, screen, userEvent } from 'tests/utils'
+
+const mockSearchState: jest.Mock<{ searchState: Partial<SearchState> }> = jest
+  .fn()
+  .mockReturnValue({
+    searchState: initialSearchState,
+  })
+
+jest.mock('features/search/context/SearchWrapper', () => ({
+  useSearch: () => mockSearchState(),
+}))
+
+const user = userEvent.setup()
+
+jest.useFakeTimers()
+
+describe('CalendarFilter', () => {
+  it('should display description with only beginning date', async () => {
+    mockSearchState.mockReturnValueOnce({
+      searchState: {
+        beginningDatetime: '2025-04-30T00:00:00.000Z',
+        endingDatetime: undefined,
+      },
+    })
+
+    render(<CalendarFilter />)
+
+    expect(await screen.findByText('le mercredi 30 avril')).toBeOnTheScreen()
+  })
+
+  it('should display description with beginning and ending dates', async () => {
+    mockSearchState.mockReturnValueOnce({
+      searchState: {
+        beginningDatetime: '2025-04-30T00:00:00.000Z',
+        endingDatetime: '2025-05-05T00:00:00.000Z',
+      },
+    })
+
+    render(<CalendarFilter />)
+
+    expect(await screen.findByText('du mercredi 30 avril au lundi 5 mai')).toBeOnTheScreen()
+  })
+
+  it('should open modal when pressing button', async () => {
+    render(<CalendarFilter />)
+
+    await user.press(screen.getByText('Dates'))
+
+    expect(screen.getByTestId('calendar')).toBeOnTheScreen()
+  })
+})

--- a/src/features/search/components/sections/CalendarFilter/CalendarFilter.tsx
+++ b/src/features/search/components/sections/CalendarFilter/CalendarFilter.tsx
@@ -1,0 +1,53 @@
+import { format } from 'date-fns'
+import { fr } from 'date-fns/locale'
+import React, { useMemo } from 'react'
+
+import { FilterRow } from 'features/search/components/FilterRow/FilterRow'
+import { useSearch } from 'features/search/context/SearchWrapper'
+import { FilterBehaviour } from 'features/search/enums'
+import { CalendarModal } from 'features/search/pages/modals/CalendarModal/CalendarModal'
+import { useModal } from 'ui/components/modals/useModal'
+import { CalendarS } from 'ui/svg/icons/CalendarS'
+
+type Props = {
+  onClose?: VoidFunction
+}
+
+export const CalendarFilter = ({ onClose }: Props) => {
+  const { searchState } = useSearch()
+  const { beginningDatetime, endingDatetime } = searchState
+  const { visible, showModal, hideModal } = useModal(false)
+
+  const calendarString = useMemo(() => {
+    if (!beginningDatetime) return undefined
+
+    const formattedBeginningDate = format(new Date(beginningDatetime), 'EEEE d MMMM', {
+      locale: fr,
+    })
+
+    if (!endingDatetime) {
+      return `le ${formattedBeginningDate}`
+    }
+
+    const formattedEndingDate = format(new Date(endingDatetime), 'EEEE d MMMM', {
+      locale: fr,
+    })
+
+    return `du ${formattedBeginningDate} au ${formattedEndingDate}`
+  }, [beginningDatetime, endingDatetime])
+
+  return (
+    <React.Fragment>
+      <FilterRow icon={CalendarS} title="Dates" description={calendarString} onPress={showModal} />
+
+      <CalendarModal
+        title="Dates"
+        accessibilityLabel="Ne pas filtrer sur les dates puis retourner aux résultats"
+        isVisible={visible}
+        hideModal={hideModal}
+        filterBehaviour={FilterBehaviour.APPLY_WITHOUT_SEARCHING}
+        onClose={onClose}
+      />
+    </React.Fragment>
+  )
+}

--- a/src/features/search/components/sections/index.ts
+++ b/src/features/search/components/sections/index.ts
@@ -1,4 +1,5 @@
 import { Accessibility } from './Accessibility/Accessibility'
+import { CalendarFilter } from './CalendarFilter/CalendarFilter'
 import { Category } from './Category/Category'
 import { DateHour } from './DateHour/DateHour'
 import { OfferDuo } from './OfferDuo/OfferDuo'
@@ -7,6 +8,7 @@ import { Venue } from './Venue/Venue'
 
 export default {
   Category,
+  CalendarFilter,
   DateHour,
   OfferDuo,
   Price,

--- a/src/features/search/pages/SearchFilter/SearchFilter.native.test.tsx
+++ b/src/features/search/pages/SearchFilter/SearchFilter.native.test.tsx
@@ -7,6 +7,7 @@ import { initialSearchState } from 'features/search/context/reducer'
 import { ISearchContext } from 'features/search/context/SearchWrapper'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { GeoCoordinates } from 'libs/location'
 import { ILocationContext, LocationMode } from 'libs/location/types'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
@@ -200,6 +201,20 @@ describe('<SearchFilter/>', () => {
     renderSearchFilter()
 
     expect(await screen.findByText('Accessibilité')).toBeOnTheScreen()
+  })
+
+  it('should display date and hour section when wipTimeFilterV2 FF deactivated', async () => {
+    renderSearchFilter()
+
+    expect(await screen.findByText('Dates & heures')).toBeOnTheScreen()
+  })
+
+  it('should display calendar section when wipTimeFilterV2 FF activated', async () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_TIME_FILTER_V2])
+
+    renderSearchFilter()
+
+    expect(await screen.findByText('Dates')).toBeOnTheScreen()
   })
 })
 

--- a/src/features/search/pages/SearchFilter/SearchFilter.tsx
+++ b/src/features/search/pages/SearchFilter/SearchFilter.tsx
@@ -27,7 +27,7 @@ import { Li } from 'ui/components/Li'
 import { VerticalUl } from 'ui/components/Ul'
 import { Page } from 'ui/pages/Page'
 import { SecondaryPageWithBlurHeader } from 'ui/pages/SecondaryPageWithBlurHeader'
-import { Spacer } from 'ui/theme'
+import { getSpacing } from 'ui/theme'
 
 export const SearchFilter: React.FC = () => {
   const currency = useGetCurrencyToDisplay()
@@ -109,7 +109,7 @@ export const SearchFilter: React.FC = () => {
 
   return (
     <Page>
-      <SecondaryPageWithBlurHeader
+      <StyledSecondaryPageWithBlurHeader
         title="Filtres"
         onGoBack={onGoBack}
         scrollViewProps={{ keyboardShouldPersistTaps: 'always' }}>
@@ -139,8 +139,7 @@ export const SearchFilter: React.FC = () => {
             <Section.Accessibility onClose={onClose} />
           </SectionWrapper>
         </VerticalUl>
-      </SecondaryPageWithBlurHeader>
-      <Spacer.Column numberOfSpaces={4} />
+      </StyledSecondaryPageWithBlurHeader>
       <FilterPageButtons
         onResetPress={onResetPress}
         onSearchPress={onSearchPress}
@@ -156,11 +155,9 @@ const SectionWrapper: React.FunctionComponent<{
   isFirstSectionItem?: boolean
 }> = ({ children, isFirstSectionItem = false }) => {
   return (
-    <StyledLi>
+    <StyledLi isFirstSectionItem={isFirstSectionItem}>
       {isFirstSectionItem ? null : <Separator />}
-      <Spacer.Column numberOfSpaces={6} />
       {children}
-      <Spacer.Column numberOfSpaces={6} />
     </StyledLi>
   )
 }
@@ -169,8 +166,15 @@ const Separator = styled.View(({ theme }) => ({
   width: '100%',
   height: 2,
   backgroundColor: theme.colors.greyLight,
+  marginBottom: getSpacing(6),
 }))
 
-const StyledLi = styled(Li)({
+const StyledLi = styled(Li)<{ isFirstSectionItem?: boolean }>(({ isFirstSectionItem }) => ({
   display: 'flex',
+  marginBottom: getSpacing(6),
+  marginTop: isFirstSectionItem ? getSpacing(6) : undefined,
+}))
+
+const StyledSecondaryPageWithBlurHeader = styled(SecondaryPageWithBlurHeader)({
+  marginBottom: getSpacing(4),
 })

--- a/src/features/search/pages/SearchFilter/SearchFilter.tsx
+++ b/src/features/search/pages/SearchFilter/SearchFilter.tsx
@@ -17,6 +17,8 @@ import { useNavigateToSearch } from 'features/search/helpers/useNavigateToSearch
 import { useSync } from 'features/search/helpers/useSync/useSync'
 import { LocationFilter } from 'features/search/types'
 import { analytics } from 'libs/analytics/provider'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useFunctionOnce } from 'libs/hooks'
 import { useLocation } from 'libs/location'
 import { LocationMode } from 'libs/location/types'
@@ -46,6 +48,7 @@ export const SearchFilter: React.FC = () => {
   const { place, selectedLocationMode, aroundMeRadius, aroundPlaceRadius } = useLocation()
   const { user } = useAuthContext()
   const { isMobileViewport } = useTheme()
+  const shouldDisplayCalendarModal = useFeatureFlag(RemoteStoreFeatureFlags.WIP_TIME_FILTER_V2)
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const oldAccessibilityFilter = useMemo(() => disabilities, [])
@@ -115,7 +118,11 @@ export const SearchFilter: React.FC = () => {
         scrollViewProps={{ keyboardShouldPersistTaps: 'always' }}>
         <VerticalUl>
           <SectionWrapper isFirstSectionItem>
-            <Section.DateHour onClose={onClose} />
+            {shouldDisplayCalendarModal ? (
+              <Section.CalendarFilter onClose={onClose} />
+            ) : (
+              <Section.DateHour onClose={onClose} />
+            )}
           </SectionWrapper>
           <SectionWrapper>
             <Section.Category onClose={onClose} />

--- a/src/features/search/pages/SearchFilter/SearchFilter.tsx
+++ b/src/features/search/pages/SearchFilter/SearchFilter.tsx
@@ -115,6 +115,9 @@ export const SearchFilter: React.FC = () => {
         scrollViewProps={{ keyboardShouldPersistTaps: 'always' }}>
         <VerticalUl>
           <SectionWrapper isFirstSectionItem>
+            <Section.DateHour onClose={onClose} />
+          </SectionWrapper>
+          <SectionWrapper>
             <Section.Category onClose={onClose} />
           </SectionWrapper>
           {hasDuoOfferToggle ? (
@@ -131,9 +134,6 @@ export const SearchFilter: React.FC = () => {
               euroToPacificFrancRate={euroToPacificFrancRate}
               onClose={onClose}
             />
-          </SectionWrapper>
-          <SectionWrapper>
-            <Section.DateHour onClose={onClose} />
           </SectionWrapper>
           <SectionWrapper>
             <Section.Accessibility onClose={onClose} />

--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.native.test.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.native.test.tsx
@@ -93,8 +93,8 @@ describe('CalendarModal', () => {
   it('should execute search with selected dates and close the modal when pressing search button', async () => {
     renderCalendarModal()
 
-    await user.press(screen.getByLabelText(' Saturday 14 June 2025 '))
-    await user.press(screen.getByLabelText(' Tuesday 17 June 2025 '))
+    await user.press(screen.getByLabelText(' Samedi 14 Juin 2025 '))
+    await user.press(screen.getByLabelText(' Mardi 17 Juin 2025 '))
 
     await user.press(screen.getByText('Rechercher'))
 

--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
@@ -187,7 +187,7 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
         }
         minDate={format(today, 'yyyy-MM-dd')}
         maxDate={format(twoYearsLater, 'yyyy-MM-dd')}
-        futureScrollRange={24} // 24 months to have scrolling
+        futureScrollRange={12} // 1 year to have scrolling
         pastScrollRange={
           searchState.beginningDatetime
             ? getPastScrollRange(new Date(searchState.beginningDatetime), today)

--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
@@ -2,7 +2,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import { addYears, format } from 'date-fns'
 import React, { FunctionComponent, useCallback, useEffect, useMemo } from 'react'
 import { SetValueConfig, useForm } from 'react-hook-form'
-import { CalendarList, DateData } from 'react-native-calendars'
+import { CalendarList, DateData, LocaleConfig } from 'react-native-calendars'
 import { useTheme } from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -14,6 +14,8 @@ import { getMarkedDates } from 'features/search/helpers/getMarkedDates/getMarked
 import { getPastScrollRange } from 'features/search/helpers/getPastScrollRange/getPastScrollRange'
 import { calendarSchema } from 'features/search/helpers/schema/calendarSchema/calendarSchema'
 import { SearchState } from 'features/search/types'
+import { DAYS, dayNamesShort } from 'shared/date/days'
+import { CAPITALIZED_MONTHS, CAPITALIZED_SHORT_MONTHS } from 'shared/date/months'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { Close } from 'ui/svg/icons/Close'
 
@@ -30,6 +32,14 @@ export type CalendarModalProps = {
   filterBehaviour: FilterBehaviour
   onClose?: VoidFunction
 }
+
+LocaleConfig.locales['fr'] = {
+  monthNames: [...CAPITALIZED_MONTHS],
+  monthNamesShort: [...CAPITALIZED_SHORT_MONTHS],
+  dayNames: [...DAYS],
+  dayNamesShort,
+}
+LocaleConfig.defaultLocale = 'fr'
 
 const titleId = uuidv4()
 const today = new Date()

--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
@@ -196,6 +196,7 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
         markingType="period" // to have visible period
         onDayPress={onDayPress}
         markedDates={markedDates}
+        testID="calendar"
       />
     </AppModal>
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35835

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |![Capture d’écran 2025-04-30 à 15 08 00](https://github.com/user-attachments/assets/9534a475-7680-4f0d-bbde-45d14219d027)|![Capture d’écran 2025-04-30 à 15 02 03](https://github.com/user-attachments/assets/8cf06ffa-0738-4f97-a608-94686be1831c) ![Capture d’écran 2025-04-30 à 15 01 48](https://github.com/user-attachments/assets/7012dced-9e00-4453-b266-259fdb1fb76d) ![Capture d’écran 2025-04-30 à 15 01 27](https://github.com/user-attachments/assets/40041545-5723-4327-a329-62533ce28177)|
| Android          |               |![Capture d’écran 2025-04-30 à 15 06 08](https://github.com/user-attachments/assets/0e0d87f0-70df-483a-b30a-6aad73c8bc32) ![Capture d’écran 2025-04-30 à 15 06 31](https://github.com/user-attachments/assets/ddd1aed2-c906-4a9e-a055-67fcc79539f2) ![Capture d’écran 2025-04-30 à 15 06 45](https://github.com/user-attachments/assets/4d7dee67-198c-4c76-9254-f1011fccba9e)|
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |<img width="1718" alt="Capture d’écran 2025-04-30 à 15 00 35" src="https://github.com/user-attachments/assets/d2875142-1d67-44c4-9cc2-978f193fde0e" /> <img width="1723" alt="Capture d’écran 2025-04-30 à 15 00 19" src="https://github.com/user-attachments/assets/2c305297-ec17-41b3-89aa-38eca66f047f" /> <img width="1722" alt="Capture d’écran 2025-04-30 à 14 59 54" src="https://github.com/user-attachments/assets/efdb2a18-5ee9-4342-bf58-b321162e1222" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
