### PR TITLE
(PC-36023) feat(location): to be compliant with apple design for location dialog boxes

### DIFF
--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
@@ -102,97 +102,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
             ]
           }
           testID="close-button-container"
-        >
-          <View
-            accessibilityLabel="Passer à la page suivante"
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": undefined,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              [
-                [
-                  {
-                    "userSelect": "auto",
-                  },
-                  {
-                    "alignItems": "center",
-                    "borderRadius": 0,
-                    "borderWidth": 0,
-                    "flexDirection": "row",
-                    "justifyContent": "center",
-                    "marginTop": 0,
-                    "maxWidth": 500,
-                    "minHeight": 16,
-                    "paddingBottom": 0,
-                    "paddingLeft": 0,
-                    "paddingRight": 0,
-                    "paddingTop": 0,
-                    "width": "auto",
-                  },
-                  {
-                    "backgroundColor": "#ffffff",
-                  },
-                ],
-                {
-                  "opacity": 1,
-                },
-              ]
-            }
-            testID="Passer à la page suivante"
-          >
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                adjustsFontSizeToFit={false}
-                numberOfLines={1}
-                style={
-                  [
-                    {
-                      "color": "#696a6f",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 16,
-                      "lineHeight": 25.6,
-                      "maxWidth": "100%",
-                    },
-                  ]
-                }
-              >
-                Passer
-              </Text>
-            </View>
-          </View>
-        </View>
+        />
       </View>
     </View>
   </View>
@@ -213,11 +123,11 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
     }
   >
     <View
-      height={65}
+      height={16}
       style={
         [
           {
-            "height": 65,
+            "height": 16,
           },
         ]
       }
@@ -318,7 +228,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
       }
     >
       <View
-        accessibilityLabel="Utiliser ma position"
+        accessibilityLabel="Continuer"
         accessibilityState={
           {
             "busy": undefined,
@@ -372,7 +282,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
             },
           ]
         }
-        testID="Utiliser ma position"
+        testID="Continuer"
       >
         <View
           style={
@@ -399,7 +309,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
               ]
             }
           >
-            Utiliser ma position
+            Continuer
           </Text>
         </View>
       </View>

--- a/src/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react'
 
-import { navigate } from '__mocks__/@react-navigation/native'
 import { OnboardingGeolocation } from 'features/onboarding/pages/onboarding/OnboardingGeolocation'
 import { analytics } from 'libs/analytics/provider'
-import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
-import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
@@ -30,46 +27,23 @@ describe('OnboardingGeolocation', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should redirect to OnboardingAgeSelectionFork when "Passer" is clicked when feature flag passForAll is enable', async () => {
-    setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_PASS_FOR_ALL])
+  it('should request geoloc permission when "Continuer" is clicked', async () => {
     render(<OnboardingGeolocation />)
 
-    const button = screen.getByLabelText('Passer à la page suivante')
-    await user.press(button)
-
-    expect(navigate).toHaveBeenCalledWith('OnboardingStackNavigator', {
-      screen: 'OnboardingAgeSelectionFork',
-    })
-  })
-
-  it('should request geoloc permission when "Utiliser ma position" is clicked', async () => {
-    render(<OnboardingGeolocation />)
-
-    const loginButton = screen.getByLabelText('Utiliser ma position')
+    const loginButton = screen.getByLabelText('Continuer')
     await user.press(loginButton)
 
     expect(mockRequestGeolocPermission).toHaveBeenCalledTimes(1)
   })
 
-  it('should log analytics when "Utiliser ma position" is clicked', async () => {
+  it('should log analytics when "Continuer" is clicked', async () => {
     render(<OnboardingGeolocation />)
 
-    const loginButton = screen.getByLabelText('Utiliser ma position')
+    const loginButton = screen.getByLabelText('Continuer')
     await user.press(loginButton)
 
     expect(analytics.logOnboardingGeolocationClicked).toHaveBeenNthCalledWith(1, {
       type: 'use_my_position',
-    })
-  })
-
-  it('should log analytics when skip button is clicked', async () => {
-    render(<OnboardingGeolocation />)
-
-    const loginButton = screen.getByLabelText('Passer à la page suivante')
-    await user.press(loginButton)
-
-    expect(analytics.logOnboardingGeolocationClicked).toHaveBeenNthCalledWith(1, {
-      type: 'skipped',
     })
   })
 })

--- a/src/features/onboarding/pages/onboarding/OnboardingGeolocation.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingGeolocation.tsx
@@ -16,11 +16,6 @@ export const OnboardingGeolocation = () => {
     navigate(...getOnboardingStackConfig('OnboardingAgeSelectionFork'))
   }, [navigate])
 
-  const onSkip = useCallback(() => {
-    analytics.logOnboardingGeolocationClicked({ type: 'skipped' })
-    navigateToNextScreen()
-  }, [navigateToNextScreen])
-
   const onGeolocationButtonPress = useCallback(async () => {
     analytics.logOnboardingGeolocationClicked({ type: 'use_my_position' })
     await requestGeolocPermission({
@@ -31,12 +26,11 @@ export const OnboardingGeolocation = () => {
 
   return (
     <GenericInfoPage
-      withSkipAction={onSkip}
       animation={GeolocationAnimation}
       title="Découvre les offres près de chez toi"
       subtitle="Librairie, ciné, festival... Active ta géolocalisation pour retrouver les offres culturelles à proximité."
       buttonPrimary={{
-        wording: 'Utiliser ma position',
+        wording: 'Continuer',
         onPress: onGeolocationButtonPress,
       }}
     />


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36023

Apple reject 338.1 because the design of the location dialog box include a button "Passer" and the label of the main button is not "Continuer".

So we change all this.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
