### PR TITLE
(PC-35976) test(app): replace some fireEvent.press by userEvent.press

### DIFF
--- a/src/cheatcodes/components/CrashTestButton.native.test.tsx
+++ b/src/cheatcodes/components/CrashTestButton.native.test.tsx
@@ -1,14 +1,17 @@
 import React from 'react'
 
-import { render, fireEvent, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { CrashTestButton } from './CrashTestButton'
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('CrashTestButton component', () => {
   it('should throw an error', async () => {
     render(<CrashTestButton />)
     const Button = screen.getByTestId('crashTestButton')
 
-    expect(() => fireEvent.press(Button)).toThrow('Test crash')
+    await expect(user.press(Button)).rejects.toThrow('Test crash')
   })
 })

--- a/src/features/search/pages/SuggestedPlacesOrVenues/SuggestedVenues.native.test.tsx
+++ b/src/features/search/pages/SuggestedPlacesOrVenues/SuggestedVenues.native.test.tsx
@@ -40,6 +40,7 @@ describe('<SuggestedVenues/>', () => {
     mockUseVenues.mockReturnValueOnce(useVenuesWithData)
     render(<SuggestedVenues query="Librairie" setSelectedVenue={mockSetSelectedVenue} />)
     // TO-DO(PC-34194): simply replacing by a userEvent is not working, should be investigated
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(screen.getByText('La librairie quantique DATA'))
 
     expect(mockSetSelectedVenue).toHaveBeenCalledWith(firstVenue)

--- a/src/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx
+++ b/src/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx
@@ -6,14 +6,14 @@ import { v4 as uuidv4 } from 'uuid'
 import { initialSearchState } from 'features/search/context/reducer'
 import { DATE_FILTER_OPTIONS, FilterBehaviour } from 'features/search/enums'
 import {
+  DATE_TYPES,
   DatesHoursModal,
   DatesHoursModalProps,
-  DATE_TYPES,
   RadioButtonDate,
 } from 'features/search/pages/modals/DatesHoursModal/DatesHoursModal'
 import { SearchState } from 'features/search/types'
 import { formatToCompleteFrenchDate } from 'libs/parsers/formatDates'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { act, fireEvent, render, screen, userEvent, waitFor } from 'tests/utils'
 
 const searchId = uuidv4()
 const searchState = { ...initialSearchState, searchId }
@@ -38,6 +38,10 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+
+jest.useFakeTimers()
 
 describe('<DatesHoursModal/>', () => {
   beforeAll(() => {
@@ -64,9 +68,7 @@ describe('<DatesHoursModal/>', () => {
 
       expect(screen.queryByText('Choisis une date')).not.toBeOnTheScreen()
 
-      await act(async () => {
-        fireEvent.press(screen.getByText('Date précise'))
-      })
+      await user.press(screen.getByText('Date précise'))
 
       expect(screen.getByText('Choisis une date')).toBeOnTheScreen()
     })
@@ -77,9 +79,8 @@ describe('<DatesHoursModal/>', () => {
         date: { option: DATE_FILTER_OPTIONS.USER_PICK, selectedDate: TOMORROW.toISOString() },
       }
       renderDatesHoursModal()
-      await act(async () => {
-        expect(screen.getByText('Samedi 29 octobre 2022')).toBeOnTheScreen()
-      })
+
+      expect(await screen.findByText('Samedi 29 octobre 2022')).toBeOnTheScreen()
     })
 
     it('by default time range defined in search state', async () => {
@@ -89,9 +90,7 @@ describe('<DatesHoursModal/>', () => {
       }
       renderDatesHoursModal()
 
-      await act(async () => {
-        expect(screen.getByText(`18\u00a0h et 22\u00a0h`)).toBeOnTheScreen()
-      })
+      expect(await screen.findByText(`18\u00a0h et 22\u00a0h`)).toBeOnTheScreen()
     })
   })
 
@@ -106,15 +105,11 @@ describe('<DatesHoursModal/>', () => {
       `${RadioButtonDate.PRECISE_DATE} ${formatToCompleteFrenchDate(TODAY)}`
     )
 
-    await act(async () => {
-      fireEvent.press(radioButton)
-    })
+    await user.press(radioButton)
 
     expect(screen.getByText('Choisis une date')).toBeOnTheScreen()
 
-    await act(async () => {
-      fireEvent.press(radioButton)
-    })
+    await user.press(radioButton)
 
     expect(screen.getByText('Choisis une date')).toBeOnTheScreen()
   })
@@ -127,16 +122,12 @@ describe('<DatesHoursModal/>', () => {
       renderDatesHoursModal()
 
       const toggleDate = screen.getByTestId('Interrupteur date')
-      await act(async () => {
-        fireEvent.press(toggleDate)
-      })
+      await user.press(toggleDate)
 
       expect(toggleDate.props.accessibilityState.checked).toEqual(true)
 
       const resetButton = screen.getByText('Réinitialiser')
-      await act(async () => {
-        fireEvent.press(resetButton)
-      })
+      await user.press(resetButton)
 
       expect(toggleDate.props.accessibilityState.checked).toEqual(false)
     })
@@ -148,16 +139,12 @@ describe('<DatesHoursModal/>', () => {
       renderDatesHoursModal()
 
       const toggleHour = screen.getByTestId('Interrupteur hour')
-      await act(async () => {
-        fireEvent.press(toggleHour)
-      })
+      await user.press(toggleHour)
 
       expect(toggleHour.props.accessibilityState.checked).toEqual(true)
 
       const resetButton = screen.getByText('Réinitialiser')
-      await act(async () => {
-        fireEvent.press(resetButton)
-      })
+      await user.press(resetButton)
 
       expect(toggleHour.props.accessibilityState.checked).toEqual(false)
     })
@@ -173,20 +160,19 @@ describe('<DatesHoursModal/>', () => {
         renderDatesHoursModal()
 
         const toggleDate = screen.getByTestId('Interrupteur date')
-        await act(async () => {
-          fireEvent.press(toggleDate)
-        })
+        await user.press(toggleDate)
 
         const radioButton = screen.getByTestId(option)
-        await act(async () => {
-          fireEvent.press(radioButton)
-        })
+        await user.press(radioButton)
 
         expect(radioButton.props.accessibilityState).toEqual({ checked: true })
 
-        const resetButton = screen.getByText('Réinitialiser')
+        const resetButton = await screen.findByText('Réinitialiser')
         await act(async () => {
+          // userEvent.press not working correctly here
+          // eslint-disable-next-line local-rules/no-fireEvent
           fireEvent.press(resetButton)
+          // eslint-disable-next-line local-rules/no-fireEvent
           fireEvent.press(toggleDate)
         })
 
@@ -203,19 +189,18 @@ describe('<DatesHoursModal/>', () => {
         renderDatesHoursModal()
 
         const toggleDate = screen.getByTestId('Interrupteur date')
-        await act(async () => {
-          fireEvent.press(toggleDate)
-        })
+        await user.press(toggleDate)
 
         const radioButton = screen.getByTestId(option)
-        await act(async () => {
-          fireEvent.press(radioButton)
-        })
+        await user.press(radioButton)
 
         expect(radioButton.props.accessibilityState).toEqual({ checked: true })
 
         await act(async () => {
+          // userEvent.press not working correctly here
+          // eslint-disable-next-line local-rules/no-fireEvent
           fireEvent.press(toggleDate)
+          // eslint-disable-next-line local-rules/no-fireEvent
           fireEvent.press(toggleDate)
         })
 
@@ -230,9 +215,7 @@ describe('<DatesHoursModal/>', () => {
       renderDatesHoursModal()
 
       const toggleHour = screen.getByTestId('Interrupteur hour')
-      await act(async () => {
-        fireEvent.press(toggleHour)
-      })
+      await user.press(toggleHour)
 
       expect(toggleHour.props.accessibilityState.checked).toEqual(true)
 
@@ -244,12 +227,9 @@ describe('<DatesHoursModal/>', () => {
       expect(screen.getByText(`18\u00a0h et 23\u00a0h`)).toBeOnTheScreen()
 
       const resetButton = screen.getByText('Réinitialiser')
-      await act(async () => {
-        fireEvent.press(resetButton)
-      })
-      await act(async () => {
-        fireEvent.press(toggleHour)
-      })
+      await user.press(resetButton)
+
+      await user.press(toggleHour)
 
       expect(screen.getByText(`8\u00a0h et 22\u00a0h`)).toBeOnTheScreen()
     })
@@ -261,9 +241,7 @@ describe('<DatesHoursModal/>', () => {
       renderDatesHoursModal()
 
       const toggleHour = screen.getByTestId('Interrupteur hour')
-      await act(async () => {
-        fireEvent.press(toggleHour)
-      })
+      await user.press(toggleHour)
 
       await act(async () => {
         const slider = screen.getByTestId('slider').children[0] as ReactTestInstance
@@ -272,12 +250,8 @@ describe('<DatesHoursModal/>', () => {
 
       expect(screen.getByText(`18\u00a0h et 23\u00a0h`)).toBeOnTheScreen()
 
-      await act(async () => {
-        fireEvent.press(toggleHour)
-      })
-      await act(async () => {
-        fireEvent.press(toggleHour)
-      })
+      await user.press(toggleHour)
+      await user.press(toggleHour)
 
       expect(screen.getByText(`8\u00a0h et 22\u00a0h`)).toBeOnTheScreen()
     })
@@ -286,12 +260,10 @@ describe('<DatesHoursModal/>', () => {
   it('should close the modal when pressing previous button', async () => {
     renderDatesHoursModal()
 
-    await waitFor(() => {
-      expect(screen.getByLabelText('Rechercher')).toBeEnabled()
-    })
+    await screen.findByLabelText('Rechercher')
 
     const previousButton = screen.getByTestId('Fermer')
-    fireEvent.press(previousButton)
+    await user.press(previousButton)
 
     expect(mockHideModal).toHaveBeenCalledTimes(1)
   })
@@ -366,16 +338,20 @@ describe('<DatesHoursModal/>', () => {
 
       const toggleDate = screen.getByTestId('Interrupteur date')
       await act(async () => {
+        // With userEvent, test too long to execute for the CI
+        // eslint-disable-next-line local-rules/no-fireEvent
         fireEvent.press(toggleDate)
       })
 
       const radioButton = screen.getByText(RadioButtonDate.WEEK)
       await act(async () => {
+        // eslint-disable-next-line local-rules/no-fireEvent
         fireEvent.press(radioButton)
       })
 
       const searchButton = screen.getByText('Appliquer le filtre')
       await act(async () => {
+        // eslint-disable-next-line local-rules/no-fireEvent
         fireEvent.press(searchButton)
       })
 
@@ -402,13 +378,9 @@ describe('<DatesHoursModal/>', () => {
         }
         renderDatesHoursModal()
 
-        const searchButton = screen.getByLabelText('Rechercher')
-        await waitFor(() => {
-          expect(searchButton).toBeEnabled()
-        })
-        await act(async () => {
-          fireEvent.press(searchButton)
-        })
+        const searchButton = await screen.findByLabelText('Rechercher')
+
+        await user.press(searchButton)
 
         expect(mockDispatch).toHaveBeenCalledWith({
           type: 'SET_STATE',
@@ -426,16 +398,20 @@ describe('<DatesHoursModal/>', () => {
 
           const toggleDate = screen.getByTestId('Interrupteur date')
           await act(async () => {
+            // With userEvent, test too long to execute for the CI
+            // eslint-disable-next-line local-rules/no-fireEvent
             fireEvent.press(toggleDate)
           })
 
           const radioButton = screen.getByTestId(label)
           await act(async () => {
+            // eslint-disable-next-line local-rules/no-fireEvent
             fireEvent.press(radioButton)
           })
 
           const searchButton = screen.getByText('Rechercher')
           await act(async () => {
+            // eslint-disable-next-line local-rules/no-fireEvent
             fireEvent.press(searchButton)
           })
 
@@ -457,6 +433,8 @@ describe('<DatesHoursModal/>', () => {
 
         const toggleHour = screen.getByTestId('Interrupteur hour')
         await act(async () => {
+          // With userEvent, test too long to execute for the CI
+          // eslint-disable-next-line local-rules/no-fireEvent
           fireEvent.press(toggleHour)
         })
 
@@ -467,6 +445,7 @@ describe('<DatesHoursModal/>', () => {
 
         const searchButton = screen.getByText('Rechercher')
         await act(async () => {
+          // eslint-disable-next-line local-rules/no-fireEvent
           fireEvent.press(searchButton)
         })
 
@@ -487,13 +466,8 @@ describe('<DatesHoursModal/>', () => {
         }
         renderDatesHoursModal()
 
-        const searchButton = screen.getByLabelText('Rechercher')
-        await waitFor(() => {
-          expect(searchButton).toBeEnabled()
-        })
-        await act(async () => {
-          fireEvent.press(searchButton)
-        })
+        const searchButton = await screen.findByLabelText('Rechercher')
+        await user.press(searchButton)
 
         expect(mockDispatch).toHaveBeenCalledWith({
           type: 'SET_STATE',
@@ -514,12 +488,8 @@ describe('<DatesHoursModal/>', () => {
         onClose: mockOnClose,
       })
 
-      await waitFor(() => {
-        expect(screen.getByLabelText('Appliquer le filtre')).toBeEnabled()
-      })
-
       const closeButton = screen.getByTestId('Fermer')
-      fireEvent.press(closeButton)
+      await user.press(closeButton)
 
       expect(mockOnClose).toHaveBeenCalledTimes(1)
     })
@@ -527,12 +497,8 @@ describe('<DatesHoursModal/>', () => {
     it('should only close the modal when pressing close button when the modal is opening from search results', async () => {
       renderDatesHoursModal()
 
-      await waitFor(() => {
-        expect(screen.getByLabelText('Rechercher')).toBeEnabled()
-      })
-
       const closeButton = screen.getByTestId('Fermer')
-      fireEvent.press(closeButton)
+      await user.press(closeButton)
 
       expect(mockOnClose).not.toHaveBeenCalled()
     })

--- a/src/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx
+++ b/src/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx
@@ -78,6 +78,8 @@ describe('VenueModal', () => {
     await user.type(venueSearchInput, mockVenues[0].label) // userEvent.type does more than fireEvent.replaceText so the next fireEvent can't be remove until we find how to properly use userEvent in this case
 
     const suggestedVenue = await screen.findByText(mockVenues[0].label)
+    // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(suggestedVenue)
 
     const validateButton = screen.getByText('Rechercher')
@@ -146,6 +148,8 @@ describe('VenueModal', () => {
     await user.type(venueSearchInput, mockVenues[0].label)
 
     const suggestedVenue = await screen.findByText(mockVenues[0].label)
+    // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(suggestedVenue)
 
     const validateButton = screen.getByText('Rechercher')

--- a/src/features/subscription/NotificationsSettingsModal.native.test.tsx
+++ b/src/features/subscription/NotificationsSettingsModal.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { NotificationsSettingsModal } from 'features/subscription/NotificationsSettingsModal'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen, act } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('features/profile/pages/NotificationSettings/usePushPermission', () => ({
   usePushPermission: jest.fn(() => ({
@@ -19,6 +19,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<NotificationsSettingsModal />', () => {
   it('should render correctly', () => {
     renderModal(true)
@@ -26,46 +29,46 @@ describe('<NotificationsSettingsModal />', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should dismiss modal on press rightIconButton', () => {
+  it('should dismiss modal on press rightIconButton', async () => {
     renderModal(true)
 
     const dismissModalButton = screen.getByTestId('rightIcon')
 
-    fireEvent.press(dismissModalButton)
+    await user.press(dismissModalButton)
 
     expect(mockDismissModal).toHaveBeenCalledTimes(1)
   })
 
-  it('should reset the switch when dismissing the modal', () => {
+  it('should reset the switch when dismissing the modal', async () => {
     renderModal(true)
 
     const toggleSwitch = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-    fireEvent.press(toggleSwitch)
+    await user.press(toggleSwitch)
 
     const dismissModalButton = screen.getByTestId('rightIcon')
-    fireEvent.press(dismissModalButton)
+    await user.press(dismissModalButton)
 
     expect(toggleSwitch).toHaveAccessibilityState({ checked: false })
   })
 
-  it('should dismiss modal on press "Tout refuser..."', () => {
+  it('should dismiss modal on press "Tout refuser..."', async () => {
     renderModal(true)
 
     const declineButton = screen.getByText('Tout refuser et ne pas recevoir d’actus')
 
-    fireEvent.press(declineButton)
+    await user.press(declineButton)
 
     expect(mockDismissModal).toHaveBeenCalledTimes(1)
   })
 
-  it('should reset the switch on press "Tout refuser..."', () => {
+  it('should reset the switch on press "Tout refuser..."', async () => {
     renderModal(true)
 
     const toggleSwitch = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-    fireEvent.press(toggleSwitch)
+    await user.press(toggleSwitch)
 
     const declineButton = screen.getByText('Tout refuser et ne pas recevoir d’actus')
-    fireEvent.press(declineButton)
+    await user.press(declineButton)
 
     expect(toggleSwitch).toHaveAccessibilityState({ checked: false })
   })
@@ -74,11 +77,9 @@ describe('<NotificationsSettingsModal />', () => {
     renderModal(true)
 
     const toggleSwitch = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-    fireEvent.press(toggleSwitch)
+    await user.press(toggleSwitch)
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Valider'))
-    })
+    await user.press(screen.getByText('Valider'))
 
     expect(mockDismissModal).toHaveBeenCalledTimes(1)
   })
@@ -87,11 +88,9 @@ describe('<NotificationsSettingsModal />', () => {
     renderModal(true)
 
     const toggleSwitch = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-    fireEvent.press(toggleSwitch)
+    await user.press(toggleSwitch)
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Valider'))
-    })
+    await user.press(screen.getByText('Valider'))
 
     expect(mockOnPressSaveChanges).toHaveBeenCalledWith({ allowEmails: true, allowPush: false })
   })
@@ -100,11 +99,9 @@ describe('<NotificationsSettingsModal />', () => {
     renderModal(true)
 
     const toggleSwitch = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
-    fireEvent.press(toggleSwitch)
+    await user.press(toggleSwitch)
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Valider'))
-    })
+    await user.press(screen.getByText('Valider'))
 
     expect(mockOnPressSaveChanges).toHaveBeenCalledWith({ allowEmails: true, allowPush: false })
   })
@@ -113,11 +110,9 @@ describe('<NotificationsSettingsModal />', () => {
     renderModal(true)
 
     const toggleSwitch = screen.getByTestId('Interrupteur Autoriser les notifications')
-    fireEvent.press(toggleSwitch)
+    await user.press(toggleSwitch)
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('Valider'))
-    })
+    await user.press(screen.getByText('Valider'))
 
     expect(mockOnPressSaveChanges).toHaveBeenCalledWith({ allowEmails: false, allowPush: true })
   })

--- a/src/features/trustedDevice/pages/SuspensionChoice.native.test.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.native.test.tsx
@@ -11,7 +11,7 @@ import { FetchError, MonitoringError } from 'libs/monitoring/errors'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 
 import { SuspensionChoice } from './SuspensionChoice'
@@ -40,6 +40,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<SuspensionChoice/>', () => {
   it('should match snapshot', async () => {
     renderSuspensionChoice()
@@ -54,11 +57,9 @@ describe('<SuspensionChoice/>', () => {
     renderSuspensionChoice()
 
     const acceptSuspensionButton = screen.getByText('Oui, suspendre mon compte')
-    fireEvent.press(acceptSuspensionButton)
+    await user.press(acceptSuspensionButton)
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenNthCalledWith(1, 'SuspiciousLoginSuspendedAccount')
-    })
+    expect(navigate).toHaveBeenNthCalledWith(1, 'SuspiciousLoginSuspendedAccount')
   })
 
   it('should show snackbar on suspension error', async () => {
@@ -66,14 +67,12 @@ describe('<SuspensionChoice/>', () => {
     renderSuspensionChoice()
 
     const acceptSuspensionButton = screen.getByText('Oui, suspendre mon compte')
-    fireEvent.press(acceptSuspensionButton)
+    await user.press(acceptSuspensionButton)
 
-    await waitFor(() => {
-      expect(mockShowErrorSnackBar).toHaveBeenCalledWith({
-        message:
-          'Une erreur est survenue. Pour suspendre ton compte, contacte le support par e-mail.',
-        timeout: SNACK_BAR_TIME_OUT,
-      })
+    expect(mockShowErrorSnackBar).toHaveBeenCalledWith({
+      message:
+        'Une erreur est survenue. Pour suspendre ton compte, contacte le support par e-mail.',
+      timeout: SNACK_BAR_TIME_OUT,
     })
   })
 
@@ -91,7 +90,7 @@ describe('<SuspensionChoice/>', () => {
 
       const acceptSuspensionButton = screen.getByText('Oui, suspendre mon compte')
 
-      await act(async () => fireEvent.press(acceptSuspensionButton))
+      await user.press(acceptSuspensionButton)
 
       expect(eventMonitoring.captureException).toHaveBeenCalledTimes(0)
     })
@@ -115,7 +114,7 @@ describe('<SuspensionChoice/>', () => {
 
       const acceptSuspensionButton = screen.getByText('Oui, suspendre mon compte')
 
-      await act(async () => fireEvent.press(acceptSuspensionButton))
+      await user.press(acceptSuspensionButton)
 
       expect(eventMonitoring.captureException).toHaveBeenNthCalledWith(
         1,
@@ -138,9 +137,7 @@ describe('<SuspensionChoice/>', () => {
     renderSuspensionChoice()
 
     const acceptSuspensionButton = screen.getByText('Oui, suspendre mon compte')
-    fireEvent.press(acceptSuspensionButton)
-
-    await act(async () => {})
+    await user.press(acceptSuspensionButton)
 
     expect(eventMonitoring.captureException).toHaveBeenCalledWith(error, undefined)
   })
@@ -149,31 +146,29 @@ describe('<SuspensionChoice/>', () => {
     renderSuspensionChoice()
 
     const contactSupportButton = screen.getByText('Contacter le service fraude')
-    fireEvent.press(contactSupportButton)
+    await user.press(contactSupportButton)
 
-    await waitFor(() => {
-      expect(openUrl).toHaveBeenCalledWith(
-        `mailto:service.fraude@test.passculture.app`,
-        undefined,
-        true
-      )
-    })
+    expect(openUrl).toHaveBeenCalledWith(
+      `mailto:service.fraude@test.passculture.app`,
+      undefined,
+      true
+    )
   })
 
-  it('should log analytics when clicking on "Contacter le service fraude" button', () => {
+  it('should log analytics when clicking on "Contacter le service fraude" button', async () => {
     renderSuspensionChoice()
 
     const contactSupportButton = screen.getByText('Contacter le service fraude')
-    fireEvent.press(contactSupportButton)
+    await user.press(contactSupportButton)
 
     expect(analytics.logContactFraudTeam).toHaveBeenCalledWith({ from: 'suspensionchoice' })
   })
 
-  it('should open CGU url when clicking on "conditions générales d’utilisation" button', () => {
+  it('should open CGU url when clicking on "conditions générales d’utilisation" button', async () => {
     renderSuspensionChoice()
 
     const cguButton = screen.getByText('conditions générales d’utilisation')
-    fireEvent.press(cguButton)
+    await user.press(cguButton)
 
     expect(openUrl).toHaveBeenNthCalledWith(1, env.CGU_LINK, undefined, true)
   })

--- a/src/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx
@@ -5,7 +5,7 @@ import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { SuspensionChoiceExpiredLink } from 'features/trustedDevice/pages/SuspensionChoiceExpiredLink'
 import { env } from 'libs/environment/env'
-import { render, screen, fireEvent } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 const mockOpenUrl = jest.spyOn(NavigationHelpers, 'openUrl')
 
@@ -17,6 +17,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<SuspensionChoiceExpiredLink/>', () => {
   it('should match snapshot', () => {
     render(<SuspensionChoiceExpiredLink />)
@@ -24,11 +27,11 @@ describe('<SuspensionChoiceExpiredLink/>', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should redirect to home page when "Retourner à l’accueil" button is clicked', () => {
+  it('should redirect to home page when "Retourner à l’accueil" button is clicked', async () => {
     render(<SuspensionChoiceExpiredLink />)
 
     const goHomeButton = screen.getByText('Retourner à l’accueil')
-    fireEvent.press(goHomeButton)
+    await user.press(goHomeButton)
 
     expect(navigate).toHaveBeenNthCalledWith(
       1,
@@ -41,7 +44,7 @@ describe('<SuspensionChoiceExpiredLink/>', () => {
     render(<SuspensionChoiceExpiredLink />)
 
     const contactFraudButton = screen.getByText('Contacter le service fraude')
-    fireEvent.press(contactFraudButton)
+    await user.press(contactFraudButton)
 
     expect(mockOpenUrl).toHaveBeenNthCalledWith(
       1,

--- a/src/features/venue/components/ContactBlock/ContactBlock.native.test.tsx
+++ b/src/features/venue/components/ContactBlock/ContactBlock.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { venueDataTest } from 'features/venue/fixtures/venueDataTest'
 import { analytics } from 'libs/analytics/provider'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { ContactBlock } from './ContactBlock'
 
@@ -20,35 +20,32 @@ const openUrlSpy = jest.spyOn(NavigationHelpers, 'openUrl')
 
 jest.mock('libs/firebase/analytics/analytics')
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<ContactBlock/>', () => {
   it('should navigate to mail when pressing on email', async () => {
     render(<ContactBlock venue={venueDataTest} />)
 
-    fireEvent.press(screen.getByText('contact@venue.com'))
+    await user.press(screen.getByText('contact@venue.com'))
 
-    await waitFor(() => {
-      expect(openUrlSpy).toHaveBeenCalledWith('mailto:contact@venue.com', undefined, true)
-    })
+    expect(openUrlSpy).toHaveBeenCalledWith('mailto:contact@venue.com', undefined, true)
   })
 
   it('should navigate to tel when pressing on phoneNumber', async () => {
     render(<ContactBlock venue={venueDataTest} />)
 
-    fireEvent.press(screen.getByText('+33102030405'))
+    await user.press(screen.getByText('+33102030405'))
 
-    await waitFor(() => {
-      expect(openUrlSpy).toHaveBeenCalledWith('tel:+33102030405', undefined, true)
-    })
+    expect(openUrlSpy).toHaveBeenCalledWith('tel:+33102030405', undefined, true)
   })
 
   it('should navigate to website when pressing on website adress', async () => {
     render(<ContactBlock venue={venueDataTest} />)
 
-    fireEvent.press(screen.getByText('https://my@website.com'))
+    await user.press(screen.getByText('https://my@website.com'))
 
-    await waitFor(() => {
-      expect(openUrlSpy).toHaveBeenCalledWith('https://my@website.com', undefined, true)
-    })
+    expect(openUrlSpy).toHaveBeenCalledWith('https://my@website.com', undefined, true)
   })
 
   it('should display the email, phoneNumber and website', () => {
@@ -59,9 +56,9 @@ describe('<ContactBlock/>', () => {
     expect(screen.getByText('https://my@website.com')).toBeOnTheScreen()
   })
 
-  it('should log event VenueContact when opening email', () => {
+  it('should log event VenueContact when opening email', async () => {
     render(<ContactBlock venue={venueDataTest} />)
-    fireEvent.press(screen.getByText('contact@venue.com'))
+    await user.press(screen.getByText('contact@venue.com'))
 
     expect(analytics.logVenueContact).toHaveBeenNthCalledWith(1, {
       type: 'email',
@@ -69,9 +66,9 @@ describe('<ContactBlock/>', () => {
     })
   })
 
-  it('should log event VenueContact when opening phone number', () => {
+  it('should log event VenueContact when opening phone number', async () => {
     render(<ContactBlock venue={venueDataTest} />)
-    fireEvent.press(screen.getByText('+33102030405'))
+    await user.press(screen.getByText('+33102030405'))
 
     expect(analytics.logVenueContact).toHaveBeenNthCalledWith(1, {
       type: 'phoneNumber',
@@ -79,9 +76,9 @@ describe('<ContactBlock/>', () => {
     })
   })
 
-  it('should log event VenueContact when opening website', () => {
+  it('should log event VenueContact when opening website', async () => {
     render(<ContactBlock venue={venueDataTest} />)
-    fireEvent.press(screen.getByText('https://my@website.com'))
+    await user.press(screen.getByText('https://my@website.com'))
 
     expect(analytics.logVenueContact).toHaveBeenNthCalledWith(1, {
       type: 'website',
@@ -93,11 +90,9 @@ describe('<ContactBlock/>', () => {
     openUrlSpy.mockRejectedValueOnce(new Error('error'))
     render(<ContactBlock venue={venueDataTest} />)
 
-    fireEvent.press(screen.getByText('https://my@website.com'))
+    await user.press(screen.getByText('https://my@website.com'))
 
-    await waitFor(() => {
-      expect(mockShowErrorSnackBar).toHaveBeenCalledWith({ message: 'Une erreur est survenue.' })
-    })
+    expect(mockShowErrorSnackBar).toHaveBeenCalledWith({ message: 'Une erreur est survenue.' })
   })
 
   it('should display nothing when contact section is empty', () => {

--- a/src/features/venue/components/VenueThematicSection/VenueThematicSection.native.test.tsx
+++ b/src/features/venue/components/VenueThematicSection/VenueThematicSection.native.test.tsx
@@ -6,10 +6,10 @@ import { VenueThematicSection } from 'features/venue/components/VenueThematicSec
 import { venueDataTest } from 'features/venue/fixtures/venueDataTest'
 import { beneficiaryUser, nonBeneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics/provider'
-import { mockAuthContextWithoutUser, mockAuthContextWithUser } from 'tests/AuthContextUtils'
+import { mockAuthContextWithUser, mockAuthContextWithoutUser } from 'tests/AuthContextUtils'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { fireEvent, render, screen, userEvent, waitFor } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 
 jest.mock('libs/jwt/jwt')
@@ -40,6 +40,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<VenueThematicSection/>', () => {
   beforeEach(() => {
@@ -76,13 +79,11 @@ describe('<VenueThematicSection/>', () => {
 
       render(reactQueryProviderHOC(<VenueThematicSection venue={venueFixture} />))
 
-      fireEvent.press(screen.getByText('Suivre le thème'))
+      await user.press(screen.getByText('Suivre le thème'))
 
-      await waitFor(() => {
-        expect(mockShowSuccessSnackBar).toHaveBeenCalledWith({
-          message: 'Tu suis le thème “Cinéma”\u00a0! Tu peux gérer tes alertes depuis ton profil.',
-          timeout: SNACK_BAR_TIME_OUT,
-        })
+      expect(mockShowSuccessSnackBar).toHaveBeenCalledWith({
+        message: 'Tu suis le thème “Cinéma”\u00a0! Tu peux gérer tes alertes depuis ton profil.',
+        timeout: SNACK_BAR_TIME_OUT,
       })
     })
 
@@ -93,13 +94,11 @@ describe('<VenueThematicSection/>', () => {
 
       render(reactQueryProviderHOC(<VenueThematicSection venue={venueFixture} />))
 
-      fireEvent.press(screen.getByText('Suivre le thème'))
+      await user.press(screen.getByText('Suivre le thème'))
 
-      await waitFor(() => {
-        expect(mockShowErrorSnackBar).toHaveBeenCalledWith({
-          message: 'Une erreur est survenue, veuillez réessayer',
-          timeout: SNACK_BAR_TIME_OUT,
-        })
+      expect(mockShowErrorSnackBar).toHaveBeenCalledWith({
+        message: 'Une erreur est survenue, veuillez réessayer',
+        timeout: SNACK_BAR_TIME_OUT,
       })
     })
 
@@ -107,6 +106,8 @@ describe('<VenueThematicSection/>', () => {
       mockAuthContextWithoutUser()
       render(reactQueryProviderHOC(<VenueThematicSection venue={venueFixture} />))
 
+      // userEvent.press not working correctly here
+      // eslint-disable-next-line local-rules/no-fireEvent
       fireEvent.press(screen.getByText('Suivre le thème'))
 
       expect(await screen.findByText('Identifie-toi pour t’abonner à un thème')).toBeOnTheScreen()
@@ -120,6 +121,8 @@ describe('<VenueThematicSection/>', () => {
       mockAuthContextWithUser(userWithNoNotifications)
       render(reactQueryProviderHOC(<VenueThematicSection venue={venueFixture} />))
 
+      // userEvent.press not working correctly here
+      // eslint-disable-next-line local-rules/no-fireEvent
       fireEvent.press(screen.getByText('Suivre le thème'))
 
       expect(await screen.findByText('Autoriser l’envoi d’e-mails')).toBeOnTheScreen()
@@ -133,8 +136,11 @@ describe('<VenueThematicSection/>', () => {
       // Due to too many re-renders, we need to mock the auth context globally
       // eslint-disable-next-line local-rules/independent-mocks
       mockAuthContextWithUser(alreadySubscribedUser, { persist: true })
-      await act(async () => fireEvent.press(screen.getByText('Suivre le thème')))
-      fireEvent.press(await screen.findByText('Thème suivi'))
+
+      // userEvent.press not working correctly here
+      // eslint-disable-next-line local-rules/no-fireEvent
+      fireEvent.press(screen.getByText('Suivre le thème'))
+      await user.press(screen.getByText('Thème suivi'))
 
       expect(
         await screen.findByText('Es-tu sûr de ne plus vouloir suivre ce thème ?')
@@ -147,12 +153,12 @@ describe('<VenueThematicSection/>', () => {
 
     render(reactQueryProviderHOC(<VenueThematicSection venue={venueFixture} />))
 
+    // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(screen.getByText('Suivre le thème'))
 
-    fireEvent.press(await screen.findByText('Se connecter'))
+    await user.press(screen.getByText('Se connecter'))
 
-    await waitFor(() => {
-      expect(analytics.logLoginClicked).toHaveBeenCalledWith({ from: 'venue' })
-    })
+    expect(analytics.logLoginClicked).toHaveBeenCalledWith({ from: 'venue' })
   })
 })

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
@@ -20,6 +20,8 @@ const mockCurrentRegion = {
 
 const pressVenueMarker = (venue: GeolocatedVenue) => {
   return act(() => {
+    // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(screen.getByTestId(`marker-${venue.venueId}`), {
       stopPropagation: () => false,
       nativeEvent: {

--- a/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.native.test.tsx
@@ -93,6 +93,8 @@ const mockUseVenueOffers = (emptyResponse = false) => {
 
 const pressVenueMarker = (venue: GeolocatedVenue, forcedVenueId?: string) => {
   return act(() => {
+    // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(screen.getByTestId(`marker-${venue.venueId}`), {
       stopPropagation: () => false,
       nativeEvent: {

--- a/src/shared/forms/controllers/EmailInputController.native.test.tsx
+++ b/src/shared/forms/controllers/EmailInputController.native.test.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
-import { useForm, ErrorOption } from 'react-hook-form'
+import { ErrorOption, useForm } from 'react-hook-form'
 
 import { EmailInputController } from 'shared/forms/controllers/EmailInputController'
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { act, fireEvent, render, screen, userEvent } from 'tests/utils'
 import { SUGGESTION_DELAY_IN_MS } from 'ui/components/inputs/EmailInputWithSpellingHelp/useEmailSpellingHelp'
 
 type EmailForm = {
   email: string
 }
+
+const user = userEvent.setup()
 
 jest.useFakeTimers()
 
@@ -67,7 +69,7 @@ describe('<EmailInputController />', () => {
     await screen.findByText('Veux-tu plutôt dire firstname.lastname@gmail.com ?')
 
     const suggestionButton = screen.getByText('Appliquer la modification')
-    fireEvent.press(suggestionButton)
+    await user.press(suggestionButton)
 
     expect(mockOnSpellingHelpPress).toHaveBeenCalledTimes(1)
   })

--- a/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx
+++ b/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx
@@ -8,7 +8,7 @@ import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setF
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useGetDepositAmountsByAge } from 'shared/user/useGetDepositAmountsByAge'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { FinishSubscriptionModal } from './FinishSubscriptionModal'
 
@@ -35,6 +35,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<FinishSubscriptionModal />', () => {
   beforeEach(() => {
@@ -63,19 +66,19 @@ describe('<FinishSubscriptionModal />', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should close modal and navigate to stepper when pressing "Confirmer mes informations" button', () => {
+  it('should close modal and navigate to stepper when pressing "Confirmer mes informations" button', async () => {
     render(<FinishSubscriptionModal {...modalProps} />)
 
-    fireEvent.press(screen.getByText('Confirmer mes informations'))
+    await user.press(screen.getByText('Confirmer mes informations'))
 
     expect(hideModal).toHaveBeenCalledTimes(1)
     expect(navigate).toHaveBeenCalledWith('Stepper', { from: StepperOrigin.FAVORITE })
   })
 
-  it('should close modal when pressing right header icon', () => {
+  it('should close modal when pressing right header icon', async () => {
     render(<FinishSubscriptionModal {...modalProps} />)
 
-    fireEvent.press(screen.getByTestId('Fermer la modale'))
+    await user.press(screen.getByTestId('Fermer la modale'))
 
     expect(hideModal).toHaveBeenCalledTimes(1)
   })

--- a/src/ui/components/Accordion.native.test.tsx
+++ b/src/ui/components/Accordion.native.test.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 import { View } from 'react-native'
 
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { act, render, screen, userEvent } from 'tests/utils'
 
 import { Accordion } from './Accordion'
 
 const Children = () => <View testID="accordion-child-view" />
 
 const accordionTitle = 'accordion title'
+
+const user = userEvent.setup()
 
 jest.unmock('react-native/Libraries/Animated/createAnimatedComponent')
 jest.useFakeTimers()
@@ -25,10 +27,7 @@ describe('Accordion', () => {
 
     expect(screen.queryByTestId('accordion-child-view')).not.toBeOnTheScreen()
 
-    act(() => {
-      fireEvent.press(screen.getByText('accordion title'))
-      jest.runAllTimers()
-    })
+    await user.press(screen.getByText('accordion title'))
 
     expect(screen.getByTestId('accordion-child-view')).toBeOnTheScreen()
   })
@@ -38,8 +37,8 @@ describe('Accordion', () => {
 
     expect(screen.getByTestId('accordionTouchable')).toHaveAccessibilityState({ expanded: false })
 
+    await user.press(screen.getByText('accordion title'))
     act(() => {
-      fireEvent.press(screen.getByText('accordion title'))
       jest.runAllTimers()
     })
 
@@ -53,8 +52,8 @@ describe('Accordion', () => {
     // ArrowNext (right) + 90° => arrow facing up.
     expect(accordionArrow.props.style.transform[0]).toEqual({ rotateZ: `${Math.PI / 2}rad` })
 
+    await user.press(screen.getByText('accordion title'))
     act(() => {
-      fireEvent.press(screen.getByText('accordion title'))
       jest.runAllTimers()
     })
 

--- a/src/ui/components/SectionRowContent.native.test.tsx
+++ b/src/ui/components/SectionRowContent.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { render, fireEvent, screen } from 'tests/utils'
+import { fireEvent, render, screen } from 'tests/utils'
 import { Close } from 'ui/svg/icons/Close'
 
 import { SectionRowContent } from './SectionRowContent'
@@ -13,6 +13,8 @@ describe('SectionRowContent', () => {
       <SectionRowContent type="clickable" title="Clickable title" icon={Close} onPress={onPress} />
     )
 
+    // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(screen.getByText('Clickable title'))
 
     expect(onPress).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35976

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
