### PR TITLE
(BSR) fix(ts): exclude large folders

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "jsx": "react",
-    "lib": ["es2022","dom", "dom.iterable", "esnext"],
+    "lib": ["es2022", "dom", "dom.iterable", "esnext"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noEmit": true,
@@ -29,6 +29,9 @@
   },
   "exclude": [
     "build/**",
+    "dist/**",
+    "maestro/**",
+    "allure-results/**",
     "node_modules/**",
     "babel.config.js",
     "metro.config.js",


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/issues/53492#issuecomment-1515349300

Solves the: "To enable project-wide JavaScript/TypeScript language features, exclude large folders with source files that you do not work on."

Also seems to solve TS server crashes