### PR TITLE
(PC-35521) feat(a11y): add format example to inputs where it's needed

### DIFF
--- a/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
@@ -235,39 +235,30 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
         Mot de passe oublié ?
       </Text>
       <View
-        numberOfSpaces={2}
         style={
           [
             {
-              "height": 8,
-            },
-          ]
-        }
-      />
-      <Text
-        style={
-          [
-            {
-              "color": "#161617",
-              "fontFamily": "Montserrat-Medium",
-              "fontSize": 16,
-              "lineHeight": 25.6,
+              "marginBottom": 32,
+              "marginTop": 8,
             },
           ]
         }
       >
-        Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton mot de passe !
-      </Text>
-      <View
-        numberOfSpaces={8}
-        style={
-          [
-            {
-              "height": 32,
-            },
-          ]
-        }
-      />
+        <Text
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
+              },
+            ]
+          }
+        >
+          Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton mot de passe !
+        </Text>
+      </View>
       <View
         style={
           [
@@ -299,6 +290,7 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
                     "alignItems": "flex-end",
                     "flexDirection": "row",
                     "justifyContent": "space-between",
+                    "marginBottom": 8,
                     "width": "100%",
                   },
                 ]
@@ -321,15 +313,29 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
             </View>
           </View>
           <View
-            numberOfSpaces={2}
             style={
               [
                 {
-                  "height": 8,
+                  "marginBottom": 8,
                 },
               ]
             }
-          />
+          >
+            <Text
+              style={
+                [
+                  {
+                    "color": "#696a6f",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 12,
+                    "lineHeight": 19.2,
+                  },
+                ]
+              }
+            >
+              Exemple : tonadresse@email.com
+            </Text>
+          </View>
           <View
             height="small"
             isDisabled={false}
@@ -397,99 +403,99 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
           </View>
         </View>
         <View
-          numberOfSpaces={8}
           style={
             [
               {
-                "height": 32,
+                "marginTop": 32,
               },
             ]
           }
-        />
-        <View
-          accessibilityLabel="Valider"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": true,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          focusable={false}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            [
-              [
-                {
-                  "userSelect": "auto",
-                },
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "#f1f1f4",
-                  "borderRadius": 24,
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "maxWidth": 500,
-                  "minHeight": 40,
-                  "paddingBottom": 2,
-                  "paddingLeft": 20,
-                  "paddingRight": 20,
-                  "paddingTop": 2,
-                  "width": "100%",
-                },
-                {},
-              ],
-              {
-                "opacity": 1,
-              },
-            ]
-          }
-          testID="Valider"
         >
           <View
+            accessibilityLabel="Valider"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": true,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={false}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#f1f1f4",
+                    "borderRadius": 24,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "maxWidth": 500,
+                    "minHeight": 40,
+                    "paddingBottom": 2,
+                    "paddingLeft": 20,
+                    "paddingRight": 20,
+                    "paddingTop": 2,
+                    "width": "100%",
+                  },
+                  {},
+                ],
                 {
-                  "alignItems": "center",
-                  "flexDirection": "row",
+                  "opacity": 1,
                 },
               ]
             }
+            testID="Valider"
           >
-            <Text
-              adjustsFontSizeToFit={false}
-              numberOfLines={1}
+            <View
               style={
                 [
                   {
-                    "color": "#696a6f",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 16,
-                    "lineHeight": 25.6,
-                    "maxWidth": "100%",
+                    "alignItems": "center",
+                    "flexDirection": "row",
                   },
                 ]
               }
             >
-              Valider
-            </Text>
+              <Text
+                adjustsFontSizeToFit={false}
+                numberOfLines={1}
+                style={
+                  [
+                    {
+                      "color": "#696a6f",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
+                      "maxWidth": "100%",
+                    },
+                  ]
+                }
+              >
+                Valider
+              </Text>
+            </View>
           </View>
         </View>
       </View>

--- a/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
@@ -337,6 +337,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
                     "alignItems": "flex-end",
                     "flexDirection": "row",
                     "justifyContent": "space-between",
+                    "marginBottom": 8,
                     "width": "100%",
                   },
                 ]
@@ -372,16 +373,6 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
               </Text>
             </View>
           </View>
-          <View
-            numberOfSpaces={2}
-            style={
-              [
-                {
-                  "height": 8,
-                },
-              ]
-            }
-          />
           <View
             height="small"
             isDisabled={false}
@@ -447,69 +438,69 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
               value=""
             />
             <View
-              numberOfSpaces={2}
               style={
                 [
                   {
-                    "width": 8,
+                    "marginTop": 8,
                   },
                 ]
               }
-            />
-            <View
-              accessibilityLabel="Afficher le mot de passe"
-              accessibilityRole="button"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": undefined,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
-              }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                [
-                  [
-                    {
-                      "userSelect": "auto",
-                    },
-                    {
-                      "maxWidth": 60,
-                    },
-                  ],
-                  {
-                    "opacity": 1,
-                  },
-                ]
-              }
-              testID="Afficher le mot de passe"
             >
               <View
-                fill="#161617"
-                height={24}
-                width={24}
+                accessibilityLabel="Afficher le mot de passe"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "maxWidth": 60,
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Afficher le mot de passe"
               >
-                <Text>
-                  undefined-SVG-Mock
-                </Text>
+                <View
+                  fill="#161617"
+                  height={24}
+                  width={24}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -929,6 +920,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
                     "alignItems": "flex-end",
                     "flexDirection": "row",
                     "justifyContent": "space-between",
+                    "marginBottom": 8,
                     "width": "100%",
                   },
                 ]
@@ -964,16 +956,6 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
               </Text>
             </View>
           </View>
-          <View
-            numberOfSpaces={2}
-            style={
-              [
-                {
-                  "height": 8,
-                },
-              ]
-            }
-          />
           <View
             height="small"
             isDisabled={false}
@@ -1039,69 +1021,69 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
               value=""
             />
             <View
-              numberOfSpaces={2}
               style={
                 [
                   {
-                    "width": 8,
+                    "marginTop": 8,
                   },
                 ]
               }
-            />
-            <View
-              accessibilityLabel="Afficher le mot de passe"
-              accessibilityRole="button"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": undefined,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
-              }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                [
-                  [
-                    {
-                      "userSelect": "auto",
-                    },
-                    {
-                      "maxWidth": 60,
-                    },
-                  ],
-                  {
-                    "opacity": 1,
-                  },
-                ]
-              }
-              testID="Afficher le mot de passe"
             >
               <View
-                fill="#161617"
-                height={24}
-                width={24}
+                accessibilityLabel="Afficher le mot de passe"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "maxWidth": 60,
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Afficher le mot de passe"
               >
-                <Text>
-                  undefined-SVG-Mock
-                </Text>
+                <View
+                  fill="#161617"
+                  height={24}
+                  width={24}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
               </View>
             </View>
           </View>

--- a/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
@@ -220,30 +220,30 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
           ]
         }
       />
-      <Text
+      <View
         style={
           [
             {
-              "color": "#161617",
-              "fontFamily": "Montserrat-Bold",
-              "fontSize": 19,
-              "lineHeight": 30.4,
+              "marginBottom": 8,
             },
           ]
         }
       >
-        Connecte-toi
-      </Text>
-      <View
-        numberOfSpaces={2}
-        style={
-          [
-            {
-              "height": 8,
-            },
-          ]
-        }
-      />
+        <Text
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 19,
+                "lineHeight": 30.4,
+              },
+            ]
+          }
+        >
+          Connecte-toi
+        </Text>
+      </View>
       <View
         style={
           [
@@ -255,55 +255,81 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
         }
       >
         <View
-          numberOfSpaces={7}
           style={
             [
               {
-                "height": 28,
-              },
-            ]
-          }
-        />
-        <View
-          style={
-            [
-              {
-                "alignItems": "flex-start",
-                "display": "flex",
-                "flexDirection": "column",
-                "maxWidth": 500,
-                "width": "100%",
+                "marginBottom": 24,
+                "marginTop": 28,
               },
             ]
           }
         >
-          <View>
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "flex-end",
-                    "flexDirection": "row",
-                    "justifyContent": "space-between",
-                    "width": "100%",
-                  },
-                ]
-              }
-            >
-              <Text
+          <View
+            style={
+              [
+                {
+                  "alignItems": "flex-start",
+                  "display": "flex",
+                  "flexDirection": "column",
+                  "maxWidth": 500,
+                  "width": "100%",
+                },
+              ]
+            }
+          >
+            <View>
+              <View
                 style={
                   [
                     {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Medium",
-                      "fontSize": 16,
-                      "lineHeight": 25.6,
+                      "alignItems": "flex-end",
+                      "flexDirection": "row",
+                      "justifyContent": "space-between",
+                      "marginBottom": 8,
+                      "width": "100%",
                     },
                   ]
                 }
               >
-                Adresse e-mail
-              </Text>
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                      },
+                    ]
+                  }
+                >
+                  Adresse e-mail
+                </Text>
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#696a6f",
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 12,
+                        "lineHeight": 19.2,
+                      },
+                    ]
+                  }
+                >
+                  Obligatoire
+                </Text>
+              </View>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "marginBottom": 8,
+                  },
+                ]
+              }
+            >
               <Text
                 style={
                   [
@@ -316,97 +342,77 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
                   ]
                 }
               >
-                Obligatoire
+                Exemple : tonadresse@email.com
               </Text>
             </View>
-          </View>
-          <View
-            numberOfSpaces={2}
-            style={
-              [
-                {
-                  "height": 8,
-                },
-              ]
-            }
-          />
-          <View
-            height="small"
-            isDisabled={false}
-            isError={false}
-            isFocus={false}
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "#90949d",
-                  "borderRadius": 22,
-                  "borderStyle": "solid",
-                  "borderWidth": 1,
-                  "flexDirection": "row",
-                  "height": 40,
-                  "paddingBottom": 0,
-                  "paddingLeft": 17,
-                  "paddingRight": 17,
-                  "paddingTop": 0,
-                  "width": "100%",
-                },
-              ]
-            }
-            testID="styled-input-container"
-          >
-            <TextInput
-              accessibilityDescribedBy="testUuidV4"
-              accessibilityRequired={true}
-              autoCapitalize="none"
-              autoComplete="email"
-              editable={true}
-              isEmpty={true}
-              keyboardType="email-address"
-              maxLength={120}
-              multiline={false}
-              nativeID="testUuidV4"
-              onBlur={[Function]}
-              onChangeText={[Function]}
-              onFocus={[Function]}
-              placeholder="tonadresse@email.com"
-              placeholderTextColor="#696A6F"
-              returnKeyType="next"
+            <View
+              height="small"
+              isDisabled={false}
+              isError={false}
+              isFocus={false}
               style={
                 [
                   {
-                    "color": "#161617",
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "flexShrink": 1,
-                    "fontFamily": "Montserrat-MediumItalic",
-                    "fontSize": 16,
-                    "height": "100%",
+                    "alignItems": "center",
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "#90949d",
+                    "borderRadius": 22,
+                    "borderStyle": "solid",
+                    "borderWidth": 1,
+                    "flexDirection": "row",
+                    "height": 40,
                     "paddingBottom": 0,
-                    "paddingLeft": 0,
-                    "paddingRight": 0,
+                    "paddingLeft": 17,
+                    "paddingRight": 17,
                     "paddingTop": 0,
+                    "width": "100%",
                   },
                 ]
               }
-              testID="Entrée pour l’email"
-              textAlignVertical="center"
-              textContentType="emailAddress"
-              value=""
-            />
+              testID="styled-input-container"
+            >
+              <TextInput
+                accessibilityDescribedBy="testUuidV4"
+                accessibilityRequired={true}
+                autoCapitalize="none"
+                autoComplete="email"
+                editable={true}
+                isEmpty={true}
+                keyboardType="email-address"
+                maxLength={120}
+                multiline={false}
+                nativeID="testUuidV4"
+                onBlur={[Function]}
+                onChangeText={[Function]}
+                onFocus={[Function]}
+                placeholder="tonadresse@email.com"
+                placeholderTextColor="#696A6F"
+                returnKeyType="next"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                      "fontFamily": "Montserrat-MediumItalic",
+                      "fontSize": 16,
+                      "height": "100%",
+                      "paddingBottom": 0,
+                      "paddingLeft": 0,
+                      "paddingRight": 0,
+                      "paddingTop": 0,
+                    },
+                  ]
+                }
+                testID="Entrée pour l’email"
+                textAlignVertical="center"
+                textContentType="emailAddress"
+                value=""
+              />
+            </View>
           </View>
         </View>
-        <View
-          numberOfSpaces={6}
-          style={
-            [
-              {
-                "height": 24,
-              },
-            ]
-          }
-        />
         <View
           style={
             [
@@ -428,6 +434,7 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
                     "alignItems": "flex-end",
                     "flexDirection": "row",
                     "justifyContent": "space-between",
+                    "marginBottom": 8,
                     "width": "100%",
                   },
                 ]
@@ -463,16 +470,6 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
               </Text>
             </View>
           </View>
-          <View
-            numberOfSpaces={2}
-            style={
-              [
-                {
-                  "height": 8,
-                },
-              ]
-            }
-          />
           <View
             height="small"
             isDisabled={false}
@@ -538,88 +535,80 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
               value=""
             />
             <View
-              numberOfSpaces={2}
               style={
                 [
                   {
-                    "width": 8,
+                    "marginTop": 8,
                   },
                 ]
               }
-            />
-            <View
-              accessibilityLabel="Afficher le mot de passe"
-              accessibilityRole="button"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": undefined,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
-              }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                [
-                  [
-                    {
-                      "userSelect": "auto",
-                    },
-                    {
-                      "maxWidth": 60,
-                    },
-                  ],
-                  {
-                    "opacity": 1,
-                  },
-                ]
-              }
-              testID="Afficher le mot de passe"
             >
               <View
-                fill="#161617"
-                height={24}
-                width={24}
+                accessibilityLabel="Afficher le mot de passe"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "maxWidth": 60,
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Afficher le mot de passe"
               >
-                <Text>
-                  undefined-SVG-Mock
-                </Text>
+                <View
+                  fill="#161617"
+                  height={24}
+                  width={24}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
         </View>
         <View
