### PR TITLE
(PC-36087) feat(onboarding): add accessibilityLabel in GenericInfoPag…

### DIFF
--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
@@ -228,7 +228,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
       }
     >
       <View
-        accessibilityLabel="Continuer"
+        accessibilityLabel="Continuer vers l’étape suivante"
         accessibilityState={
           {
             "busy": undefined,
@@ -282,7 +282,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
             },
           ]
         }
-        testID="Continuer"
+        testID="Continuer vers l’étape suivante"
       >
         <View
           style={

--- a/src/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx
@@ -30,7 +30,7 @@ describe('OnboardingGeolocation', () => {
   it('should request geoloc permission when "Continuer" is clicked', async () => {
     render(<OnboardingGeolocation />)
 
-    const loginButton = screen.getByLabelText('Continuer')
+    const loginButton = screen.getByLabelText('Continuer vers l’étape suivante')
     await user.press(loginButton)
 
     expect(mockRequestGeolocPermission).toHaveBeenCalledTimes(1)
@@ -39,7 +39,7 @@ describe('OnboardingGeolocation', () => {
   it('should log analytics when "Continuer" is clicked', async () => {
     render(<OnboardingGeolocation />)
 
-    const loginButton = screen.getByLabelText('Continuer')
+    const loginButton = screen.getByLabelText('Continuer vers l’étape suivante')
     await user.press(loginButton)
 
     expect(analytics.logOnboardingGeolocationClicked).toHaveBeenNthCalledWith(1, {

--- a/src/features/onboarding/pages/onboarding/OnboardingGeolocation.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingGeolocation.tsx
@@ -32,6 +32,7 @@ export const OnboardingGeolocation = () => {
       buttonPrimary={{
         wording: 'Continuer',
         onPress: onGeolocationButtonPress,
+        accessibilityLabel: 'Continuer vers l’étape suivante',
       }}
     />
   )

--- a/src/ui/pages/GenericInfoPage.tsx
+++ b/src/ui/pages/GenericInfoPage.tsx
@@ -29,6 +29,7 @@ export type ButtonProps = {
   icon?: FunctionComponent<AccessibleIcon>
   disabled?: boolean
   isLoading?: boolean
+  accessibilityLabel?: string
 } & (
   | {
       onPress: () => void
@@ -127,6 +128,7 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
               isLoading={buttonPrimary.isLoading}
               disabled={buttonPrimary.disabled}
               icon={buttonPrimary.icon}
+              accessibilityLabel={buttonPrimary.accessibilityLabel}
             />
           ) : null}
 
@@ -141,6 +143,7 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
               isLoading={buttonPrimary.isLoading}
               disabled={buttonPrimary.disabled}
               icon={buttonPrimary.icon}
+              accessibilityLabel={buttonPrimary.accessibilityLabel}
             />
           ) : null}
 
@@ -155,6 +158,7 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
               isLoading={buttonPrimary.isLoading}
               disabled={buttonPrimary.disabled}
               icon={ExternalSiteFilled}
+              accessibilityLabel={buttonPrimary.accessibilityLabel}
             />
           ) : null}
 
@@ -166,6 +170,7 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
               isLoading={buttonSecondary.isLoading}
               disabled={buttonSecondary.disabled}
               icon={buttonSecondary.icon}
+              accessibilityLabel={buttonSecondary.accessibilityLabel}
             />
           ) : null}
 
@@ -180,6 +185,7 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
               isLoading={buttonSecondary.isLoading}
               disabled={buttonSecondary.disabled}
               icon={buttonSecondary.icon}
+              accessibilityLabel={buttonSecondary.accessibilityLabel}
             />
           ) : null}
 
@@ -194,6 +200,7 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
               isLoading={buttonSecondary.isLoading}
               disabled={buttonSecondary.disabled}
               icon={ExternalSiteFilled}
+              accessibilityLabel={buttonSecondary.accessibilityLabel}
             />
           ) : null}
 
@@ -205,6 +212,7 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
               isLoading={buttonTertiary.isLoading}
               disabled={buttonTertiary.disabled}
               icon={buttonTertiary.icon}
+              accessibilityLabel={buttonTertiary.accessibilityLabel}
             />
           ) : null}
 
@@ -219,6 +227,7 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
               isLoading={buttonTertiary.isLoading}
               disabled={buttonTertiary.disabled}
               icon={buttonTertiary.icon}
+              accessibilityLabel={buttonTertiary.accessibilityLabel}
             />
           ) : null}
 
@@ -233,6 +242,7 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
               isLoading={buttonTertiary.isLoading}
               disabled={buttonTertiary.disabled}
               icon={ExternalSiteFilled}
+              accessibilityLabel={buttonTertiary.accessibilityLabel}
             />
           ) : null}
         </ButtonContainer>


### PR DESCRIPTION
…e and OnboardingGeolocation

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36087

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
