### PR TITLE
(IC-185) ci(allure): fix permissions for github_token

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -1,16 +1,17 @@
-name: '2 [pull/pr] Initiate workflow'
+name: "2 [pull/pr] Initiate workflow"
 
 on:
   push:
     branches:
       - master
     tags:
-      - '**'
+      - "**"
   pull_request:
 
 permissions:
   contents: read
   id-token: write
+  pages: write
 
 jobs:
   yarn-install:
@@ -207,7 +208,12 @@ jobs:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
   deploy-web-proxy-staging:
-    needs: [check-server-folder-changes-staging, deploy-web-staging, check-proxy-version-staging]
+    needs:
+      [
+        check-server-folder-changes-staging,
+        deploy-web-staging,
+        check-proxy-version-staging,
+      ]
     if: needs.check-server-folder-changes-staging.outputs.folder_changed == 'true' && needs.check-proxy-version-staging.outputs.proxy_base_tag
     uses: ./.github/workflows/dev_on_workflow_web_proxy_deploy.yml
     with:


### PR DESCRIPTION
Fix du workflow qui ne se lance pas car le job top level n'a pas les bonnes permissions : https://github.com/pass-culture/pass-culture-app-native/actions/runs/15137419371