-          numberOfSpaces={5}
-          style={
-            [
-              {
-                "height": 20,
-              },
-            ]
-          }
-        />
-        <View
           style={
             [
               {
                 "flexDirection": "row",
+                "marginBottom": 32,
+                "marginTop": 20,
                 "maxWidth": 500,
                 "width": "100%",
               },
@@ -747,16 +736,6 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
           </View>
         </View>
         <View
-          numberOfSpaces={8}
-          style={
-            [
-              {
-                "height": 32,
-              },
-            ]
-          }
-        />
-        <View
           accessibilityLabel="Se connecter"
           accessibilityState={
             {
@@ -843,142 +822,16 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
           </View>
         </View>
         <View
-          numberOfSpaces={4}
+          gap={4}
           style={
             [
               {
-                "height": 16,
+                "gap": 16,
+                "marginBottom": 40,
+                "marginTop": 16,
               },
             ]
           }
-        />
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingHorizontal": 4,
-              },
-            ]
-          }
-        >
-          <View
-            backgroundColor="#cbcdd2"
-            style={
-              [
-                {
-                  "backgroundColor": "#cbcdd2",
-                  "flexBasis": 0,
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "height": 1,
-                  "width": "100%",
-                },
-              ]
-            }
-          />
-          <Text
-            style={
-              [
-                {
-                  "color": "#161617",
-                  "fontFamily": "Montserrat-SemiBold",
-                  "fontSize": 12,
-                  "lineHeight": 19.2,
-                  "marginHorizontal": 10,
-                },
-              ]
-            }
-          >
-            ou
-          </Text>
-          <View
-            backgroundColor="#cbcdd2"
-            style={
-              [
-                {
-                  "backgroundColor": "#cbcdd2",
-                  "flexBasis": 0,
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "height": 1,
-                  "width": "100%",
-                },
-              ]
-            }
-          />
-        </View>
-        <View
-          numberOfSpaces={4}
-          style={
-            [
-              {
-                "height": 16,
-              },
-            ]
-          }
-        />
-        <View
-          accessibilityLabel="Se connecter avec Google"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            [
-              [
-                {
-                  "userSelect": "auto",
-                },
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "transparent",
-                  "borderRadius": 24,
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "maxWidth": 500,
-                  "minHeight": 40,
-                  "paddingBottom": 2,
-                  "paddingLeft": 20,
-                  "paddingRight": 20,
-                  "paddingTop": 2,
-                  "width": "100%",
-                },
-                {
-                  "borderColor": "#cbcdd2",
-                  "borderStyle": "solid",
-                  "borderWidth": 2,
-                },
-              ],
-              {
-                "opacity": 1,
-              },
-            ]
-          }
-          testID="Se connecter avec Google"
         >
           <View
             style={
@@ -986,69 +839,178 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "paddingHorizontal": 4,
                 },
               ]
             }
           >
             <View
+              backgroundColor="#cbcdd2"
               style={
                 [
                   {
-                    "flexDirection": "row",
-                    "flexShrink": 0,
+                    "backgroundColor": "#cbcdd2",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "height": 1,
+                    "width": "100%",
                   },
                 ]
               }
-            >
-              <View
-                height={20}
-                testID="button-icon-left"
-                width={20}
-              >
-                <Text>
-                  button-icon-left-SVG-Mock
-                </Text>
-              </View>
-              <View
-                numberOfSpaces={2}
-                style={
-                  [
-                    {
-                      "width": 8,
-                    },
-                  ]
-                }
-              />
-            </View>
+            />
             <Text
-              adjustsFontSizeToFit={false}
-              numberOfLines={1}
               style={
                 [
                   {
                     "color": "#161617",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 16,
-                    "lineHeight": 25.6,
-                    "maxWidth": "100%",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 12,
+                    "lineHeight": 19.2,
+                    "marginHorizontal": 10,
                   },
                 ]
               }
             >
-              Se connecter avec Google
+              ou
             </Text>
+            <View
+              backgroundColor="#cbcdd2"
+              style={
+                [
+                  {
+                    "backgroundColor": "#cbcdd2",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "height": 1,
+                    "width": "100%",
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            accessibilityLabel="Se connecter avec Google"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "transparent",
+                    "borderRadius": 24,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "maxWidth": 500,
+                    "minHeight": 40,
+                    "paddingBottom": 2,
+                    "paddingLeft": 20,
+                    "paddingRight": 20,
+                    "paddingTop": 2,
+                    "width": "100%",
+                  },
+                  {
+                    "borderColor": "#cbcdd2",
+                    "borderStyle": "solid",
+                    "borderWidth": 2,
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Se connecter avec Google"
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "row",
+                      "flexShrink": 0,
+                    },
+                  ]
+                }
+              >
+                <View
+                  height={20}
+                  testID="button-icon-left"
+                  width={20}
+                >
+                  <Text>
+                    button-icon-left-SVG-Mock
+                  </Text>
+                </View>
+                <View
+                  numberOfSpaces={2}
+                  style={
+                    [
+                      {
+                        "width": 8,
+                      },
+                    ]
+                  }
+                />
+              </View>
+              <Text
+                adjustsFontSizeToFit={false}
+                numberOfLines={1}
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
+                      "maxWidth": "100%",
+                    },
+                  ]
+                }
+              >
+                Se connecter avec Google
+              </Text>
+            </View>
           </View>
         </View>
