### PR TITLE
(PC-35759) fix(BookingDetails): email on two lines if small screen

### DIFF
--- a/src/features/bookings/components/BookingPrecision.tsx
+++ b/src/features/bookings/components/BookingPrecision.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
+import { ButtonQuaternaryBlack } from 'ui/components/buttons/ButtonQuaternaryBlack'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
@@ -12,42 +12,36 @@ export const BookingPrecisions: React.FC<{
   bookingContactEmail?: string | null
   onEmailPress: () => void
 }> = ({ bookingContactEmail, withdrawalDetails, onEmailPress }) => (
-  <Container>
+  <Container gap={6}>
     {withdrawalDetails ? (
-      <ExplanationContainer>
+      <ViewGap gap={4}>
         <Typo.BodyAccentS>Précisions de l’organisateur</Typo.BodyAccentS>
         <Typo.BodyS testID="withdrawalDetails">{withdrawalDetails}</Typo.BodyS>
-      </ExplanationContainer>
+      </ViewGap>
     ) : null}
     {bookingContactEmail ? (
-      <ViewGap gap={2}>
-        <CaptionNeutralInfo>
-          Pour toute question à propos de ta réservation, contacte l’organisateur.
-        </CaptionNeutralInfo>
-        <SendEmailContainer>
-          <ExternalTouchableLink
-            as={ButtonTertiaryBlack}
-            inline
-            wording={bookingContactEmail}
-            accessibilityLabel="Ouvrir le gestionnaire mail pour contacter l’organisateur"
-            externalNav={{ url: `mailto:${bookingContactEmail}` }}
-            icon={EmailFilled}
-            onBeforeNavigate={onEmailPress}
-          />
-        </SendEmailContainer>
-      </ViewGap>
+      <EmailContainer gap={2}>
+        <CaptionNeutralInfo numberOfLines={2}>{bookingContactEmail}</CaptionNeutralInfo>
+        <ExternalTouchableLink
+          as={ButtonQuaternaryBlack}
+          inline
+          wording="Contacter l’organisateur"
+          accessibilityLabel="Ouvrir le gestionnaire mail pour contacter l’organisateur"
+          externalNav={{ url: `mailto:${bookingContactEmail}` }}
+          icon={EmailFilled}
+          onBeforeNavigate={onEmailPress}
+        />
+      </EmailContainer>
     ) : null}
   </Container>
 )
 
-const SendEmailContainer = styled.View({
+const EmailContainer = styled(ViewGap)({
   alignItems: 'flex-start',
 })
 
-const Container = styled.View({ marginHorizontal: getSpacing(6), gap: getSpacing(6) })
+const Container = styled(ViewGap)({ marginHorizontal: getSpacing(6) })
 
-const ExplanationContainer = styled.View({ gap: getSpacing(4) })
-
-const CaptionNeutralInfo = styled(Typo.BodyAccentXs)(({ theme }) => ({
+const CaptionNeutralInfo = styled(Typo.BodyAccentS)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
@@ -677,7 +677,7 @@ describe('BookingDetails', () => {
         },
       })
 
-      await user.press(screen.getByText(organizerEmail))
+      await user.press(screen.getByText('Contacter l’organisateur'))
 
       expect(analytics.logClickEmailOrganizer).toHaveBeenCalledTimes(1)
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35759

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Phone - Chrome   |<img width="222" alt="Screenshot 2025-05-12 at 17 35 22" src="https://github.com/user-attachments/assets/a82d40c0-d37a-439f-a0e6-aa05bd2a3b61" />|<img width="347" alt="Screenshot 2025-05-12 at 17 22 23" src="https://github.com/user-attachments/assets/7a3d1ecb-ec38-46bc-ad32-7b6c146a09c1" />|


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
