### PR TITLE
(PC-34311) fix(BookingDetails): missing margins in native

### DIFF
--- a/src/features/bookings/components/BookingDetailsContentMobile.tsx
+++ b/src/features/bookings/components/BookingDetailsContentMobile.tsx
@@ -66,7 +66,7 @@ export const BookingDetailsContentMobile = ({
 const MAX_CONTENT_WIDTH = getSpacing(100)
 const HORIZONTAL_PADDING = getSpacing(6)
 const VERTICAL_SPACING = getSpacing(8)
-const MARGIN_TICKET_CUTOUT_TO_COMPENSATE = getSpacing(6) * 2
+const MARGIN_TICKET_CUTOUT_TO_COMPENSATE = getSpacing(4)
 
 const StyledSeparator = styled(Separator.Horizontal)({
   marginVertical: VERTICAL_SPACING,
@@ -85,6 +85,7 @@ const Container = styled.View({
 })
 
 const TicketCutoutContainer = styled.View({
+  width: '100%',
   maxWidth: MAX_CONTENT_WIDTH + MARGIN_TICKET_CUTOUT_TO_COMPENSATE,
   marginBottom: getSpacing(8),
   alignSelf: 'center',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34311

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |    ![simulator_screenshot_A3DC709D-06AD-4D5C-BACC-0514944F0233](https://github.com/user-attachments/assets/2014b1af-824e-4f74-adba-5a679cb87a62) |   ![Simulator Screenshot - iPhone 16 Pro - 2025-06-05 at 12 00 44](https://github.com/user-attachments/assets/58e58d19-933f-48b5-a737-4a08ee918c41) |
| Android          |  <img width="333" alt="Screenshot 2025-06-05 at 11 28 01" src="https://github.com/user-attachments/assets/87a3c70d-e9f0-4362-acee-2d90e9ce4f54" /> |<img width="331" alt="Screenshot 2025-06-05 at 11 27 33" src="https://github.com/user-attachments/assets/6e4a8a45-313f-4e1d-becf-65e929afd704" />|
| Phone - Chrome   |    <img width="327" alt="Screenshot 2025-06-05 at 11 19 50" src="https://github.com/user-attachments/assets/96d154a8-6ddf-475c-83bb-40719e58f403" /> |  ![Screenshot 2025-06-05 at 11 24 13](https://github.com/user-attachments/assets/f78e8217-d282-421c-a9b0-9f9673e90404) |
| Desktop - Chrome |      <img width="1440" alt="Screenshot 2025-06-05 at 11 19 34" src="https://github.com/user-attachments/assets/8ef3ce6e-c1ba-4808-b202-e6f556650812" />|  <img width="1437" alt="Screenshot 2025-06-05 at 11 19 25" src="https://github.com/user-attachments/assets/65f823c5-332e-4c80-ab8c-42d49f097204" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
