### PR TITLE
(IC-185) ci(allure): allow github_token to push on repo

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
   pages: write
 

--- a/.github/workflows/dev_on_workflow_tester.yml
+++ b/.github/workflows/dev_on_workflow_tester.yml
@@ -1,4 +1,4 @@
-name: '4 [on_workflow] Tester yaml'
+name: "4 [on_workflow] Tester yaml"
 
 on:
   workflow_call:
@@ -22,7 +22,7 @@ env:
 
 jobs:
   yarn_test_web:
-    name: 'Run Web unit tests'
+    name: "Run Web unit tests"
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
@@ -33,14 +33,14 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - uses: actions/checkout@v4
-      - name: 'OpenID Connect Authentication'
-        uses: 'google-github-actions/auth@v2'
+      - name: "OpenID Connect Authentication"
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       - name: Cache the node_modules
         id: yarn-modules-cache
         uses: pass-culture-github-actions/cache@v1.0.0
@@ -78,7 +78,7 @@ jobs:
           key: v1-allure-dependency-cache-web-${{ runner.os }}-${{ github.sha }}-${{ matrix.shard }}
 
   yarn_test_native:
-    name: 'Run native unit tests'
+    name: "Run native unit tests"
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
@@ -89,14 +89,14 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - uses: actions/checkout@v4
-      - name: 'OpenID Connect Authentication'
-        uses: 'google-github-actions/auth@v2'
+      - name: "OpenID Connect Authentication"
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       - name: Cache the node_modules
         id: yarn-modules-cache
         uses: pass-culture-github-actions/cache@v1.0.0
@@ -152,7 +152,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       id-token: write
-      contents: read
+      contents: write
       pages: write
     needs: [yarn_test_native, yarn_test_web]
 
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       - name: Cache the node_modules
         id: yarn-modules-cache
         uses: pass-culture-github-actions/cache@v1.0.0
@@ -175,18 +175,18 @@ jobs:
           restore-keys: |
             v1-yarn-dependency-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
-      - name: 'Authentification to Google'
-        uses: 'google-github-actions/auth@v2'
+      - name: "Authentification to Google"
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK to get gsutils
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: "google-github-actions/setup-gcloud@v2"
         with:
-          version: '>= 416.0.0'
+          version: ">= 416.0.0"
 
-      - name: 'Retrieve reports from bucket'
+      - name: "Retrieve reports from bucket"
         run: |
           mkdir allure-results
           gsutil cp 'gs://${{ inputs.CACHE_BUCKET_NAME }}/pass-culture/pass-culture-app-native/v1-allure-dependency-cache-${{ runner.os }}-${{ github.sha }}-*' allure-results
@@ -198,7 +198,7 @@ jobs:
           done
           rm -rf allure-results-*
 
-      - name: 'Retrieve previous Allure history from bucket'
+      - name: "Retrieve previous Allure history from bucket"
         run: |
           mkdir -p allure-results/history
           # Check if history exists and copy it directly
@@ -209,7 +209,7 @@ jobs:
       - name: Generate Allure Report
         run: yarn generate:allure-report
 
-      - name: 'Save Allure history to bucket'
+      - name: "Save Allure history to bucket"
         run: |
           # Check if history was generated and save it
           if [ -d "allure-report/history" ] && [ "$(ls -A allure-report/history)" ]; then
@@ -218,7 +218,7 @@ jobs:
             echo "Warning: No history generated in allure-report/history"
           fi
 
-      - name: 'Author'
+      - name: "Author"
         run: |
           git config --global user.email PassCulture-SA@users.noreply.github.com
           git config --global user.name ${{ github.actor }}
@@ -230,7 +230,7 @@ jobs:
           publish_dir: ./allure-report
           publish_branch: allure-report
           user_name: ${{ github.actor }}
-          user_email: 'PassCulture-SA@users.noreply.github.com'
+          user_email: "PassCulture-SA@users.noreply.github.com"
 
   report-coverage:
     runs-on: ubuntu-24.04
@@ -240,31 +240,31 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - uses: actions/checkout@v4
-      - name: 'OpenID Connect Authentication'
-        uses: 'google-github-actions/auth@v2'
+      - name: "OpenID Connect Authentication"
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - name: Get Secret
-        id: 'sonar_secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        id: "sonar_secrets"
+        uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
             SONAR_TOKEN:passculture-metier-ehp/passculture-app-native-sonar-token
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       - name: Set up Cloud SDK to get gsutils
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: "google-github-actions/setup-gcloud@v2"
         with:
-          version: '>= 416.0.0'
-      - name: 'Get from bucket the differents coverages'
+          version: ">= 416.0.0"
+      - name: "Get from bucket the differents coverages"
         run: |
           mkdir coverage
           gsutil cp 'gs://${{ inputs.CACHE_BUCKET_NAME }}/pass-culture/pass-culture-app-native/v1-coverage-dependency-cache-${{ runner.os }}-${{ github.sha }}-*' coverage
           for file in `ls coverage/*tar`; do tar  --use-compress-program='zstd --long=30' -xf $file; done 
           rm -f coverage/*.tar
-      - name: 'Merge each coverage into one'
+      - name: "Merge each coverage into one"
         run: |
           npx nyc merge coverage coverage/coverage-final.json
           npx nyc report -t coverage --report-dir coverage --reporter=clover --reporter=lcov
@@ -286,9 +286,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-      - name: 'OpenID Connect Authentication'
-        uses: 'google-github-actions/auth@v2'
+          node-version-file: ".nvmrc"
+      - name: "OpenID Connect Authentication"
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
@@ -309,8 +309,8 @@ jobs:
         # the test https://github.com/pass-culture/pass-culture-app-native/blob/64e47e0bd8887e80fa20b6d7df00e110d77fd22e/server/src/middlewares/tests/webAppProxyMiddleware.test.ts#L275 fails sometimes, we suppose the backend doesn't respond sometimes
         run: cd server && (yarn test:unit:ci || yarn test:unit:ci || yarn test:unit:ci) && cd ..
       - name: Get secrets for SonarCloud
-        id: 'sonar_secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        id: "sonar_secrets"
+        uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
             SONAR_TOKEN:passculture-metier-ehp/passculture-app-native-sonar-token
@@ -330,14 +330,14 @@ jobs:
       - yarn_test_proxy
       - yarn_test_web
     steps:
-      - name: 'OpenID Connect Authentication'
-        uses: 'google-github-actions/auth@v2'
+      - name: "OpenID Connect Authentication"
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - name: Get secrets for Slack
-        id: 'slack_secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        id: "slack_secrets"
+        uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
             SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
@@ -349,7 +349,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.27.0
         with:
           # channel #alertes-deploiement-native
-          channel-id: 'C0309RP8K42'
+          channel-id: "C0309RP8K42"
           payload: |
             {
               "attachments": [


### PR DESCRIPTION
# PR description

To publish allure report we also need to be able to push on the repo so I'm adding permisisons to the github token

