### PR TITLE
(PC-36222) refactor(ui): use Modal from react-native in AppModal

### DIFF
--- a/src/features/bookings/components/ArchiveBookingModal.tsx
+++ b/src/features/bookings/components/ArchiveBookingModal.tsx
@@ -47,7 +47,6 @@ export const ArchiveBookingModal = (props: ArchiveBookingModalProps) => {
 
   return (
     <AppModal
-      animationOutTiming={1}
       visible={props.visible}
       title="Tu es sur le point d’archiver"
       rightIconAccessibilityLabel="Ne pas archiver"

--- a/src/features/bookings/components/CancelBookingModal.tsx
+++ b/src/features/bookings/components/CancelBookingModal.tsx
@@ -80,7 +80,6 @@ export const CancelBookingModal: FunctionComponent<Props> = ({
 
   return (
     <AppModal
-      animationOutTiming={1}
       visible={visible}
       title="Tu es sur le point d’annuler"
       rightIconAccessibilityLabel="Ne pas annuler"

--- a/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.tsx
+++ b/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.tsx
@@ -19,7 +19,6 @@ export const ChroniclesWritersModal: FunctionComponent<Props> = ({
 }) => {
   return (
     <AppModal
-      animationOutTiming={1}
       visible={isVisible}
       title="Qui écrit les avis&nbsp;?"
       rightIconAccessibilityLabel="Fermer la modale"

--- a/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.tsx
+++ b/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.tsx
@@ -25,7 +25,6 @@ export const UnsavedSettingsModal: FunctionComponent<Props> = ({
 
   return (
     <AppModal
-      animationOutTiming={1}
       visible={visible}
       title="Quitter sans enregistrer&nbsp;?"
       rightIconAccessibilityLabel="Ne pas quitter"

--- a/src/ui/components/modals/AppModal.tsx
+++ b/src/ui/components/modals/AppModal.tsx
@@ -215,81 +215,84 @@ export const AppModal: FunctionComponent<Props> = ({
   }, [onBackdropPress, onLeftIconPress, onRightIconPress])
 
   return (
-    <Modal
-      transparent
-      visible={visible}
-      animationType={isDesktopViewport ? 'fade' : 'slide'}
-      onRequestClose={handleBackdropPress}
-      onDismiss={onModalHide}
-      supportedOrientations={['portrait', 'landscape']}
-      statusBarTranslucent
-      testID={testID}
-      accessible
-      accessibilityViewIsModal
-      accessibilityLabelledBy={titleId}>
-      <ModalView>
-        {shouldDisplayOverlay ? (
-          <StyledPressable
-            onPress={handleBackdropPress}
-            accessibilityRole="button"
-            accessibilityHint="Ferme la fenêtre modale"
-          />
-        ) : null}
-        <StatusBar barStyle="light-content" translucent />
-        <ModalContainer
-          height={maxHeight ? undefined : modalContainerHeight}
-          testID="modalContainer"
-          maxHeight={maxContainerHeight}
-          desktopConstraints={containerDesktopConstraints}
-          onLayout={onLayout}
-          noPadding={noPadding}
-          noPaddingBottom={noPaddingBottom}>
-          {customModalHeader ? (
-            <CustomModalHeaderContainer nativeID={titleId} testID="customModalHeader">
-              {customModalHeader}
-            </CustomModalHeaderContainer>
-          ) : (
-            <ModalHeader
-              title={title}
-              numberOfLines={titleNumberOfLines}
-              onLayout={updateHeaderHeight}
-              titleID={titleId}
-              modalSpacing={modalSpacing}
-              {...iconProps}
+    <React.Fragment>
+      {visible ? <Blackscreen /> : null}
+      <Modal
+        transparent
+        visible={visible}
+        animationType={isDesktopViewport ? 'fade' : 'slide'}
+        onRequestClose={handleBackdropPress}
+        onDismiss={onModalHide}
+        supportedOrientations={['portrait', 'landscape']}
+        statusBarTranslucent
+        testID={testID}
+        accessible
+        accessibilityViewIsModal
+        accessibilityLabelledBy={titleId}>
+        <ModalView>
+          {shouldDisplayOverlay && visible ? (
+            <StyledPressable
+              onPress={handleBackdropPress}
+              accessibilityRole="button"
+              accessibilityHint="Ferme la fenêtre modale"
             />
-          )}
-          {isFullscreen || maxHeight || isUpToStatusBar ? (
-            fullscreenModalBody
-          ) : (
-            <React.Fragment>
-              {shouldAddSpacerBetweenHeaderAndContent ? (
-                <SpacerBetweenHeaderAndContent testID="spacerBetweenHeaderAndContent" />
-              ) : null}
-              <ScrollViewContainer
-                paddingBottom={scrollViewPaddingBottom}
-                modalSpacing={modalSpacing}>
-                <ScrollView
-                  contentContainerStyle={fixedModalBottom ? undefined : contentContainerStyle}
-                  ref={scrollViewRef}
-                  scrollEnabled={scrollEnabled}
-                  onContentSizeChange={updateScrollViewContentHeight}
-                  testID="modalScrollView">
-                  {children}
-                </ScrollView>
-              </ScrollViewContainer>
-            </React.Fragment>
-          )}
-          {fixedModalBottom ? (
-            <React.Fragment>
-              <FixedModalBottomContainer testID="fixedModalBottom">
-                {fixedModalBottom}
-              </FixedModalBottomContainer>
-              <Spacer.BottomScreen />
-            </React.Fragment>
           ) : null}
-        </ModalContainer>
-      </ModalView>
-    </Modal>
+          <StatusBar barStyle="light-content" translucent />
+          <ModalContainer
+            height={maxHeight ? undefined : modalContainerHeight}
+            testID="modalContainer"
+            maxHeight={maxContainerHeight}
+            desktopConstraints={containerDesktopConstraints}
+            onLayout={onLayout}
+            noPadding={noPadding}
+            noPaddingBottom={noPaddingBottom}>
+            {customModalHeader ? (
+              <CustomModalHeaderContainer nativeID={titleId} testID="customModalHeader">
+                {customModalHeader}
+              </CustomModalHeaderContainer>
+            ) : (
+              <ModalHeader
+                title={title}
+                numberOfLines={titleNumberOfLines}
+                onLayout={updateHeaderHeight}
+                titleID={titleId}
+                modalSpacing={modalSpacing}
+                {...iconProps}
+              />
+            )}
+            {isFullscreen || maxHeight || isUpToStatusBar ? (
+              fullscreenModalBody
+            ) : (
+              <React.Fragment>
+                {shouldAddSpacerBetweenHeaderAndContent ? (
+                  <SpacerBetweenHeaderAndContent testID="spacerBetweenHeaderAndContent" />
+                ) : null}
+                <ScrollViewContainer
+                  paddingBottom={scrollViewPaddingBottom}
+                  modalSpacing={modalSpacing}>
+                  <ScrollView
+                    contentContainerStyle={fixedModalBottom ? undefined : contentContainerStyle}
+                    ref={scrollViewRef}
+                    scrollEnabled={scrollEnabled}
+                    onContentSizeChange={updateScrollViewContentHeight}
+                    testID="modalScrollView">
+                    {children}
+                  </ScrollView>
+                </ScrollViewContainer>
+              </React.Fragment>
+            )}
+            {fixedModalBottom ? (
+              <React.Fragment>
+                <FixedModalBottomContainer testID="fixedModalBottom">
+                  {fixedModalBottom}
+                </FixedModalBottomContainer>
+                <Spacer.BottomScreen />
+              </React.Fragment>
+            ) : null}
+          </ModalContainer>
+        </ModalView>
+      </Modal>
+    </React.Fragment>
   )
 }
 
@@ -328,16 +331,36 @@ const ModalContainer = styled.View<{
   maxHeight?: number
   noPadding?: boolean
   noPaddingBottom?: boolean
-}>(({ height, desktopConstraints, maxHeight, noPadding, theme, noPaddingBottom }) => {
-  return appModalContainerStyle({
-    theme,
+  isDesktopViewport?: boolean
+}>(
+  ({
     height,
     desktopConstraints,
-    maxHeight: maxHeight ?? MAX_HEIGHT,
+    maxHeight,
     noPadding,
+    theme,
     noPaddingBottom,
-  })
-})
+    isDesktopViewport,
+  }) => {
+    return {
+      ...appModalContainerStyle({
+        theme,
+        height,
+        desktopConstraints,
+        maxHeight: maxHeight ?? MAX_HEIGHT,
+        noPadding,
+        noPaddingBottom,
+      }),
+      position: 'absolute',
+      right: 0,
+      left: 0,
+      bottom: isDesktopViewport ? 'auto' : 0,
+      top: isDesktopViewport ? 0 : 'auto',
+      alignItems: 'center',
+      margin: 'auto',
+    }
+  }
+)
 
 const StyledScrollView = styled(ScrollView)<{
   modalSpacing?: ModalSpacing
@@ -369,11 +392,21 @@ const ModalView = styled.View({
   alignItems: 'center',
 })
 
-const StyledPressable = styled.Pressable({
+const StyledPressable = styled.Pressable(({ theme }) => ({
   position: 'absolute',
   top: 0,
   left: 0,
   right: 0,
   bottom: 0,
-  backgroundColor: 'rgba(0, 0, 0, 0.5)',
-})
+  // backgroundColor: theme.uniqueColors.greyOverlay,
+}))
+
+const Blackscreen = styled.Pressable(({ theme }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: theme.uniqueColors.greyOverlay,
+  zIndex: theme.zIndex.header,
+}))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36222

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