-        <View
-          numberOfSpaces={10}
-          style={
-            [
-              {
-                "height": 40,
-              },
-            ]
-          }
-        />
       </View>
       <View
         style={

--- a/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
@@ -56,6 +56,7 @@ exports[`SetPassword Page should render correctly 1`] = `
               "alignItems": "flex-end",
               "flexDirection": "row",
               "justifyContent": "space-between",
+              "marginBottom": 8,
               "width": "100%",
             },
           ]
@@ -77,16 +78,6 @@ exports[`SetPassword Page should render correctly 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
     <View
       height="small"
       isDisabled={false}
@@ -152,69 +143,69 @@ exports[`SetPassword Page should render correctly 1`] = `
         value=""
       />
       <View
-        numberOfSpaces={2}
         style={
           [
             {
-              "width": 8,
+              "marginTop": 8,
             },
           ]
         }
-      />
-      <View
-        accessibilityLabel="Afficher le mot de passe"
-        accessibilityRole="button"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          [
-            [
-              {
-                "userSelect": "auto",
-              },
-              {
-                "maxWidth": 60,
-              },
-            ],
-            {
-              "opacity": 1,
-            },
-          ]
-        }
-        testID="Afficher le mot de passe"
       >
         <View
-          fill="#161617"
-          height={24}
-          width={24}
+          accessibilityLabel="Afficher le mot de passe"
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            [
+              [
+                {
+                  "userSelect": "auto",
+                },
+                {
+                  "maxWidth": 60,
+                },
+              ],
+              {
+                "opacity": 1,
+              },
+            ]
+          }
+          testID="Afficher le mot de passe"
         >
-          <Text>
-            undefined-SVG-Mock
-          </Text>
+          <View
+            fill="#161617"
+            height={24}
+            width={24}
+          >
+            <Text>
+              undefined-SVG-Mock
+            </Text>
+          </View>
         </View>
       </View>
     </View>

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -269,16 +269,7 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
           [
             {
               "height": 65,
-            },
-          ]
-        }
-      />
-      <View
-        numberOfSpaces={8}
-        style={
-          [
-            {
-              "height": 32,
+              "marginBottom": 32,
             },
           ]
         }
@@ -308,240 +299,245 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
           Crée-toi un compte
         </Text>
         <View
-          numberOfSpaces={10}
           style={
             [
               {
-                "height": 40,
-              },
-            ]
-          }
-        />
-        <View
-          style={
-            [
-              {
-                "alignItems": "flex-start",
-                "display": "flex",
-                "flexDirection": "column",
-                "maxWidth": 500,
-                "width": "100%",
+                "marginVertical": 40,
               },
             ]
           }
         >
-          <View>
+          <View
+            style={
+              [
+                {
+                  "marginBottom": 32,
+                },
+              ]
+            }
+          >
             <View
               style={
                 [
                   {
-                    "alignItems": "flex-end",
-                    "flexDirection": "row",
-                    "justifyContent": "space-between",
+                    "alignItems": "flex-start",
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "maxWidth": 500,
                     "width": "100%",
                   },
                 ]
               }
             >
-              <Text
+              <View>
+                <View
+                  style={
+                    [
+                      {
+                        "alignItems": "flex-end",
+                        "flexDirection": "row",
+                        "justifyContent": "space-between",
+                        "marginBottom": 8,
+                        "width": "100%",
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        },
+                      ]
+                    }
+                  >
+                    Adresse e-mail
+                  </Text>
+                </View>
+              </View>
+              <View
                 style={
                   [
                     {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Medium",
-                      "fontSize": 16,
-                      "lineHeight": 25.6,
+                      "marginBottom": 8,
                     },
                   ]
                 }
               >
-                Adresse e-mail
-              </Text>
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#696a6f",
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 12,
+                        "lineHeight": 19.2,
+                      },
+                    ]
+                  }
+                >
+                  Exemple : tonadresse@email.com
+                </Text>
+              </View>
+              <View
+                height="small"
+                isDisabled={false}
+                isError={false}
+                isFocus={false}
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "backgroundColor": "#ffffff",
+                      "borderColor": "#90949d",
+                      "borderRadius": 22,
+                      "borderStyle": "solid",
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "height": 40,
+                      "paddingBottom": 0,
+                      "paddingLeft": 17,
+                      "paddingRight": 17,
+                      "paddingTop": 0,
+                      "width": "100%",
+                    },
+                  ]
+                }
+                testID="styled-input-container"
+              >
+                <TextInput
+                  accessibilityDescribedBy="testUuidV4"
+                  autoCapitalize="none"
+                  autoComplete="email"
+                  editable={true}
+                  isEmpty={true}
+                  keyboardType="email-address"
+                  maxLength={120}
+                  multiline={false}
+                  nativeID="testUuidV4"
+                  onBlur={[Function]}
+                  onChangeText={[Function]}
+                  onFocus={[Function]}
+                  placeholder="tonadresse@email.com"
+                  placeholderTextColor="#696A6F"
+                  returnKeyType="next"
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                        "fontFamily": "Montserrat-MediumItalic",
+                        "fontSize": 16,
+                        "height": "100%",
+                        "paddingBottom": 0,
+                        "paddingLeft": 0,
+                        "paddingRight": 0,
+                        "paddingTop": 0,
+                      },
+                    ]
+                  }
+                  testID="Entrée pour l’email"
+                  textAlignVertical="center"
+                  textContentType="emailAddress"
+                  value=""
+                />
+              </View>
             </View>
           </View>
           <View
-            numberOfSpaces={2}
+            accessibilityLabel="J’accepte de recevoir les newsletters, bons plans et les recommandations personnalisées du pass Culture."
+            accessibilityRole="checkbox"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": false,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "columnGap": 16,
+                    "cursor": "pointer",
+                    "display": "flex",
+                    "flexDirection": "row",
+                  },
+                ],
                 {
-                  "height": 8,
+                  "opacity": 1,
                 },
               ]
             }
-          />
-          <View
-            height="small"
-            isDisabled={false}
-            isError={false}
-            isFocus={false}
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "#90949d",
-                  "borderRadius": 22,
-                  "borderStyle": "solid",
-                  "borderWidth": 1,
-                  "flexDirection": "row",
-                  "height": 40,
-                  "paddingBottom": 0,
-                  "paddingLeft": 17,
-                  "paddingRight": 17,
-                  "paddingTop": 0,
-                  "width": "100%",
-                },
-              ]
-            }
-            testID="styled-input-container"
+            testID="J’accepte de recevoir les newsletters, bons plans et les recommandations personnalisées du pass Culture."
           >
-            <TextInput
-              accessibilityDescribedBy="testUuidV4"
-              autoCapitalize="none"
-              autoComplete="email"
-              editable={true}
-              isEmpty={true}
-              keyboardType="email-address"
-              maxLength={120}
-              multiline={false}
-              nativeID="testUuidV4"
-              onBlur={[Function]}
-              onChangeText={[Function]}
-              onFocus={[Function]}
-              placeholder="tonadresse@email.com"
-              placeholderTextColor="#696A6F"
-              returnKeyType="next"
+            <View
+              isChecked={false}
               style={
                 [
                   {
+                    "alignItems": "center",
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "#696A6F",
+                    "borderRadius": 4,
+                    "borderStyle": "solid",
+                    "borderWidth": 1,
+                    "height": 24,
+                    "justifyContent": "center",
+                    "width": 24,
+                  },
+                ]
+              }
+            />
+            <Text
+              style={
+                [
+                  {
+                    "alignSelf": "center",
                     "color": "#161617",
                     "flexBasis": 0,
                     "flexGrow": 1,
                     "flexShrink": 1,
-                    "fontFamily": "Montserrat-MediumItalic",
+                    "fontFamily": "Montserrat-Medium",
                     "fontSize": 16,
-                    "height": "100%",
-                    "paddingBottom": 0,
-                    "paddingLeft": 0,
-                    "paddingRight": 0,
-                    "paddingTop": 0,
+                    "lineHeight": 25.6,
                   },
                 ]
               }
-              testID="Entrée pour l’email"
-              textAlignVertical="center"
-              textContentType="emailAddress"
-              value=""
-            />
+            >
+              J’accepte de recevoir les newsletters, bons plans et les recommandations personnalisées du pass Culture.
+            </Text>
           </View>
         </View>
-        <View
-          numberOfSpaces={8}
-          style={
-            [
-              {
-                "height": 32,
-              },
-            ]
-          }
-        />
-        <View
-          accessibilityLabel="J’accepte de recevoir les newsletters, bons plans et les recommandations personnalisées du pass Culture."
-          accessibilityRole="checkbox"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": false,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            [
-              [
-                {
-                  "userSelect": "auto",
-                },
-                {
-                  "alignItems": "center",
-                  "columnGap": 16,
-                  "cursor": "pointer",
-                  "display": "flex",
-                  "flexDirection": "row",
-                },
-              ],
-              {
-                "opacity": 1,
-              },
-            ]
-          }
-          testID="J’accepte de recevoir les newsletters, bons plans et les recommandations personnalisées du pass Culture."
-        >
-          <View
-            isChecked={false}
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "#696A6F",
-                  "borderRadius": 4,
-                  "borderStyle": "solid",
-                  "borderWidth": 1,
-                  "height": 24,
-                  "justifyContent": "center",
-                  "width": 24,
-                },
-              ]
-            }
-          />
-          <Text
-            style={
-              [
-                {
-                  "alignSelf": "center",
-                  "color": "#161617",
-                  "flexBasis": 0,
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
-                },
-              ]
-            }
-          >
-            J’accepte de recevoir les newsletters, bons plans et les recommandations personnalisées du pass Culture.
-          </Text>
-        </View>
-        <View
-          numberOfSpaces={10}
-          style={
-            [
-              {
-                "height": 40,
-              },
-            ]
-          }
-        />
         <View
           accessibilityLabel="Continuer vers l’étape Mot de passe"
           accessibilityState={
@@ -629,7 +625,6 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
           </View>
         </View>
         <View
-          numberOfSpaces={8}
           style={
             [
               {
@@ -642,133 +637,133 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
           style={
             [
               {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "gap": 4,
-                "justifyContent": "center",
+                "marginBottom": 20,
               },
             ]
           }
         >
-          <Text
-            style={
-              [
-                {
-                  "color": "#161617",
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
-                  "textAlign": "center",
-                },
-              ]
-            }
-          >
-            Déjà un compte ?
-          </Text>
           <View
-            accessibilityLabel="Se connecter"
-            accessibilityRole="link"
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": undefined,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               [
-                [
-                  {
-                    "userSelect": "auto",
-                  },
-                ],
                 {
-                  "opacity": 1,
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 4,
+                  "justifyContent": "center",
                 },
               ]
             }
-            testID="Se connecter"
           >
-            <View
-              paddingForIcon={0}
+            <Text
               style={
                 [
                   {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                    "top": 0,
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
+                    "textAlign": "center",
                   },
                 ]
               }
             >
+              Déjà un compte ?
+            </Text>
+            <View
+              accessibilityLabel="Se connecter"
+              accessibilityRole="link"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  [
+                    {
+                      "userSelect": "auto",
+                    },
+                  ],
+                  {
+                    "opacity": 1,
+                  },
+                ]
+              }
+              testID="Se connecter"
+            >
               <View
-                fill="#320096"
-                height={20}
-                testID="button-icon"
-                width={20}
+                paddingForIcon={0}
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "top": 0,
+                    },
+                  ]
+                }
               >
-                <Text>
-                  button-icon-SVG-Mock
+                <View
+                  fill="#320096"
+                  height={20}
+                  testID="button-icon"
+                  width={20}
+                >
+                  <Text>
+                    button-icon-SVG-Mock
+                  </Text>
+                </View>
+                <View
+                  numberOfSpaces={1}
+                  style={
+                    [
+                      {
+                        "width": 4,
+                      },
+                    ]
+                  }
+                />
+                <Text
+                  color="#320096"
+                  style={
+                    [
+                      {
+                        "color": "#320096",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                      },
+                    ]
+                  }
+                  typography="Button"
+                >
+                  Se connecter
                 </Text>
               </View>
-              <View
-                numberOfSpaces={1}
-                style={
-                  [
-                    {
-                      "width": 4,
-                    },
-                  ]
-                }
-              />
-              <Text
-                color="#320096"
-                style={
-                  [
-                    {
-                      "color": "#320096",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 16,
-                      "lineHeight": 25.6,
-                    },
-                  ]
-                }
-                typography="Button"
-              >
-                Se connecter
-              </Text>
             </View>
           </View>
         </View>
-        <View
-          numberOfSpaces={5}
-          style={
-            [
-              {
-                "height": 20,
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </RCTScrollView>
@@ -1141,16 +1136,7 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
           [
             {
               "height": 65,
-            },
-          ]
-        }
-      />
-      <View
-        numberOfSpaces={8}
-        style={
-          [
-            {
-              "height": 32,
+              "marginBottom": 32,
             },
           ]
         }
@@ -1210,6 +1196,7 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
                     "alignItems": "flex-end",
                     "flexDirection": "row",
                     "justifyContent": "space-between",
+                    "marginBottom": 8,
                     "width": "100%",
                   },
                 ]
@@ -1231,16 +1218,6 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
               </Text>
             </View>
           </View>
-          <View
-            numberOfSpaces={2}
-            style={
-              [
-                {
-                  "height": 8,
-                },
-              ]
-            }
-          />
           <View
             height="small"
             isDisabled={false}
@@ -1306,69 +1283,69 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
               value=""
             />
             <View
-              numberOfSpaces={2}
               style={
                 [
                   {
-                    "width": 8,
+                    "marginTop": 8,
                   },
                 ]
               }
-            />
-            <View
-              accessibilityLabel="Afficher le mot de passe"
-              accessibilityRole="button"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": undefined,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
-              }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                [
-                  [
-                    {
-                      "userSelect": "auto",
-                    },
-                    {
-                      "maxWidth": 60,
-                    },
-                  ],
-                  {
-                    "opacity": 1,
-                  },
-                ]
-              }
-              testID="Afficher le mot de passe"
             >
               <View
-                fill="#161617"
-                height={24}
-                width={24}
+                accessibilityLabel="Afficher le mot de passe"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "maxWidth": 60,
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Afficher le mot de passe"
               >
-                <Text>
-                  undefined-SVG-Mock
-                </Text>
+                <View
+                  fill="#161617"
+                  height={24}
+                  width={24}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -2235,16 +2212,7 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
           [
             {
               "height": 65,
-            },
-          ]
-        }
-      />
-      <View
-        numberOfSpaces={8}
-        style={
-          [
-            {
-              "height": 32,
+              "marginBottom": 32,
             },
           ]
         }
@@ -2984,16 +2952,7 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
           [
             {
               "height": 65,
-            },
-          ]
-        }
-      />
-      <View
-        numberOfSpaces={8}
-        style={
-          [
-            {
-              "height": 32,
+              "marginBottom": 32,
             },
           ]
         }

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
@@ -358,6 +358,7 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
                               "alignItems": "flex-end",
                               "flexDirection": "row",
                               "justifyContent": "space-between",
+                              "marginBottom": 8,
                               "width": "100%",
                             },
                           ]
@@ -379,16 +380,6 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
                         </Text>
                       </View>
                     </View>
-                    <View
-                      numberOfSpaces={2}
-                      style={
-                        [
-                          {
-                            "height": 8,
-                          },
-                        ]
-                      }
-                    />
                     <View
                       height="small"
                       isDisabled={false}
@@ -416,110 +407,110 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
                       testID="styled-input-container"
                     >
                       <View
-                        accessibilityLabel="Ouvrir la modale de choix de l’indicatif téléphonique"
-                        accessibilityRole="button"
-                        accessibilityState={
-                          {
-                            "busy": undefined,
-                            "checked": undefined,
-                            "disabled": undefined,
-                            "expanded": undefined,
-                            "selected": undefined,
-                          }
-                        }
-                        accessibilityValue={
-                          {
-                            "max": undefined,
-                            "min": undefined,
-                            "now": undefined,
-                            "text": undefined,
-                          }
-                        }
-                        accessible={true}
-                        focusable={true}
-                        onClick={[Function]}
-                        onResponderGrant={[Function]}
-                        onResponderMove={[Function]}
-                        onResponderRelease={[Function]}
-                        onResponderTerminate={[Function]}
-                        onResponderTerminationRequest={[Function]}
-                        onStartShouldSetResponder={[Function]}
                         style={
                           [
-                            [
-                              {
-                                "userSelect": "auto",
-                              },
-                              {
-                                "alignItems": "center",
-                                "flexDirection": "row",
-                                "flexShrink": 0,
-                              },
-                            ],
                             {
-                              "opacity": 1,
+                              "marginBottom": 8,
                             },
                           ]
                         }
-                        testID="Ouvrir la modale de choix de l’indicatif téléphonique"
                       >
-                        <Text
-                          style={
-                            [
-                              {
-                                "color": "#161617",
-                                "fontFamily": "Montserrat-Medium",
-                                "fontSize": 16,
-                                "lineHeight": 25.6,
-                                "marginLeft": -4,
-                                "marginRight": 4,
-                              },
-                            ]
-                          }
-                        >
-                          +33
-                        </Text>
                         <View
-                          fill="#161617"
-                          height={16}
-                          width={16}
-                        >
-                          <Text>
-                            undefined-SVG-Mock
-                          </Text>
-                        </View>
-                        <View
-                          numberOfSpaces={2}
-                          style={
-                            [
-                              {
-                                "width": 8,
-                              },
-                            ]
-                          }
-                        />
-                        <View
-                          style={
-                            [
-                              {
-                                "borderRightColor": "#696A6F",
-                                "borderRightWidth": 1,
-                                "paddingVertical": 10,
-                              },
-                            ]
-                          }
-                        />
-                      </View>
-                      <View
-                        numberOfSpaces={2}
-                        style={
-                          [
+                          accessibilityLabel="Ouvrir la modale de choix de l’indicatif téléphonique"
+                          accessibilityRole="button"
+                          accessibilityState={
                             {
-                              "width": 8,
-                            },
-                          ]
-                        }
-                      />
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          focusable={true}
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            [
+                              [
+                                {
+                                  "userSelect": "auto",
+                                },
+                                {
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "flexShrink": 0,
+                                },
+                              ],
+                              {
+                                "opacity": 1,
+                              },
+                            ]
+                          }
+                          testID="Ouvrir la modale de choix de l’indicatif téléphonique"
+                        >
+                          <Text
+                            style={
+                              [
+                                {
+                                  "color": "#161617",
+                                  "fontFamily": "Montserrat-Medium",
+                                  "fontSize": 16,
+                                  "lineHeight": 25.6,
+                                  "marginLeft": -4,
+                                  "marginRight": 4,
+                                },
+                              ]
+                            }
+                          >
+                            +33
+                          </Text>
+                          <View
+                            fill="#161617"
+                            height={16}
+                            width={16}
+                          >
+                            <Text>
+                              undefined-SVG-Mock
+                            </Text>
+                          </View>
+                          <View
+                            numberOfSpaces={2}
+                            style={
+                              [
+                                {
+                                  "width": 8,
+                                },
+                              ]
+                            }
+                          />
+                          <View
+                            style={
+                              [
+                                {
+                                  "borderRightColor": "#696A6F",
+                                  "borderRightWidth": 1,
+                                  "paddingVertical": 10,
+                                },
+                              ]
+                            }
+                          />
+                        </View>
+                      </View>
                       <TextInput
                         accessibilityDescribedBy="testUuidV4"
                         autoCapitalize="none"

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
@@ -400,6 +400,7 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
                               "alignItems": "flex-end",
                               "flexDirection": "row",
                               "justifyContent": "space-between",
+                              "marginBottom": 8,
                               "width": "100%",
                             },
                           ]
@@ -422,15 +423,29 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
                       </View>
                     </View>
                     <View
-                      numberOfSpaces={2}
                       style={
                         [
                           {
-                            "height": 8,
+                            "marginBottom": 8,
                           },
                         ]
                       }
-                    />
+                    >
+                      <Text
+                        style={
+                          [
+                            {
+                              "color": "#696a6f",
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 12,
+                              "lineHeight": 19.2,
+                            },
+                          ]
+                        }
+                      >
+                        Exemple : 0610203040
+                      </Text>
+                    </View>
                     <View
                       height="small"
                       isDisabled={false}
@@ -458,103 +473,103 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
                       testID="styled-input-container"
                     >
                       <View
-                        accessibilityLabel="Ouvrir la modale de choix de l’indicatif téléphonique"
-                        accessibilityRole="button"
-                        accessibilityState={
-                          {
-                            "busy": undefined,
-                            "checked": undefined,
-                            "disabled": undefined,
-                            "expanded": undefined,
-                            "selected": undefined,
-                          }
-                        }
-                        accessibilityValue={
-                          {
-                            "max": undefined,
-                            "min": undefined,
-                            "now": undefined,
-                            "text": undefined,
-                          }
-                        }
-                        accessible={true}
-                        collapsable={false}
-                        focusable={true}
-                        onClick={[Function]}
-                        onResponderGrant={[Function]}
-                        onResponderMove={[Function]}
-                        onResponderRelease={[Function]}
-                        onResponderTerminate={[Function]}
-                        onResponderTerminationRequest={[Function]}
-                        onStartShouldSetResponder={[Function]}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "flexShrink": 0,
-                            "opacity": 1,
-                            "userSelect": "auto",
-                          }
-                        }
-                        testID="Ouvrir la modale de choix de l’indicatif téléphonique"
-                      >
-                        <Text
-                          style={
-                            [
-                              {
-                                "color": "#161617",
-                                "fontFamily": "Montserrat-Medium",
-                                "fontSize": 16,
-                                "lineHeight": 25.6,
-                                "marginLeft": -4,
-                                "marginRight": 4,
-                              },
-                            ]
-                          }
-                        >
-                          +33
-                        </Text>
-                        <View
-                          fill="#161617"
-                          height={16}
-                          width={16}
-                        >
-                          <Text>
-                            undefined-SVG-Mock
-                          </Text>
-                        </View>
-                        <View
-                          numberOfSpaces={2}
-                          style={
-                            [
-                              {
-                                "width": 8,
-                              },
-                            ]
-                          }
-                        />
-                        <View
-                          style={
-                            [
-                              {
-                                "borderRightColor": "#696A6F",
-                                "borderRightWidth": 1,
-                                "paddingVertical": 10,
-                              },
-                            ]
-                          }
-                        />
-                      </View>
-                      <View
-                        numberOfSpaces={2}
                         style={
                           [
                             {
-                              "width": 8,
+                              "marginBottom": 8,
                             },
                           ]
                         }
-                      />
+                      >
+                        <View
+                          accessibilityLabel="Ouvrir la modale de choix de l’indicatif téléphonique"
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          focusable={true}
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "flexDirection": "row",
+                              "flexShrink": 0,
+                              "opacity": 1,
+                              "userSelect": "auto",
+                            }
+                          }
+                          testID="Ouvrir la modale de choix de l’indicatif téléphonique"
+                        >
+                          <Text
+                            style={
+                              [
+                                {
+                                  "color": "#161617",
+                                  "fontFamily": "Montserrat-Medium",
+                                  "fontSize": 16,
+                                  "lineHeight": 25.6,
+                                  "marginLeft": -4,
+                                  "marginRight": 4,
+                                },
+                              ]
+                            }
+                          >
+                            +33
+                          </Text>
+                          <View
+                            fill="#161617"
+                            height={16}
+                            width={16}
+                          >
+                            <Text>
+                              undefined-SVG-Mock
+                            </Text>
+                          </View>
+                          <View
+                            numberOfSpaces={2}
+                            style={
+                              [
+                                {
+                                  "width": 8,
+                                },
+                              ]
+                            }
+                          />
+                          <View
+                            style={
+                              [
+                                {
+                                  "borderRightColor": "#696A6F",
+                                  "borderRightWidth": 1,
+                                  "paddingVertical": 10,
+                                },
+                              ]
+                            }
+                          />
+                        </View>
+                      </View>
                       <TextInput
                         accessibilityDescribedBy="testUuidV4"
                         autoCapitalize="none"

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
@@ -358,6 +358,7 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
                               "alignItems": "flex-end",
                               "flexDirection": "row",
                               "justifyContent": "space-between",
+                              "marginBottom": 8,
                               "width": "100%",
                             },
                           ]
@@ -393,16 +394,6 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
                         </Text>
                       </View>
                     </View>
-                    <View
-                      numberOfSpaces={2}
-                      style={
-                        [
-                          {
-                            "height": 8,
-                          },
-                        ]
-                      }
-                    />
                     <View
                       height="small"
                       isDisabled={false}

--- a/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
@@ -292,136 +292,151 @@ exports[`<SetAddress/> should render correctly 1`] = `
                 Quelle est ton adresse ?
               </Text>
               <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "height": 20,
-                    },
-                  ]
-                }
-              />
-              <View
                 style={
                   [
                     {
                       "marginBottom": 8,
+                      "marginTop": 20,
                     },
                   ]
                 }
               >
