### PR TITLE
(PC-36341) feat(search): use filter button list in search results and clean tests

### DIFF
--- a/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -298,15 +298,14 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
     </View>
     <View>
       <RCTScrollView
+        contentContainerStyle={
+          {
+            "marginBottom": 8,
+            "paddingHorizontal": 20,
+          }
+        }
         horizontal={true}
         showsHorizontalScrollIndicator={false}
-        style={
-          [
-            {
-              "marginBottom": 8,
-            },
-          ]
-        }
       >
         <View>
           <View
@@ -315,7 +314,6 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
               [
                 {
                   "flexDirection": "row",
-                  "marginHorizontal": 20,
                   "paddingLeft": 0,
                 },
               ]
@@ -842,7 +840,6 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                     "display": "flex",
                     "marginBottom": 4,
                     "marginLeft": 4,
-                    "marginRight": 4,
                     "marginTop": 4,
                   },
                 ]

--- a/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.native.test.tsx
+++ b/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.native.test.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 
 import { SingleFilterButton } from 'features/search/components/Buttons/SingleFilterButton/SingleFilterButton'
-import { userEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 const user = userEvent.setup()
 jest.useFakeTimers()
 
+const mockedOnPress = jest.fn()
+
 describe('SingleFilterButton', () => {
   it('should execute onPress function when the button is clicked', async () => {
-    const mockedOnPress = jest.fn()
-
     render(
       <SingleFilterButton
         label="CD, vinyles, musique en ligne"
@@ -23,5 +23,22 @@ describe('SingleFilterButton', () => {
     await user.press(button)
 
     expect(mockedOnPress).toHaveBeenCalledTimes(1)
+  })
+
+  it('should display an icon and change color in filter button when filter is applied', () => {
+    render(
+      <SingleFilterButton
+        label="CD, vinyles, musique en ligne"
+        onPress={mockedOnPress}
+        testID="filterButton"
+        isSelected
+      />
+    )
+    const button = screen.getByTestId('CD, vinyles, musique en ligne\u00a0: Filtre sélectionné')
+
+    expect(button).toHaveStyle({
+      borderWidth: 2,
+      backgroundColor: '#F1F1F4',
+    })
   })
 })

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -30,7 +30,6 @@ import { useVenuesInRegionQuery } from 'queries/venueMap/useVenuesInRegionQuery'
 import { mockAuthContextWithUser, mockAuthContextWithoutUser } from 'tests/AuthContextUtils'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render, screen, userEvent, waitFor } from 'tests/utils'
-import { theme } from 'theme'
 
 import { SearchResultsContent, SearchResultsContentProps } from './SearchResultsContent'
 
@@ -283,29 +282,6 @@ describe('SearchResultsContent component', () => {
 
       expect(fullscreenModalScrollView).toBeOnTheScreen()
     })
-
-    it('should display an icon and change color in category button when has category selected', async () => {
-      mockUseSearch.mockReturnValueOnce({
-        searchState: {
-          ...mockSearchState,
-          offerCategories: [SearchGroupNameEnumv2.MUSIQUE],
-        },
-        dispatch: mockDispatch,
-      })
-
-      renderSearchResultContent()
-
-      const categoryButtonIcon = await screen.findByTestId('categoryButtonIcon')
-
-      expect(categoryButtonIcon).toBeOnTheScreen()
-
-      const categoryButton = screen.getByTestId('Catégories\u00a0: Filtre sélectionné')
-
-      expect(categoryButton).toHaveStyle({
-        borderWidth: 2,
-        backgroundColor: theme.colors.greyLight,
-      })
-    })
   })
 
   describe('Price filter', () => {
@@ -324,26 +300,6 @@ describe('SearchResultsContent component', () => {
       const fullscreenModalScrollView = screen.getByTestId('fullscreenModalScrollView')
 
       expect(fullscreenModalScrollView).toBeOnTheScreen()
-    })
-
-    it('should display an icon and change color in prices filter button when has prices filter selected', async () => {
-      mockUseSearch.mockReturnValueOnce({
-        searchState: {
-          ...mockSearchState,
-          minPrice: '5',
-        },
-        dispatch: mockDispatch,
-      })
-
-      renderSearchResultContent()
-
-      const priceButtonIcon = await screen.findByTestId('priceButtonIcon')
-
-      expect(priceButtonIcon).toBeOnTheScreen()
-
-      const priceButton = screen.getByTestId('Prix\u00a0: Filtre sélectionné')
-
-      expect(priceButton).toHaveStyle({ borderWidth: 2, backgroundColor: theme.colors.greyLight })
     })
   })
 
@@ -564,35 +520,6 @@ describe('SearchResultsContent component', () => {
 
       expect(fullscreenModalScrollView).toBeOnTheScreen()
     })
-
-    it.each`
-      type       | params
-      ${'date'}  | ${{ date: { option: 'today', selectedDate: new Date() } }}
-      ${'hours'} | ${{ timeRange: [8, 24] }}
-    `(
-      'should display an icon and change color in dates and hours filter button when has $type selected',
-      async ({ params }: { params: SearchState }) => {
-        mockUseSearch.mockReturnValueOnce({
-          searchState: {
-            ...mockSearchState,
-            ...params,
-          },
-          dispatch: mockDispatch,
-        })
-        renderSearchResultContent()
-
-        const datesHoursButtonIcon = await screen.findByTestId('datesHoursButtonIcon')
-
-        expect(datesHoursButtonIcon).toBeOnTheScreen()
-
-        const datesHoursButton = screen.getByTestId('Dates & heures\u00a0: Filtre sélectionné')
-
-        expect(datesHoursButton).toHaveStyle({
-          borderWidth: 2,
-          backgroundColor: theme.colors.greyLight,
-        })
-      }
-    )
   })
 
   describe('Accessibility filter', () => {
@@ -981,7 +908,7 @@ describe('SearchResultsContent component', () => {
     })
   })
 
