### PR TITLE
(PC-35833) feat(search): trigger ConsultArtist log when pressing item on artists playlist + refacto

### DIFF
--- a/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -965,7 +965,6 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
           }
           ListHeaderComponent={
             <SearchListHeader
-              artists={[]}
               nbHits={4}
               venues={
                 [
@@ -1369,7 +1368,6 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                   "withComponent": [Function],
                 },
                 "ListHeaderComponent": <SearchListHeader
-                  artists={[]}
                   nbHits={4}
                   venues={
                     [

--- a/src/features/search/components/SearchList/SearchList.tsx
+++ b/src/features/search/components/SearchList/SearchList.tsx
@@ -26,6 +26,7 @@ export const SearchList: React.FC<SearchListProps> = React.forwardRef<
       onScroll,
       userData,
       venuesUserData,
+      artistSection,
     },
     ref
   ) => {
@@ -43,7 +44,7 @@ export const SearchList: React.FC<SearchListProps> = React.forwardRef<
             nbHits={nbHits}
             userData={userData}
             venues={hits.venues}
-            artists={hits.artists}
+            artistSection={artistSection}
             venuesUserData={venuesUserData}
           />
         }

--- a/src/features/search/components/SearchList/SearchList.web.tsx
+++ b/src/features/search/components/SearchList/SearchList.web.tsx
@@ -128,6 +128,7 @@ export const SearchList = forwardRef<never, SearchListProps>(
       onPress,
       userData,
       venuesUserData,
+      artistSection,
     },
     _ref
   ) => {
@@ -184,7 +185,7 @@ export const SearchList = forwardRef<never, SearchListProps>(
       nbHits,
       offers: hits.offers,
       venues: hits.venues,
-      artists: hits.artists,
+      artistSection,
       isFetchingNextPage,
       autoScrollEnabled,
       onPress,
@@ -214,10 +215,17 @@ export const SearchList = forwardRef<never, SearchListProps>(
           itemsCount: data.items.length,
           userData,
           hasVenuesPlaylist,
-          hasArtistsPlaylist: !!data.artists?.length,
+          hasArtistsPlaylist: !!artistSection,
           windowWidth,
         }),
-      [hasGeolocPosition, data.items.length, userData, hasVenuesPlaylist, data.artists, windowWidth]
+      [
+        hasGeolocPosition,
+        data.items.length,
+        userData,
+        hasVenuesPlaylist,
+        artistSection,
+        windowWidth,
+      ]
     )
 
     return (

--- a/src/features/search/components/SearchListHeader/ArtistSection.tsx
+++ b/src/features/search/components/SearchListHeader/ArtistSection.tsx
@@ -12,10 +12,11 @@ const TITLE = 'Les artistes'
 
 type ArtistSectionProps = {
   artists: Artist[]
+  onItemPress: (artistName: string) => void
   style?: StyleProp<ViewStyle>
 }
 
-export const ArtistSection = ({ artists, style }: ArtistSectionProps) => {
+export const ArtistSection = ({ artists, onItemPress, style }: ArtistSectionProps) => {
   return (
     <View style={style}>
       <Title>{TITLE}</Title>
@@ -23,7 +24,7 @@ export const ArtistSection = ({ artists, style }: ArtistSectionProps) => {
       <AvatarList
         data={artists}
         avatarConfig={{ size: AVATAR_MEDIUM, borderWidth: 4 }}
-        onItemPress={() => false}
+        onItemPress={onItemPress}
       />
     </View>
   )

--- a/src/features/search/components/SearchListHeader/SearchListHeader.tsx
+++ b/src/features/search/components/SearchListHeader/SearchListHeader.tsx
@@ -8,12 +8,10 @@ import { useAccessibilityFiltersContext } from 'features/accessibility/context/A
 import { usePreviousRoute } from 'features/navigation/helpers/usePreviousRoute'
 import { SearchOfferHits } from 'features/search/api/useSearchResults/useSearchResults'
 import { NumberOfResults } from 'features/search/components/NumberOfResults/NumberOfResults'
-import { ArtistSection } from 'features/search/components/SearchListHeader/ArtistSection'
 import { VenuePlaylist } from 'features/search/components/VenuePlaylist/VenuePlaylist'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { getSearchVenuePlaylistTitle } from 'features/search/helpers/getSearchVenuePlaylistTitle/getSearchVenuePlaylistTitle'
 import { SearchView, VenuesUserData } from 'features/search/types'
-import { Artist } from 'features/venue/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { analytics } from 'libs/analytics/provider'
 import { useLocation } from 'libs/location'
@@ -29,7 +27,7 @@ interface SearchListHeaderProps extends ScrollViewProps {
   userData: SearchResponse<Offer[]>['userData']
   venues?: SearchOfferHits['venues']
   venuesUserData: VenuesUserData
-  artists?: Artist[]
+  artistSection?: React.ReactNode
 }
 
 export const SearchListHeader: React.FC<SearchListHeaderProps> = ({
@@ -37,7 +35,7 @@ export const SearchListHeader: React.FC<SearchListHeaderProps> = ({
   userData,
   venues,
   venuesUserData,
-  artists,
+  artistSection,
 }) => {
   const { geolocPosition, showGeolocPermissionModal, selectedLocationMode } = useLocation()
   const { disabilities } = useAccessibilityFiltersContext()
@@ -100,7 +98,7 @@ export const SearchListHeader: React.FC<SearchListHeaderProps> = ({
           <InfoBanner message={unavailableOfferMessage} icon={Error} />
         </BannerOfferNotPresentContainer>
       ) : null}
-      {artists?.length ? <StyledArtistSection artists={artists} /> : null}
+      {artistSection}
       {shouldDisplayVenuesPlaylist ? (
         <StyledVenuePlaylist
           venuePlaylistTitle={venuePlaylistTitle}
@@ -127,10 +125,6 @@ const BannerOfferNotPresentContainer = styled.View<{ nbHits: number }>(({ nbHits
 
 const Title = styled(Typo.Title3)({
   marginHorizontal: getSpacing(6),
-  marginTop: getSpacing(4),
-})
-
-const StyledArtistSection = styled(ArtistSection)({
   marginTop: getSpacing(4),
 })
 

--- a/src/features/search/components/SearchListItem.web.tsx
+++ b/src/features/search/components/SearchListItem.web.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from 'react'
+import React, { CSSProperties, ReactNode } from 'react'
 import styled from 'styled-components/native'
 
 import { SearchListFooter } from 'features/search/components/SearchListFooter/SearchListFooter.web'
@@ -25,6 +25,7 @@ export type RowData = {
   autoScrollEnabled: SearchListProps['autoScrollEnabled']
   onPress: SearchListProps['onPress']
   searchState: SearchState
+  artistSection?: ReactNode
 }
 
 interface RowProps {
@@ -44,7 +45,7 @@ export function SearchListItem({ index, style, data }: Readonly<RowProps>) {
       <li style={style}>
         <SearchListHeader
           nbHits={data.nbHits}
-          artists={data.artists}
+          artistSection={data.artistSection}
           userData={data.userData}
           venuesUserData={data.venuesUserData}
           venues={data.venues}

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -1097,4 +1097,30 @@ describe('SearchResultsContent component', () => {
       expect(screen.getByTestId('calendar')).toBeOnTheScreen()
     })
   })
+
+  describe('Artists section', () => {
+    beforeEach(() => {
+      mockUseLocation.mockReturnValue(aroundMeUseLocation)
+    })
+
+    it('should display artists playlist when there are artists', async () => {
+      renderSearchResultContent()
+
+      await initSearchResultsFlashlist()
+
+      expect(await screen.findByText('Les artistes')).toBeOnTheScreen()
+    })
+
+    it('should not display artists playlist when there are not artists', async () => {
+      renderSearchResultContent({
+        ...DEFAULT_SEARCH_RESULT_CONTENT_PROPS,
+        hits: { ...DEFAULT_SEARCH_RESULT_CONTENT_PROPS.hits, artists: [] },
+      })
+
+      await initSearchResultsFlashlist()
+
+      expect(screen.queryByText('Les artistes')).not.toBeOnTheScreen()
+    })
+
+  })
 })

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -1122,5 +1122,17 @@ describe('SearchResultsContent component', () => {
       expect(screen.queryByText('Les artistes')).not.toBeOnTheScreen()
     })
 
+    it('should trigger consult artist log when pressing artists playlist item', async () => {
+      renderSearchResultContent()
+
+      await initSearchResultsFlashlist()
+
+      await user.press(screen.getByText('Artist 1'))
+
+      expect(analytics.logConsultArtist).toHaveBeenCalledWith({
+        artistName: 'Artist 1',
+        from: 'search',
+      })
+    })
   })
 })

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -323,6 +323,10 @@ export const SearchResultsContent: React.FC<SearchResultsContentProps> = ({
     hideVenueMapLocationModal()
   }
 
+  const handleOnArtistPlaylistItemPress = (artistName: string) => {
+    analytics.logConsultArtist({ artistName, from: 'search' })
+  }
+
   if (showSkeleton) return <SearchResultsPlaceHolder />
 
   const numberOfResults =
@@ -362,7 +366,7 @@ export const SearchResultsContent: React.FC<SearchResultsContentProps> = ({
           hits.artists.length ? (
             <StyledArtistSection
               artists={hits.artists}
-              onItemPress={() => false}
+              onItemPress={handleOnArtistPlaylistItemPress}
             />
           ) : undefined
         }
@@ -639,6 +643,10 @@ const StyledUl = styled(Ul)({
 
 const FiltersScrollView = styled(ScrollView)({
   marginBottom: getSpacing(2),
+})
+
+const StyledArtistSection = styled(ArtistSection)({
+  marginTop: getSpacing(4),
 })
 
 const FAVORITE_LIST_PLACEHOLDER = Array.from({ length: 20 }).map((_, index) => ({

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -16,6 +16,7 @@ import { FilterButton } from 'features/search/components/Buttons/FilterButton/Fi
 import { SingleFilterButton } from 'features/search/components/Buttons/SingleFilterButton/SingleFilterButton'
 import { NoSearchResult } from 'features/search/components/NoSearchResults/NoSearchResult'
 import { SearchList } from 'features/search/components/SearchList/SearchList'
+import { ArtistSection } from 'features/search/components/SearchListHeader/ArtistSection'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { FilterBehaviour } from 'features/search/enums'
 import { getStringifySearchStateWithoutLocation } from 'features/search/helpers/getStringifySearchStateWithoutLocation/getStringifySearchStateWithoutLocation'
@@ -357,6 +358,14 @@ export const SearchResultsContent: React.FC<SearchResultsContentProps> = ({
         onPress={onEndReached}
         userData={userData}
         venuesUserData={venuesUserData}
+        artistSection={
+          hits.artists.length ? (
+            <StyledArtistSection
+              artists={hits.artists}
+              onItemPress={() => false}
+            />
+          ) : undefined
+        }
       />
     ),
     [Tab.MAP]: selectedLocationMode === LocationMode.EVERYWHERE ? null : <VenueMapViewContainer />,

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -1,6 +1,6 @@
 import { SearchResponse } from '@algolia/client-search'
 import { FlashList } from '@shopify/flash-list'
-import React, { Ref } from 'react'
+import React, { ReactNode, Ref } from 'react'
 
 import {
   GenreType,
@@ -91,6 +91,7 @@ export interface SearchListProps {
   userData: SearchResponse<Offer[]>['userData']
   onScroll?: () => void
   onPress?: () => void
+  artistSection?: ReactNode
 }
 
 export type CreateHistoryItem = {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35833

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