-                <View>
-                  <View
-                    style={
-                      [
-                        {
-                          "alignItems": "flex-end",
-                          "flexDirection": "row",
-                          "justifyContent": "space-between",
-                          "width": "100%",
-                        },
-                      ]
-                    }
-                  >
-                    <Text
+                <View
+                  style={
+                    [
+                      {
+                        "marginBottom": 8,
+                      },
+                    ]
+                  }
+                >
+                  <View>
+                    <View
                       style={
                         [
                           {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
+                            "alignItems": "flex-end",
+                            "flexDirection": "row",
+                            "justifyContent": "space-between",
+                            "width": "100%",
                           },
                         ]
                       }
                     >
-                      Recherche et sélectionne ton adresse
-                    </Text>
+                      <Text
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Recherche et sélectionne ton adresse
+                      </Text>
+                    </View>
                   </View>
                 </View>
-              </View>
-              <View
-                height="small"
-                isDisabled={false}
-                isError={false}
-                isFocus={false}
-                style={
-                  [
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "#ffffff",
-                      "borderColor": "#90949d",
-                      "borderRadius": 22,
-                      "borderStyle": "solid",
-                      "borderWidth": 1,
-                      "flexDirection": "row",
-                      "height": 40,
-                      "paddingBottom": 0,
-                      "paddingLeft": 17,
-                      "paddingRight": 17,
-                      "paddingTop": 0,
-                      "width": "100%",
-                    },
-                    {
-                      "borderRadius": 24,
-                      "outlineOffset": 0,
-                    },
-                  ]
-                }
-                testID="styled-input-container"
-              >
-                <TextInput
-                  accessibilityDescribedBy="testUuidV4"
-                  accessibilityHidden={false}
-                  autoComplete="street-address"
-                  autoCorrect={false}
-                  editable={true}
-                  enablesReturnKeyAutomatically={true}
-                  focusable={true}
-                  isEmpty={true}
-                  multiline={false}
-                  nativeID="testUuidV4"
-                  onBlur={[Function]}
-                  onChangeText={[Function]}
-                  onFocus={[Function]}
-                  placeholder="Ex : 34 avenue de l’Opéra"
-                  placeholderTextColor="#696A6F"
-                  returnKeyType="next"
-                  selectionColor="#696A6F"
+                <View
                   style={
                     [
                       {
-                        "color": "#161617",
-                        "flexBasis": 0,
-                        "flexGrow": 1,
-                        "flexShrink": 1,
-                        "fontFamily": "Montserrat-MediumItalic",
-                        "fontSize": 16,
-                        "height": "100%",
-                        "paddingBottom": 0,
-                        "paddingLeft": 0,
-                        "paddingRight": 0,
-                        "paddingTop": 0,
+                        "marginBottom": 8,
                       },
-                      {},
                     ]
                   }
-                  testID="Entrée pour l’adresse"
-                  textAlignVertical="center"
-                  textContentType="fullStreetAddress"
-                  value=""
-                />
+                >
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#696a6f",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Exemple : 34 avenue de l’Opéra
+                  </Text>
+                </View>
+                <View
+                  height="small"
+                  isDisabled={false}
+                  isError={false}
+                  isFocus={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#90949d",
+                        "borderRadius": 22,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "height": 40,
+                        "paddingBottom": 0,
+                        "paddingLeft": 17,
+                        "paddingRight": 17,
+                        "paddingTop": 0,
+                        "width": "100%",
+                      },
+                      {
+                        "borderRadius": 24,
+                        "outlineOffset": 0,
+                      },
+                    ]
+                  }
+                  testID="styled-input-container"
+                >
+                  <TextInput
+                    accessibilityDescribedBy="testUuidV4"
+                    accessibilityHidden={false}
+                    autoComplete="street-address"
+                    autoCorrect={false}
+                    editable={true}
+                    enablesReturnKeyAutomatically={true}
+                    focusable={true}
+                    isEmpty={true}
+                    multiline={false}
+                    nativeID="testUuidV4"
+                    onBlur={[Function]}
+                    onChangeText={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Ex : 34 avenue de l’Opéra"
+                    placeholderTextColor="#696A6F"
+                    returnKeyType="next"
+                    selectionColor="#696A6F"
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "flexBasis": 0,
+                          "flexGrow": 1,
+                          "flexShrink": 1,
+                          "fontFamily": "Montserrat-MediumItalic",
+                          "fontSize": 16,
+                          "height": "100%",
+                          "paddingBottom": 0,
+                          "paddingLeft": 0,
+                          "paddingRight": 0,
+                          "paddingTop": 0,
+                        },
+                        {},
+                      ]
+                    }
+                    testID="Entrée pour l’adresse"
+                    textAlignVertical="center"
+                    textContentType="fullStreetAddress"
+                    value=""
+                  />
+                </View>
               </View>
-              <View
-                numberOfSpaces={2}
-                style={
-                  [
-                    {
-                      "height": 8,
-                    },
-                  ]
-                }
-              />
             </View>
             <View
               accessibilityRole="radiogroup"

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
@@ -350,6 +350,30 @@ exports[`<SetCity/> should render correctly 1`] = `
                   </View>
                 </View>
                 <View
+                  style={
+                    [
+                      {
+                        "marginBottom": 8,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#696a6f",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Exemple : 75017
+                  </Text>
+                </View>
+                <View
                   height="small"
                   isDisabled={false}
                   isError={false}

--- a/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
@@ -396,6 +396,7 @@ exports[`<SetName/> should render correctly 1`] = `
                           "alignItems": "flex-end",
                           "flexDirection": "row",
                           "justifyContent": "space-between",
+                          "marginBottom": 8,
                           "width": "100%",
                         },
                       ]
@@ -431,16 +432,6 @@ exports[`<SetName/> should render correctly 1`] = `
                     </Text>
                   </View>
                 </View>
-                <View
-                  numberOfSpaces={2}
-                  style={
-                    [
-                      {
-                        "height": 8,
-                      },
-                    ]
-                  }
-                />
                 <View
                   height="small"
                   isDisabled={false}
@@ -536,6 +527,7 @@ exports[`<SetName/> should render correctly 1`] = `
                           "alignItems": "flex-end",
                           "flexDirection": "row",
                           "justifyContent": "space-between",
+                          "marginBottom": 8,
                           "width": "100%",
                         },
                       ]
@@ -571,16 +563,6 @@ exports[`<SetName/> should render correctly 1`] = `
                     </Text>
                   </View>
                 </View>
-                <View
-                  numberOfSpaces={2}
-                  style={
-                    [
-                      {
-                        "height": 8,
-                      },
-                    ]
-                  }
-                />
                 <View
                   height="small"
                   isDisabled={false}

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
@@ -267,30 +267,30 @@ exports[`ChangeCity should render correctly 1`] = `
                 }
               }
             />
-            <Text
+            <View
               style={
                 [
                   {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 19,
-                    "lineHeight": 30.4,
+                    "marginBottom": 20,
                   },
                 ]
               }
             >
-              Renseigne ta ville de résidence
-            </Text>
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "height": 20,
-                  },
-                ]
-              }
-            />
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 19,
+                      "lineHeight": 30.4,
+                    },
+                  ]
+                }
+              >
+                Renseigne ta ville de résidence
+              </Text>
+            </View>
             <View
               style={
                 [
@@ -348,6 +348,30 @@ exports[`ChangeCity should render correctly 1`] = `
                       </Text>
                     </View>
                   </View>
+                </View>
+                <View
+                  style={
+                    [
+                      {
+                        "marginBottom": 8,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#696a6f",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Exemple : 75017
+                  </Text>
                 </View>
                 <View
                   height="small"

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
@@ -210,17 +210,18 @@ exports[`ChangeCity should render correctly 1`] = `
                 class="css-view-175oi2r"
                 style="height: 65px;"
               />
-              <h1
-                aria-level="1"
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-19e3y8m r-lineHeight-1w51ilw"
-                dir="ltr"
-                role="heading"
-              >
-                Renseigne ta ville de résidence
-              </h1>
               <div
-                class="css-view-175oi2r r-height-z80fyv"
-              />
+                class="css-view-175oi2r r-marginBottom-117bsoe"
+              >
+                <h1
+                  aria-level="1"
+                  class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-19e3y8m r-lineHeight-1w51ilw"
+                  dir="ltr"
+                  role="heading"
+                >
+                  Renseigne ta ville de résidence
+                </h1>
+              </div>
               <form
                 class="c2"
               >
@@ -244,6 +245,16 @@ exports[`ChangeCity should render correctly 1`] = `
                         </div>
                       </div>
                     </label>
+                  </div>
+                  <div
+                    class="css-view-175oi2r r-marginBottom-5oul0u"
+                  >
+                    <div
+                      class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
+                      dir="ltr"
+                    >
+                      Exemple : 75017
+                    </div>
                   </div>
                   <div
                     class="css-view-175oi2r r-alignItems-1awozwy r-backgroundColor-14lw9ot r-borderColor-w7parf r-borderStyle-1phboty r-borderWidth-rs99b7 r-flexDirection-18u37iz r-height-eu3ka r-paddingBottom-1mdbw0j r-paddingLeft-1937ghh r-paddingRight-145ew9a r-paddingTop-wk8lta r-width-13qz1uu r-borderRadius-1fuqb1j r-outlineOffset-2fw26j"

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
@@ -346,6 +346,7 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
                       "alignItems": "flex-end",
                       "flexDirection": "row",
                       "justifyContent": "space-between",
+                      "marginBottom": 8,
                       "width": "100%",
                     },
                   ]
@@ -368,15 +369,29 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
               </View>
             </View>
             <View
-              numberOfSpaces={2}
               style={
                 [
                   {
-                    "height": 8,
+                    "marginBottom": 8,
                   },
                 ]
               }
-            />
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#696a6f",
+                      "fontFamily": "Montserrat-SemiBold",
+                      "fontSize": 12,
+                      "lineHeight": 19.2,
+                    },
+                  ]
+                }
+              >
+                Exemple : tonadresse@email.com
+              </Text>
+            </View>
             <View
               height="small"
               isDisabled={true}

--- a/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
@@ -337,6 +337,7 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
                       "alignItems": "flex-end",
                       "flexDirection": "row",
                       "justifyContent": "space-between",
+                      "marginBottom": 8,
                       "width": "100%",
                     },
                   ]
@@ -372,16 +373,6 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={2}
-              style={
-                [
-                  {
-                    "height": 8,
-                  },
-                ]
-              }
-            />
             <View
               height="small"
               isDisabled={false}
@@ -446,69 +437,69 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
                 value=""
               />
               <View
-                numberOfSpaces={2}
                 style={
                   [
                     {
-                      "width": 8,
+                      "marginTop": 8,
                     },
                   ]
                 }
-              />
-              <View
-                accessibilityLabel="Afficher le mot de passe"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "maxWidth": 60,
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Afficher le mot de passe"
               >
                 <View
-                  fill="#161617"
-                  height={24}
-                  width={24}
+                  accessibilityLabel="Afficher le mot de passe"
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "maxWidth": 60,
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Afficher le mot de passe"
                 >
-                  <Text>
-                    undefined-SVG-Mock
-                  </Text>
+                  <View
+                    fill="#161617"
+                    height={24}
+                    width={24}
+                  >
+                    <Text>
+                      undefined-SVG-Mock
+                    </Text>
+                  </View>
                 </View>
               </View>
             </View>
@@ -928,6 +919,7 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
                       "alignItems": "flex-end",
                       "flexDirection": "row",
                       "justifyContent": "space-between",
+                      "marginBottom": 8,
                       "width": "100%",
                     },
                   ]
@@ -963,16 +955,6 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={2}
-              style={
-                [
-                  {
-                    "height": 8,
-                  },
-                ]
-              }
-            />
             <View
               height="small"
               isDisabled={false}
@@ -1037,69 +1019,69 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
                 value=""
               />
               <View
-                numberOfSpaces={2}
                 style={
                   [
                     {
-                      "width": 8,
+                      "marginTop": 8,
                     },
                   ]
                 }
-              />
-              <View
-                accessibilityLabel="Afficher le mot de passe"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "maxWidth": 60,
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Afficher le mot de passe"
               >
                 <View
-                  fill="#161617"
-                  height={24}
-                  width={24}
+                  accessibilityLabel="Afficher le mot de passe"
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "maxWidth": 60,
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Afficher le mot de passe"
                 >
-                  <Text>
-                    undefined-SVG-Mock
-                  </Text>
+                  <View
+                    fill="#161617"
+                    height={24}
+                    width={24}
+                  >
+                    <Text>
+                      undefined-SVG-Mock
+                    </Text>
+                  </View>
                 </View>
               </View>
             </View>

--- a/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
@@ -266,6 +266,7 @@ exports[`ChangePassword should render correctly 1`] = `
                       "alignItems": "flex-end",
                       "flexDirection": "row",
                       "justifyContent": "space-between",
+                      "marginBottom": 8,
                       "width": "100%",
                     },
                   ]
@@ -301,16 +302,6 @@ exports[`ChangePassword should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={2}
-              style={
-                [
-                  {
-                    "height": 8,
-                  },
-                ]
-              }
-            />
             <View
               height="small"
               isDisabled={false}
@@ -375,69 +366,69 @@ exports[`ChangePassword should render correctly 1`] = `
                 value=""
               />
               <View
-                numberOfSpaces={2}
                 style={
                   [
                     {
-                      "width": 8,
+                      "marginTop": 8,
                     },
                   ]
                 }
-              />
-              <View
-                accessibilityLabel="Afficher le mot de passe"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "maxWidth": 60,
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Afficher le mot de passe"
               >
                 <View
-                  fill="#161617"
-                  height={24}
-                  width={24}
+                  accessibilityLabel="Afficher le mot de passe"
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "maxWidth": 60,
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Afficher le mot de passe"
                 >
-                  <Text>
-                    undefined-SVG-Mock
-                  </Text>
+                  <View
+                    fill="#161617"
+                    height={24}
+                    width={24}
+                  >
+                    <Text>
+                      undefined-SVG-Mock
+                    </Text>
+                  </View>
                 </View>
               </View>
             </View>
@@ -473,6 +464,7 @@ exports[`ChangePassword should render correctly 1`] = `
                       "alignItems": "flex-end",
                       "flexDirection": "row",
                       "justifyContent": "space-between",
+                      "marginBottom": 8,
                       "width": "100%",
                     },
                   ]
@@ -508,16 +500,6 @@ exports[`ChangePassword should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={2}
-              style={
-                [
-                  {
-                    "height": 8,
-                  },
-                ]
-              }
-            />
             <View
               height="small"
               isDisabled={false}
@@ -582,69 +564,69 @@ exports[`ChangePassword should render correctly 1`] = `
                 value=""
               />
               <View
-                numberOfSpaces={2}
                 style={
                   [
                     {
-                      "width": 8,
+                      "marginTop": 8,
                     },
                   ]
                 }
-              />
-              <View
-                accessibilityLabel="Afficher le mot de passe"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "maxWidth": 60,
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Afficher le mot de passe"
               >
                 <View
-                  fill="#161617"
-                  height={24}
-                  width={24}
+                  accessibilityLabel="Afficher le mot de passe"
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "maxWidth": 60,
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Afficher le mot de passe"
                 >
-                  <Text>
-                    undefined-SVG-Mock
-                  </Text>
+                  <View
+                    fill="#161617"
+                    height={24}
+                    width={24}
+                  >
+                    <Text>
+                      undefined-SVG-Mock
+                    </Text>
+                  </View>
                 </View>
               </View>
             </View>
@@ -693,6 +675,7 @@ exports[`ChangePassword should render correctly 1`] = `
                       "alignItems": "flex-end",
                       "flexDirection": "row",
                       "justifyContent": "space-between",
+                      "marginBottom": 8,
                       "width": "100%",
                     },
                   ]
