### PR TITLE
(BSR) refactor(ESLint): create a rule to not import a query of a different feature

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 const { softRules } = require('./eslint-soft-rules')
+const { boundariesRule, boundariesElements } = require('./eslint-custom-rules/boundaries-rule')
 
 module.exports = {
   root: true,
@@ -10,6 +11,7 @@ module.exports = {
     'eslint-plugin-local-rules',
     'testing-library',
     'jest',
+    'boundaries',
   ],
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   extends: [
@@ -21,6 +23,7 @@ module.exports = {
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
     'plugin:import/errors',
     'plugin:react-hooks/recommended',
+    'plugin:boundaries/recommended',
   ],
   parserOptions: {
     ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
@@ -298,6 +301,7 @@ module.exports = {
     react: {
       version: 'detect', // Tells eslint-plugin-react to automatically detect the version of React to use
     },
+    'boundaries/elements': boundariesElements,
     'import/resolver': {
       node: {
         extensions: [

--- a/eslint-custom-rules/boundaries-rule.js
+++ b/eslint-custom-rules/boundaries-rule.js
@@ -1,0 +1,42 @@
+const fs = require('fs')
+const path = require('path')
+
+const featureDirs = fs
+  .readdirSync(path.resolve(__dirname, '../src/features'))
+  .filter((dir) => fs.statSync(path.resolve(__dirname, '../src/features', dir)).isDirectory())
+  .map((dir) => ({
+    type: `feature-${dir}`,
+    pattern: `src/features/${dir}`,
+  }))
+
+const queryDirs = featureDirs.map((dir) => {
+  return {
+    type: `queries-${dir.type}`,
+    pattern: `${dir.pattern.slice(4)}/queries`,
+  }
+})
+
+const boundariesElements = [...featureDirs, ...queryDirs]
+
+const boundariesRule = {
+  default: 'allow',
+  rules: [
+    ...featureDirs.map((feature) => {
+      const forbiddenQueries = queryDirs
+        .filter((query) => !query.type.includes(feature.type))
+        .map((query) => query.type)
+
+      return {
+        from: feature.type,
+        disallow: forbiddenQueries,
+        message:
+          'Importing queries from other features is not allowed. If this query is used by multiple features, please move it to src/queries. Otherwise, keep it within its feature directory.',
+      }
+    }),
+  ],
+}
+
+module.exports = {
+  boundariesRule,
+  boundariesElements,
+}

--- a/eslint-soft-rules.js
+++ b/eslint-soft-rules.js
@@ -1,24 +1,24 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { boundariesRule } = require('./eslint-custom-rules/boundaries-rule')
+
 const softRules = {
-  cleancode: [
-    'react/no-unstable-nested-components', // TODO(PC-25291): enable when its issues are fixed
-    'local-rules/no-fireEvent',
-    'react/no-unused-prop-types', // has false positives
-    'local-rules/no-spacer',
-    'local-rules/no-ts-expect-error',
-  ],
-  archi: [
-    'local-rules/no-queries-outside-query-files',
-    'local-rules/queries-only-in-use-query-functions',
-    'local-rules/queries-must-be-in-queries-folder',
-  ],
+  cleancode: {
+    'react/no-unstable-nested-components': 'warn', // TODO(PC-25291): enable when its issues are fixed
+    'local-rules/no-fireEvent': 'warn',
+    'react/no-unused-prop-types': 'warn', // has false positives
+    'local-rules/no-spacer': 'warn',
+    'local-rules/no-ts-expect-error': 'warn',
+  },
+  archi: {
+    'local-rules/no-queries-outside-query-files': 'warn',
+    'local-rules/queries-only-in-use-query-functions': 'warn',
+    'local-rules/queries-must-be-in-queries-folder': 'warn',
+    'boundaries/element-types': ['warn', boundariesRule],
+  },
 }
 
-const getConditionalRules = (scope, rulesArray) => {
-  if (!process.env.ESLINT_SCOPE || process.env.ESLINT_SCOPE === scope) {
-    return rulesArray.reduce((acc, rule) => ({ ...acc, [rule]: 'warn' }), {})
-  }
-  return {}
-}
+const getConditionalRules = (scope, rules) =>
+  !process.env.ESLINT_SCOPE || process.env.ESLINT_SCOPE === scope ? rules : {}
 
 module.exports = {
   softRules: Object.entries(softRules).reduce(

--- a/package.json
+++ b/package.json
@@ -286,6 +286,7 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-alias": "^1.1.2",
+    "eslint-plugin-boundaries": "^5.0.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^27.1.4",
     "eslint-plugin-jest-formatting": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10840,6 +10840,7 @@ __metadata:
     eslint: ^8.57.0
     eslint-config-prettier: ^9.1.0
     eslint-import-resolver-alias: ^1.1.2
+    eslint-plugin-boundaries: ^5.0.1
     eslint-plugin-import: ^2.22.1
     eslint-plugin-jest: ^27.1.4
     eslint-plugin-jest-formatting: ^3.1.0
@@ -15497,6 +15498,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-import-resolver-node@npm:0.3.9":
+  version: 0.3.9
+  resolution: "eslint-import-resolver-node@npm:0.3.9"
+  dependencies:
+    debug: ^3.2.7
+    is-core-module: ^2.13.0
+    resolve: ^1.22.4
+  checksum: 439b91271236b452d478d0522a44482e8c8540bf9df9bd744062ebb89ab45727a3acd03366a6ba2bdbcde8f9f718bab7fe8db64688aca75acf37e04eafd25e22
+  languageName: node
+  linkType: hard
+
 "eslint-import-resolver-node@npm:^0.3.6":
   version: 0.3.6
   resolution: "eslint-import-resolver-node@npm:0.3.6"
@@ -15504,6 +15516,18 @@ __metadata:
     debug: ^3.2.7
     resolve: ^1.20.0
   checksum: 6266733af1e112970e855a5bcc2d2058fb5ae16ad2a6d400705a86b29552b36131ffc5581b744c23d550de844206fb55e9193691619ee4dbf225c4bde526b1c8
+  languageName: node
+  linkType: hard
+
+"eslint-module-utils@npm:2.12.0":
+  version: 2.12.0
+  resolution: "eslint-module-utils@npm:2.12.0"
+  dependencies:
+    debug: ^3.2.7
+  peerDependenciesMeta:
+    eslint:
+      optional: true
+  checksum: be3ac52e0971c6f46daeb1a7e760e45c7c45f820c8cc211799f85f10f04ccbf7afc17039165d56cb2da7f7ca9cec2b3a777013cddf0b976784b37eb9efa24180
   languageName: node
   linkType: hard
 
@@ -15515,6 +15539,20 @@ __metadata:
     find-up: ^2.1.0
     pkg-dir: ^2.0.0
   checksum: c30dfa125aafe65e5f6a30a31c26932106fcf09934a2f47d7f8a393ed9106da7b07416f2337b55c85f9db0175c873ee0827be5429a24ec381b49940f342b9ac3
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-boundaries@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eslint-plugin-boundaries@npm:5.0.1"
+  dependencies:
+    chalk: 4.1.2
+    eslint-import-resolver-node: 0.3.9
+    eslint-module-utils: 2.12.0
+    micromatch: 4.0.8
+  peerDependencies:
+    eslint: ">=6.0.0"
+  checksum: f698c908d09cadc4fb17d0da1cae4070676522f91d52fadf39538cadb28a6dfb90ac1772c029939fad9f3f30906e6ff660dd445a70131451659d878c3af2e930
   languageName: node
   linkType: hard
 
@@ -21803,7 +21841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.8":
+"micromatch@npm:4.0.8, micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
   dependencies:
@@ -25635,7 +25673,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.22.1, resolve@npm:^1.22.8":
+"resolve@npm:^1.22.1, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
   version: 1.22.10
   resolution: "resolve@npm:1.22.10"
   dependencies:
@@ -25674,7 +25712,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.8#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.4#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.8#~builtin<compat/resolve>":
   version: 1.22.10
   resolution: "resolve@patch:resolve@npm%3A1.22.10#~builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
   dependencies:


### PR DESCRIPTION
Cette nouvelle règle permet de signaler si une query est dans un dossier feature dans laquelle elle ne devrait pas être:

```ts
import { useGTLPlaylistsQuery } from 'features/gtlPlaylist/queries/useGTLPlaylistsQuery'
```

✅  utilisé seulement dans `features/gtlPlaylist`

❌  utilisé dans `features/gtlPlaylist` et `features/offer`, doit être déplacé dans `src/queries`
