### PR TITLE
(BSR) fix(Calendar): fix width after react-native-calendar update

### DIFF
--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
@@ -291,6 +291,6 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
   )
 }
 
-const StyledCalendarList = styled(CalendarList)({
+const StyledCalendarList = styled(CalendarList).attrs({ calendarStyle: { width: '100%' } })({
   marginTop: getSpacing(4),
 })


### PR DESCRIPTION
Un bug a été repéré par @cedricls1 après la MAJ de [](https://github.com/pass-culture/pass-culture-app-native/pull/8205)

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Phone - Chrome   |<img width="390" alt="Capture d’écran 2025-06-05 à 10 43 22" src="https://github.com/user-attachments/assets/fd1e8598-c9f8-4cf8-b2b2-829f1b8e9d02" />|<img width="392" alt="Capture d’écran 2025-06-05 à 10 41 16" src="https://github.com/user-attachments/assets/0a203173-810b-4e51-bf9e-0d46746c79c2" />|
| Desktop - Chrome |<img width="1120" alt="Capture d’écran 2025-06-05 à 10 42 49" src="https://github.com/user-attachments/assets/bf882526-1271-43f9-a021-fb3dc6a37cd6" />|<img width="1121" alt="Capture d’écran 2025-06-05 à 10 42 01" src="https://github.com/user-attachments/assets/bc7fa3aa-7a34-4c74-ba7f-59d5e422fa0a" />|