-  describe('when feature flag map in search desactivated', () => {
+  describe('when feature flag map in search deactivated', () => {
     beforeEach(() => {
       mockUseLocation.mockReturnValue(aroundMeUseLocation)
     })

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -2,7 +2,7 @@ import { useFocusEffect, useIsFocused } from '@react-navigation/native'
 import { FlashList } from '@shopify/flash-list'
 import { debounce } from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { FlatList, Platform, ScrollView, useWindowDimensions, View } from 'react-native'
+import { FlatList, Platform, useWindowDimensions, View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { AccessibilityFiltersModal } from 'features/accessibility/components/AccessibilityFiltersModal'
@@ -13,7 +13,6 @@ import { PlaylistType } from 'features/offer/enums'
 import { SearchOfferHits } from 'features/search/api/useSearchResults/useSearchResults'
 import { AutoScrollSwitch } from 'features/search/components/AutoScrollSwitch/AutoScrollSwitch'
 import { FilterButton } from 'features/search/components/Buttons/FilterButton/FilterButton'
-import { SingleFilterButton } from 'features/search/components/Buttons/SingleFilterButton/SingleFilterButton'
 import { NoSearchResult } from 'features/search/components/NoSearchResults/NoSearchResult'
 import { SearchList } from 'features/search/components/SearchList/SearchList'
 import { ArtistSection } from 'features/search/components/SearchListHeader/ArtistSection'
@@ -60,6 +59,7 @@ import { plural } from 'libs/plural'
 import { Offer } from 'shared/offer/types'
 import { ellipseString } from 'shared/string/ellipseString'
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
+import { FilterButtonList, FilterButtonListItem } from 'ui/components/FilterButtonList'
 import { Li } from 'ui/components/Li'
 import { useModal } from 'ui/components/modals/useModal'
 import {
@@ -68,8 +68,6 @@ import {
 } from 'ui/components/placeholders/Placeholders'
 import { ScrollToTopButton } from 'ui/components/ScrollToTopButton'
 import { HorizontalOfferTile } from 'ui/components/tiles/HorizontalOfferTile'
-import { Ul } from 'ui/components/Ul'
-import { Check } from 'ui/svg/icons/Check'
 import { Map } from 'ui/svg/icons/Map'
 import { Sort } from 'ui/svg/icons/Sort'
 import { getSpacing, Spacer } from 'ui/theme'
@@ -448,6 +446,51 @@ export const SearchResultsContent: React.FC<SearchResultsContentProps> = ({
     return renderNoSearchResults()
   }
 
+  const filterButtonListItems: FilterButtonListItem[] = [
+    {
+      label: shouldDisplayCalendarModal ? 'Dates' : 'Dates & heures',
+      testID: 'datesHoursButton',
+      onPress: shouldDisplayCalendarModal ? showCalendarModal : showDatesHoursModal,
+      isApplied: appliedFilters.includes(FILTER_TYPES.DATES_HOURS),
+    },
+    {
+      label: searchState.venue
+        ? ellipseString(searchState.venue.label, MAX_VENUE_CHARACTERS)
+        : 'Lieu culturel',
+      testID: 'venueButton',
+      onPress: showVenueModal,
+      isApplied: isVenue,
+    },
+    {
+      label: 'Catégories',
+      testID: 'categoryButton',
+      onPress: showCategoriesModal,
+      isApplied: appliedFilters.includes(FILTER_TYPES.CATEGORIES),
+    },
+    {
+      label: 'Prix',
+      testID: 'priceButton',
+      onPress: showSearchPriceModal,
+      isApplied: appliedFilters.includes(FILTER_TYPES.PRICES),
+    },
+    ...(hasDuoOfferToggle
+      ? [
+          {
+            label: 'Duo',
+            testID: 'DuoButton',
+            onPress: showOfferDuoModal,
+            isApplied: appliedFilters.includes(FILTER_TYPES.OFFER_DUO),
+          },
+        ]
+      : []),
+    {
+      label: 'Accessibilité',
+      testID: 'lieuxAccessiblesButton',
+      onPress: showAccessibilityModal,
+      isApplied: appliedFilters.includes(FILTER_TYPES.ACCESSIBILITY),
+    },
+  ]
+
   return (
     <React.Fragment>
       {isFocused ? <Helmet title={helmetTitle} /> : null}
@@ -457,70 +500,16 @@ export const SearchResultsContent: React.FC<SearchResultsContentProps> = ({
         toggle={() => setAutoScrollEnabled((autoScroll) => !autoScroll)}
       />
       <View>
-        <FiltersScrollView horizontal showsHorizontalScrollIndicator={false}>
-          <StyledUl>
-            <StyledLi>
-              <FilterButton
-                activeFilters={activeFiltersCount}
-                navigateTo={{ screen: 'SearchFilter' }}
-              />
-            </StyledLi>
-            <StyledLi>
-              <StyledSingleFilterButton
-                label={shouldDisplayCalendarModal ? 'Dates' : 'Dates & heures'}
-                testID="datesHoursButton"
-                onPress={shouldDisplayCalendarModal ? showCalendarModal : showDatesHoursModal}
-                isSelected={appliedFilters.includes(FILTER_TYPES.DATES_HOURS)}
-              />
-            </StyledLi>
-            <StyledLi>
-              <StyledSingleFilterButton
-                label={
-                  searchState.venue
-                    ? ellipseString(searchState.venue.label, MAX_VENUE_CHARACTERS)
-                    : 'Lieu culturel'
-                }
-                testID="venueButton"
-                onPress={showVenueModal}
-                isSelected={isVenue}
-              />
-            </StyledLi>
-            <StyledLi>
-              <StyledSingleFilterButton
-                label="Catégories"
-                testID="categoryButton"
-                onPress={showCategoriesModal}
-                isSelected={appliedFilters.includes(FILTER_TYPES.CATEGORIES)}
-              />
-            </StyledLi>
-            <StyledLi>
-              <StyledSingleFilterButton
-                label="Prix"
-                testID="priceButton"
-                onPress={showSearchPriceModal}
-                isSelected={appliedFilters.includes(FILTER_TYPES.PRICES)}
-              />
-            </StyledLi>
-            {hasDuoOfferToggle ? (
-              <StyledLi>
-                <StyledSingleFilterButton
-                  label="Duo"
-                  testID="DuoButton"
-                  onPress={showOfferDuoModal}
-                  isSelected={appliedFilters.includes(FILTER_TYPES.OFFER_DUO)}
-                />
-              </StyledLi>
-            ) : null}
-            <StyledLastLi>
-              <StyledSingleFilterButton
-                label="Accessibilité"
-                testID="lieuxAccessiblesButton"
-                onPress={showAccessibilityModal}
-                isSelected={appliedFilters.includes(FILTER_TYPES.ACCESSIBILITY)}
-              />
-            </StyledLastLi>
-          </StyledUl>
-        </FiltersScrollView>
+        <FilterButtonList
+          items={filterButtonListItems}
+          contentContainerStyle={{ marginBottom: getSpacing(2), paddingHorizontal: getSpacing(5) }}>
+          <StyledLi>
+            <FilterButton
+              activeFilters={activeFiltersCount}
+              navigateTo={{ screen: 'SearchFilter' }}
+            />
+          </StyledLi>
+        </FilterButtonList>
       </View>
       <Container testID="searchResults">{renderSearchList()}</Container>
       {shouldRenderScrollToTopButton ? (
@@ -618,21 +607,6 @@ const StyledLi = styled(Li)({
   marginBottom: getSpacing(1),
 })
 
-const StyledLastLi = styled(StyledLi)({
-  marginRight: getSpacing(1),
-})
-
-const FilterSelectedIcon = styled(Check).attrs(({ theme }) => ({
-  size: theme.icons.sizes.extraSmall,
-  color: theme.colors.black,
-}))``
-
-const StyledSingleFilterButton = styled(SingleFilterButton).attrs((props) => ({
-  icon: props.isSelected ? (
-    <FilterSelectedIcon testID={props.testID ? `${props.testID}Icon` : 'filterButtonIcon'} />
-  ) : undefined,
-}))``
-
 const ScrollToTopContainer = styled.View(({ theme }) => ({
   alignSelf: 'center',
   position: 'absolute',
@@ -640,14 +614,6 @@ const ScrollToTopContainer = styled.View(({ theme }) => ({
   bottom: theme.tabBar.height + getSpacing(6),
   zIndex: theme.zIndex.floatingButton,
 }))
-
-const StyledUl = styled(Ul)({
-  marginHorizontal: getSpacing(5),
-})
-
-const FiltersScrollView = styled(ScrollView)({
-  marginBottom: getSpacing(2),
-})
 
 const StyledArtistSection = styled(ArtistSection)({
   marginTop: getSpacing(4),

--- a/src/ui/components/FilterButtonList.native.test.tsx
+++ b/src/ui/components/FilterButtonList.native.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import { render, screen } from 'tests/utils'
+import { FilterButtonList } from 'ui/components/FilterButtonList'
+
+const items = [
+  { label: 'Filter 1', onPress: jest.fn(), isApplied: false, testID: 'filter1' },
+  { label: 'Filter 2', onPress: jest.fn(), isApplied: true, testID: 'filter2' },
+]
+
+describe('<FilterButtonList />', () => {
+  it('should render a list of filter buttons', () => {
+    render(<FilterButtonList items={items} />)
+
+    expect(screen.getByText('Filter 1')).toBeOnTheScreen()
+    expect(screen.getByText('Filter 2')).toBeOnTheScreen()
+  })
+})

--- a/src/ui/components/FilterButtonList.tsx
+++ b/src/ui/components/FilterButtonList.tsx
@@ -1,0 +1,61 @@
+import React, { PropsWithChildren } from 'react'
+import { ScrollView, StyleProp, ViewStyle } from 'react-native'
+import styled from 'styled-components/native'
+
+import { SingleFilterButton } from 'features/search/components/Buttons/SingleFilterButton/SingleFilterButton'
+import { Li } from 'ui/components/Li'
+import { Ul } from 'ui/components/Ul'
+import { Check } from 'ui/svg/icons/Check'
+import { getSpacing } from 'ui/theme'
+
+export type FilterButtonListItem = {
+  label: string
+  onPress: VoidFunction
+  isApplied: boolean
+  testID?: string
+}
+
+type Props = {
+  items: FilterButtonListItem[]
+  contentContainerStyle?: StyleProp<ViewStyle>
+} & PropsWithChildren
+
+export const FilterButtonList: React.FC<Props> = ({ items, contentContainerStyle, children }) => {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={contentContainerStyle}>
+      <Ul>
+        {children}
+        {items.map((item) => (
+          <StyledLi key={item.testID ? `${item.testID}Li` : item.label}>
+            <StyledSingleFilterButton
+              label={item.label}
+              testID={item.testID}
+              onPress={item.onPress}
+              isSelected={item.isApplied}
+            />
+          </StyledLi>
+        ))}
+      </Ul>
+    </ScrollView>
+  )
+}
+
+const StyledLi = styled(Li)({
+  marginLeft: getSpacing(1),
+  marginTop: getSpacing(1),
+  marginBottom: getSpacing(1),
+})
+
+const FilterSelectedIcon = styled(Check).attrs(({ theme }) => ({
+  size: theme.icons.sizes.extraSmall,
+  color: theme.colors.black,
+}))``
+
+const StyledSingleFilterButton = styled(SingleFilterButton).attrs((props) => ({
+  icon: props.isSelected ? (
+    <FilterSelectedIcon testID={props.testID ? `${props.testID}Icon` : 'filterButtonIcon'} />
+  ) : undefined,
+}))``


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36341

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