@@ -728,16 +711,6 @@ exports[`ChangePassword should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={2}
-              style={
-                [
-                  {
-                    "height": 8,
-                  },
-                ]
-              }
-            />
             <View
               height="small"
               isDisabled={false}
@@ -802,69 +775,69 @@ exports[`ChangePassword should render correctly 1`] = `
                 value=""
               />
               <View
-                numberOfSpaces={2}
                 style={
                   [
                     {
-                      "width": 8,
+                      "marginTop": 8,
                     },
                   ]
                 }
-              />
-              <View
-                accessibilityLabel="Afficher le mot de passe"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "maxWidth": 60,
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Afficher le mot de passe"
               >
                 <View
-                  fill="#161617"
-                  height={24}
-                  width={24}
+                  accessibilityLabel="Afficher le mot de passe"
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "maxWidth": 60,
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Afficher le mot de passe"
                 >
-                  <Text>
-                    undefined-SVG-Mock
-                  </Text>
+                  <View
+                    fill="#161617"
+                    height={24}
+                    width={24}
+                  >
+                    <Text>
+                      undefined-SVG-Mock
+                    </Text>
+                  </View>
                 </View>
               </View>
             </View>

--- a/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
@@ -336,6 +336,7 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
                         "alignItems": "flex-end",
                         "flexDirection": "row",
                         "justifyContent": "space-between",
+                        "marginBottom": 8,
                         "width": "100%",
                       },
                     ]
@@ -371,16 +372,6 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
                   </Text>
                 </View>
               </View>
-              <View
-                numberOfSpaces={2}
-                style={
-                  [
-                    {
-                      "height": 8,
-                    },
-                  ]
-                }
-              />
               <View
                 height="small"
                 isDisabled={false}

--- a/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
@@ -255,6 +255,7 @@ exports[`<NewEmailSelection /> should match snapshot 1`] = `
                     "alignItems": "flex-end",
                     "flexDirection": "row",
                     "justifyContent": "space-between",
+                    "marginBottom": 8,
                     "width": "100%",
                   },
                 ]
@@ -277,15 +278,29 @@ exports[`<NewEmailSelection /> should match snapshot 1`] = `
             </View>
           </View>
           <View
-            numberOfSpaces={2}
             style={
               [
                 {
-                  "height": 8,
+                  "marginBottom": 8,
                 },
               ]
             }
-          />
+          >
+            <Text
+              style={
+                [
+                  {
+                    "color": "#696a6f",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 12,
+                    "lineHeight": 19.2,
+                  },
+                ]
+              }
+            >
+              Exemple : tonadresse@email.com
+            </Text>
+          </View>
           <View
             height="small"
             isDisabled={false}

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -357,718 +357,702 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
       >
         <View>
           <View
-            numberOfSpaces={6}
+            isKeyboardOpen={false}
             style={
               [
                 {
-                  "height": 24,
-                },
-              ]
-            }
-          />
-          <View
-            style={
-              [
-                {
-                  "maxWidth": 500,
-                  "width": "100%",
+                  "marginBottom": 0,
+                  "marginTop": 24,
                 },
               ]
             }
           >
             <View
-              backgroundColor="#f3ecff"
               style={
                 [
                   {
-                    "alignItems": "center",
-                    "backgroundColor": "#f3ecff",
-                    "borderRadius": 8,
-                    "flexDirection": "row",
-                    "justifyContent": "space-between",
-                    "paddingBottom": 16,
-                    "paddingLeft": 16,
-                    "paddingRight": 16,
-                    "paddingTop": 16,
-                  },
-                ]
-              }
-              testID="creditBanner"
-            >
-              <View
-                style={
-                  [
-                    {
-                      "paddingRight": 16,
-                    },
-                  ]
-                }
-              >
-                <View
-                  height={24}
-                  width={24}
-                >
-                  <Text>
-                    undefined-SVG-Mock
-                  </Text>
-                </View>
-              </View>
-              <View
-                style={
-                  [
-                    {
-                      "flexBasis": 0,
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                    },
-                  ]
-                }
-              >
-                <Text
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-SemiBold",
-                        "fontSize": 12,
-                        "lineHeight": 19.2,
-                      },
-                    ]
-                  }
-                  textColor="#161617"
-                >
-                  Il te reste 70 € sur ton pass Culture.
-                </Text>
-              </View>
-            </View>
-            <View
-              numberOfSpaces={6}
-              style={
-                [
-                  {
-                    "height": 24,
-                  },
-                ]
-              }
-            />
-            <View
-              inverseLayout={false}
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                    "justifyContent": "space-between",
-                  },
-                ]
-              }
-            >
-              <View
-                style={
-                  [
-                    {
-                      "flexShrink": 1,
-                    },
-                  ]
-                }
-              >
-                <Text
-                  accessibilityDescribedBy="testUuidV4"
-                  htmlFor="testUuidV4"
-                  id="testUuidV4"
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-SemiBold",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      },
-                    ]
-                  }
-                >
-                  Uniquement les offres gratuites
-                </Text>
-              </View>
-              <View
-                numberOfSpaces={6}
-                style={
-                  [
-                    {
-                      "width": 24,
-                    },
-                  ]
-                }
-              />
-              <View
-                style={
-                  [
-                    {
-                      "flexShrink": 0,
-                    },
-                  ]
-                }
-              >
-                <View
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                      },
-                    ]
-                  }
-                >
-                  <Text
-                    accessibilityHidden={true}
-                    style={
-                      [
-                        {
-                          "display": "none",
-                        },
-                      ]
-                    }
-                  >
-                    Case à cocher - 
-                    non cochée
-                  </Text>
-                  <View
-                    accessibilityRole="checkbox"
-                    accessibilityState={
-                      {
-                        "busy": undefined,
-                        "checked": false,
-                        "disabled": false,
-                        "expanded": undefined,
-                        "selected": undefined,
-                      }
-                    }
-                    accessibilityValue={
-                      {
-                        "max": undefined,
-                        "min": undefined,
-                        "now": undefined,
-                        "text": undefined,
-                      }
-                    }
-                    accessible={false}
-                    focusable={true}
-                    onClick={[Function]}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
-                    style={
-                      [
-                        [
-                          {
-                            "userSelect": "auto",
-                          },
-                        ],
-                        {
-                          "opacity": 1,
-                        },
-                      ]
-                    }
-                    testID="Interrupteur onlyFreeOffers"
-                  >
-                    <View
-                      active={false}
-                      style={
-                        [
-                          {
-                            "backgroundColor": "#90949D",
-                            "borderRadius": 16,
-                            "height": 32,
-                            "justifyContent": "center",
-                            "width": 56,
-                          },
-                        ]
-                      }
-                    >
-                      <View
-                        disabled={false}
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "aspectRatio": 1,
-                              "backgroundColor": "#ffffff",
-                              "borderRadius": 28,
-                              "height": 28,
-                              "justifyContent": "center",
-                              "shadowColor": "#161617",
-                              "shadowOffset": {
-                                "height": 2,
-                                "width": 0,
-                              },
-                              "shadowOpacity": 0.2,
-                              "shadowRadius": 2.5,
-                              "width": 28,
-                            },
-                            {
-                              "marginLeft": 2,
-                            },
-                          ]
-                        }
-                      />
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-            <View
-              style={
-                [
-                  {
-                    "backgroundColor": "#F1F1F4",
-                    "height": 1,
-                    "marginVertical": 24,
-                    "width": "100%",
-                  },
-                ]
-              }
-            />
-            <View
-              inverseLayout={false}
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                    "justifyContent": "space-between",
-                  },
-                ]
-              }
-            >
-              <View
-                style={
-                  [
-                    {
-                      "flexShrink": 1,
-                    },
-                  ]
-                }
-              >
-                <Text
-                  accessibilityDescribedBy="testUuidV4"
-                  htmlFor="testUuidV4"
-                  id="testUuidV4"
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-SemiBold",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      },
-                    ]
-                  }
-                >
-                  Limiter la recherche à mon crédit
-                </Text>
-              </View>
-              <View
-                numberOfSpaces={6}
-                style={
-                  [
-                    {
-                      "width": 24,
-                    },
-                  ]
-                }
-              />
-              <View
-                style={
-                  [
-                    {
-                      "flexShrink": 0,
-                    },
-                  ]
-                }
-              >
-                <View
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                      },
-                    ]
-                  }
-                >
-                  <Text
-                    accessibilityHidden={true}
-                    style={
-                      [
-                        {
-                          "display": "none",
-                        },
-                      ]
-                    }
-                  >
-                    Case à cocher - 
-                    non cochée
-                  </Text>
-                  <View
-                    accessibilityRole="checkbox"
-                    accessibilityState={
-                      {
-                        "busy": undefined,
-                        "checked": false,
-                        "disabled": false,
-                        "expanded": undefined,
-                        "selected": undefined,
-                      }
-                    }
-                    accessibilityValue={
-                      {
-                        "max": undefined,
-                        "min": undefined,
-                        "now": undefined,
-                        "text": undefined,
-                      }
-                    }
-                    accessible={false}
-                    focusable={true}
-                    onClick={[Function]}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
-                    style={
-                      [
-                        [
-                          {
-                            "userSelect": "auto",
-                          },
-                        ],
-                        {
-                          "opacity": 1,
-                        },
-                      ]
-                    }
-                    testID="Interrupteur limitCreditSearch"
-                  >
-                    <View
-                      active={false}
-                      style={
-                        [
-                          {
-                            "backgroundColor": "#90949D",
-                            "borderRadius": 16,
-                            "height": 32,
-                            "justifyContent": "center",
-                            "width": 56,
-                          },
-                        ]
-                      }
-                    >
-                      <View
-                        disabled={false}
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "aspectRatio": 1,
-                              "backgroundColor": "#ffffff",
-                              "borderRadius": 28,
-                              "height": 28,
-                              "justifyContent": "center",
-                              "shadowColor": "#161617",
-                              "shadowOffset": {
-                                "height": 2,
-                                "width": 0,
-                              },
-                              "shadowOpacity": 0.2,
-                              "shadowRadius": 2.5,
-                              "width": 28,
-                            },
-                            {
-                              "marginLeft": 2,
-                            },
-                          ]
-                        }
-                      />
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-            <View
-              style={
-                [
-                  {
-                    "backgroundColor": "#F1F1F4",
-                    "height": 1,
-                    "marginVertical": 24,
-                    "width": "100%",
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "flex-start",
-                    "display": "flex",
-                    "flexDirection": "column",
                     "maxWidth": 500,
                     "width": "100%",
                   },
                 ]
               }
             >
-              <View>
+              <View
+                style={
+                  [
+                    {
+                      "marginBottom": 24,
+                    },
+                  ]
+                }
+              >
                 <View
+                  backgroundColor="#f3ecff"
                   style={
                     [
                       {
-                        "alignItems": "flex-end",
+                        "alignItems": "center",
+                        "backgroundColor": "#f3ecff",
+                        "borderRadius": 8,
                         "flexDirection": "row",
                         "justifyContent": "space-between",
-                        "width": "100%",
+                        "paddingBottom": 16,
+                        "paddingLeft": 16,
+                        "paddingRight": 16,
+                        "paddingTop": 16,
                       },
                     ]
                   }
+                  testID="creditBanner"
                 >
-                  <Text
+                  <View
                     style={
                       [
                         {
-                          "color": "#161617",
-                          "fontFamily": "Montserrat-Medium",
-                          "fontSize": 16,
-                          "lineHeight": 25.6,
+                          "paddingRight": 16,
                         },
                       ]
                     }
                   >
-                    Prix minimum (en €)
-                  </Text>
+                    <View
+                      height={24}
+                      width={24}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    style={
+                      [
+                        {
+                          "flexBasis": 0,
+                          "flexGrow": 1,
+                          "flexShrink": 1,
+                        },
+                      ]
+                    }
+                  >
+                    <Text
+                      style={
+                        [
+                          {
+                            "color": "#161617",
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 12,
+                            "lineHeight": 19.2,
+                          },
+                        ]
+                      }
+                      textColor="#161617"
+                    >
+                      Il te reste 70 € sur ton pass Culture.
+                    </Text>
+                  </View>
                 </View>
               </View>
               <View
-                numberOfSpaces={2}
-                style={
-                  [
-                    {
-                      "height": 8,
-                    },
-                  ]
-                }
-              />
-              <View
-                height="small"
-                isDisabled={false}
-                isError={false}
-                isFocus={false}
+                inverseLayout={false}
                 style={
                   [
                     {
                       "alignItems": "center",
-                      "backgroundColor": "#ffffff",
-                      "borderColor": "#90949d",
-                      "borderRadius": 22,
-                      "borderStyle": "solid",
-                      "borderWidth": 1,
                       "flexDirection": "row",
-                      "height": 40,
-                      "paddingBottom": 0,
-                      "paddingLeft": 17,
-                      "paddingRight": 17,
-                      "paddingTop": 0,
-                      "width": "100%",
+                      "justifyContent": "space-between",
                     },
                   ]
                 }
-                testID="styled-input-container"
               >
-                <TextInput
-                  accessibilityDescribedBy="testUuidV4"
-                  autoCapitalize="none"
-                  autoComplete="off"
-                  disabled={false}
-                  editable={true}
-                  isEmpty={true}
-                  keyboardType="numeric"
-                  multiline={false}
-                  nativeID="testUuidV4"
-                  onBlur={[Function]}
-                  onChangeText={[Function]}
-                  onFocus={[Function]}
-                  placeholder="0"
-                  placeholderTextColor="#696A6F"
-                  returnKeyType="next"
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "flexBasis": 0,
-                        "flexGrow": 1,
-                        "flexShrink": 1,
-                        "fontFamily": "Montserrat-MediumItalic",
-                        "fontSize": 16,
-                        "height": "100%",
-                        "paddingBottom": 0,
-                        "paddingLeft": 0,
-                        "paddingRight": 0,
-                        "paddingTop": 0,
-                      },
-                    ]
-                  }
-                  testID="Entrée pour le prix minimum"
-                  textAlignVertical="center"
-                  textContentType="none"
-                  value=""
-                />
-              </View>
-            </View>
-            <View
-              numberOfSpaces={6}
-              style={
-                [
-                  {
-                    "height": 24,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "flex-start",
-                    "display": "flex",
-                    "flexDirection": "column",
-                    "maxWidth": 500,
-                    "width": "100%",
-                  },
-                ]
-              }
-            >
-              <View>
                 <View
                   style={
                     [
                       {
-                        "alignItems": "flex-end",
-                        "flexDirection": "row",
-                        "justifyContent": "space-between",
-                        "width": "100%",
+                        "flexShrink": 1,
                       },
                     ]
                   }
                 >
                   <Text
