### PR TITLE
(PC-36326) test(app): manage last fireEvent.press + change rule configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,7 @@ module.exports = {
     'local-rules/independent-mocks': 'error',
     'local-rules/no-direct-consult-offer-log': 'error',
     'local-rules/no-empty-arrow-function': 'off',
+    'local-rules/no-fireEvent': 'error',
     'local-rules/no-hardcoded-id-in-svg': 'error',
     'local-rules/no-raw-text': 'error',
     'local-rules/use-ternary-operator-in-jsx': 'error',
@@ -202,8 +203,9 @@ module.exports = {
           {
             name: 'ui/theme',
             importNames: ['theme'],
-            message: 'Use StyledComponent or import theme via the useTheme() hook instead of directly importing it',
-          }          
+            message:
+              'Use StyledComponent or import theme via the useTheme() hook instead of directly importing it',
+          },
         ],
         patterns: [
           {

--- a/eslint-soft-rules.js
+++ b/eslint-soft-rules.js
@@ -4,7 +4,6 @@ const { boundariesRule } = require('./eslint-custom-rules/boundaries-rule')
 const softRules = {
   cleancode: {
     'react/no-unstable-nested-components': 'warn', // TODO(PC-25291): enable when its issues are fixed
-    'local-rules/no-fireEvent': 'warn',
     'local-rules/no-spacer': 'warn',
     'local-rules/no-ts-expect-error': 'warn',
   },

--- a/src/features/auth/pages/signup/SignupForm.native.test.tsx
+++ b/src/features/auth/pages/signup/SignupForm.native.test.tsx
@@ -915,5 +915,6 @@ const pressSSOButton = async () => {
     SSOButton = await screen.findByTestId('S’inscrire avec Google')
   })
   // userEvent.press is not working correctly with SSOButton :'(
+  // eslint-disable-next-line local-rules/no-fireEvent
   await act(async () => fireEvent.press(SSOButton))
 }

--- a/src/features/bookings/components/OldBookingDetails/BookingDetailsCancelButton.native.test.tsx
+++ b/src/features/bookings/components/OldBookingDetails/BookingDetailsCancelButton.native.test.tsx
@@ -82,6 +82,8 @@ describe('<BookingDetailsCancelButton />', () => {
       onCancel,
     })
     const button = screen.getByTestId('Annuler ma réservation')
+    // userEvent.press is not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(button)
 
     expect(onCancel).toHaveBeenCalledTimes(1)
@@ -98,6 +100,8 @@ describe('<BookingDetailsCancelButton />', () => {
       onTerminate,
     })
     const button = screen.getByTestId('Terminer')
+    // userEvent.press is not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(button)
 
     expect(onTerminate).toHaveBeenCalledTimes(1)

--- a/src/features/home/components/SubscribeButtonWithModals.native.test.tsx
+++ b/src/features/home/components/SubscribeButtonWithModals.native.test.tsx
@@ -44,6 +44,7 @@ describe('SubscribeButtonWithModals', () => {
     render(reactQueryProviderHOC(<SubscribeButtonWithModals homeId="fakeEntryId" />))
 
     // userEvent.press is not working correctly (MSW warning)
+    // eslint-disable-next-line local-rules/no-fireEvent
     await act(async () => fireEvent.press(screen.getByText('Suivre')))
 
     expect(screen.getByText('Identifie-toi pour t’abonner à un thème')).toBeOnTheScreen()
@@ -82,6 +83,8 @@ describe('SubscribeButtonWithModals', () => {
 
     render(reactQueryProviderHOC(<SubscribeButtonWithModals homeId="fakeEntryId" />))
 
+    // userEvent.press is not working correctly (MSW warning)
+    // eslint-disable-next-line local-rules/no-fireEvent
     await act(async () => fireEvent.press(screen.getByText('Suivre')))
 
     expect(screen.getByText('Autoriser l’envoi d’e-mails')).toBeOnTheScreen()
@@ -99,6 +102,8 @@ describe('SubscribeButtonWithModals', () => {
 
     render(reactQueryProviderHOC(<SubscribeButtonWithModals homeId="fakeEntryId" />))
 
+    // userEvent.press is not working correctly (MSW warning)
+    // eslint-disable-next-line local-rules/no-fireEvent
     await act(async () => fireEvent.press(screen.getByText('Déjà suivi')))
 
     expect(
@@ -112,6 +117,8 @@ describe('SubscribeButtonWithModals', () => {
     await storage.saveObject('times_user_subscribed_to_a_theme', 1)
     render(reactQueryProviderHOC(<SubscribeButtonWithModals homeId="fakeEntryId" />))
 
+    // userEvent.press is not working correctly (MSW warning)
+    // eslint-disable-next-line local-rules/no-fireEvent
     await act(async () => fireEvent.press(screen.getByText('Suivre')))
 
     expect(screen.getByText('Tu suis le thème "Cinéma"')).toBeOnTheScreen()
@@ -124,6 +131,8 @@ describe('SubscribeButtonWithModals', () => {
     await storage.saveObject('times_user_subscribed_to_a_theme', 3)
     render(reactQueryProviderHOC(<SubscribeButtonWithModals homeId="fakeEntryId" />))
 
+    // userEvent.press is not working correctly (MSW warning)
+    // eslint-disable-next-line local-rules/no-fireEvent
     await act(async () => fireEvent.press(screen.getByText('Suivre')))
 
     expect(mockShowSuccessSnackBar).toHaveBeenCalledWith({

--- a/src/features/home/components/modules/video/VideoCarouselModule.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoCarouselModule.native.test.tsx
@@ -131,6 +131,8 @@ describe.skip('<VideoCarouselModule />', () => {
     await screen.findByText(MOCKED_ALGOLIA_RESPONSE_OFFER.offer.name)
 
     const attachedOfferButton = screen.getByText(THEMATIC_HOME_TITLE)
+    // file skip for the moment
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(attachedOfferButton)
 
     expect(navigate).toHaveBeenCalledWith('ThematicHome', {
@@ -151,6 +153,8 @@ describe.skip('<VideoCarouselModule />', () => {
     })
 
     const attachedOfferButton = await screen.findByText(OFFER_NAME)
+    // file skip for the moment
+    // eslint-disable-next-line local-rules/no-fireEvent
     await act(async () => fireEvent.press(attachedOfferButton))
 
     expect(navigate).toHaveBeenCalledWith('Offer', {
@@ -180,6 +184,8 @@ describe.skip('<VideoCarouselModule />', () => {
       const nextVideoButton = await screen.findByRole(AccessibilityRole.BUTTON, {
         name: VideoPlayerButtonsWording.NEXT_VIDEO,
       })
+      // file skip for the moment
+      // eslint-disable-next-line local-rules/no-fireEvent
       await act(async () => fireEvent.press(nextVideoButton))
 
       await waitFor(() => {
@@ -202,6 +208,8 @@ describe.skip('<VideoCarouselModule />', () => {
       })
 
       const attachedOfferButton = await screen.findByText(OFFER_NAME)
+      // file skip for the moment
+      // eslint-disable-next-line local-rules/no-fireEvent
       await act(async () => fireEvent.press(attachedOfferButton))
 
       expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {

--- a/src/features/home/components/modules/video/VideoEndView.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoEndView.native.test.tsx
@@ -23,6 +23,7 @@ describe('VideoEndView', () => {
 
     const replayButton = await screen.findByText('Revoir')
     // userEvent.press is not working correctly
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(replayButton)
 
     expect(mockReplay).toHaveBeenCalledTimes(1)
@@ -32,7 +33,8 @@ describe('VideoEndView', () => {
     renderVideoEndView()
 
     const seeOfferButton = await screen.findByText('Voir l’offre')
-
+    // userEvent.press is not working correctly
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(seeOfferButton)
 
     expect(mockHideModal).toHaveBeenCalledTimes(1)
@@ -42,7 +44,8 @@ describe('VideoEndView', () => {
     renderVideoEndView()
 
     const seeOfferButton = await screen.findByText('Voir l’offre')
-
+    // userEvent.press is not working correctly
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(seeOfferButton)
 
     expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {

--- a/src/features/location/components/HomeLocationModal.native.test.tsx
+++ b/src/features/location/components/HomeLocationModal.native.test.tsx
@@ -76,6 +76,7 @@ describe('HomeLocationModal', () => {
 
     const suggestedPlace = await screen.findByText(mockPlaces[0].label)
     // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(suggestedPlace)
 
     const validateButon = screen.getByText('Valider la localisation')
@@ -137,6 +138,7 @@ describe('HomeLocationModal', () => {
     hideModalMock.mockImplementationOnce(() => {
       // simulate the modal closing
       // userEvent.press not working correctly here
+      // eslint-disable-next-line local-rules/no-fireEvent
       fireEvent.press(screen.getByText('Close'))
     })
 

--- a/src/features/location/components/SearchLocationModal.native.test.tsx
+++ b/src/features/location/components/SearchLocationModal.native.test.tsx
@@ -93,6 +93,7 @@ describe('SearchLocationModal', () => {
 
     const suggestedPlace = await screen.findByText(mockPlaces[0].label)
     // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(suggestedPlace)
 
     const validateButon = screen.getByText('Valider la localisation')
@@ -165,6 +166,7 @@ describe('SearchLocationModal', () => {
             <SearchLocationModal
               visible={visible}
               // userEvent.press not working correctly here
+              // eslint-disable-next-line local-rules/no-fireEvent
               dismissModal={async () => fireEvent.press(screen.getByText('Close'))}
             />
             <Button title="Close" onPress={() => setVisible(false)} />
@@ -203,6 +205,7 @@ describe('SearchLocationModal', () => {
       await act(async () => {
         const suggestedPlace = await screen.findByText(mockPlaces[0].label)
         // userEvent.press not working correctly here
+        // eslint-disable-next-line local-rules/no-fireEvent
         fireEvent.press(suggestedPlace)
       })
 
@@ -224,6 +227,7 @@ describe('SearchLocationModal', () => {
 
       const suggestedPlace = await screen.findByText(mockPlaces[0].label)
       // userEvent.press not working correctly here
+      // eslint-disable-next-line local-rules/no-fireEvent
       fireEvent.press(suggestedPlace)
 
       await act(async () => {
@@ -264,6 +268,7 @@ describe('SearchLocationModal', () => {
 
       const suggestedPlace = await screen.findByText(mockPlaces[0].label)
       // userEvent.press not working correctly here
+      // eslint-disable-next-line local-rules/no-fireEvent
       fireEvent.press(suggestedPlace)
 
       expect(screen.getByText(radiusWithKm(DEFAULT_RADIUS))).toBeOnTheScreen()
@@ -328,6 +333,7 @@ describe('SearchLocationModal', () => {
 
       const suggestedPlace = await screen.findByText(mockPlaces[0].label)
       // userEvent.press not working correctly here
+      // eslint-disable-next-line local-rules/no-fireEvent
       fireEvent.press(suggestedPlace)
 
       await act(async () => {

--- a/src/features/location/components/VenueMapLocationModal.native.test.tsx
+++ b/src/features/location/components/VenueMapLocationModal.native.test.tsx
@@ -95,6 +95,7 @@ describe('VenueMapLocationModal', () => {
 
     const suggestedPlace = await screen.findByText(mockPlaces[0].label)
     // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(suggestedPlace)
 
     const validateButon = screen.getByText('Valider et voir sur la carte')
@@ -162,6 +163,7 @@ describe('VenueMapLocationModal', () => {
 
     const suggestedPlace = await screen.findByText(mockPlaces[0].label)
     // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(suggestedPlace)
 
     await act(async () => {
@@ -194,6 +196,7 @@ describe('VenueMapLocationModal', () => {
 
     const suggestedPlace = await screen.findByText(mockPlaces[0].label)
     // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(suggestedPlace)
 
     await act(async () => {
@@ -226,6 +229,7 @@ describe('VenueMapLocationModal', () => {
 
     const suggestedPlace = await screen.findByText(mockPlaces[0].label)
     // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(suggestedPlace)
 
     await act(async () => {
@@ -258,6 +262,7 @@ describe('VenueMapLocationModal', () => {
 
     const suggestedPlace = await screen.findByText(mockPlaces[0].label)
     // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(suggestedPlace)
 
     await act(async () => {
@@ -291,6 +296,7 @@ describe('VenueMapLocationModal', () => {
 
     const suggestedPlace = await screen.findByText(mockPlaces[0].label)
     // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(suggestedPlace)
 
     await act(async () => {
@@ -328,6 +334,7 @@ describe('VenueMapLocationModal', () => {
             <SearchLocationModal
               visible={visible}
               // userEvent.press not working correctly here
+              // eslint-disable-next-line local-rules/no-fireEvent
               dismissModal={() => fireEvent.press(screen.getByText('Close'))}
             />
             <Button title="Close" onPress={() => setVisible(false)} />
@@ -366,6 +373,7 @@ describe('VenueMapLocationModal', () => {
       await act(async () => {
         const suggestedPlace = await screen.findByText(mockPlaces[0].label)
         // userEvent.press not working correctly here
+        // eslint-disable-next-line local-rules/no-fireEvent
         fireEvent.press(suggestedPlace)
       })
 
@@ -394,6 +402,7 @@ describe('VenueMapLocationModal', () => {
 
       const suggestedPlace = await screen.findByText(mockPlaces[0].label)
       // userEvent.press not working correctly here
+      // eslint-disable-next-line local-rules/no-fireEvent
       fireEvent.press(suggestedPlace)
 
       expect(screen.getByText(radiusWithKm(DEFAULT_RADIUS))).toBeOnTheScreen()
@@ -435,6 +444,7 @@ describe('VenueMapLocationModal', () => {
 
       const suggestedPlace = await screen.findByText(mockPlaces[0].label)
       // userEvent.press not working correctly here
+      // eslint-disable-next-line local-rules/no-fireEvent
       fireEvent.press(suggestedPlace)
 
       await act(async () => {

--- a/src/features/offer/components/OfferArtists/OfferArtists.native.test.tsx
+++ b/src/features/offer/components/OfferArtists/OfferArtists.native.test.tsx
@@ -17,6 +17,7 @@ describe('<OfferArtists />', () => {
     render(<OfferArtists artists="Edith Piaf" onPressArtistLink={handlePressLink} />)
 
     // userEvent.press not working correctly here
+    // eslint-disable-next-line local-rules/no-fireEvent
     fireEvent.press(screen.getByText('Edith Piaf'))
 
     expect(handlePressLink).toHaveBeenCalledWith()

--- a/src/features/offer/components/OfferCTAButton/OfferCTAButton.native.test.tsx
+++ b/src/features/offer/components/OfferCTAButton/OfferCTAButton.native.test.tsx
@@ -192,6 +192,7 @@ describe('<OfferCTAButton />', () => {
         })
 
         // userEvent.press not working correctly here
+        // eslint-disable-next-line local-rules/no-fireEvent
         fireEvent.press(screen.getByText('Accéder à l’offre en ligne'))
 
         await waitFor(() => {
@@ -224,6 +225,7 @@ describe('<OfferCTAButton />', () => {
         })
 
         // userEvent.press not working correctly here
+        // eslint-disable-next-line local-rules/no-fireEvent
         fireEvent.press(screen.getByText('Accéder à l’offre en ligne'))
 
         jest.advanceTimersByTime(500)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36326

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
