### PR TITLE
(PC-35237) fix(SearchResults): better handle of searchresults header height on web app mobile view

### DIFF
--- a/src/features/search/components/SearchList/SearchList.web.test.tsx
+++ b/src/features/search/components/SearchList/SearchList.web.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { SearchList } from 'features/search/components/SearchList/SearchList'
+import { getHeaderSize } from 'features/search/components/SearchList/SearchList.web'
 import { initialSearchState } from 'features/search/context/reducer'
 import { SearchListProps } from 'features/search/types'
 import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
@@ -45,6 +46,17 @@ const props: SearchListProps = {
   venuesUserData: [],
 }
 
+const WIDTH_MOCK = 465
+
+const mockUseWindowDimensions = jest.fn().mockReturnValue({
+  width: WIDTH_MOCK,
+  scale: 1,
+  fontScale: 1,
+})
+jest.mock('react-native/Libraries/Utilities/useWindowDimensions', () => ({
+  default: mockUseWindowDimensions,
+}))
+
 describe('<SearchList />', () => {
   beforeEach(() => {
     setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_PACIFIC_FRANC_CURRENCY])
@@ -55,4 +67,23 @@ describe('<SearchList />', () => {
 
     expect(screen.getByTestId('searchListHeader')).toBeInTheDocument()
   })
+})
+
+describe('getHeaderSize', () => {
+  it.each`
+    userData                    | isGeolocated | hasVenuesPlaylist | windowWidth | expected
+    ${undefined}                | ${true}      | ${false}          | ${465}      | ${112}
+    ${undefined}                | ${false}     | ${false}          | ${465}      | ${218}
+    ${undefined}                | ${false}     | ${false}          | ${464}      | ${242}
+    ${undefined}                | ${false}     | ${true}           | ${464}      | ${539}
+    ${undefined}                | ${true}      | ${true}           | ${464}      | ${409}
+    ${[{ message: 'coucou ' }]} | ${false}     | ${false}          | ${464}      | ${184}
+  `(
+    'getHeaderSize should render correct header size',
+    ({ userData, isGeolocated, hasVenuesPlaylist, windowWidth, expected }) => {
+      expect(getHeaderSize({ userData, isGeolocated, hasVenuesPlaylist, windowWidth })).toBe(
+        expected
+      )
+    }
+  )
 })

--- a/src/features/search/components/SearchListHeader/SearchListHeader.tsx
+++ b/src/features/search/components/SearchListHeader/SearchListHeader.tsx
@@ -20,7 +20,7 @@ import { GeolocationBanner } from 'shared/Banners/GeolocationBanner'
 import { Offer } from 'shared/offer/types'
 import { InfoBanner } from 'ui/components/banners/InfoBanner'
 import { Error } from 'ui/svg/icons/Error'
-import { Spacer, Typo, getSpacing } from 'ui/theme'
+import { Typo, getSpacing } from 'ui/theme'
 
 interface SearchListHeaderProps extends ScrollViewProps {
   nbHits: number
@@ -79,8 +79,7 @@ export const SearchListHeader: React.FC<SearchListHeaderProps> = ({
   return (
     <View testID="searchListHeader">
       {shouldDisplayGeolocationButton ? (
-        <React.Fragment>
-          <Spacer.Column numberOfSpaces={4} />
+        <Container>
           <GeolocationButtonContainer>
             <GeolocationBanner
               title="Géolocalise-toi"
@@ -89,7 +88,7 @@ export const SearchListHeader: React.FC<SearchListHeaderProps> = ({
               onPress={onPress}
             />
           </GeolocationButtonContainer>
-        </React.Fragment>
+        </Container>
       ) : null}
       {shouldDisplayAvailableUserDataMessage ? (
         <BannerOfferNotPresentContainer
@@ -100,21 +99,22 @@ export const SearchListHeader: React.FC<SearchListHeaderProps> = ({
         </BannerOfferNotPresentContainer>
       ) : null}
       {shouldDisplayVenuesPlaylist ? (
-        <React.Fragment>
-          <Spacer.Column numberOfSpaces={4} />
+        <Container>
           <VenuePlaylist
             venuePlaylistTitle={venuePlaylistTitle}
             venues={venues}
             isLocated={isLocated}
           />
-        </React.Fragment>
+        </Container>
       ) : null}
-      <Spacer.Column numberOfSpaces={4} />
-      <Title>{offerTitle}</Title>
-      <NumberOfResults nbHits={nbHits} />
+      <Container>
+        <Title>{offerTitle}</Title>
+        <NumberOfResults nbHits={nbHits} />
+      </Container>
     </View>
   )
 }
+const Container = styled.View({ marginTop: getSpacing(4) })
 
 const GeolocationButtonContainer = styled.View(({ theme }) => ({
   marginLeft: theme.contentPage.marginHorizontal,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35237

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [x] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Phone - Chrome   |![Screenshot 2025-04-30 at 17 06 36](https://github.com/user-attachments/assets/8d649b94-93c6-41ea-934e-bf68d641744f)|![Screenshot 2025-04-30 at 17 06 20](https://github.com/user-attachments/assets/6211fa91-122a-45f0-96a1-dc31db3a5a71)|


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
