### PR TITLE
(PC-35955) test(app): replace some fireEvent.press by userEvent.press

### DIFF
--- a/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
@@ -9,7 +9,7 @@ import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/fixtures'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { PersonalData } from './PersonalData'
 
@@ -45,6 +45,10 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+
+jest.useFakeTimers()
 
 describe('PersonalData', () => {
   beforeEach(() => {
@@ -154,7 +158,7 @@ describe('PersonalData', () => {
 
     render(reactQueryProviderHOC(<PersonalData />))
 
-    fireEvent.press(await screen.findByTestId('Modifier mot de passe'))
+    await user.press(screen.getByTestId('Modifier mot de passe'))
 
     expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
       params: undefined,
@@ -169,7 +173,7 @@ describe('PersonalData', () => {
 
     render(reactQueryProviderHOC(<PersonalData />))
 
-    fireEvent.press(await screen.findByTestId('Modifier la ville de résidence'))
+    await user.press(screen.getByTestId('Modifier la ville de résidence'))
 
     expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
       params: undefined,
@@ -188,14 +192,12 @@ describe('PersonalData', () => {
 
     render(reactQueryProviderHOC(<PersonalData />))
 
-    fireEvent.press(await screen.findByText('Supprimer mon compte'))
+    await user.press(screen.getByText('Supprimer mon compte'))
 
-    await waitFor(() => {
-      expect(analytics.logAccountDeletion).toHaveBeenCalledTimes(1)
-      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
-        params: undefined,
-        screen: 'DeleteProfileReason',
-      })
+    expect(analytics.logAccountDeletion).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'DeleteProfileReason',
     })
   })
 
@@ -218,9 +220,7 @@ describe('PersonalData', () => {
 
     render(reactQueryProviderHOC(<PersonalData />))
 
-    await screen.findByText('Informations personnelles')
-
-    fireEvent.press(screen.getByText('Comment gérer tes données personnelles ?'))
+    await user.press(screen.getByText('Comment gérer tes données personnelles ?'))
 
     expect(openUrl).toHaveBeenNthCalledWith(1, env.FAQ_LINK_PERSONAL_DATA, undefined, true)
   })
@@ -232,7 +232,7 @@ describe('PersonalData', () => {
 
     render(reactQueryProviderHOC(<PersonalData />))
 
-    fireEvent.press(await screen.findByTestId('Modifier e-mail'))
+    await user.press(screen.getByTestId('Modifier e-mail'))
 
     expect(screen.getByTestId('Modifier e-mail')).toBeOnTheScreen()
 

--- a/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.native.test.tsx
+++ b/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.native.test.tsx
@@ -10,7 +10,7 @@ import { ProfileStackParamList } from 'features/navigation/ProfileStackNavigator
 import { RootStackParamList } from 'features/navigation/RootNavigator/types'
 import * as useEmailUpdateStatus from 'features/profile/helpers/useEmailUpdateStatus'
 import { SuspendAccountConfirmation } from 'features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 type useEmailUpdateStatusMock = ReturnType<(typeof useEmailUpdateStatus)['useEmailUpdateStatus']>
 
@@ -62,6 +62,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<SuspendAccountConfirmation />', () => {
   describe('should navigate to home', () => {
     it('When there is no email change', () => {
@@ -74,7 +77,7 @@ describe('<SuspendAccountConfirmation />', () => {
       expect(navigateToHome).toHaveBeenCalledTimes(1)
     })
 
-    it('When pressing "Ne pas suspendre mon compte" button', () => {
+    it('When pressing "Ne pas suspendre mon compte" button', async () => {
       useEmailUpdateStatusSpy.mockReturnValueOnce({
         data: {
           expired: false,
@@ -85,7 +88,7 @@ describe('<SuspendAccountConfirmation />', () => {
       } as useEmailUpdateStatusMock)
       renderSuspendAccountConfirmation()
 
-      fireEvent.press(screen.getByText('Ne pas suspendre mon compte'))
+      await user.press(screen.getByText('Ne pas suspendre mon compte'))
 
       expect(navigateToHome).toHaveBeenCalledTimes(1)
     })
@@ -94,9 +97,7 @@ describe('<SuspendAccountConfirmation />', () => {
       emailUpdateCancelSpy.mockRejectedValueOnce(new ApiError(500, 'API error'))
       renderSuspendAccountConfirmation()
 
-      await act(async () => {
-        fireEvent.press(screen.getByText('Oui, suspendre mon compte'))
-      })
+      await user.press(screen.getByText('Oui, suspendre mon compte'))
 
       expect(navigateToHome).toHaveBeenCalledTimes(1)
     })
@@ -120,13 +121,11 @@ describe('<SuspendAccountConfirmation />', () => {
 
   it('should navigate to email change tracking when pressing "Confirmer la demande" button and API response is success', async () => {
     renderSuspendAccountConfirmation()
-    fireEvent.press(screen.getByText('Oui, suspendre mon compte'))
+    await user.press(screen.getByText('Oui, suspendre mon compte'))
 
-    await waitFor(() => {
-      expect(navigation.navigate).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
-        params: undefined,
-        screen: 'TrackEmailChange',
-      })
+    expect(navigation.navigate).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
+      params: undefined,
+      screen: 'TrackEmailChange',
     })
   })
 
@@ -134,9 +133,7 @@ describe('<SuspendAccountConfirmation />', () => {
     emailUpdateCancelSpy.mockRejectedValueOnce(new ApiError(500, 'API error'))
     renderSuspendAccountConfirmation()
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Oui, suspendre mon compte'))
-    })
+    await user.press(screen.getByText('Oui, suspendre mon compte'))
 
     expect(mockShowErrorSnackbar).toHaveBeenCalledTimes(1)
   })
@@ -145,9 +142,7 @@ describe('<SuspendAccountConfirmation />', () => {
     emailUpdateCancelSpy.mockRejectedValueOnce(new ApiError(401, 'unauthorized'))
     renderSuspendAccountConfirmation()
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Oui, suspendre mon compte'))
-    })
+    await user.press(screen.getByText('Oui, suspendre mon compte'))
 
     expect(mockShowErrorSnackbar).not.toHaveBeenCalled()
   })
@@ -173,9 +168,7 @@ describe('<SuspendAccountConfirmation />', () => {
       emailUpdateCancelSpy.mockRejectedValueOnce(new ApiError(401, 'unauthorized'))
       renderSuspendAccountConfirmation()
 
-      await act(async () => {
-        fireEvent.press(screen.getByText('Oui, suspendre mon compte'))
-      })
+      await user.press(screen.getByText('Oui, suspendre mon compte'))
 
       expect(navigation.reset).toHaveBeenNthCalledWith(1, {
         routes: [{ name: 'ChangeEmailExpiredLink' }],

--- a/src/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx
+++ b/src/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx
@@ -6,7 +6,7 @@ import { TrackEmailChange } from 'features/profile/pages/TrackEmailChange/TrackE
 import { nonBeneficiaryUser } from 'fixtures/user'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('libs/network/NetInfoWrapper')
 
@@ -28,6 +28,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('TrackEmailChange', () => {
   it('should redirect to previous screen when clicking on ArrowPrevious icon', async () => {
     mockServer.getApi<EmailUpdateStatusResponse>('/v2/profile/email_update/status', {
@@ -38,7 +41,7 @@ describe('TrackEmailChange', () => {
     })
     render(reactQueryProviderHOC(<TrackEmailChange />))
 
-    fireEvent.press(await screen.findByLabelText('Revenir en arrière'))
+    await user.press(await screen.findByLabelText('Revenir en arrière'))
 
     expect(mockGoBack).toHaveBeenCalledTimes(1)
   })

--- a/src/features/profile/pages/TrackEmailChange/TrackEmailChangeContent.native.test.tsx
+++ b/src/features/profile/pages/TrackEmailChange/TrackEmailChangeContent.native.test.tsx
@@ -8,7 +8,7 @@ import { TrackEmailChangeContent } from 'features/profile/pages/TrackEmailChange
 import { beneficiaryUser, nonBeneficiaryUser } from 'fixtures/user'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 
 jest.mock('libs/network/NetInfoWrapper')
 
@@ -32,6 +32,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('TrackEmailChangeContent', () => {
   it('should open mail app when pressing first step and first step is active', async () => {
     mockServer.getApi<EmailUpdateStatusResponse>(
@@ -41,7 +44,7 @@ describe('TrackEmailChangeContent', () => {
 
     render(reactQueryProviderHOC(<TrackEmailChangeContent />))
 
-    fireEvent.press(await screen.findByText('Confirme ta demande'))
+    await user.press(screen.getByText('Confirme ta demande'))
 
     expect(openInbox).toHaveBeenCalledTimes(1)
   })
@@ -55,7 +58,7 @@ describe('TrackEmailChangeContent', () => {
 
     render(reactQueryProviderHOC(<TrackEmailChangeContent />))
 
-    fireEvent.press(await screen.findByText('Choisis ta nouvelle adresse e-mail'))
+    await user.press(await screen.findByText('Choisis ta nouvelle adresse e-mail'))
 
     expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
       params: {
@@ -74,7 +77,7 @@ describe('TrackEmailChangeContent', () => {
 
     render(reactQueryProviderHOC(<TrackEmailChangeContent />))
 
-    fireEvent.press(await screen.findByText('Valide ta nouvelle adresse'))
+    await user.press(await screen.findByText('Valide ta nouvelle adresse'))
 
     expect(openInbox).toHaveBeenCalledTimes(1)
   })
@@ -121,7 +124,7 @@ describe('TrackEmailChangeContent', () => {
 
       render(reactQueryProviderHOC(<TrackEmailChangeContent />))
 
-      fireEvent.press(await screen.findByText('Crée ton mot de passe'))
+      await user.press(await screen.findByText('Crée ton mot de passe'))
 
       expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
         params: {

--- a/src/features/profile/pages/ValidateEmailChange/ValidateEmailChange.native.test.tsx
+++ b/src/features/profile/pages/ValidateEmailChange/ValidateEmailChange.native.test.tsx
@@ -13,7 +13,7 @@ import { homeNavConfig } from 'features/navigation/TabBar/helpers'
 import * as useEmailUpdateStatus from 'features/profile/helpers/useEmailUpdateStatus'
 import { ValidateEmailChange } from 'features/profile/pages/ValidateEmailChange/ValidateEmailChange'
 import { eventMonitoring } from 'libs/monitoring/services'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 const useEmailUpdateStatusSpy = jest
   .spyOn(useEmailUpdateStatus, 'useEmailUpdateStatus')
@@ -85,6 +85,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('ValidateEmailChange', () => {
   it('should render new email address', () => {
     renderValidateEmailChange()
@@ -95,11 +98,9 @@ describe('ValidateEmailChange', () => {
   it('should sign out if submit is success and user is logged in', async () => {
     renderValidateEmailChange()
 
-    fireEvent.press(screen.getByText('Valider l’adresse e-mail'))
+    await user.press(screen.getByText('Valider l’adresse e-mail'))
 
-    await waitFor(() => {
-      expect(mockSignOut).toHaveBeenCalledTimes(1)
-    })
+    expect(mockSignOut).toHaveBeenCalledTimes(1)
   })
 
   it('should not sign out if submit is success and user is not logged in', async () => {
@@ -111,19 +112,15 @@ describe('ValidateEmailChange', () => {
     })
     renderValidateEmailChange()
 
-    fireEvent.press(screen.getByText('Valider l’adresse e-mail'))
+    await user.press(screen.getByText('Valider l’adresse e-mail'))
 
-    await waitFor(() => {
-      expect(mockSignOut).not.toHaveBeenCalled()
-    })
+    expect(mockSignOut).not.toHaveBeenCalled()
   })
 
   it('should redirect to Login if submit is success', async () => {
     renderValidateEmailChange()
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Valider l’adresse e-mail'))
-    })
+    await user.press(screen.getByText('Valider l’adresse e-mail'))
 
     expect(navigation.reset).toHaveBeenNthCalledWith(1, {
       routes: [{ name: 'Login', params: { from: StepperOrigin.VALIDATE_EMAIL_CHANGE } }],
@@ -133,9 +130,7 @@ describe('ValidateEmailChange', () => {
   it('should display a snackbar if submit is success', async () => {
     renderValidateEmailChange()
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Valider l’adresse e-mail'))
-    })
+    await user.press(screen.getByText('Valider l’adresse e-mail'))
 
     expect(mockShowSuccessSnackbar).toHaveBeenCalledTimes(1)
   })
@@ -145,9 +140,7 @@ describe('ValidateEmailChange', () => {
 
     renderValidateEmailChange()
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Valider l’adresse e-mail'))
-    })
+    await user.press(screen.getByText('Valider l’adresse e-mail'))
 
     expect(navigation.reset).toHaveBeenCalledWith({ routes: [{ name: 'ChangeEmailExpiredLink' }] })
   })
@@ -157,9 +150,7 @@ describe('ValidateEmailChange', () => {
 
     renderValidateEmailChange()
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Valider l’adresse e-mail'))
-    })
+    await user.press(screen.getByText('Valider l’adresse e-mail'))
 
     expect(mockShowErrorSnackbar).toHaveBeenCalledTimes(1)
   })
@@ -169,9 +160,7 @@ describe('ValidateEmailChange', () => {
 
     renderValidateEmailChange()
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Valider l’adresse e-mail'))
-    })
+    await user.press(screen.getByText('Valider l’adresse e-mail'))
 
     expect(mockShowErrorSnackbar).not.toHaveBeenCalled()
   })
@@ -205,9 +194,7 @@ describe('ValidateEmailChange', () => {
   it('should log to sentry, redirect to home and show error message when token is falsy', async () => {
     renderValidateEmailChange(routeWithUndefinedToken)
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Valider l’adresse e-mail'))
-    })
+    await user.press(screen.getByText('Valider l’adresse e-mail'))
 
     expect(eventMonitoring.captureException).toHaveBeenCalledWith(
       new Error('Expected a string, but received undefined')

--- a/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.native.test.tsx
+++ b/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.native.test.tsx
@@ -7,7 +7,7 @@ import { mockOffer } from 'features/bookOffer/fixtures/offer'
 import { ReactionChoiceModal } from 'features/reactions/components/ReactionChoiceModal/ReactionChoiceModal'
 import { ReactionChoiceModalBodyEnum, ReactionFromEnum } from 'features/reactions/enum'
 import { analytics } from 'libs/analytics/provider'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 const mockCloseModal = jest.fn()
 
@@ -19,6 +19,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('ReactionChoiceModal', () => {
   it('should display body with validation when body type is validation', () => {
@@ -84,7 +87,7 @@ describe('ReactionChoiceModal', () => {
   })
 
   describe('With reaction validation', () => {
-    it('should activate J’aime button when pressing it and it is deactivated', () => {
+    it('should activate J’aime button when pressing it and it is deactivated', async () => {
       render(
         <ReactionChoiceModal
           offer={mockOffer}
@@ -96,13 +99,13 @@ describe('ReactionChoiceModal', () => {
         />
       )
 
-      fireEvent.press(screen.getByText('J’aime'))
+      await user.press(screen.getByText('J’aime'))
 
       expect(screen.queryByTestId('thumbUp')).not.toBeOnTheScreen()
       expect(screen.getByTestId('thumbUpFilled')).toBeOnTheScreen()
     })
 
-    it('should deactivate J’aime button when pressing it and it is activated', () => {
+    it('should deactivate J’aime button when pressing it and it is activated', async () => {
       render(
         <ReactionChoiceModal
           offer={mockOffer}
@@ -114,14 +117,14 @@ describe('ReactionChoiceModal', () => {
         />
       )
 
-      fireEvent.press(screen.getByText('J’aime'))
-      fireEvent.press(screen.getByText('J’aime'))
+      await user.press(screen.getByText('J’aime'))
+      await user.press(screen.getByText('J’aime'))
 
       expect(screen.getByTestId('thumbUp')).toBeOnTheScreen()
       expect(screen.queryByTestId('thumbUpFilled')).not.toBeOnTheScreen()
     })
 
-    it('should activate Je n’aime pas button when pressing it and it is deactivated', () => {
+    it('should activate Je n’aime pas button when pressing it and it is deactivated', async () => {
       render(
         <ReactionChoiceModal
           offer={mockOffer}
@@ -133,13 +136,13 @@ describe('ReactionChoiceModal', () => {
         />
       )
 
-      fireEvent.press(screen.getByText('Je n’aime pas'))
+      await user.press(screen.getByText('Je n’aime pas'))
 
       expect(screen.queryByTestId('thumbDown')).not.toBeOnTheScreen()
       expect(screen.getByTestId('thumbDownFilled')).toBeOnTheScreen()
     })
 
-    it('should deactivate Je n’aime pas button when pressing it and it is activated', () => {
+    it('should deactivate Je n’aime pas button when pressing it and it is activated', async () => {
       render(
         <ReactionChoiceModal
           offer={mockOffer}
@@ -151,14 +154,14 @@ describe('ReactionChoiceModal', () => {
         />
       )
 
-      fireEvent.press(screen.getByText('Je n’aime pas'))
-      fireEvent.press(screen.getByText('Je n’aime pas'))
+      await user.press(screen.getByText('Je n’aime pas'))
+      await user.press(screen.getByText('Je n’aime pas'))
 
       expect(screen.getByTestId('thumbDown')).toBeOnTheScreen()
       expect(screen.queryByTestId('thumbDownFilled')).not.toBeOnTheScreen()
     })
 
-    it('should reset the buttons when closing modal', () => {
+    it('should reset the buttons when closing modal', async () => {
       render(
         <ReactionChoiceModal
           offer={mockOffer}
@@ -170,14 +173,14 @@ describe('ReactionChoiceModal', () => {
         />
       )
 
-      fireEvent.press(screen.getByText('J’aime'))
+      await user.press(screen.getByText('J’aime'))
 
-      fireEvent.press(screen.getByTestId('Fermer la modale'))
+      await user.press(screen.getByTestId('Fermer la modale'))
 
       expect(screen.getByTestId('thumbDown')).toBeOnTheScreen()
     })
 
-    it('should close the modal when pressing close icon', () => {
+    it('should close the modal when pressing close icon', async () => {
       render(
         <ReactionChoiceModal
           offer={mockOffer}
@@ -189,12 +192,12 @@ describe('ReactionChoiceModal', () => {
         />
       )
 
-      fireEvent.press(screen.getByTestId('Fermer la modale'))
+      await user.press(screen.getByTestId('Fermer la modale'))
 
       expect(mockCloseModal).toHaveBeenCalledTimes(1)
     })
 
-    it('should save reaction when click on reaction button', () => {
+    it('should save reaction when click on reaction button', async () => {
       const mockHandleSave = jest.fn()
       render(
         <ReactionChoiceModal
@@ -208,8 +211,8 @@ describe('ReactionChoiceModal', () => {
         />
       )
 
-      fireEvent.press(screen.getByText('J’aime'))
-      fireEvent.press(screen.getByTestId('Valider la réaction'))
+      await user.press(screen.getByText('J’aime'))
+      await user.press(screen.getByTestId('Valider la réaction'))
 
       expect(mockHandleSave).toHaveBeenCalledWith({
         offerId: mockOffer.id,
@@ -217,7 +220,7 @@ describe('ReactionChoiceModal', () => {
       })
     })
 
-    it('should trigger ValidationReaction log when click on reaction button', () => {
+    it('should trigger ValidationReaction log when click on reaction button', async () => {
       const mockHandleSave = jest.fn()
       render(
         <ReactionChoiceModal
@@ -231,8 +234,8 @@ describe('ReactionChoiceModal', () => {
         />
       )
 
-      fireEvent.press(screen.getByText('J’aime'))
-      fireEvent.press(screen.getByTestId('Valider la réaction'))
+      await user.press(screen.getByText('J’aime'))
+      await user.press(screen.getByTestId('Valider la réaction'))
 
       expect(analytics.logValidateReaction).toHaveBeenCalledWith({
         offerId: mockOffer.id,
@@ -243,7 +246,7 @@ describe('ReactionChoiceModal', () => {
   })
 
   describe('With redirection', () => {
-    it('should close the modal when pressing close icon', () => {
+    it('should close the modal when pressing close icon', async () => {
       render(
         <ReactionChoiceModal
           offer={mockOffer}
@@ -255,12 +258,12 @@ describe('ReactionChoiceModal', () => {
         />
       )
 
-      fireEvent.press(screen.getByTestId('Fermer la modale'))
+      await user.press(screen.getByTestId('Fermer la modale'))
 
       expect(mockCloseModal).toHaveBeenCalledTimes(1)
     })
 
-    it('should close the modal when pressing "Plus tard" button', () => {
+    it('should close the modal when pressing "Plus tard" button', async () => {
       render(
         <ReactionChoiceModal
           offer={mockOffer}
@@ -272,12 +275,12 @@ describe('ReactionChoiceModal', () => {
         />
       )
 
-      fireEvent.press(screen.getByText('Plus tard'))
+      await user.press(screen.getByText('Plus tard'))
 
       expect(mockCloseModal).toHaveBeenCalledTimes(1)
     })
 
-    it('should redirect to ended bookings when pressing "Donner mon avis" button', () => {
+    it('should redirect to ended bookings when pressing "Donner mon avis" button', async () => {
       render(
         <ReactionChoiceModal
           offer={mockOffer}
@@ -289,14 +292,14 @@ describe('ReactionChoiceModal', () => {
         />
       )
 
-      fireEvent.press(screen.getByText('Donner mon avis'))
+      await user.press(screen.getByText('Donner mon avis'))
 
       expect(navigate).toHaveBeenNthCalledWith(1, 'Bookings', {
         activeTab: BookingsTab.COMPLETED,
       })
     })
 
-    it('should close the modal when pressing "Donner mon avis" button', () => {
+    it('should close the modal when pressing "Donner mon avis" button', async () => {
       render(
         <ReactionChoiceModal
           offer={mockOffer}
@@ -308,7 +311,7 @@ describe('ReactionChoiceModal', () => {
         />
       )
 
-      fireEvent.press(screen.getByText('Donner mon avis'))
+      await user.press(screen.getByText('Donner mon avis'))
 
       expect(mockCloseModal).toHaveBeenCalledTimes(1)
     })

--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.native.test.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.native.test.tsx
@@ -23,7 +23,7 @@ import {
 import { SearchState } from 'features/search/types'
 import { mockedSuggestedVenue } from 'libs/venue/fixtures/mockedSuggestedVenues'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 const venue = mockedSuggestedVenue
 
@@ -50,6 +50,9 @@ const searchId = uuidv4()
 
 jest.mock('libs/firebase/analytics/analytics')
 jest.mock('features/navigation/TabBar/tabBarRoutes')
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('AutocompleteOfferItem component', () => {
   beforeEach(() => {
@@ -90,9 +93,7 @@ describe('AutocompleteOfferItem component', () => {
       }
     )
 
-    await fireEvent.press(screen.getByTestId('autocompleteOfferItem_1'))
-
-    await screen.findByText('cinéma')
+    await user.press(screen.getByTestId('autocompleteOfferItem_1'))
 
     expect(mockSendEvent).toHaveBeenCalledTimes(1)
   })
@@ -146,7 +147,7 @@ describe('AutocompleteOfferItem component', () => {
         }
       )
 
-      fireEvent.press(screen.getByTestId('autocompleteOfferItem_1'))
+      await user.press(screen.getByTestId('autocompleteOfferItem_1'))
 
       expect(mockDispatch).toHaveBeenNthCalledWith(1, {
         type: 'SET_STATE',
@@ -155,7 +156,7 @@ describe('AutocompleteOfferItem component', () => {
         }),
       })
 
-      expect(await screen.findByText('E-books')).toBeOnTheScreen()
+      expect(screen.getByText('E-books')).toBeOnTheScreen()
     })
   })
 
@@ -213,9 +214,7 @@ describe('AutocompleteOfferItem component', () => {
           wrapper: ({ children }) => reactQueryProviderHOC(children),
         }
       )
-      fireEvent.press(screen.getByTestId('autocompleteOfferItem_1'))
-
-      await screen.findByText('cinéma')
+      await user.press(screen.getByTestId('autocompleteOfferItem_1'))
 
       expect(mockDispatch).toHaveBeenNthCalledWith(1, {
         type: 'SET_STATE',
@@ -271,9 +270,7 @@ describe('AutocompleteOfferItem component', () => {
             wrapper: ({ children }) => reactQueryProviderHOC(children),
           }
         )
-        fireEvent.press(screen.getByTestId('autocompleteOfferItem_1'))
-
-        await screen.findByText('cinéma')
+        await user.press(screen.getByTestId('autocompleteOfferItem_1'))
 
         expect(mockDispatch).toHaveBeenNthCalledWith(1, {
           type: 'SET_STATE',
@@ -303,9 +300,7 @@ describe('AutocompleteOfferItem component', () => {
             wrapper: ({ children }) => reactQueryProviderHOC(children),
           }
         )
-        fireEvent.press(screen.getByTestId('autocompleteOfferItem_1'))
-
-        await screen.findByText('cinéma')
+        await user.press(screen.getByTestId('autocompleteOfferItem_1'))
 
         expect(mockDispatch).toHaveBeenNthCalledWith(1, {
           type: 'SET_STATE',
@@ -335,9 +330,7 @@ describe('AutocompleteOfferItem component', () => {
             wrapper: ({ children }) => reactQueryProviderHOC(children),
           }
         )
-        fireEvent.press(screen.getByTestId('autocompleteOfferItem_1'))
-
-        await screen.findByText('cinéma')
+        await user.press(screen.getByTestId('autocompleteOfferItem_1'))
 
         expect(mockDispatch).toHaveBeenNthCalledWith(1, {
           type: 'SET_STATE',
@@ -366,9 +359,7 @@ describe('AutocompleteOfferItem component', () => {
             wrapper: ({ children }) => reactQueryProviderHOC(children),
           }
         )
-        fireEvent.press(screen.getByTestId('autocompleteOfferItem_1'))
-
-        await screen.findByText('cinéma')
+        await user.press(screen.getByTestId('autocompleteOfferItem_1'))
 
         expect(mockDispatch).toHaveBeenNthCalledWith(1, {
           type: 'SET_STATE',
@@ -398,9 +389,7 @@ describe('AutocompleteOfferItem component', () => {
           }
         )
 
-        fireEvent.press(screen.getByTestId('autocompleteOfferItem_1'))
-
-        await screen.findByText('cinéma')
+        await user.press(screen.getByTestId('autocompleteOfferItem_1'))
 
         expect(mockDispatch).toHaveBeenNthCalledWith(1, {
           type: 'SET_STATE',
@@ -429,9 +418,7 @@ describe('AutocompleteOfferItem component', () => {
             wrapper: ({ children }) => reactQueryProviderHOC(children),
           }
         )
-        fireEvent.press(screen.getByTestId('autocompleteOfferItem_1'))
-
-        await screen.findByText('cinéma')
+        await user.press(screen.getByTestId('autocompleteOfferItem_1'))
 
         expect(mockDispatch).toHaveBeenNthCalledWith(1, {
           type: 'SET_STATE',
@@ -460,9 +447,7 @@ describe('AutocompleteOfferItem component', () => {
             wrapper: ({ children }) => reactQueryProviderHOC(children),
           }
         )
-        fireEvent.press(screen.getByTestId('autocompleteOfferItem_1'))
-
-        await screen.findByText('cinéma')
+        await user.press(screen.getByTestId('autocompleteOfferItem_1'))
 
         expect(mockDispatch).toHaveBeenNthCalledWith(1, {
           type: 'SET_STATE',

--- a/src/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx
+++ b/src/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx
@@ -11,7 +11,7 @@ import { FacetData } from 'libs/algolia/types'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 
 import { CategoriesModal, CategoriesModalProps } from './CategoriesModal'
 
@@ -44,6 +44,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<CategoriesModal/>', () => {
   beforeEach(() => {
@@ -103,11 +106,11 @@ describe('<CategoriesModal/>', () => {
       renderCategories()
 
       const someCategoryFilterCheckbox = screen.getByText('Arts & loisirs créatifs')
-      fireEvent.press(someCategoryFilterCheckbox)
+      await user.press(someCategoryFilterCheckbox)
 
       const button = screen.getByText('Rechercher')
 
-      fireEvent.press(button)
+      await user.press(button)
 
       const expectedSearchParams: SearchState = {
         ...searchState,
@@ -115,11 +118,10 @@ describe('<CategoriesModal/>', () => {
         offerNativeCategories: [],
         offerGenreTypes: [],
       }
-      await waitFor(() => {
-        expect(mockDispatch).toHaveBeenCalledWith({
-          type: 'SET_STATE',
-          payload: expectedSearchParams,
-        })
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: expectedSearchParams,
       })
     })
 
@@ -127,10 +129,10 @@ describe('<CategoriesModal/>', () => {
       renderCategories()
 
       const someCategoryFilterCheckbox = screen.getByText(ALL_CATEGORIES_LABEL)
-      fireEvent.press(someCategoryFilterCheckbox)
+      await user.press(someCategoryFilterCheckbox)
 
       const button = screen.getByText('Rechercher')
-      fireEvent.press(button)
+      await user.press(button)
 
       const expectedSearchParams: SearchState = {
         ...searchState,
@@ -138,11 +140,10 @@ describe('<CategoriesModal/>', () => {
         offerNativeCategories: [],
         offerGenreTypes: [],
       }
-      await waitFor(() => {
-        expect(mockDispatch).toHaveBeenCalledWith({
-          type: 'SET_STATE',
-          payload: expectedSearchParams,
-        })
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: expectedSearchParams,
       })
     })
 
@@ -150,7 +151,7 @@ describe('<CategoriesModal/>', () => {
       renderCategories()
 
       const button = await screen.findByText('Réinitialiser')
-      fireEvent.press(button)
+      await user.press(button)
 
       const defaultCategoryFilterCheckbox = await screen.findByText(ALL_CATEGORIES_LABEL)
 
@@ -162,22 +163,18 @@ describe('<CategoriesModal/>', () => {
         renderCategories()
 
         const button = screen.getByText('Rechercher')
-        fireEvent.press(button)
+        await user.press(button)
 
-        await waitFor(() => {
-          expect(mockHideModal).toHaveBeenCalledTimes(1)
-        })
+        expect(mockHideModal).toHaveBeenCalledTimes(1)
       })
 
       it('when pressing previous button', async () => {
         renderCategories()
 
         const previousButton = screen.getByTestId('Fermer')
-        fireEvent.press(previousButton)
+        await user.press(previousButton)
 
-        await waitFor(() => {
-          expect(mockHideModal).toHaveBeenCalledTimes(1)
-        })
+        expect(mockHideModal).toHaveBeenCalledTimes(1)
       })
     })
   })
@@ -198,12 +195,12 @@ describe('<CategoriesModal/>', () => {
       expect(screen.getByText('Films à l’affiche')).toBeOnTheScreen()
     })
 
-    it('should go back to categories view', () => {
+    it('should go back to categories view', async () => {
       renderCategories({
         filterBehaviour: FilterBehaviour.APPLY_WITHOUT_SEARCHING,
       })
       const previousButton = screen.getByTestId('Revenir en arrière')
-      fireEvent.press(previousButton)
+      await user.press(previousButton)
 
       expect(screen.getByText('Catégories')).toBeOnTheScreen()
     })
@@ -212,11 +209,10 @@ describe('<CategoriesModal/>', () => {
       renderCategories()
 
       const someCategoryFilterCheckbox = screen.getByText('Films à l’affiche')
-      fireEvent.press(someCategoryFilterCheckbox)
+      await user.press(someCategoryFilterCheckbox)
 
       const button = screen.getByText('Rechercher')
-
-      fireEvent.press(button)
+      await user.press(button)
 
       const expectedSearchParams: SearchState = {
         ...searchState,
@@ -224,11 +220,10 @@ describe('<CategoriesModal/>', () => {
         offerNativeCategories: [NativeCategoryIdEnumv2.SEANCES_DE_CINEMA],
         offerGenreTypes: [],
       }
-      await waitFor(() => {
-        expect(mockDispatch).toHaveBeenCalledWith({
-          type: 'SET_STATE',
-          payload: expectedSearchParams,
-        })
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: expectedSearchParams,
       })
     })
 
@@ -236,10 +231,10 @@ describe('<CategoriesModal/>', () => {
       renderCategories()
 
       const someCategoryFilterCheckbox = screen.getByText('Tout')
-      fireEvent.press(someCategoryFilterCheckbox)
+      await user.press(someCategoryFilterCheckbox)
 
       const button = screen.getByText('Rechercher')
-      fireEvent.press(button)
+      await user.press(button)
 
       const expectedSearchParams: SearchState = {
         ...searchState,
@@ -247,11 +242,10 @@ describe('<CategoriesModal/>', () => {
         offerNativeCategories: [],
         offerGenreTypes: [],
       }
-      await waitFor(() => {
-        expect(mockDispatch).toHaveBeenCalledWith({
-          type: 'SET_STATE',
-          payload: expectedSearchParams,
-        })
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: expectedSearchParams,
       })
     })
 
@@ -259,13 +253,11 @@ describe('<CategoriesModal/>', () => {
       renderCategories()
 
       const button = screen.getByText('Réinitialiser')
-      fireEvent.press(button)
+      await user.press(button)
 
-      await waitFor(() => {
-        const defaultCategoryFilterCheckbox = screen.getByText(ALL_CATEGORIES_LABEL)
+      const defaultCategoryFilterCheckbox = screen.getByText(ALL_CATEGORIES_LABEL)
 
-        expect(defaultCategoryFilterCheckbox).toHaveProp('isSelected', true)
-      })
+      expect(defaultCategoryFilterCheckbox).toHaveProp('isSelected', true)
     })
 
     describe('When wipDisplaySearchNbFacetResults feature flag is activated', () => {
@@ -335,13 +327,13 @@ describe('<CategoriesModal/>', () => {
       expect(screen.getByText('Romans et littérature')).toBeOnTheScreen()
     })
 
-    it('should go back to native categories view', () => {
+    it('should go back to native categories view', async () => {
       renderCategories({
         filterBehaviour: FilterBehaviour.APPLY_WITHOUT_SEARCHING,
       })
 
       const goBackButton = screen.getByTestId('Revenir en arrière')
-      fireEvent.press(goBackButton)
+      await user.press(goBackButton)
 
       expect(screen.getByText('Livres')).toBeOnTheScreen()
     })
@@ -349,17 +341,15 @@ describe('<CategoriesModal/>', () => {
     it('should set search state when search button is pressed', async () => {
       renderCategories()
 
-      fireEvent.press(screen.getByText('Loisirs & Bien-être'))
-      fireEvent.press(screen.getByText('Cuisine'))
-      fireEvent.press(screen.getByText('Rechercher'))
+      await user.press(screen.getByText('Loisirs & Bien-être'))
+      await user.press(screen.getByText('Cuisine'))
+      await user.press(screen.getByText('Rechercher'))
 
       const expectedSearchParams: SearchState = BOOKS_WELLNESS_CATEGORY_SEARCH_STATE
 
-      await waitFor(() => {
-        expect(mockDispatch).toHaveBeenCalledWith({
-          type: 'SET_STATE',
-          payload: expectedSearchParams,
-        })
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: expectedSearchParams,
       })
     })
 
@@ -369,12 +359,12 @@ describe('<CategoriesModal/>', () => {
       renderCategories()
 
       const goBackButton = screen.getByTestId('Revenir en arrière')
-      fireEvent.press(goBackButton)
+      await user.press(goBackButton)
 
-      fireEvent.press(await screen.findByText('Tout'))
+      await user.press(screen.getByText('Tout'))
 
       const button = screen.getByText('Rechercher')
-      fireEvent.press(button)
+      await user.press(button)
 
       const expectedSearchParams: SearchState = {
         ...mockSearchState,
@@ -384,20 +374,18 @@ describe('<CategoriesModal/>', () => {
         gtls: undefined,
       }
 
-      await waitFor(() => {
-        expect(mockDispatch).toHaveBeenCalledWith({
-          type: 'SET_STATE',
-          payload: expectedSearchParams,
-        })
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: expectedSearchParams,
       })
     })
 
     it('should reset filters and come back on categories view', async () => {
       renderCategories()
 
-      fireEvent.press(screen.getByText('BD & Comics'))
+      await user.press(screen.getByText('BD & Comics'))
 
-      fireEvent.press(screen.getByText('Réinitialiser'))
+      await user.press(screen.getByText('Réinitialiser'))
 
       const defaultCategoryFilterCheckbox = await screen.findByText(ALL_CATEGORIES_LABEL)
 
@@ -408,12 +396,12 @@ describe('<CategoriesModal/>', () => {
       renderCategories()
 
       const button = screen.getByText('Réinitialiser')
-      fireEvent.press(button)
+      await user.press(button)
 
       const closeButton = screen.getByTestId('Fermer')
-      fireEvent.press(closeButton)
+      await user.press(closeButton)
 
-      expect(await screen.findByText('Livres papier')).toBeOnTheScreen()
+      expect(screen.getByText('Livres papier')).toBeOnTheScreen()
     })
 
     it('should filter on category, native category and genre/type then only on category with all native categories', async () => {
@@ -422,11 +410,11 @@ describe('<CategoriesModal/>', () => {
       renderCategories()
 
       const goBackButton = screen.getByTestId('Revenir en arrière')
-      fireEvent.press(goBackButton)
-      fireEvent.press(goBackButton)
+      await user.press(goBackButton)
+      await user.press(goBackButton)
 
-      fireEvent.press(screen.getByText('Jeux & jeux vidéos'))
-      fireEvent.press(screen.getByText('Rechercher'))
+      await user.press(screen.getByText('Jeux & jeux vidéos'))
+      await user.press(screen.getByText('Rechercher'))
 
       const expectedSearchParams: SearchState = {
         ...mockSearchState,
@@ -436,11 +424,9 @@ describe('<CategoriesModal/>', () => {
         gtls: [],
       }
 
-      await waitFor(() => {
-        expect(mockDispatch).toHaveBeenCalledWith({
-          type: 'SET_STATE',
-          payload: expectedSearchParams,
-        })
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: expectedSearchParams,
       })
     })
   })
@@ -460,12 +446,12 @@ describe('<CategoriesModal/>', () => {
       renderCategories({
         filterBehaviour: FilterBehaviour.APPLY_WITHOUT_SEARCHING,
       })
-      fireEvent.press(screen.getByTestId('Revenir en arrière'))
-      fireEvent.press(screen.getByTestId('Revenir en arrière'))
-      fireEvent.press(screen.getByText('Jeux & jeux vidéos'))
+      await user.press(screen.getByTestId('Revenir en arrière'))
+      await user.press(screen.getByTestId('Revenir en arrière'))
+      await user.press(screen.getByText('Jeux & jeux vidéos'))
 
       const searchButton = screen.getByText('Appliquer le filtre')
-      fireEvent.press(searchButton)
+      await user.press(searchButton)
 
       const expectedSearchParams: SearchState = {
         ...searchState,
@@ -474,11 +460,9 @@ describe('<CategoriesModal/>', () => {
         offerGenreTypes: [],
       }
 
-      await waitFor(() => {
-        expect(mockDispatch).toHaveBeenCalledWith({
-          type: 'SET_STATE',
-          payload: expectedSearchParams,
-        })
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: expectedSearchParams,
       })
     })
   })
@@ -501,18 +485,16 @@ describe('<CategoriesModal/>', () => {
       })
 
       const closeButton = screen.getByTestId('Fermer')
-      fireEvent.press(closeButton)
+      await user.press(closeButton)
 
-      await waitFor(() => {
-        expect(mockOnClose).toHaveBeenCalledTimes(1)
-      })
+      expect(mockOnClose).toHaveBeenCalledTimes(1)
     })
 
     it('should only close the modal when pressing close button when the modal is opening from search results', async () => {
       renderCategories()
 
       const closeButton = screen.getByTestId('Fermer')
-      fireEvent.press(closeButton)
+      await user.press(closeButton)
 
       expect(mockOnClose).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35955

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
