### PR TITLE
(PC-36097) refactor(search): improve filter modals

### DIFF
--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -827,11 +827,13 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
             }
           >
             <View
+              gap={4}
               isModal={true}
               style={
                 [
                   {
                     "flexDirection": "row",
+                    "gap": 16,
                     "justifyContent": "center",
                     "paddingHorizontal": 24,
                     "paddingTop": 8,
@@ -888,7 +890,6 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                       },
                       {
                         "backgroundColor": "transparent",
-                        "marginRight": 16,
                         "width": "auto",
                       },
                     ],
@@ -958,16 +959,6 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                   </Text>
                 </View>
               </View>
-              <View
-                numberOfSpaces={4}
-                style={
-                  [
-                    {
-                      "height": 16,
-                    },
-                  ]
-                }
-              />
               <View
                 accessibilityLabel="Rechercher"
                 accessibilityState={

--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -847,7 +847,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": undefined,
+                    "disabled": true,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -861,7 +861,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                   }
                 }
                 accessible={true}
-                focusable={true}
+                focusable={false}
                 onClick={[Function]}
                 onResponderGrant={[Function]}
                 onResponderMove={[Function]}
@@ -946,7 +946,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                     style={
                       [
                         {
-                          "color": "#161617",
+                          "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
                           "lineHeight": 19.2,

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -1009,7 +1009,7 @@ exports[`<SearchFilter/> should render correctly 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": undefined,
+          "disabled": false,
           "expanded": undefined,
           "selected": undefined,
         }

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -988,11 +988,13 @@ exports[`<SearchFilter/> should render correctly 1`] = `
     </View>
   </View>
   <View
+    gap={4}
     isModal={false}
     style={
       [
         {
           "flexDirection": "row",
+          "gap": 16,
           "justifyContent": "center",
           "paddingBottom": 24,
           "paddingHorizontal": 24,
@@ -1050,7 +1052,6 @@ exports[`<SearchFilter/> should render correctly 1`] = `
             },
             {
               "backgroundColor": "transparent",
-              "marginRight": 16,
               "width": "auto",
             },
           ],
@@ -1120,16 +1121,6 @@ exports[`<SearchFilter/> should render correctly 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      numberOfSpaces={4}
-      style={
-        [
-          {
-            "height": 16,
-          },
-        ]
-      }
-    />
     <View
       accessibilityLabel="Rechercher"
       accessibilityState={

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -2470,11 +2470,13 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
           }
         >
           <View
+            gap={4}
             isModal={true}
             style={
               [
                 {
                   "flexDirection": "row",
+                  "gap": 16,
                   "justifyContent": "center",
                   "paddingHorizontal": 24,
                   "paddingTop": 8,
@@ -2531,7 +2533,6 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                     },
                     {
                       "backgroundColor": "transparent",
-                      "marginRight": 16,
                       "width": "auto",
                     },
                   ],
@@ -2601,16 +2602,6 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={4}
-              style={
-                [
-                  {
-                    "height": 16,
-                  },
-                ]
-              }
-            />
             <View
               accessibilityLabel="Rechercher"
               accessibilityState={

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -357,19 +357,11 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
       >
         <View>
           <View
-            numberOfSpaces={3}
+            marginTop={12}
             style={
               [
                 {
-                  "height": 12,
-                },
-              ]
-            }
-          />
-          <View
-            style={
-              [
-                {
+                  "marginTop": 12,
                   "maxWidth": 500,
                   "width": "100%",
                 },
@@ -2490,7 +2482,7 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": undefined,
+                  "disabled": true,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -2504,7 +2496,7 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                 }
               }
               accessible={true}
-              focusable={true}
+              focusable={false}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -2589,7 +2581,7 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                   style={
                     [
                       {
-                        "color": "#161617",
+                        "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,

--- a/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
@@ -805,11 +805,13 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
           }
         >
           <View
+            gap={4}
             isModal={true}
             style={
               [
                 {
                   "flexDirection": "row",
+                  "gap": 16,
                   "justifyContent": "center",
                   "paddingHorizontal": 24,
                   "paddingTop": 8,
@@ -866,7 +868,6 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
                     },
                     {
                       "backgroundColor": "transparent",
-                      "marginRight": 16,
                       "width": "auto",
                     },
                   ],
@@ -936,16 +937,6 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={4}
-              style={
-                [
-                  {
-                    "height": 16,
-                  },
-                ]
-              }
-            />
             <View
               accessibilityLabel="Rechercher"
               accessibilityState={

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -357,19 +357,11 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
       >
         <View>
           <View
-            numberOfSpaces={6}
+            marginTop={24}
             style={
               [
                 {
-                  "height": 24,
-                },
-              ]
-            }
-          />
-          <View
-            style={
-              [
-                {
+                  "marginTop": 24,
                   "maxWidth": 500,
                   "width": "100%",
                 },
@@ -559,16 +551,6 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                 </View>
               </View>
             </View>
-            <View
-              numberOfSpaces={6}
-              style={
-                [
-                  {
-                    "height": 24,
-                  },
-                ]
-              }
-            />
           </View>
         </View>
       </RCTScrollView>
@@ -611,7 +593,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": undefined,
+                  "disabled": true,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -625,7 +607,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                 }
               }
               accessible={true}
-              focusable={true}
+              focusable={false}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -710,7 +692,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                   style={
                     [
                       {
-                        "color": "#161617",
+                        "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -591,11 +591,13 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
           }
         >
           <View
+            gap={4}
             isModal={true}
             style={
               [
                 {
                   "flexDirection": "row",
+                  "gap": 16,
                   "justifyContent": "center",
                   "paddingHorizontal": 24,
                   "paddingTop": 8,
@@ -652,7 +654,6 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                     },
                     {
                       "backgroundColor": "transparent",
-                      "marginRight": 16,
                       "width": "auto",
                     },
                   ],
@@ -722,16 +723,6 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={4}
-              style={
-                [
-                  {
-                    "height": 16,
-                  },
-                ]
-              }
-            />
             <View
               accessibilityLabel="Rechercher"
               accessibilityState={

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -1077,11 +1077,13 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
           }
         >
           <View
+            gap={4}
             isModal={true}
             style={
               [
                 {
                   "flexDirection": "row",
+                  "gap": 16,
                   "justifyContent": "center",
                   "paddingHorizontal": 24,
                   "paddingTop": 8,
@@ -1138,7 +1140,6 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                     },
                     {
                       "backgroundColor": "transparent",
-                      "marginRight": 16,
                       "width": "auto",
                     },
                   ],
@@ -1208,16 +1209,6 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={4}
-              style={
-                [
-                  {
-                    "height": 16,
-                  },
-                ]
-              }
-            />
             <View
               accessibilityLabel="Rechercher"
               accessibilityState={

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -1097,7 +1097,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": undefined,
+                  "disabled": true,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -1111,7 +1111,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                 }
               }
               accessible={true}
-              focusable={true}
+              focusable={false}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -1196,7 +1196,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                   style={
                     [
                       {
-                        "color": "#161617",
+                        "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,

--- a/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
@@ -574,11 +574,13 @@ exports[`VenueModal should render correctly 1`] = `
           }
         >
           <View
+            gap={4}
             isModal={true}
             style={
               [
                 {
                   "flexDirection": "row",
+                  "gap": 16,
                   "justifyContent": "center",
                   "paddingHorizontal": 24,
                   "paddingTop": 8,
@@ -635,7 +637,6 @@ exports[`VenueModal should render correctly 1`] = `
                     },
                     {
                       "backgroundColor": "transparent",
-                      "marginRight": 16,
                       "width": "auto",
                     },
                   ],
@@ -705,16 +706,6 @@ exports[`VenueModal should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <View
-              numberOfSpaces={4}
-              style={
-                [
-                  {
-                    "height": 16,
-                  },
-                ]
-              }
-            />
             <View
               accessibilityLabel="Rechercher"
               accessibilityState={

--- a/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
@@ -594,7 +594,7 @@ exports[`VenueModal should render correctly 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": undefined,
+                  "disabled": false,
                   "expanded": undefined,
                   "selected": undefined,
                 }

--- a/src/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx
+++ b/src/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx
@@ -47,6 +47,31 @@ describe('<AccessibilityFiltersModal />', () => {
     expect(audioCheckbox).toHaveAccessibilityState({ checked: true })
   })
 
+  it('should apply default disabilities when reset button is pressed', async () => {
+    renderAccessibilityFiltersModal()
+
+    const audioCheckbox = await screen.findByRole('checkbox', { name: 'Handicap auditif' })
+    await user.press(audioCheckbox)
+
+    const searchButton = await screen.findByText('Rechercher')
+    await user.press(searchButton)
+
+    const openModalButton = await screen.findByText('Show modal')
+    await user.press(openModalButton)
+    jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
+
+    const resetButton = await screen.findByText('Réinitialiser')
+    await user.press(resetButton)
+
+    const closeButton = await screen.findByTestId('icon-close')
+    user.press(closeButton)
+
+    await user.press(openModalButton)
+    jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
+
+    expect(audioCheckbox).toHaveAccessibilityState({ checked: false })
+  })
+
   it('should not save modified disabilities when pressing close button', async () => {
     renderAccessibilityFiltersModal()
 

--- a/src/features/accessibility/components/AccessibilityFiltersModal.tsx
+++ b/src/features/accessibility/components/AccessibilityFiltersModal.tsx
@@ -58,6 +58,7 @@ export const AccessibilityFiltersModal: React.FC<AccessibilityModalProps> = ({
 
   const handleFilterReset = () => {
     setDisplayedDisabilities(defaultDisabilitiesProperties)
+    setDisabilities(defaultDisabilitiesProperties)
   }
 
   const capitalizeFirstLetter = (word: string) => {
@@ -75,6 +76,8 @@ export const AccessibilityFiltersModal: React.FC<AccessibilityModalProps> = ({
     setDisabilities(displayedDisabilities)
     hideModal()
   }
+
+  const hasDefaultValues = isEqual(defaultDisabilitiesProperties, displayedDisabilities)
 
   return (
     <AppModal
@@ -101,6 +104,7 @@ export const AccessibilityFiltersModal: React.FC<AccessibilityModalProps> = ({
           onResetPress={handleFilterReset}
           onSearchPress={handleSubmit}
           filterBehaviour={filterBehaviour}
+          isResetDisabled={hasDefaultValues}
         />
       }>
       <AccessibilityFiltersContainer gap={8}>

--- a/src/features/search/components/FilterPageButtons/FilterPageButtons.tsx
+++ b/src/features/search/components/FilterPageButtons/FilterPageButtons.tsx
@@ -5,24 +5,27 @@ import { FilterBehaviour } from 'features/search/enums'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonQuaternaryBlack } from 'ui/components/buttons/ButtonQuaternaryBlack'
 import { styledButton } from 'ui/components/buttons/styledButton'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Again } from 'ui/svg/icons/Again'
-import { getSpacing, Spacer } from 'ui/theme'
+import { getSpacing } from 'ui/theme'
 
 type Props = {
-  isModal?: boolean
   onResetPress: () => void
   onSearchPress: () => void
+  filterBehaviour: FilterBehaviour
+  isModal?: boolean
   isSearchDisabled?: boolean
   children?: never
-  filterBehaviour: FilterBehaviour
+  isResetDisabled?: boolean
 }
 
 export const FilterPageButtons: FunctionComponent<Props> = ({
   isModal = false,
   onResetPress,
   onSearchPress,
-  isSearchDisabled,
   filterBehaviour,
+  isSearchDisabled,
+  isResetDisabled,
 }) => {
   let searchButtonText = ''
   switch (filterBehaviour) {
@@ -37,9 +40,13 @@ export const FilterPageButtons: FunctionComponent<Props> = ({
   }
 
   return (
-    <Container isModal={isModal}>
-      <ResetButton wording="Réinitialiser" icon={Again} onPress={onResetPress} />
-      <Spacer.Column numberOfSpaces={4} />
+    <Container isModal={isModal} gap={4}>
+      <ResetButton
+        wording="Réinitialiser"
+        icon={Again}
+        onPress={onResetPress}
+        disabled={isResetDisabled}
+      />
       <SearchButton
         wording={searchButtonText}
         onPress={onSearchPress}
@@ -49,7 +56,7 @@ export const FilterPageButtons: FunctionComponent<Props> = ({
   )
 }
 
-const Container = styled.View<{ isModal: boolean }>(({ isModal, theme }) => ({
+const Container = styled(ViewGap)<{ isModal: boolean }>(({ isModal, theme }) => ({
   flexDirection: theme.appContentWidth > theme.breakpoints.xs ? 'row' : 'column',
   justifyContent: 'center',
   paddingHorizontal: theme.modal.spacing.MD,
@@ -59,7 +66,6 @@ const Container = styled.View<{ isModal: boolean }>(({ isModal, theme }) => ({
 
 const ResetButton = styledButton(ButtonQuaternaryBlack)({
   width: 'auto',
-  marginRight: getSpacing(4),
 })
 
 const SearchButton = styledButton(ButtonPrimary)({

--- a/src/features/search/components/SearchFixedModalBottom.tsx
+++ b/src/features/search/components/SearchFixedModalBottom.tsx
@@ -9,15 +9,17 @@ import { useForHeightKeyboardEvents } from 'ui/components/keyboard/useKeyboardEv
 type Props = {
   onResetPress: () => void
   onSearchPress: () => void
-  isSearchDisabled?: boolean
   filterBehaviour: FilterBehaviour
+  isSearchDisabled?: boolean
+  isResetDisabled?: boolean
 }
 
 export const SearchFixedModalBottom = memo(function SearchFixedModalBottom({
   onResetPress,
   onSearchPress,
-  isSearchDisabled,
   filterBehaviour,
+  isSearchDisabled,
+  isResetDisabled,
 }: Props) {
   const { modal } = useTheme()
   const [keyboardHeight, setKeyboardHeight] = useState(0)
@@ -33,6 +35,7 @@ export const SearchFixedModalBottom = memo(function SearchFixedModalBottom({
         isModal
         isSearchDisabled={isSearchDisabled}
         filterBehaviour={filterBehaviour}
+        isResetDisabled={isResetDisabled}
       />
     </FilterPageButtonsContainer>
   )

--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.native.test.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.native.test.tsx
@@ -31,39 +31,61 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('CalendarModal', () => {
-  beforeEach(() => {
-    mockUseSearch.mockReturnValueOnce(initialMockUseSearch)
-  })
-
   beforeAll(() => {
     mockdate.set(TODAY)
   })
 
-  it('should display modal with title', async () => {
-    renderCalendarModal()
+  describe('In initial state', () => {
+    beforeEach(() => {
+      mockUseSearch.mockReturnValueOnce(initialMockUseSearch)
+    })
 
-    await act(() => {
-      expect(screen.getByText('Dates')).toBeOnTheScreen()
+    it('should display modal with title', async () => {
+      renderCalendarModal()
+
+      await act(() => {
+        expect(screen.getByText('Dates')).toBeOnTheScreen()
+      })
+    })
+
+    it('should close the modal when pressing close button', async () => {
+      renderCalendarModal()
+
+      await user.press(screen.getByLabelText('Fermer'))
+
+      expect(mockOnClose).toHaveBeenCalledWith()
+    })
+
+    it('should hide the modal when pressing close button', async () => {
+      renderCalendarModal()
+
+      await user.press(screen.getByLabelText('Fermer'))
+
+      expect(mockHideModal).toHaveBeenCalledWith()
+    })
+
+    it('should execute search with selected dates and close the modal when pressing search button', async () => {
+      renderCalendarModal()
+
+      await user.press(screen.getByLabelText(' Samedi 14 Juin 2025 '))
+      await user.press(screen.getByLabelText(' Mardi 17 Juin 2025 '))
+
+      await user.press(screen.getByText('Rechercher'))
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'SET_STATE',
+          payload: expect.objectContaining({
+            beginningDatetime: '2025-06-14T00:00:00.000Z',
+            endingDatetime: '2025-06-17T00:00:00.000Z',
+          }),
+        })
+      )
+      expect(mockHideModal).toHaveBeenCalledWith()
     })
   })
 
-  it('should close the modal when pressing close button', async () => {
-    renderCalendarModal()
-
-    await user.press(screen.getByLabelText('Fermer'))
-
-    expect(mockOnClose).toHaveBeenCalledWith()
-  })
-
-  it('should hide the modal when pressing close button', async () => {
-    renderCalendarModal()
-
-    await user.press(screen.getByLabelText('Fermer'))
-
-    expect(mockHideModal).toHaveBeenCalledWith()
-  })
-
-  it('should reset dates when pressing reset button and execute search after', async () => {
+  it('should reset search when pressing reset button', async () => {
     mockUseSearch.mockReturnValueOnce({
       ...initialMockUseSearch,
       searchState: {
@@ -77,37 +99,13 @@ describe('CalendarModal', () => {
 
     await user.press(screen.getByText('Réinitialiser'))
 
-    await user.press(screen.getByText('Rechercher'))
-
-    expect(mockDispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'SET_STATE',
-        payload: expect.objectContaining({
-          beginningDatetime: undefined,
-          endingDatetime: undefined,
-        }),
-      })
-    )
-  })
-
-  it('should execute search with selected dates and close the modal when pressing search button', async () => {
-    renderCalendarModal()
-
-    await user.press(screen.getByLabelText(' Samedi 14 Juin 2025 '))
-    await user.press(screen.getByLabelText(' Mardi 17 Juin 2025 '))
-
-    await user.press(screen.getByText('Rechercher'))
-
-    expect(mockDispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'SET_STATE',
-        payload: expect.objectContaining({
-          beginningDatetime: '2025-06-14T00:00:00.000Z',
-          endingDatetime: '2025-06-17T00:00:00.000Z',
-        }),
-      })
-    )
-    expect(mockHideModal).toHaveBeenCalledWith()
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'SET_STATE',
+      payload: expect.objectContaining({
+        beginningDatetime: undefined,
+        endingDatetime: undefined,
+      }),
+    })
   })
 })
 

--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
@@ -1,6 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup'
 import { addYears, format } from 'date-fns'
-import React, { FunctionComponent, useCallback, useEffect, useMemo } from 'react'
+import React, { FunctionComponent, useCallback, useMemo } from 'react'
 import { SetValueConfig, useForm } from 'react-hook-form'
 import { CalendarList, DateData, LocaleConfig } from 'react-native-calendars'
 import { useTheme } from 'styled-components/native'
@@ -94,10 +94,6 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
     ]
   )
 
-  useEffect(() => {
-    reset(defaultValues)
-  }, [defaultValues, reset])
-
   const closeModal = useCallback(() => {
     reset(defaultValues)
     hideModal()
@@ -109,11 +105,23 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
   }, [closeModal, onClose])
 
   const onResetPress = useCallback(() => {
-    reset({
-      selectedStartDate: undefined,
-      selectedEndDate: undefined,
+    reset(
+      {
+        selectedStartDate: undefined,
+        selectedEndDate: undefined,
+      },
+      { keepDefaultValues: true }
+    )
+
+    dispatch({
+      type: 'SET_STATE',
+      payload: {
+        ...searchState,
+        beginningDatetime: undefined,
+        endingDatetime: undefined,
+      },
     })
-  }, [reset])
+  }, [dispatch, reset, searchState])
 
   const search = useCallback(
     ({ selectedStartDate, selectedEndDate }: CalendarModalFormData) => {
@@ -159,6 +167,7 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
 
   const disabled = !isValid || isSubmitting
   const shouldDisplayBackButton = filterBehaviour === FilterBehaviour.APPLY_WITHOUT_SEARCHING
+  const hasDefaultValues = !selectedStartDate && !selectedEndDate
 
   return (
     <AppModal
@@ -186,6 +195,7 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
           onResetPress={onResetPress}
           isSearchDisabled={disabled}
           filterBehaviour={filterBehaviour}
+          isResetDisabled={hasDefaultValues}
         />
       }
       scrollEnabled={false}>

--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
@@ -217,6 +217,7 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
         onDayPress={onDayPress}
         markedDates={markedDates}
         testID="calendar"
+        firstDay={1}
       />
     </AppModal>
   )

--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.web.test.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.web.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import { initialSearchState } from 'features/search/context/reducer'
+import { ISearchContext } from 'features/search/context/SearchWrapper'
+import { FilterBehaviour } from 'features/search/enums'
+import { CalendarModal } from 'features/search/pages/modals/CalendarModal/CalendarModal'
+import { act, checkAccessibilityFor, render } from 'tests/utils/web'
+
+const mockDispatch = jest.fn()
+
+const initialMockUseSearch = {
+  searchState: initialSearchState,
+  dispatch: mockDispatch,
+}
+const mockUseSearch: jest.Mock<Partial<ISearchContext>> = jest.fn(() => initialMockUseSearch)
+jest.mock('features/search/context/SearchWrapper', () => ({
+  useSearch: () => mockUseSearch(),
+}))
+
+describe('<CalendarModal/>', () => {
+  describe('Accessibility', () => {
+    it('should not have basic accessibility issues', async () => {
+      const { container } = render(
+        <CalendarModal
+          title="Dates"
+          accessibilityLabel="Ne pas filtrer sur les dates"
+          isVisible
+          hideModal={jest.fn()}
+          filterBehaviour={FilterBehaviour.SEARCH}
+        />
+      )
+
+      await act(async () => {
+        const results = await checkAccessibilityFor(container)
+
+        expect(results).toHaveNoViolations()
+      })
+    })
+  })
+})

--- a/src/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx
+++ b/src/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx
@@ -260,6 +260,25 @@ describe('<CategoriesModal/>', () => {
       expect(defaultCategoryFilterCheckbox).toHaveProp('isSelected', true)
     })
 
+    it('should execute search when pressing reset button', async () => {
+      renderCategories()
+
+      const button = await screen.findByText('Réinitialiser')
+      await user.press(button)
+
+      const expectedSearchParams: SearchState = {
+        ...searchState,
+        offerCategories: [],
+        offerNativeCategories: [],
+        offerGenreTypes: [],
+      }
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: expectedSearchParams,
+      })
+    })
+
     describe('When wipDisplaySearchNbFacetResults feature flag is activated', () => {
       beforeEach(() => {
         setFeatureFlags([RemoteStoreFeatureFlags.WIP_DISPLAY_SEARCH_NB_FACET_RESULTS])

--- a/src/features/search/pages/modals/CategoriesModal/CategoriesModal.tsx
+++ b/src/features/search/pages/modals/CategoriesModal/CategoriesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTheme } from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
@@ -17,9 +17,9 @@ import {
   handleCategoriesSearchPress,
 } from 'features/search/helpers/categoriesHelpers/categoriesHelpers'
 import {
-  createMappingTree,
   MappedGenreTypes,
   MappedNativeCategories,
+  createMappingTree,
 } from 'features/search/helpers/categoriesHelpers/mapping-tree'
 import { NativeCategoryEnum, SearchState } from 'features/search/types'
 import { FacetData } from 'libs/algolia/types'
@@ -29,7 +29,7 @@ import { Form } from 'ui/components/Form'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Close } from 'ui/svg/icons/Close'
-import { Spacer } from 'ui/theme'
+import { getSpacing } from 'ui/theme'
 
 const titleId = uuidv4()
 
@@ -75,10 +75,6 @@ export const CategoriesModal = ({
     defaultValues: getDefaultFormValues(tree, searchState),
   })
   const { category, currentView, nativeCategory, genreType } = watch()
-
-  useEffect(() => {
-    reset(getDefaultFormValues(tree, searchState))
-  }, [reset, searchState, tree])
 
   const nativeCategories = useMemo(() => {
     return (category &&
@@ -158,7 +154,7 @@ export const CategoriesModal = ({
     }
   }, [currentView, handleModalClose, setValue])
 
-  const handleSearchPress = useCallback(
+  const triggerDispatch = useCallback(
     (form: CategoriesModalFormProps) => {
       const searchPressData = handleCategoriesSearchPress(form, data)
 
@@ -169,19 +165,29 @@ export const CategoriesModal = ({
       }
 
       dispatch({ type: 'SET_STATE', payload: additionalSearchState })
+    },
+    [data, dispatch, searchState]
+  )
+
+  const handleSearchPress = useCallback(
+    (form: CategoriesModalFormProps) => {
+      triggerDispatch(form)
       hideModal()
     },
-    [data, dispatch, hideModal, searchState]
+    [hideModal, triggerDispatch]
   )
 
   const handleReset = useCallback(() => {
-    reset({
+    const resetForm: CategoriesModalFormProps = {
       category: SearchGroupNameEnumv2.NONE,
       nativeCategory: null,
       genreType: null,
       currentView: CategoriesModalView.CATEGORIES,
-    })
-  }, [reset])
+    }
+    reset(resetForm)
+
+    triggerDispatch(resetForm)
+  }, [reset, triggerDispatch])
 
   const descriptionContext = useMemo(
     () => ({
@@ -228,6 +234,8 @@ export const CategoriesModal = ({
     )
   }
 
+  const hasDefaultValue = category === SearchGroupNameEnumv2.NONE
+
   return (
     <AppModal
       customModalHeader={
@@ -257,10 +265,10 @@ export const CategoriesModal = ({
           onSearchPress={handleSubmit(handleSearchPress)}
           isSearchDisabled={isSubmitting}
           filterBehaviour={filterBehaviour}
+          isResetDisabled={hasDefaultValue}
         />
       }>
-      <Spacer.Column numberOfSpaces={3} />
-      <Form.MaxWidth>
+      <Form.MaxWidth marginTop={getSpacing(3)}>
         {currentView === CategoriesModalView.CATEGORIES ? (
           <CategoriesSection
             itemsMapping={tree}

--- a/src/features/search/pages/modals/OfferDuoModal/OfferDuoModal.tsx
+++ b/src/features/search/pages/modals/OfferDuoModal/OfferDuoModal.tsx
@@ -1,19 +1,18 @@
-import React, { FunctionComponent, useCallback, useEffect } from 'react'
-import { useForm, Controller, ControllerRenderProps } from 'react-hook-form'
+import React, { FunctionComponent, useCallback } from 'react'
+import { Controller, ControllerRenderProps, useForm } from 'react-hook-form'
 import { useTheme } from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
 
 import { FilterSwitchWithLabel } from 'features/search/components/FilterSwitchWithLabel/FilterSwitchWithLabel'
 import { SearchCustomModalHeader } from 'features/search/components/SearchCustomModalHeader'
 import { SearchFixedModalBottom } from 'features/search/components/SearchFixedModalBottom'
-import { initialSearchState } from 'features/search/context/reducer'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { FilterBehaviour } from 'features/search/enums'
 import { SearchState } from 'features/search/types'
 import { Form } from 'ui/components/Form'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { Close } from 'ui/svg/icons/Close'
-import { Spacer } from 'ui/theme'
+import { getSpacing } from 'ui/theme'
 
 type SearchTypeFormData = {
   offerIsDuo: boolean
@@ -48,6 +47,7 @@ export const OfferDuoModal: FunctionComponent<OfferDuoModalProps> = ({
     getValues,
     setValue,
     formState: { isSubmitting },
+    watch,
   } = useForm<SearchTypeFormData>({
     mode: 'onChange',
     defaultValues: {
@@ -55,9 +55,7 @@ export const OfferDuoModal: FunctionComponent<OfferDuoModalProps> = ({
     },
   })
 
-  useEffect(() => {
-    reset({ offerIsDuo: searchState.offerIsDuo })
-  }, [reset, searchState])
+  const { offerIsDuo } = watch()
 
   const toggleLimitDuoOfferSearch = useCallback(() => {
     const toggleLimitDuoOffer = !getValues('offerIsDuo')
@@ -74,25 +72,29 @@ export const OfferDuoModal: FunctionComponent<OfferDuoModalProps> = ({
     }) => React.ReactElement
   >(
     ({ field: { value } }) => (
-      <React.Fragment>
-        <FilterSwitchWithLabel
-          isActive={value}
-          toggle={toggleLimitDuoOfferSearch}
-          label="Uniquement les offres duo"
-          subtitle={subtitleToggle}
-          testID="limitDuoOfferSearch"
-        />
-        <Spacer.Column numberOfSpaces={6} />
-      </React.Fragment>
+      <FilterSwitchWithLabel
+        isActive={value}
+        toggle={toggleLimitDuoOfferSearch}
+        label="Uniquement les offres duo"
+        subtitle={subtitleToggle}
+        testID="limitDuoOfferSearch"
+      />
     ),
     [toggleLimitDuoOfferSearch]
   )
 
   const onResetPress = useCallback(() => {
     reset({
-      offerIsDuo: initialSearchState.offerIsDuo,
+      offerIsDuo: false,
     })
-  }, [reset])
+
+    const additionalSearchState: SearchState = {
+      ...searchState,
+      offerIsDuo: false,
+    }
+
+    dispatch({ type: 'SET_STATE', payload: additionalSearchState })
+  }, [dispatch, reset, searchState])
 
   const closeModal = useCallback(() => {
     reset({
@@ -123,6 +125,7 @@ export const OfferDuoModal: FunctionComponent<OfferDuoModalProps> = ({
 
   const onSubmit = handleSubmit(search)
   const shouldDisplayBackButton = filterBehaviour === FilterBehaviour.APPLY_WITHOUT_SEARCHING
+  const hasDefaultValue = !offerIsDuo
 
   return (
     <AppModal
@@ -150,10 +153,10 @@ export const OfferDuoModal: FunctionComponent<OfferDuoModalProps> = ({
           onResetPress={onResetPress}
           isSearchDisabled={isSubmitting}
           filterBehaviour={filterBehaviour}
+          isResetDisabled={hasDefaultValue}
         />
       }>
-      <Spacer.Column numberOfSpaces={6} />
-      <Form.MaxWidth>
+      <Form.MaxWidth marginTop={getSpacing(6)}>
         <Controller control={control} name="offerIsDuo" render={ToggleOfferDuoController} />
       </Form.MaxWidth>
     </AppModal>

--- a/src/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx
+++ b/src/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx
@@ -90,18 +90,6 @@ describe('<PriceModal/>', () => {
       expect(minPriceInput.props.value).toStrictEqual('')
     })
 
-    it('should call dispatch with default search when pressing reset button', async () => {
-      renderSearchPrice()
-
-      const resetButton = screen.getByText('Réinitialiser')
-      await user.press(resetButton)
-
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: 'SET_STATE',
-        payload: searchState,
-      })
-    })
-
     it('should reset maximum price when pressing reset button', async () => {
       renderSearchPrice()
 
@@ -148,6 +136,19 @@ describe('<PriceModal/>', () => {
       await user.press(resetButton)
 
       expect(minPriceInput.props.value).toStrictEqual('')
+    })
+
+    it('should call dispatch with default search when pressing reset button', async () => {
+      mockSearchState = { ...searchState, minPrice: '5', defaultMinPrice: '5' }
+      renderSearchPrice()
+
+      const resetButton = screen.getByText('Réinitialiser')
+      await user.press(resetButton)
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: searchState,
+      })
     })
 
     it('should preserve minimum price when closing the modal', async () => {

--- a/src/features/search/pages/modals/PriceModal/PriceModal.tsx
+++ b/src/features/search/pages/modals/PriceModal/PriceModal.tsx
@@ -171,15 +171,14 @@ export const PriceModal: FunctionComponent<PriceModalProps> = ({
     setValue,
     trigger,
     formState: { isSubmitting, isValid, isValidating },
+    watch,
   } = useForm<PriceModalFormData>({
     mode: 'onChange',
     defaultValues: initialFormValues,
     resolver: yupResolver(searchPriceSchema),
   })
 
-  useEffect(() => {
-    reset(initialFormValues)
-  }, [initialFormValues, reset])
+  const { minPrice, maxPrice, isLimitCreditSearch, isOnlyFreeOffersSearch } = watch()
 
   const onSubmit = handleSubmit(search)
 
@@ -275,6 +274,8 @@ export const PriceModal: FunctionComponent<PriceModalProps> = ({
   const disabled = !isValid || (!isValidating && isSubmitting)
   const isKeyboardOpen = keyboardHeight > 0
   const shouldDisplayBackButton = filterBehaviour === FilterBehaviour.APPLY_WITHOUT_SEARCHING
+  const hasDefaultValues =
+    !isLimitCreditSearch && !isOnlyFreeOffersSearch && maxPrice === '' && minPrice === ''
 
   return (
     <AppModal
@@ -302,6 +303,7 @@ export const PriceModal: FunctionComponent<PriceModalProps> = ({
           onResetPress={onResetPress}
           isSearchDisabled={disabled}
           filterBehaviour={filterBehaviour}
+          isResetDisabled={hasDefaultValues}
         />
       }>
       <FormContainer isKeyboardOpen={isKeyboardOpen}>

--- a/src/features/search/pages/modals/VenueModal/VenueModal.tsx
+++ b/src/features/search/pages/modals/VenueModal/VenueModal.tsx
@@ -28,6 +28,7 @@ export const VenueModal = ({ visible, dismissModal }: Props) => {
     shouldShowSuggestedVenues,
     venueQuery,
     isSearchButtonDisabled,
+    isResetButtonDisabled,
     onClose,
   } = useVenueModal({ dismissModal })
 
@@ -58,6 +59,7 @@ export const VenueModal = ({ visible, dismissModal }: Props) => {
           onSearchPress={doApplySearch}
           onResetPress={onResetPress}
           isSearchDisabled={isSearchButtonDisabled}
+          isResetDisabled={isResetButtonDisabled}
           filterBehaviour={FilterBehaviour.SEARCH}
         />
       }>

--- a/src/features/search/pages/modals/VenueModal/type.ts
+++ b/src/features/search/pages/modals/VenueModal/type.ts
@@ -13,5 +13,6 @@ export type VenueModalHook = {
   shouldShowSuggestedVenues: boolean
   venueQuery: string
   isSearchButtonDisabled: boolean
+  isResetButtonDisabled: boolean
   onClose: VoidFunction
 }

--- a/src/features/search/pages/modals/VenueModal/useVenueModal.ts
+++ b/src/features/search/pages/modals/VenueModal/useVenueModal.ts
@@ -43,7 +43,15 @@ const useVenueModal = ({ dismissModal }: VenueModalHookProps): VenueModalHook =>
   const doResetVenue = useCallback(() => {
     setVenueQuery('')
     setSelectedVenue(null)
-  }, [])
+    const payload: SearchState = {
+      ...searchState,
+      venue: undefined,
+    }
+    dispatch({
+      type: 'SET_STATE',
+      payload,
+    })
+  }, [dispatch, searchState])
 
   const doSetSelectedVenue = useCallback((venue: Venue) => {
     setSelectedVenue(venue)
@@ -75,6 +83,7 @@ const useVenueModal = ({ dismissModal }: VenueModalHookProps): VenueModalHook =>
   const isQueryProvided = !!venueQuery && !!debouncedVenueQuery
   const shouldShowSuggestedVenues = isQueryProvided && !selectedVenue
   const isSearchButtonDisabled = !selectedVenue && !!venueQuery
+  const isResetButtonDisabled = !selectedVenue
 
   return {
     doChangeVenue,
@@ -85,6 +94,7 @@ const useVenueModal = ({ dismissModal }: VenueModalHookProps): VenueModalHook =>
     shouldShowSuggestedVenues,
     venueQuery,
     isSearchButtonDisabled,
+    isResetButtonDisabled,
     onClose,
   }
 }

--- a/src/ui/components/Form.tsx
+++ b/src/ui/components/Form.tsx
@@ -2,10 +2,12 @@ import styled from 'styled-components/native'
 
 const MaxWidth = styled.View<{
   flex?: number
-}>(({ theme, flex }) => ({
+  marginTop?: number
+}>(({ theme, flex, marginTop }) => ({
   width: '100%',
   maxWidth: theme.forms.maxWidth,
   flex,
+  marginTop,
 }))
 
 const Flex = styled.View({

--- a/src/ui/components/Form.web.tsx
+++ b/src/ui/components/Form.web.tsx
@@ -3,10 +3,11 @@ import styled from 'styled-components'
 
 const MaxWidth: React.FC<{ flex?: number }> = styled.form.attrs({
   onSubmit: (e: FormEvent) => e.preventDefault(),
-})<{ flex?: number }>(({ theme, flex }) => ({
+})<{ flex?: number; marginTop?: number }>(({ theme, flex, marginTop }) => ({
   width: '100%',
   maxWidth: theme.forms.maxWidth,
   flex,
+  marginTop,
 }))
 
 const Flex: React.FC = styled.form.attrs({


### PR DESCRIPTION
L'objectif de cette PR est d'améliorer et d'harmoniser l'utilisation des filtres dans la recherche :
- Le bouton Réinitialiser est désactivé quand il n'y aucun filtre d'appliqué
- Le bouton Réinitialiser permet d'exécuter directement la recherche sans passer par le bouton Rechercher (comme pour le filtre des prix)

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36097

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

https://github.com/user-attachments/assets/97840a90-972a-4d4c-a385-4f6f32b23e84

Capture avec le lundi en 1er jour de semaine (fait après la vidéo) :

![Capture d’écran 2025-05-15 à 11 47 53](https://github.com/user-attachments/assets/dcdc33fc-e9e7-4816-8faa-236a3a2f9cb2)



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