+                    accessibilityDescribedBy="testUuidV4"
+                    htmlFor="testUuidV4"
+                    id="testUuidV4"
                     style={
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Medium",
-                          "fontSize": 16,
-                          "lineHeight": 25.6,
-                        },
-                      ]
-                    }
-                  >
-                    Prix maximum (en €)
-                  </Text>
-                  <Text
-                    style={
-                      [
-                        {
-                          "color": "#696a6f",
                           "fontFamily": "Montserrat-SemiBold",
-                          "fontSize": 12,
-                          "lineHeight": 19.2,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
                   >
-                    max : 80 €
+                    Uniquement les offres gratuites
                   </Text>
+                </View>
+                <View
+                  numberOfSpaces={6}
+                  style={
+                    [
+                      {
+                        "width": 24,
+                      },
+                    ]
+                  }
+                />
+                <View
+                  style={
+                    [
+                      {
+                        "flexShrink": 0,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                        },
+                      ]
+                    }
+                  >
+                    <Text
+                      accessibilityHidden={true}
+                      style={
+                        [
+                          {
+                            "display": "none",
+                          },
+                        ]
+                      }
+                    >
+                      Case à cocher - 
+                      non cochée
+                    </Text>
+                    <View
+                      accessibilityRole="checkbox"
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": false,
+                          "disabled": false,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={false}
+                      focusable={true}
+                      onClick={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      style={
+                        [
+                          [
+                            {
+                              "userSelect": "auto",
+                            },
+                          ],
+                          {
+                            "opacity": 1,
+                          },
+                        ]
+                      }
+                      testID="Interrupteur onlyFreeOffers"
+                    >
+                      <View
+                        active={false}
+                        style={
+                          [
+                            {
+                              "backgroundColor": "#90949D",
+                              "borderRadius": 16,
+                              "height": 32,
+                              "justifyContent": "center",
+                              "width": 56,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          disabled={false}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "aspectRatio": 1,
+                                "backgroundColor": "#ffffff",
+                                "borderRadius": 28,
+                                "height": 28,
+                                "justifyContent": "center",
+                                "shadowColor": "#161617",
+                                "shadowOffset": {
+                                  "height": 2,
+                                  "width": 0,
+                                },
+                                "shadowOpacity": 0.2,
+                                "shadowRadius": 2.5,
+                                "width": 28,
+                              },
+                              {
+                                "marginLeft": 2,
+                              },
+                            ]
+                          }
+                        />
+                      </View>
+                    </View>
+                  </View>
                 </View>
               </View>
               <View
-                numberOfSpaces={2}
                 style={
                   [
                     {
-                      "height": 8,
+                      "backgroundColor": "#F1F1F4",
+                      "height": 1,
+                      "marginVertical": 24,
+                      "width": "100%",
                     },
                   ]
                 }
               />
               <View
-                height="small"
-                isDisabled={false}
-                isError={false}
-                isFocus={false}
+                inverseLayout={false}
                 style={
                   [
                     {
                       "alignItems": "center",
-                      "backgroundColor": "#ffffff",
-                      "borderColor": "#90949d",
-                      "borderRadius": 22,
-                      "borderStyle": "solid",
-                      "borderWidth": 1,
                       "flexDirection": "row",
-                      "height": 40,
-                      "paddingBottom": 0,
-                      "paddingLeft": 17,
-                      "paddingRight": 17,
-                      "paddingTop": 0,
+                      "justifyContent": "space-between",
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "flexShrink": 1,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    accessibilityDescribedBy="testUuidV4"
+                    htmlFor="testUuidV4"
+                    id="testUuidV4"
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        },
+                      ]
+                    }
+                  >
+                    Limiter la recherche à mon crédit
+                  </Text>
+                </View>
+                <View
+                  numberOfSpaces={6}
+                  style={
+                    [
+                      {
+                        "width": 24,
+                      },
+                    ]
+                  }
+                />
+                <View
+                  style={
+                    [
+                      {
+                        "flexShrink": 0,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                        },
+                      ]
+                    }
+                  >
+                    <Text
+                      accessibilityHidden={true}
+                      style={
+                        [
+                          {
+                            "display": "none",
+                          },
+                        ]
+                      }
+                    >
+                      Case à cocher - 
+                      non cochée
+                    </Text>
+                    <View
+                      accessibilityRole="checkbox"
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": false,
+                          "disabled": false,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={false}
+                      focusable={true}
+                      onClick={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      style={
+                        [
+                          [
+                            {
+                              "userSelect": "auto",
+                            },
+                          ],
+                          {
+                            "opacity": 1,
+                          },
+                        ]
+                      }
+                      testID="Interrupteur limitCreditSearch"
+                    >
+                      <View
+                        active={false}
+                        style={
+                          [
+                            {
+                              "backgroundColor": "#90949D",
+                              "borderRadius": 16,
+                              "height": 32,
+                              "justifyContent": "center",
+                              "width": 56,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          disabled={false}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "aspectRatio": 1,
+                                "backgroundColor": "#ffffff",
+                                "borderRadius": 28,
+                                "height": 28,
+                                "justifyContent": "center",
+                                "shadowColor": "#161617",
+                                "shadowOffset": {
+                                  "height": 2,
+                                  "width": 0,
+                                },
+                                "shadowOpacity": 0.2,
+                                "shadowRadius": 2.5,
+                                "width": 28,
+                              },
+                              {
+                                "marginLeft": 2,
+                              },
+                            ]
+                          }
+                        />
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "backgroundColor": "#F1F1F4",
+                      "height": 1,
+                      "marginVertical": 24,
                       "width": "100%",
                     },
                   ]
                 }
-                testID="styled-input-container"
+              />
+              <View
+                style={
+                  [
+                    {
+                      "marginBottom": 24,
+                    },
+                  ]
+                }
               >
-                <TextInput
-                  accessibilityDescribedBy="testUuidV4"
-                  autoCapitalize="none"
-                  autoComplete="off"
-                  disabled={false}
-                  editable={true}
-                  isEmpty={true}
-                  keyboardType="numeric"
-                  multiline={false}
-                  nativeID="testUuidV4"
-                  onBlur={[Function]}
-                  onChangeText={[Function]}
-                  onFocus={[Function]}
-                  placeholder="80"
-                  placeholderTextColor="#696A6F"
-                  returnKeyType="next"
+                <View
                   style={
                     [
                       {
-                        "color": "#161617",
-                        "flexBasis": 0,
-                        "flexGrow": 1,
-                        "flexShrink": 1,
-                        "fontFamily": "Montserrat-MediumItalic",
-                        "fontSize": 16,
-                        "height": "100%",
-                        "paddingBottom": 0,
-                        "paddingLeft": 0,
-                        "paddingRight": 0,
-                        "paddingTop": 0,
+                        "alignItems": "flex-start",
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "maxWidth": 500,
+                        "width": "100%",
                       },
                     ]
                   }
-                  testID="Entrée pour le prix maximum"
-                  textAlignVertical="center"
-                  textContentType="none"
-                  value=""
-                />
+                >
+                  <View>
+                    <View
+                      style={
+                        [
+                          {
+                            "alignItems": "flex-end",
+                            "flexDirection": "row",
+                            "justifyContent": "space-between",
+                            "marginBottom": 8,
+                            "width": "100%",
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Prix minimum (en €)
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    height="small"
+                    isDisabled={false}
+                    isError={false}
+                    isFocus={false}
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "backgroundColor": "#ffffff",
+                          "borderColor": "#90949d",
+                          "borderRadius": 22,
+                          "borderStyle": "solid",
+                          "borderWidth": 1,
+                          "flexDirection": "row",
+                          "height": 40,
+                          "paddingBottom": 0,
+                          "paddingLeft": 17,
+                          "paddingRight": 17,
+                          "paddingTop": 0,
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                    testID="styled-input-container"
+                  >
+                    <TextInput
+                      accessibilityDescribedBy="testUuidV4"
+                      autoCapitalize="none"
+                      autoComplete="off"
+                      disabled={false}
+                      editable={true}
+                      isEmpty={true}
+                      keyboardType="numeric"
+                      multiline={false}
+                      nativeID="testUuidV4"
+                      onBlur={[Function]}
+                      onChangeText={[Function]}
+                      onFocus={[Function]}
+                      placeholder="0"
+                      placeholderTextColor="#696A6F"
+                      returnKeyType="next"
+                      style={
+                        [
+                          {
+                            "color": "#161617",
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                            "fontFamily": "Montserrat-MediumItalic",
+                            "fontSize": 16,
+                            "height": "100%",
+                            "paddingBottom": 0,
+                            "paddingLeft": 0,
+                            "paddingRight": 0,
+                            "paddingTop": 0,
+                          },
+                        ]
+                      }
+                      testID="Entrée pour le prix minimum"
+                      textAlignVertical="center"
+                      textContentType="none"
+                      value=""
+                    />
+                  </View>
+                </View>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "flex-start",
+                      "display": "flex",
+                      "flexDirection": "column",
+                      "maxWidth": 500,
+                      "width": "100%",
+                    },
+                  ]
+                }
+              >
+                <View>
+                  <View
+                    style={
+                      [
+                        {
+                          "alignItems": "flex-end",
+                          "flexDirection": "row",
+                          "justifyContent": "space-between",
+                          "marginBottom": 8,
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                  >
+                    <Text
+                      style={
+                        [
+                          {
+                            "color": "#161617",
+                            "fontFamily": "Montserrat-Medium",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
+                          },
+                        ]
+                      }
+                    >
+                      Prix maximum (en €)
+                    </Text>
+                    <Text
+                      style={
+                        [
+                          {
+                            "color": "#696a6f",
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 12,
+                            "lineHeight": 19.2,
+                          },
+                        ]
+                      }
+                    >
+                      max : 80 €
+                    </Text>
+                  </View>
+                </View>
+                <View
+                  height="small"
+                  isDisabled={false}
+                  isError={false}
+                  isFocus={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#90949d",
+                        "borderRadius": 22,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "height": 40,
+                        "paddingBottom": 0,
+                        "paddingLeft": 17,
+                        "paddingRight": 17,
+                        "paddingTop": 0,
+                        "width": "100%",
+                      },
+                    ]
+                  }
+                  testID="styled-input-container"
+                >
+                  <TextInput
+                    accessibilityDescribedBy="testUuidV4"
+                    autoCapitalize="none"
+                    autoComplete="off"
+                    disabled={false}
+                    editable={true}
+                    isEmpty={true}
+                    keyboardType="numeric"
+                    multiline={false}
+                    nativeID="testUuidV4"
+                    onBlur={[Function]}
+                    onChangeText={[Function]}
+                    onFocus={[Function]}
+                    placeholder="80"
+                    placeholderTextColor="#696A6F"
+                    returnKeyType="next"
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "flexBasis": 0,
+                          "flexGrow": 1,
+                          "flexShrink": 1,
+                          "fontFamily": "Montserrat-MediumItalic",
+                          "fontSize": 16,
+                          "height": "100%",
+                          "paddingBottom": 0,
+                          "paddingLeft": 0,
+                          "paddingRight": 0,
+                          "paddingTop": 0,
+                        },
+                      ]
+                    }
+                    testID="Entrée pour le prix maximum"
+                    textAlignVertical="center"
+                    textContentType="none"
+                    value=""
+                  />
+                </View>
               </View>
             </View>
           </View>

--- a/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
+++ b/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
@@ -2,6 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 import React, { useCallback, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import { UseQueryResult } from 'react-query'
+import styled from 'styled-components/native'
 
 import { api } from 'api/api'
 import { ApiError } from 'api/ApiError'
@@ -19,7 +20,7 @@ import { Form } from 'ui/components/Form'
 import { isEmailValid } from 'ui/components/inputs/emailCheck'
 import { isValueEmpty } from 'ui/components/inputs/helpers'
 import { SecondaryPageWithBlurHeader } from 'ui/pages/SecondaryPageWithBlurHeader'
-import { Spacer, Typo } from 'ui/theme'
+import { getSpacing, Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type FormValues = {
@@ -62,25 +63,34 @@ export const ForgottenPassword = () => {
         />
       ) : null}
       <Typo.Title3 {...getHeadingAttrs(2)}>Mot de passe oublié&nbsp;?</Typo.Title3>
-      <Spacer.Column numberOfSpaces={2} />
-      <Typo.Body>
-        Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton mot de
-        passe&nbsp;!
-      </Typo.Body>
-      <Spacer.Column numberOfSpaces={8} />
+      <Container>
+        <Typo.Body>
+          Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton mot
+          de passe&nbsp;!
+        </Typo.Body>
+      </Container>
       <Form.MaxWidth>
         <EmailInputController control={control} name="email" autoFocus />
-        <Spacer.Column numberOfSpaces={8} />
-        <ButtonPrimary
-          wording="Valider"
-          onPress={settings?.isRecaptchaEnabled ? openReCaptchaChallenge : requestPasswordReset}
-          isLoading={isDoingReCaptchaChallenge || isFetching || areSettingsLoading}
-          disabled={shouldDisableValidateButton}
-        />
+        <ButtonContainer>
+          <ButtonPrimary
+            wording="Valider"
+            onPress={settings?.isRecaptchaEnabled ? openReCaptchaChallenge : requestPasswordReset}
+            isLoading={isDoingReCaptchaChallenge || isFetching || areSettingsLoading}
+            disabled={shouldDisableValidateButton}
+          />
+        </ButtonContainer>
       </Form.MaxWidth>
     </SecondaryPageWithBlurHeader>
   )
 }
