### PR TITLE
(PC-35836) fix(HighLight): correct display for ascii code &

### DIFF
--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
@@ -7,7 +7,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { NativeCategoryIdEnumv2, SearchGroupNameEnumv2 } from 'api/gen'
 import { useAccessibilityFiltersContext } from 'features/accessibility/context/AccessibilityFiltersWrapper'
-import { Highlight } from 'features/search/components/Highlight/Highlight'
+import { SuggestionHitHighlight } from 'features/search/components/Highlight/Highlight'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import {
   getNativeCategoryFromEnum,
@@ -224,7 +224,7 @@ const SuggestionContainer: FunctionComponent<{
       <MagnifyingGlassFilledIcon />
     </MagnifyingGlassIconContainer>
     <StyledText numberOfLines={1} ellipsizeMode="tail">
-      <Highlight suggestionHit={hit} attribute="query" />
+      <SuggestionHitHighlight suggestionHit={hit} attribute="query" />
       {children}
     </StyledText>
   </AutocompleteItemTouchable>

--- a/src/features/search/components/AutocompleteVenueItem/AutocompleteVenueItem.tsx
+++ b/src/features/search/components/AutocompleteVenueItem/AutocompleteVenueItem.tsx
@@ -4,7 +4,7 @@ import { Text } from 'react-native'
 import styled from 'styled-components/native'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { Highlight } from 'features/search/components/Highlight/Highlight'
+import { VenueHitHighlight } from 'features/search/components/Highlight/Highlight'
 import { AlgoliaVenue } from 'libs/algolia/types'
 import { LocationBuildingFilled } from 'ui/svg/icons/LocationBuildingFilled'
 import { getSpacing, Typo } from 'ui/theme'
@@ -31,7 +31,7 @@ export function AutocompleteVenueItem({ hit, onPress }: AutocompleteVenueItemPro
         <LocationBuildingFilledIcon />
       </LocationBuildingIconContainer>
       <StyledText numberOfLines={2} ellipsizeMode="tail">
-        <Highlight venueHit={hit} attribute="name" />
+        <VenueHitHighlight venueHit={hit} />
         <Typo.Body>{city}</Typo.Body>
       </StyledText>
     </AutocompleteItemTouchable>

--- a/src/features/search/components/Highlight/Highlight.native.test.tsx
+++ b/src/features/search/components/Highlight/Highlight.native.test.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 
 import { NativeCategoryIdEnumv2, SearchGroupNameEnumv2 } from 'api/gen'
 import {
-  Highlight,
+  HistoryItemHighlight,
+  SuggestionHitHighlight,
+  VenueHitHighlight,
   HighlightHistoryItemPart,
   HighlightPart,
 } from 'features/search/components/Highlight/Highlight'
@@ -12,7 +14,7 @@ import { AlgoliaSuggestionHit } from 'libs/algolia/types'
 import { env } from 'libs/environment/env'
 import { render, screen } from 'tests/utils'
 
-describe('Highlight component for a offer suggestion', () => {
+describe('SuggestionHitHighlight for a offer suggestion', () => {
   const hit = {
     query: 'guerre et youpi matin',
     objectID: 'guerre et youpi matin',
@@ -55,45 +57,45 @@ describe('Highlight component for a offer suggestion', () => {
   } as AlgoliaSuggestionHit
 
   it('should use highlight part for display', () => {
-    render(<Highlight suggestionHit={hit} attribute="query" />)
+    render(<SuggestionHitHighlight suggestionHit={hit} attribute="query" />)
 
     expect(screen.getByTestId('nonHighlightedText')).toBeOnTheScreen()
   })
 
   it('should not use highlight history item part for display', () => {
-    render(<Highlight suggestionHit={hit} attribute="query" />)
+    render(<SuggestionHitHighlight suggestionHit={hit} attribute="query" />)
 
     expect(screen.queryByTestId('nonHighlightedHistoryItemText')).not.toBeOnTheScreen()
   })
 })
 
-describe('Highlight component for a venue suggestion', () => {
+describe('VenueHitHighlight for a venue suggestion', () => {
   const hit = mockVenueHits[0]
 
   it('should use highlight part for display', () => {
-    render(<Highlight venueHit={hit} attribute="name" />)
+    render(<VenueHitHighlight venueHit={hit} />)
 
     expect(screen.getByTestId('nonHighlightedText')).toBeOnTheScreen()
   })
 
   it('should not use highlight history item part for display', () => {
-    render(<Highlight venueHit={hit} attribute="name" />)
+    render(<VenueHitHighlight venueHit={hit} />)
 
     expect(screen.queryByTestId('nonHighlightedHistoryItemText')).not.toBeOnTheScreen()
   })
 })
 
-describe('Highlight component for an history item', () => {
+describe('HistoryItemHighlight for an history item', () => {
   const historyItem = { ...mockedSearchHistory[0], _highlightResult: { query: { value: 'manga' } } }
 
   it('should use highlight history item part for display', () => {
-    render(<Highlight historyItem={historyItem} />)
+    render(<HistoryItemHighlight historyItem={historyItem} />)
 
     expect(screen.getByTestId('nonHighlightedHistoryItemText')).toBeOnTheScreen()
   })
 
   it('should not use highlight part for display', () => {
-    render(<Highlight historyItem={historyItem} />)
+    render(<HistoryItemHighlight historyItem={historyItem} />)
 
     expect(screen.queryByTestId('nonHighlightedText')).not.toBeOnTheScreen()
   })

--- a/src/features/search/components/SearchHistoryItem/SearchHistoryItem.tsx
+++ b/src/features/search/components/SearchHistoryItem/SearchHistoryItem.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react'
 import { Text } from 'react-native'
 import styled from 'styled-components/native'
 
-import { Highlight } from 'features/search/components/Highlight/Highlight'
+import { HistoryItemHighlight } from 'features/search/components/Highlight/Highlight'
 import { Highlighted, HistoryItem } from 'features/search/types'
 import { ClockFilled } from 'ui/svg/icons/ClockFilled'
 import { getSpacing, Typo } from 'ui/theme'
@@ -32,7 +32,7 @@ export function SearchHistoryItem({ item, queryHistory, onPress }: Props) {
           {queryHistory === '' ? (
             <Typo.BodyItalic testID="withoutUsingHighlight">{item.query}</Typo.BodyItalic>
           ) : (
-            <Highlight historyItem={item} />
+            <HistoryItemHighlight historyItem={item} />
           )}
           {shouldDisplaySearchGroupOrNativeCategory ? (
             <React.Fragment>

--- a/src/features/search/helpers/decodeHTMLValue/decodeHTMLValue.test.ts
+++ b/src/features/search/helpers/decodeHTMLValue/decodeHTMLValue.test.ts
@@ -1,0 +1,21 @@
+import { decodeHTMLValue } from 'features/search/helpers/decodeHTMLValue/decodeHTMLValue'
+
+describe('decodeHTMLValue', () => {
+  it('should return a string with encoded marks', () => {
+    const attribute = decodeHTMLValue('&lt;em&gt;test&lt;/em&gt;')
+
+    expect(attribute).toEqual('<mark>test</mark>')
+  })
+
+  it('should encode properly single quotes', () => {
+    const attribute = decodeHTMLValue('&#39;test&#39;')
+
+    expect(attribute).toEqual("'test'")
+  })
+
+  it('should encode properly commercial and', () => {
+    const attribute = decodeHTMLValue('dupond&amp;dupont')
+
+    expect(attribute).toEqual('dupond&dupont')
+  })
+})

--- a/src/features/search/helpers/decodeHTMLValue/decodeHTMLValue.ts
+++ b/src/features/search/helpers/decodeHTMLValue/decodeHTMLValue.ts
@@ -1,0 +1,6 @@
+export const decodeHTMLValue = (value: string) =>
+  value
+    .replaceAll('&lt;em&gt;', '<mark>')
+    .replaceAll('&lt;/em&gt;', '</mark>')
+    .replaceAll('&#39;', "'")
+    .replaceAll('&amp;', '&')


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35836

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