+const ButtonContainer = styled.View({
+  marginTop: getSpacing(8),
+})
+
+const Container = styled.View({
+  marginTop: getSpacing(2),
+  marginBottom: getSpacing(8),
+})
 
 const useForgottenPasswordForm = (settings: UseQueryResult<SettingsResponse, unknown>['data']) => {
   const { navigate } = useNavigation<UseNavigationType>()

--- a/src/features/auth/pages/login/Login.tsx
+++ b/src/features/auth/pages/login/Login.tsx
@@ -32,9 +32,10 @@ import { SUGGESTION_DELAY_IN_MS } from 'ui/components/inputs/EmailInputWithSpell
 import { InputError } from 'ui/components/inputs/InputError'
 import { SeparatorWithText } from 'ui/components/SeparatorWithText'
 import { SNACK_BAR_TIME_OUT_LONG, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { SecondaryPageWithBlurHeader } from 'ui/pages/SecondaryPageWithBlurHeader'
 import { Key } from 'ui/svg/icons/Key'
-import { Spacer, Typo } from 'ui/theme'
+import { getSpacing, Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type LoginFormData = {
@@ -207,8 +208,9 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
         />
       ) : null}
       <SecondaryPageWithBlurHeader title="Connexion" shouldDisplayBackButton>
-        <Typo.Title3 {...getHeadingAttrs(2)}>{titlePage}</Typo.Title3>
-        <Spacer.Column numberOfSpaces={2} />
+        <TitleContainer>
+          <Typo.Title3 {...getHeadingAttrs(2)}>{titlePage}</Typo.Title3>
+        </TitleContainer>
         <Form.MaxWidth>
           <InputError
             visible={!!errorMessage}
@@ -216,16 +218,15 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
             numberOfSpacesTop={5}
             centered
           />
-          <Spacer.Column numberOfSpaces={7} />
-          <EmailInputController name="email" control={control} isRequiredField />
-          <Spacer.Column numberOfSpaces={6} />
+          <Container>
+            <EmailInputController name="email" control={control} isRequiredField />
+          </Container>
           <PasswordInputController
             name="password"
             control={control}
             onSubmitEditing={handleSubmit(onSubmit)}
             isRequiredField
           />
-          <Spacer.Column numberOfSpaces={5} />
           <ButtonContainer>
             <ButtonTertiaryBlack
               wording="Mot de passe oublié&nbsp;?"
@@ -234,22 +235,18 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
               inline
             />
           </ButtonContainer>
-          <Spacer.Column numberOfSpaces={8} />
           <ButtonPrimary
             wording="Se connecter"
             onPress={handleSubmit(onSubmit)}
             disabled={shouldDisableLoginButton}
           />
           {enableGoogleSSO ? (
-            <React.Fragment>
-              <Spacer.Column numberOfSpaces={4} />
+            <StyledViewGap gap={4}>
               <StyledSeparatorWithText label="ou" />
-              <Spacer.Column numberOfSpaces={4} />
               <SSOButtonBase type="login" onSuccess={signIn} />
-              <Spacer.Column numberOfSpaces={10} />
-            </React.Fragment>
+            </StyledViewGap>
           ) : (
-            <Spacer.Column numberOfSpaces={8} />
+            <NoSSOSpace />
           )}
         </Form.MaxWidth>
         <SignUpButton onAdditionalPress={onLogSignUpAnalytics} />
@@ -262,7 +259,14 @@ const ButtonContainer = styled.View(({ theme }) => ({
   flexDirection: 'row',
   width: '100%',
   maxWidth: theme.buttons.maxWidth,
+  marginTop: getSpacing(5),
+  marginBottom: getSpacing(8),
 }))
+
+const Container = styled.View({
+  marginTop: getSpacing(7),
+  marginBottom: getSpacing(6),
+})
 
 const SignUpButton = styled(AuthenticationButton).attrs(({ theme }) => ({
   linkColor: theme.designSystem.color.text.brandSecondary,
@@ -272,3 +276,9 @@ const SignUpButton = styled(AuthenticationButton).attrs(({ theme }) => ({
 const StyledSeparatorWithText = styled(SeparatorWithText).attrs(({ theme }) => ({
   backgroundColor: theme.designSystem.separator.color.subtle,
 }))``
+
+const TitleContainer = styled.View({ marginBottom: getSpacing(2) })
+
+const StyledViewGap = styled(ViewGap)({ marginTop: getSpacing(4), marginBottom: getSpacing(10) })
+
+const NoSSOSpace = styled.View({ height: getSpacing(8) })

--- a/src/features/auth/pages/signup/SetEmail/SetEmail.tsx
+++ b/src/features/auth/pages/signup/SetEmail/SetEmail.tsx
@@ -2,8 +2,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import { useRoute } from '@react-navigation/native'
 import React, { FunctionComponent, useCallback } from 'react'
 import { useForm } from 'react-hook-form'
-import styled from 'styled-components'
-import { useTheme } from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
 import { AuthenticationButton } from 'features/auth/components/AuthenticationButton/AuthenticationButton'
 import { SSOButton } from 'features/auth/components/SSOButton/SSOButton'
@@ -19,7 +18,8 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { Form } from 'ui/components/Form'
 import { SeparatorWithText } from 'ui/components/SeparatorWithText'
 import { SNACK_BAR_TIME_OUT_LONG, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
-import { Spacer, Typo } from 'ui/theme'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { getSpacing, Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type FormValues = {
@@ -83,19 +83,20 @@ export const SetEmail: FunctionComponent<PreValidationSignupNormalStepProps> = (
   return (
     <Form.MaxWidth>
       <Typo.Title3 {...getHeadingAttrs(2)}>Crée-toi un compte</Typo.Title3>
-      <Spacer.Column numberOfSpaces={10} />
-      <EmailInputController
-        control={control}
-        name="email"
-        onSpellingHelpPress={onLogHasCorrectedEmail}
-      />
-      <Spacer.Column numberOfSpaces={8} />
-      <CheckboxController
-        control={control}
-        label="J’accepte de recevoir les newsletters, bons plans et les recommandations personnalisées du pass Culture."
-        name="marketingEmailSubscription"
-      />
-      <Spacer.Column numberOfSpaces={10} />
+      <ControllersContainer>
+        <EmailInputContainer>
+          <EmailInputController
+            control={control}
+            name="email"
+            onSpellingHelpPress={onLogHasCorrectedEmail}
+          />
+        </EmailInputContainer>
+        <CheckboxController
+          control={control}
+          label="J’accepte de recevoir les newsletters, bons plans et les recommandations personnalisées du pass Culture."
+          name="marketingEmailSubscription"
+        />
+      </ControllersContainer>
       <ButtonPrimary
         wording="Continuer"
         accessibilityLabel={accessibilityLabelForNextStep}
@@ -103,24 +104,23 @@ export const SetEmail: FunctionComponent<PreValidationSignupNormalStepProps> = (
         isLoading={false}
         disabled={watch('email').trim() === ''}
       />
+
       {enableGoogleSSO ? (
-        <React.Fragment>
-          <Spacer.Column numberOfSpaces={4} />
+        <SSOViewGap gap={4}>
           <StyledSeparatorWithText label="ou" />
-          <Spacer.Column numberOfSpaces={4} />
           <SSOButton type="signup" onSignInFailure={onSSOSignInFailure} />
-          <Spacer.Column numberOfSpaces={10} />
-        </React.Fragment>
+        </SSOViewGap>
       ) : (
-        <Spacer.Column numberOfSpaces={8} />
+        <EmptySpace />
       )}
-      <AuthenticationButton
-        type="login"
-        onAdditionalPress={onLogAnalytics}
-        linkColor={theme.colors.secondary}
-        params={{ from: StepperOrigin.SIGNUP, offerId: params?.offerId }}
-      />
-      <Spacer.Column numberOfSpaces={5} />
+      <AuthenticationButtonContainer>
+        <AuthenticationButton
+          type="login"
+          onAdditionalPress={onLogAnalytics}
+          linkColor={theme.colors.secondary}
+          params={{ from: StepperOrigin.SIGNUP, offerId: params?.offerId }}
+        />
+      </AuthenticationButtonContainer>
     </Form.MaxWidth>
   )
 }
@@ -128,3 +128,16 @@ export const SetEmail: FunctionComponent<PreValidationSignupNormalStepProps> = (
 const StyledSeparatorWithText = styled(SeparatorWithText).attrs(({ theme }) => ({
   backgroundColor: theme.colors.greyMedium,
 }))``
+
+const SSOViewGap = styled(ViewGap)({
+  marginTop: getSpacing(4),
+  marginBottom: getSpacing(10),
+})
+
+const ControllersContainer = styled.View({ marginVertical: getSpacing(10) })
+
+const AuthenticationButtonContainer = styled.View({ marginBottom: getSpacing(5) })
+
+const EmailInputContainer = styled.View({ marginBottom: getSpacing(8) })
+
+const EmptySpace = styled.View({ height: getSpacing(8) })

--- a/src/features/auth/pages/signup/SignupForm.tsx
+++ b/src/features/auth/pages/signup/SignupForm.tsx
@@ -28,7 +28,7 @@ import {
 import { RightButtonText } from 'ui/components/headers/RightButtonText'
 import { useModal } from 'ui/components/modals/useModal'
 import { Page } from 'ui/pages/Page'
-import { getSpacing, Spacer } from 'ui/theme'
+import { getSpacing } from 'ui/theme'
 import { Helmet } from 'ui/web/global/Helmet'
 
 export const SignupForm: FunctionComponent = () => {
@@ -172,7 +172,6 @@ export const SignupForm: FunctionComponent = () => {
       </PageHeaderWithoutPlaceholder>
       <StyledScrollView>
         <Placeholder height={headerHeight} />
-        <Spacer.Column numberOfSpaces={8} />
         {stepConfig ? (
           <React.Fragment>
             <stepConfig.Component
@@ -210,4 +209,5 @@ const StyledScrollView = styled.ScrollView.attrs(({ theme }) => ({
 
 const Placeholder = styled.View<{ height: number }>(({ height }) => ({
   height,
+  marginBottom: getSpacing(8),
 }))

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
@@ -103,6 +103,7 @@ export const SetPhoneNumberWithoutValidation = () => {
                     isError={!!fieldState.error}
                     keyboardType="number-pad"
                     label="Numéro de téléphone"
+                    format="0610203040"
                     value={field.value}
                     onChangeText={field.onChange}
                     onSubmitEditing={submit}

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -29,7 +29,7 @@ import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/S
 import { Spinner } from 'ui/components/Spinner'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
-import { Spacer, Typo } from 'ui/theme'
+import { getSpacing, Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 const snackbarMessage =
@@ -136,27 +136,28 @@ export const SetAddress: FunctionComponent<Props> = ({ route }: Props) => {
         <React.Fragment>
           <Form.MaxWidth>
             <Typo.Title3 {...getHeadingAttrs(2)}>{pageInfos.title}</Typo.Title3>
-            <Spacer.Column numberOfSpaces={5} />
-            <SearchInput
-              autoFocus
-              onChangeText={onChangeAddress}
-              value={query}
-              label={label}
-              placeholder="Ex&nbsp;: 34 avenue de l’Opéra"
-              autoComplete="street-address"
-              textContentType="fullStreetAddress"
-              accessibilityDescribedBy={addressInputErrorId}
-              onPressRightIcon={resetSearch}
-              returnKeyType="next"
-              testID="Entrée pour l’adresse"
-            />
-            <InputError
-              visible={hasError}
-              messageId="Ton adresse ne doit pas contenir de caractères spéciaux ou n’être composée que d’espaces."
-              numberOfSpacesTop={2}
-              relatedInputId={addressInputErrorId}
-            />
-            <Spacer.Column numberOfSpaces={2} />
+            <Container>
+              <SearchInput
+                autoFocus
+                onChangeText={onChangeAddress}
+                value={query}
+                label={label}
+                format="34 avenue de l’Opéra"
+                placeholder="Ex&nbsp;: 34 avenue de l’Opéra"
+                autoComplete="street-address"
+                textContentType="fullStreetAddress"
+                accessibilityDescribedBy={addressInputErrorId}
+                onPressRightIcon={resetSearch}
+                returnKeyType="next"
+                testID="Entrée pour l’adresse"
+              />
+              <InputError
+                visible={hasError}
+                messageId="Ton adresse ne doit pas contenir de caractères spéciaux ou n’être composée que d’espaces."
+                numberOfSpacesTop={2}
+                relatedInputId={addressInputErrorId}
+              />
+            </Container>
           </Form.MaxWidth>
           {isLoading ? <Spinner /> : null}
           <AdressesContainer accessibilityRole={AccessibilityRole.RADIOGROUP}>
@@ -191,3 +192,5 @@ const AdressesContainer = styled.View({
   overflowY: 'scroll',
   ...(Platform.OS === 'web' ? { boxSizing: 'content-box' } : {}),
 })
+
+const Container = styled.View({ marginTop: getSpacing(5), marginBottom: getSpacing(2) })

--- a/src/features/profile/components/CitySearchInput/CitySearchInput.tsx
+++ b/src/features/profile/components/CitySearchInput/CitySearchInput.tsx
@@ -125,6 +125,7 @@ export const CitySearchInput = ({ city, onCitySelected }: CitySearchInputProps) 
                 }}
                 value={value}
                 label="Indique ton code postal et choisis ta ville"
+                format="75017"
                 placeholder="Ex&nbsp;: 75017"
                 onPressRightIcon={resetSearch}
                 keyboardType="number-pad"

--- a/src/features/profile/pages/ChangeCity/ChangeCity.tsx
+++ b/src/features/profile/pages/ChangeCity/ChangeCity.tsx
@@ -2,6 +2,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 import { Controller, useForm } from 'react-hook-form'
+import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { CityForm, cityResolver } from 'features/identityCheck/pages/profile/SetCity'
@@ -14,7 +15,7 @@ import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
-import { Spacer, Typo } from 'ui/theme'
+import { Typo, getSpacing } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const ChangeCity = () => {
@@ -64,9 +65,9 @@ export const ChangeCity = () => {
       title="Modifier ma ville de résidence"
       scrollChildren={
         <React.Fragment>
-          <Typo.Title3 {...getHeadingAttrs(1)}>Renseigne ta ville de résidence</Typo.Title3>
-          <Spacer.Column numberOfSpaces={5} />
-
+          <Container>
+            <Typo.Title3 {...getHeadingAttrs(1)}>Renseigne ta ville de résidence</Typo.Title3>
+          </Container>
           <Controller
             control={control}
             name="city"
@@ -87,3 +88,5 @@ export const ChangeCity = () => {
     />
   )
 }
+
+const Container = styled.View({ marginBottom: getSpacing(5) })

--- a/src/features/search/pages/modals/PriceModal/PriceModal.tsx
+++ b/src/features/search/pages/modals/PriceModal/PriceModal.tsx
@@ -27,7 +27,7 @@ import { AppModal } from 'ui/components/modals/AppModal'
 import { Separator } from 'ui/components/Separator'
 import { Close } from 'ui/svg/icons/Close'
 import { Error } from 'ui/svg/icons/Error'
-import { Spacer, getSpacing } from 'ui/theme'
+import { getSpacing } from 'ui/theme'
 
 type PriceModalFormData = {
   minPrice: string
@@ -304,66 +304,66 @@ export const PriceModal: FunctionComponent<PriceModalProps> = ({
           filterBehaviour={filterBehaviour}
         />
       }>
-      <Spacer.Column numberOfSpaces={6} />
-      <Form.MaxWidth>
-        {isLoggedInAndBeneficiary ? (
-          <React.Fragment>
-            <InfoBanner message={bannerTitle} icon={Error} testID="creditBanner" />
-            <Spacer.Column numberOfSpaces={6} />
-          </React.Fragment>
-        ) : null}
-        <Controller
-          control={control}
-          name="isOnlyFreeOffersSearch"
-          render={({ field: { value } }) => (
-            <FilterSwitchWithLabel
-              isActive={value}
-              toggle={toggleOnlyFreeOffersSearch}
-              label="Uniquement les offres gratuites"
-              testID="onlyFreeOffers"
-            />
-          )}
-        />
-        <StyledSeparator />
-        {isLoggedInAndBeneficiary ? (
+      <FormContainer isKeyboardOpen={isKeyboardOpen}>
+        <Form.MaxWidth>
+          {isLoggedInAndBeneficiary ? (
+            <Container>
+              <InfoBanner message={bannerTitle} icon={Error} testID="creditBanner" />
+            </Container>
+          ) : null}
           <Controller
             control={control}
-            name="isLimitCreditSearch"
+            name="isOnlyFreeOffersSearch"
             render={({ field: { value } }) => (
-              <React.Fragment>
-                <FilterSwitchWithLabel
-                  isActive={value}
-                  toggle={toggleLimitCreditSearch}
-                  label="Limiter la recherche à mon crédit"
-                  testID="limitCreditSearch"
-                />
-                <StyledSeparator />
-              </React.Fragment>
+              <FilterSwitchWithLabel
+                isActive={value}
+                toggle={toggleOnlyFreeOffersSearch}
+                label="Uniquement les offres gratuites"
+                testID="onlyFreeOffers"
+              />
             )}
           />
-        ) : null}
-        <PriceInputController
-          control={control}
-          name="minPrice"
-          label={`Prix minimum (en\u00a0${currencyFull})`}
-          placeholder="0"
-          accessibilityId={minPriceInputId}
-          testID="Entrée pour le prix minimum"
-          isDisabled={getValues('isOnlyFreeOffersSearch')}
-        />
-        <Spacer.Column numberOfSpaces={6} />
-        <PriceInputController
-          control={control}
-          name="maxPrice"
-          label={`Prix maximum (en\u00a0${currencyFull})`}
-          placeholder={`${formatInitialCredit}`}
-          rightLabel={`max\u00a0: ${formatInitialCreditWithCurrency}`}
-          accessibilityId={maxPriceInputId}
-          testID="Entrée pour le prix maximum"
-          isDisabled={getValues('isLimitCreditSearch') || getValues('isOnlyFreeOffersSearch')}
-        />
-      </Form.MaxWidth>
-      {isKeyboardOpen ? <Spacer.Column numberOfSpaces={8} /> : null}
+          <StyledSeparator />
+          {isLoggedInAndBeneficiary ? (
+            <Controller
+              control={control}
+              name="isLimitCreditSearch"
+              render={({ field: { value } }) => (
+                <React.Fragment>
+                  <FilterSwitchWithLabel
+                    isActive={value}
+                    toggle={toggleLimitCreditSearch}
+                    label="Limiter la recherche à mon crédit"
+                    testID="limitCreditSearch"
+                  />
+                  <StyledSeparator />
+                </React.Fragment>
+              )}
+            />
+          ) : null}
+          <Container>
+            <PriceInputController
+              control={control}
+              name="minPrice"
+              label={`Prix minimum (en\u00a0${currencyFull})`}
+              placeholder="0"
+              accessibilityId={minPriceInputId}
+              testID="Entrée pour le prix minimum"
+              isDisabled={getValues('isOnlyFreeOffersSearch')}
+            />
+          </Container>
+          <PriceInputController
+            control={control}
+            name="maxPrice"
+            label={`Prix maximum (en\u00a0${currencyFull})`}
+            placeholder={`${formatInitialCredit}`}
+            rightLabel={`max\u00a0: ${formatInitialCreditWithCurrency}`}
+            accessibilityId={maxPriceInputId}
+            testID="Entrée pour le prix maximum"
+            isDisabled={getValues('isLimitCreditSearch') || getValues('isOnlyFreeOffersSearch')}
+          />
+        </Form.MaxWidth>
+      </FormContainer>
     </AppModal>
   )
 }
@@ -371,3 +371,10 @@ export const PriceModal: FunctionComponent<PriceModalProps> = ({
 const StyledSeparator = styled(Separator.Horizontal)({
   marginVertical: getSpacing(6),
 })
+
+const Container = styled.View({ marginBottom: getSpacing(6) })
+
+const FormContainer = styled.View<{ isKeyboardOpen: boolean }>(({ isKeyboardOpen }) => ({
+  marginTop: getSpacing(6),
+  marginBottom: isKeyboardOpen ? getSpacing(8) : 0,
+}))

--- a/src/ui/components/inputs/EmailInput/EmailInput.tsx
+++ b/src/ui/components/inputs/EmailInput/EmailInput.tsx
@@ -22,6 +22,7 @@ const WithRefEmailInput: React.ForwardRefRenderFunction<RNTextInput, EmailInputP
       keyboardType="email-address"
       label={label ?? 'Adresse e-mail'}
       onChangeText={onEmailChange}
+      format="tonadresse@email.com"
       placeholder="tonadresse@email.com"
       textContentType="emailAddress"
       value={email}

--- a/src/ui/components/inputs/SearchInput.native.test.tsx
+++ b/src/ui/components/inputs/SearchInput.native.test.tsx
@@ -30,6 +30,35 @@ describe('SearchInput component', () => {
     expect(onReset).toHaveBeenCalledTimes(1)
   })
 
+  it('should display format when format is given', async () => {
+    render(
+      <SearchInput
+        value="Some text"
+        label="Label"
+        onChangeText={onChangeText}
+        onPressRightIcon={onReset}
+        isRequiredField
+        format="75011"
+      />
+    )
+
+    expect(screen.getByText('Exemple : 75011')).toBeOnTheScreen()
+  })
+
+  it('should not display format when no format is given', async () => {
+    render(
+      <SearchInput
+        value="Some text"
+        label="Label"
+        onChangeText={onChangeText}
+        onPressRightIcon={onReset}
+        isRequiredField
+      />
+    )
+
+    expect(screen.queryByText('Exemple : 75011')).not.toBeOnTheScreen()
+  })
+
   it('should display "Obligatoire" when isRequiredField = true and has label', async () => {
     render(
       <SearchInput

--- a/src/ui/components/inputs/SearchInput.tsx
+++ b/src/ui/components/inputs/SearchInput.tsx
@@ -62,6 +62,11 @@ const WithRefSearchInput: React.ForwardRefRenderFunction<RNTextInput, SearchInpu
           </FlexInputLabel>
         </StyledView>
       ) : null}
+      {props.format ? (
+        <StyledView>
+          <TextFormat>{`Exemple\u00a0: ${props.format}`}</TextFormat>
+        </StyledView>
+      ) : null}
       <StyledInputContainer
         inputHeight={props.inputHeight}
         isFocus={isFocus}
@@ -124,3 +129,7 @@ const StyledInputContainer = styled(InputContainer)({
 const StyledView = styled.View({
   marginBottom: getSpacing(2),
 })
+
+const TextFormat = styled(Typo.BodyAccentXs)(({ theme }) => ({
+  color: theme.designSystem.color.text.subtle,
+}))

--- a/src/ui/components/inputs/TextInput.native.test.tsx
+++ b/src/ui/components/inputs/TextInput.native.test.tsx
@@ -1,15 +1,35 @@
 import React from 'react'
 import { TextInput as RNTextInput } from 'react-native'
 
-import { render } from 'tests/utils'
+import { render, screen } from 'tests/utils'
 
 import { TextInput } from './TextInput'
 
 describe('<TextInput />', () => {
+  const myRef = React.createRef<RNTextInput>()
+
   it('should render ref correctly', () => {
-    const myRef = React.createRef<RNTextInput>()
     render(<TextInput placeholder="placeholder" onChangeText={jest.fn()} ref={myRef} />)
 
     expect(myRef.current).toBeTruthy()
+  })
+
+  it('should display format when format is given', async () => {
+    render(
+      <TextInput
+        placeholder="placeholder"
+        onChangeText={jest.fn()}
+        ref={myRef}
+        format="toto@email.com"
+      />
+    )
+
+    expect(screen.getByText('Exemple : toto@email.com')).toBeOnTheScreen()
+  })
+
+  it('should not display format when no format is given', async () => {
+    render(<TextInput placeholder="placeholder" onChangeText={jest.fn()} ref={myRef} />)
+
+    expect(screen.queryByText('Exemple : toto@email.com')).not.toBeOnTheScreen()
   })
 })

--- a/src/ui/components/inputs/TextInput.tsx
+++ b/src/ui/components/inputs/TextInput.tsx
@@ -10,7 +10,7 @@ import { ContainerWithMaxWidth } from 'ui/components/inputs/ContainerWithMaxWidt
 import { LabelContainer } from 'ui/components/inputs/LabelContainer'
 import { RequiredLabel } from 'ui/components/inputs/RequiredLabel'
 import { Touchable } from 'ui/components/touchable/Touchable'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Typo } from 'ui/theme'
 
 import { BaseTextInput } from './BaseTextInput'
 import { InputContainer } from './InputContainer'
@@ -44,30 +44,27 @@ const WithRefTextInput: React.ForwardRefRenderFunction<RNTextInput, TextInputPro
   return (
     <ContainerWithMaxWidth>
       {customProps.label ? (
-        <React.Fragment>
-          <FlexInputLabel htmlFor={textInputID}>
-            <LabelContainer>
-              <Typo.Body>{customProps.label}</Typo.Body>
-              <RightLabel
-                isRequiredField={customProps.isRequiredField}
-                rightLabel={customProps.rightLabel}
-              />
-            </LabelContainer>
-          </FlexInputLabel>
-          <Spacer.Column numberOfSpaces={2} />
-        </React.Fragment>
+        <FlexInputLabel htmlFor={textInputID}>
+          <StyledLabelContainer>
+            <Typo.Body>{customProps.label}</Typo.Body>
+            <RightLabel
+              isRequiredField={customProps.isRequiredField}
+              rightLabel={customProps.rightLabel}
+            />
+          </StyledLabelContainer>
+        </FlexInputLabel>
+      ) : null}
+      {props.format ? (
+        <StyledView>
+          <Subtitle>{`Exemple\u00a0: ${props.format}`}</Subtitle>
+        </StyledView>
       ) : null}
       <InputContainer
         isFocus={isFocus}
         isError={customProps.isError}
         isDisabled={customProps.disabled}
         style={customProps.containerStyle}>
-        {customProps.leftComponent ? (
-          <React.Fragment>
-            {customProps.leftComponent}
-            <Spacer.Row numberOfSpaces={2} />
-          </React.Fragment>
-        ) : null}
+        {customProps.leftComponent ? <StyledView>{customProps.leftComponent}</StyledView> : null}
         <BaseTextInput
           {...nativeProps}
           nativeID={textInputID}
@@ -79,15 +76,14 @@ const WithRefTextInput: React.ForwardRefRenderFunction<RNTextInput, TextInputPro
           multiline={props.multiline}
         />
         {customProps.rightButton && StyledIcon ? (
-          <React.Fragment>
-            <Spacer.Row numberOfSpaces={2} />
+          <IconContainer>
             <IconTouchableOpacity
               testID={customProps.rightButton.testID}
               accessibilityLabel={customProps.rightButton.accessibilityLabel}
               onPress={customProps.rightButton.onPress}>
               <StyledIcon />
             </IconTouchableOpacity>
-          </React.Fragment>
+          </IconContainer>
         ) : null}
       </InputContainer>
     </ContainerWithMaxWidth>
@@ -113,3 +109,15 @@ const IconTouchableOpacity = styledButton(Touchable)({
 const Subtitle = styled(Typo.BodyAccentXs)(({ theme }) => ({
   color: theme.designSystem.color.text.subtle,
 }))
+
+const StyledView = styled.View({
+  marginBottom: getSpacing(2),
+})
+
+const IconContainer = styled.View({
+  marginTop: getSpacing(2),
+})
+
+const StyledLabelContainer = styled(LabelContainer)({
+  marginBottom: getSpacing(2),
+})

--- a/src/ui/components/inputs/types.ts
+++ b/src/ui/components/inputs/types.ts
@@ -14,6 +14,7 @@ type InputProps = {
 
 type CustomTextInputProps = InputProps & {
   isError?: boolean
+  format?: string
   disabled?: boolean
   containerStyle?: ViewStyle
   isRequiredField?: boolean
@@ -30,6 +31,7 @@ type CustomTextInputProps = InputProps & {
 
 type CustomSearchInputProps = InputProps & {
   inputHeight?: 'small' | 'regular' | 'tall'
+  format?: string
   LeftIcon?: React.FC
   onPressRightIcon?: () => void
   searchInputID?: string


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35521

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Mockup/Before | After |
| :-----------: | :---: |
|![Screenshot 2025-05-05 at 10 36 28](https://github.com/user-attachments/assets/3382934b-cc15-4e35-aa95-adfa86ec70e2)| ![Screenshot 2025-05-05 at 10 35 08](https://github.com/user-attachments/assets/2d7d267e-2fc9-45af-a3a9-9edcc1b8c2ae)|
|![Screenshot 2025-05-05 at 10 37 47](https://github.com/user-attachments/assets/68f243fd-2b53-4dcd-a816-873ef8940dc7)|  ![Screenshot 2025-05-05 at 10 37 41](https://github.com/user-attachments/assets/4e8bed43-a21b-498c-a6c1-296f45e40a50)|
|![Screenshot 2025-05-05 at 10 39 39](https://github.com/user-attachments/assets/c01bba1a-7762-4001-9a68-81721efbb4ac)|![Screenshot 2025-05-05 at 10 42 37](https://github.com/user-attachments/assets/0985844e-3e20-415e-a2aa-91767652ffd0)|
|![Screenshot 2025-05-05 at 10 41 17](https://github.com/user-attachments/assets/76614109-c8ab-474b-860c-0366d1bd5b90)|![Screenshot 2025-05-05 at 10 41 10](https://github.com/user-attachments/assets/bd977918-5101-4161-9005-79ef43da0684)|
|![Screenshot 2025-05-05 at 10 44 50](https://github.com/user-attachments/assets/6fb5a8e6-2e23-428a-8eb1-13346bc8d6f4)|![Screenshot 2025-05-05 at 10 44 40](https://github.com/user-attachments/assets/8e61e7d0-d338-4172-b158-12540849714e)|
|![Screenshot 2025-05-05 at 10 46 21](https://github.com/user-attachments/assets/b10b8ba8-eb39-4826-b929-4e1a5562732f)|![Screenshot 2025-05-05 at 10 46 15](https://github.com/user-attachments/assets/ad599733-df51-45a1-8e9f-c7bde3a69446)|
|![Screenshot 2025-05-05 at 10 50 42](https://github.com/user-attachments/assets/c0c75090-f516-4923-b67b-0a40d2d352b1)|![Screenshot 2025-05-05 at 10 50 26](https://github.com/user-attachments/assets/c6e89f2e-6523-4d10-bb63-6519ce557c49)|


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
