### PR TITLE
(PC-36434) fix(DS): correct transparent issue background

### DIFF
--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -889,7 +889,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                         "width": "100%",
                       },
                       {
-                        "backgroundColor": "#ffffff",
+                        "backgroundColor": "transparent",
                         "width": "auto",
                       },
                     ],

--- a/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -368,7 +368,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                   "width": "100%",
                 },
                 {
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                 },
               ],
               {

--- a/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
@@ -669,7 +669,7 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
                     "width": "auto",
                   },
                   {
-                    "backgroundColor": "#ffffff",
+                    "backgroundColor": "transparent",
                   },
                 ],
                 {

--- a/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
@@ -309,7 +309,7 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
             "width": "100%",
           },
           {
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
           },
         ],
         {
@@ -428,7 +428,7 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
             "width": "100%",
           },
           {
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
           },
         ],
         {
@@ -1058,7 +1058,7 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
             "width": "100%",
           },
           {
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
           },
         ],
         {
@@ -1177,7 +1177,7 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
             "width": "100%",
           },
           {
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
           },
         ],
         {

--- a/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
@@ -394,7 +394,7 @@ exports[`QuitSignupModal should render correctly 1`] = `
                     "width": "100%",
                   },
                   {
-                    "backgroundColor": "#ffffff",
+                    "backgroundColor": "transparent",
                   },
                 ],
                 {

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
@@ -378,7 +378,7 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
                   "width": "100%",
                 },
                 {
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                 },
               ],
               {
@@ -506,7 +506,7 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
                     "width": "100%",
                   },
                   {
-                    "backgroundColor": "#ffffff",
+                    "backgroundColor": "transparent",
                   },
                 ],
                 {

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -3220,7 +3220,7 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
                   "width": "100%",
                 },
                 {
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                 },
               ],
               {
@@ -3339,7 +3339,7 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
                   "width": "100%",
                 },
                 {
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                 },
               ],
               {

--- a/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
@@ -401,7 +401,7 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
                   "width": "100%",
                 },
                 {
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                 },
               ],
               {

--- a/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
@@ -429,7 +429,7 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
@@ -390,7 +390,7 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -361,7 +361,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
@@ -354,7 +354,7 @@ Tu peux retrouver toutes les informations concernant ta réservation sur l’app
               },
               {
                 "alignItems": "center",
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
                 "borderRadius": 24,
                 "flexDirection": "row",
                 "justifyContent": "center",
@@ -456,7 +456,7 @@ Tu peux retrouver toutes les informations concernant ta réservation sur l’app
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -989,7 +989,7 @@ exports[`BookingDetails OldBookingDetails : when FF WIP_NEW_BOOKING_PAGE is off 
               style={
                 {
                   "alignItems": "center",
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                   "borderRadius": 0,
                   "borderWidth": 0,
                   "flexDirection": "row",

--- a/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
@@ -365,7 +365,7 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
@@ -626,7 +626,7 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
                   },
                   {
                     "alignItems": "center",
-                    "backgroundColor": "#ffffff",
+                    "backgroundColor": "transparent",
                     "borderRadius": 24,
                     "flexDirection": "row",
                     "justifyContent": "center",

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
@@ -267,7 +267,7 @@ exports[`CulturalSurveyIntro page When FF is disabled should render the page wit
                   "width": "100%",
                 },
                 {
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                 },
               ],
               {
@@ -496,7 +496,7 @@ exports[`CulturalSurveyIntro page When FF is disabled should render the page wit
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {
@@ -961,7 +961,7 @@ exports[`CulturalSurveyIntro page When FF is enabled should render the page with
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/forceUpdate/pages/ForceUpdateWithResetErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/forceUpdate/pages/ForceUpdateWithResetErrorBoundary.native.test.tsx.native-snap
@@ -260,7 +260,7 @@ exports[`<ForceUpdateWithResetErrorBoundary/> should match snapshot 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
@@ -413,7 +413,7 @@ exports[`<DMSModal/> should render correctly 1`] = `
                       "width": "100%",
                     },
                     {
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                     },
                   ],
                   {
@@ -555,7 +555,7 @@ exports[`<DMSModal/> should render correctly 1`] = `
                       "width": "100%",
                     },
                     {
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                     },
                   ],
                   {

--- a/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
@@ -395,7 +395,7 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
                     "width": "100%",
                   },
                   {
-                    "backgroundColor": "#ffffff",
+                    "backgroundColor": "transparent",
                   },
                 ],
                 {

--- a/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
@@ -327,7 +327,7 @@ Reviens lundi pour débloquer ton crédit !
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
             "borderRadius": 24,
             "flexDirection": "row",
             "justifyContent": "center",
@@ -735,7 +735,7 @@ exports[`<DisableActivation/> with RemoteActivationBanner informations should re
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
             "borderRadius": 24,
             "flexDirection": "row",
             "justifyContent": "center",

--- a/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
@@ -1235,7 +1235,7 @@ exports[`Stepper navigation should render correctly 1`] = `
                   "width": "100%",
                 },
                 {
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                 },
               ],
               {

--- a/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
@@ -516,7 +516,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                           "width": "auto",
                         },
                         {
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                         },
                       ],
                       {
@@ -919,7 +919,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                             "width": "auto",
                           },
                           {
-                            "backgroundColor": "#ffffff",
+                            "backgroundColor": "transparent",
                           },
                         ],
                         {

--- a/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
@@ -428,7 +428,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                           "width": "100%",
                         },
                         {
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                         },
                       ],
                       {
@@ -626,7 +626,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                           "width": "100%",
                         },
                         {
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                         },
                       ],
                       {

--- a/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
@@ -343,7 +343,7 @@ exports[`NotEligibleEduConnect should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
             "borderRadius": 24,
             "flexDirection": "row",
             "justifyContent": "center",

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
@@ -533,7 +533,7 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
                             "width": "auto",
                           },
                           {
-                            "backgroundColor": "#ffffff",
+                            "backgroundColor": "transparent",
                           },
                         ],
                         {

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts.native.test.tsx.native-snap
@@ -372,7 +372,7 @@ exports[`PhoneValidationTooManyAttempts should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
             "borderRadius": 24,
             "flexDirection": "row",
             "justifyContent": "center",

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManySMSSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManySMSSent.native.test.tsx.native-snap
@@ -366,7 +366,7 @@ exports[`PhoneValidationTooManySMSSent should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
             "borderRadius": 24,
             "flexDirection": "row",
             "justifyContent": "center",

--- a/__snapshots__/features/identityCheck/pages/profile/ProfileInformationValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/ProfileInformationValidation.native.test.tsx.native-snap
@@ -717,7 +717,7 @@ exports[`ProfileInformationValidation should render correctly 1`] = `
               style={
                 {
                   "alignItems": "center",
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                   "borderRadius": 24,
                   "flexDirection": "row",
                   "justifyContent": "center",

--- a/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
@@ -379,7 +379,7 @@ Un problème est survenu !
               },
               {
                 "alignItems": "center",
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
                 "borderRadius": 24,
                 "flexDirection": "row",
                 "justifyContent": "center",

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
@@ -906,7 +906,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
               "width": "100%",
             },
             {
-              "backgroundColor": "#ffffff",
+              "backgroundColor": "transparent",
             },
           ],
           {
@@ -1883,7 +1883,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
               "width": "100%",
             },
             {
-              "backgroundColor": "#ffffff",
+              "backgroundColor": "transparent",
             },
           ],
           {

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
@@ -135,7 +135,7 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
             style={
               {
                 "alignItems": "center",
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
                 "borderRadius": 0,
                 "borderWidth": 0,
                 "flexDirection": "row",
@@ -418,7 +418,7 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
             "borderColor": "#eb0055",
             "borderRadius": 24,
             "borderStyle": "solid",

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
@@ -135,7 +135,7 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
             style={
               {
                 "alignItems": "center",
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
                 "borderRadius": 0,
                 "borderWidth": 0,
                 "flexDirection": "row",
@@ -418,7 +418,7 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
             "borderColor": "#eb0055",
             "borderRadius": 24,
             "borderStyle": "solid",

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
@@ -1959,7 +1959,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {
@@ -2716,7 +2716,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {
@@ -2848,7 +2848,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {
@@ -2980,7 +2980,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
@@ -437,7 +437,7 @@ exports[`AccessibilityEngagement should render correctly 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -367,7 +367,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {
@@ -808,7 +808,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
@@ -351,7 +351,7 @@ exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/profile/pages/DebugScreen/DebugScreen.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DebugScreen/DebugScreen.native.test.tsx.native-snap
@@ -613,7 +613,7 @@ exports[`DebugScreen should render correctly 1`] = `
               style={
                 {
                   "alignItems": "center",
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                   "borderColor": "#eb0055",
                   "borderRadius": 24,
                   "borderStyle": "solid",

--- a/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
@@ -782,7 +782,7 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
@@ -413,7 +413,7 @@ exports[`DeactivateProfileSuccess component should render delete profile success
               },
               {
                 "alignItems": "center",
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
                 "borderRadius": 24,
                 "flexDirection": "row",
                 "justifyContent": "center",

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
@@ -564,7 +564,7 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
@@ -584,7 +584,7 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
@@ -426,7 +426,7 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
                     "width": "auto",
                   },
                   {
-                    "backgroundColor": "#ffffff",
+                    "backgroundColor": "transparent",
                   },
                 ],
                 {
@@ -656,7 +656,7 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
@@ -504,7 +504,7 @@ exports[`DeleteProfileContactSupport should render correctly 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
@@ -489,7 +489,7 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
               },
               {
                 "alignItems": "center",
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
                 "borderRadius": 24,
                 "flexDirection": "row",
                 "justifyContent": "center",
@@ -591,7 +591,7 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
@@ -756,7 +756,7 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
             "borderRadius": 24,
             "flexDirection": "row",
             "justifyContent": "center",

--- a/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
@@ -694,7 +694,7 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
                         "width": "100%",
                       },
                       {
-                        "backgroundColor": "#ffffff",
+                        "backgroundColor": "transparent",
                       },
                     ],
                     {

--- a/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
@@ -362,7 +362,7 @@ exports[`PersonalData should render personal data success 1`] = `
                   "width": "auto",
                 },
                 {
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                 },
               ],
               {
@@ -587,7 +587,7 @@ exports[`PersonalData should render personal data success 1`] = `
                   "width": "auto",
                 },
                 {
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                 },
               ],
               {
@@ -761,7 +761,7 @@ exports[`PersonalData should render personal data success 1`] = `
                   "width": "auto",
                 },
                 {
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                 },
               ],
               {
@@ -936,7 +936,7 @@ exports[`PersonalData should render personal data success 1`] = `
                   "width": "auto",
                 },
                 {
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                 },
               ],
               {
@@ -1133,7 +1133,7 @@ exports[`PersonalData should render personal data success 1`] = `
                       "width": "auto",
                     },
                     {
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                     },
                   ],
                   {

--- a/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
@@ -101,7 +101,7 @@ exports[`Profile component should render correctly 1`] = `
                       "width": "100%",
                     },
                     {
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                     },
                   ],
                   {
@@ -2769,7 +2769,7 @@ exports[`Profile component should render correctly 1`] = `
                           "width": "auto",
                         },
                         {
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                         },
                       ],
                       {

--- a/__snapshots__/features/profile/pages/Profile.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/Profile.web.test.tsx.web-snap
@@ -153,7 +153,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
 }
 
 .c1 {
-  background-color: #ffffff;
+  background-color: transparent;
 }
 
 .c3:disabled {
@@ -1299,7 +1299,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
 }
 
 .c1 {
-  background-color: #ffffff;
+  background-color: transparent;
 }
 
 .c3:disabled {

--- a/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
@@ -1129,7 +1129,7 @@ Les récents ajustements du dispositif peuvent en être la raison.
             style={
               {
                 "alignItems": "center",
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
                 "borderRadius": 0,
                 "borderWidth": 0,
                 "flexDirection": "row",

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -1051,7 +1051,7 @@ exports[`<SearchFilter/> should render correctly 1`] = `
               "width": "100%",
             },
             {
-              "backgroundColor": "#ffffff",
+              "backgroundColor": "transparent",
               "width": "auto",
             },
           ],

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -2404,7 +2404,7 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                       "width": "100%",
                     },
                     {
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                       "width": "auto",
                     },
                   ],

--- a/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
@@ -839,7 +839,7 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
                       "width": "100%",
                     },
                     {
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                       "width": "auto",
                     },
                   ],

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -635,7 +635,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                       "width": "100%",
                     },
                     {
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                       "width": "auto",
                     },
                   ],

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -1143,7 +1143,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                       "width": "100%",
                     },
                     {
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                       "width": "auto",
                     },
                   ],

--- a/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
@@ -636,7 +636,7 @@ exports[`VenueModal should render correctly 1`] = `
                       "width": "100%",
                     },
                     {
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                       "width": "auto",
                     },
                   ],

--- a/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
@@ -423,7 +423,7 @@ exports[`ShareAppModal should match snapshot 1`] = `
                         "width": "100%",
                       },
                       {
-                        "backgroundColor": "#ffffff",
+                        "backgroundColor": "transparent",
                       },
                     ],
                     {

--- a/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
@@ -509,7 +509,7 @@ exports[`ShareAppModalVersionA should match snapshot 1`] = `
                   style={
                     {
                       "alignItems": "center",
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                       "borderRadius": 24,
                       "flexDirection": "row",
                       "justifyContent": "center",

--- a/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
@@ -509,7 +509,7 @@ exports[`ShareAppModalVersionB should match snapshot 1`] = `
                   style={
                     {
                       "alignItems": "center",
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                       "borderRadius": 24,
                       "flexDirection": "row",
                       "justifyContent": "center",

--- a/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
+++ b/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
@@ -161,7 +161,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
 }
 
 .c3 {
-  background-color: #ffffff;
+  background-color: transparent;
 }
 
 .c0 {

--- a/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
@@ -922,7 +922,7 @@ exports[`<NotificationsSettingsModal /> should render correctly 1`] = `
                         "width": "auto",
                       },
                       {
-                        "backgroundColor": "#ffffff",
+                        "backgroundColor": "transparent",
                       },
                     ],
                     {

--- a/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
@@ -530,7 +530,7 @@ exports[`<OnboardingSubscriptionModal /> should display correctly 1`] = `
                         "width": "100%",
                       },
                       {
-                        "backgroundColor": "#ffffff",
+                        "backgroundColor": "transparent",
                       },
                     ],
                     {

--- a/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
@@ -564,7 +564,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for activites_crea
                           "width": "100%",
                         },
                         {
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                         },
                       ],
                       {
@@ -1218,7 +1218,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for cinema 1`] = `
                           "width": "100%",
                         },
                         {
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                         },
                       ],
                       {
@@ -1872,7 +1872,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for lecture 1`] = 
                           "width": "100%",
                         },
                         {
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                         },
                       ],
                       {
@@ -2526,7 +2526,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for musique 1`] = 
                           "width": "100%",
                         },
                         {
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                         },
                       ],
                       {
@@ -3180,7 +3180,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for spectacles 1`]
                           "width": "100%",
                         },
                         {
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                         },
                       ],
                       {
@@ -3834,7 +3834,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for visites 1`] = 
                           "width": "100%",
                         },
                         {
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                         },
                       ],
                       {

--- a/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
@@ -539,7 +539,7 @@ exports[`<UnsubscribingConfirmationModal /> should render correctly 1`] = `
                           "width": "100%",
                         },
                         {
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                         },
                       ],
                       {

--- a/__snapshots__/features/subscription/page/OnboardingSubscription.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/page/OnboardingSubscription.native.test.tsx.native-snap
@@ -1549,7 +1549,7 @@ exports[`OnboardingSubscription should render correctly 1`] = `
               "width": "100%",
             },
             {
-              "backgroundColor": "#ffffff",
+              "backgroundColor": "transparent",
             },
           ],
           {

--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -555,7 +555,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
               },
               {
                 "alignItems": "center",
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
                 "borderRadius": 24,
                 "flexDirection": "row",
                 "justifyContent": "center",
@@ -657,7 +657,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {
@@ -1299,7 +1299,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {
@@ -1929,7 +1929,7 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
               },
               {
                 "alignItems": "center",
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
                 "borderRadius": 24,
                 "flexDirection": "row",
                 "justifyContent": "center",
@@ -2031,7 +2031,7 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -794,7 +794,7 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
@@ -398,7 +398,7 @@ Tu peux toujours contacter le service fraude pour sécuriser ton compte.
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
@@ -423,7 +423,7 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -307,7 +307,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                   style={
                     {
                       "alignItems": "center",
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                       "borderRadius": 24,
                       "flexDirection": "row",
                       "justifyContent": "flex-start",
@@ -424,7 +424,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                     style={
                       {
                         "alignItems": "center",
-                        "backgroundColor": "#ffffff",
+                        "backgroundColor": "transparent",
                         "borderRadius": 0,
                         "borderWidth": 0,
                         "flexDirection": "row",
@@ -3301,7 +3301,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                   style={
                     {
                       "alignItems": "center",
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                       "borderRadius": 24,
                       "flexDirection": "row",
                       "justifyContent": "flex-start",
@@ -3418,7 +3418,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                     style={
                       {
                         "alignItems": "center",
-                        "backgroundColor": "#ffffff",
+                        "backgroundColor": "transparent",
                         "borderRadius": 0,
                         "borderWidth": 0,
                         "flexDirection": "row",
@@ -6621,7 +6621,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                   style={
                     {
                       "alignItems": "center",
-                      "backgroundColor": "#ffffff",
+                      "backgroundColor": "transparent",
                       "borderRadius": 24,
                       "flexDirection": "row",
                       "justifyContent": "flex-start",
@@ -6738,7 +6738,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                     style={
                       {
                         "alignItems": "center",
-                        "backgroundColor": "#ffffff",
+                        "backgroundColor": "transparent",
                         "borderRadius": 0,
                         "borderWidth": 0,
                         "flexDirection": "row",
@@ -7292,7 +7292,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                       style={
                         {
                           "alignItems": "center",
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                           "borderRadius": 24,
                           "flexDirection": "row",
                           "justifyContent": "flex-start",
@@ -7400,7 +7400,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                       style={
                         {
                           "alignItems": "center",
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                           "borderRadius": 24,
                           "flexDirection": "row",
                           "justifyContent": "flex-start",
@@ -7508,7 +7508,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                       style={
                         {
                           "alignItems": "center",
-                          "backgroundColor": "#ffffff",
+                          "backgroundColor": "transparent",
                           "borderRadius": 24,
                           "flexDirection": "row",
                           "justifyContent": "flex-start",

--- a/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
@@ -291,7 +291,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
                   "width": "100%",
                 },
                 {
-                  "backgroundColor": "#ffffff",
+                  "backgroundColor": "transparent",
                 },
               ],
               {
@@ -520,7 +520,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
                 "width": "100%",
               },
               {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
               },
             ],
             {

--- a/__snapshots__/ui/pages/GenericErrorPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericErrorPage.native.test.tsx.native-snap
@@ -260,7 +260,7 @@ exports[`<GenericErrorPage /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
             "borderRadius": 24,
             "flexDirection": "row",
             "justifyContent": "center",

--- a/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
@@ -200,7 +200,7 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
             style={
               {
                 "alignItems": "center",
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "transparent",
                 "borderRadius": 0,
                 "borderWidth": 0,
                 "flexDirection": "row",
@@ -511,7 +511,7 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
             "borderColor": "#eb0055",
             "borderRadius": 24,
             "borderStyle": "solid",
@@ -592,7 +592,7 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "transparent",
             "borderRadius": 24,
             "flexDirection": "row",
             "justifyContent": "center",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "date-fns": "^2.29.1",
     "date-fns-tz": "^2.0.0",
     "deprecated-react-native-prop-types": "^5.0.0",
-    "design-system": "https://github.com/pass-culture/design-system.git#v0.0.34",
+    "design-system": "https://github.com/pass-culture/design-system.git#v0.0.42",
     "firebase": "^10.9.0",
     "geojson": "^0.5.0",
     "globalthis": "^1.0.2",

--- a/src/ui/components/buttons/ButtonQuaternaryBlack.ts
+++ b/src/ui/components/buttons/ButtonQuaternaryBlack.ts
@@ -40,6 +40,6 @@ export const ButtonQuaternaryBlack = styledButton(AppButton).attrs<BaseButtonPro
       hoverUnderlineColor: theme.designSystem.color.text.default,
     }
   }
-)(({ theme }) => ({
-  backgroundColor: theme.designSystem.color.background.default,
-}))
+)({
+  backgroundColor: 'transparent',
+})

--- a/src/ui/components/buttons/ButtonQuaternaryPrimary.ts
+++ b/src/ui/components/buttons/ButtonQuaternaryPrimary.ts
@@ -40,6 +40,6 @@ export const ButtonQuaternaryPrimary = styledButton(AppButton).attrs<BaseButtonP
       hoverUnderlineColor: theme.designSystem.color.border.brandPrimary,
     }
   }
-)(({ theme }) => ({
-  backgroundColor: theme.designSystem.color.background.default,
-}))
+)({
+  backgroundColor: 'transparent',
+})

--- a/src/ui/components/buttons/ButtonQuaternarySecondary.ts
+++ b/src/ui/components/buttons/ButtonQuaternarySecondary.ts
@@ -40,6 +40,6 @@ export const ButtonQuaternarySecondary = styledButton(AppButton).attrs<BaseButto
       hoverUnderlineColor: theme.designSystem.color.text.brandSecondary,
     }
   }
-)(({ theme }) => ({
-  backgroundColor: theme.designSystem.color.background.default,
-}))
+)({
+  backgroundColor: 'transparent',
+})

--- a/src/ui/components/buttons/ButtonSecondary.ts
+++ b/src/ui/components/buttons/ButtonSecondary.ts
@@ -10,19 +10,18 @@ import { Typo } from 'ui/theme'
 export const ButtonSecondary = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ icon, disabled, textSize, theme, color, ...rest }) => {
     let Icon
-    const defaultColor = color ?? theme.designSystem.color.icon.brandPrimary
+    const defaultColorIcon = color ?? theme.designSystem.color.icon.brandPrimary
     if (icon) {
       Icon = styled(icon).attrs({
-        color: disabled ? theme.designSystem.color.icon.disabled : defaultColor,
+        color: disabled ? theme.designSystem.color.icon.disabled : defaultColorIcon,
         size: theme.buttons.secondary.iconSize,
       })``
     }
 
+    const defaultColorText = color ?? theme.designSystem.color.text.brandPrimary
     const Title = styled(Typo.Button)({
       maxWidth: '100%',
-      color: disabled
-        ? theme.designSystem.color.text.disabled
-        : (color ?? theme.designSystem.color.text.brandPrimary),
+      color: disabled ? theme.designSystem.color.text.disabled : defaultColorText,
       fontSize: textSize,
     })
 
@@ -31,8 +30,8 @@ export const ButtonSecondary = styledButton(AppButton).attrs<BaseButtonProps>(
       icon: Icon,
       title: Title,
       loadingIndicator: LoadingIndicator,
-      backgroundColor: theme.designSystem.color.background.default,
-      hoverUnderlineColor: color ?? theme.designSystem.color.text.brandPrimary,
+      backgroundColor: 'transparent',
+      hoverUnderlineColor: defaultColorText,
     }
   }
 )(({ theme, disabled, color }) => {

--- a/src/ui/components/buttons/ButtonSecondaryBlack.ts
+++ b/src/ui/components/buttons/ButtonSecondaryBlack.ts
@@ -33,7 +33,7 @@ export const ButtonSecondaryBlack = styledButton(AppButton).attrs<BaseButtonProp
       icon: Icon,
       title: Title,
       loadingIndicator: LoadingIndicator,
-      backgroundColor: theme.buttons.secondaryBlack.backgroundColor,
+      backgroundColor: 'transparent',
       hoverUnderlineColor: theme.buttons.secondaryBlack.textColor,
     }
   }

--- a/src/ui/components/buttons/ButtonTertiaryBlack.ts
+++ b/src/ui/components/buttons/ButtonTertiaryBlack.ts
@@ -38,9 +38,9 @@ export const ButtonTertiaryBlack = styledButton(AppButton).attrs<BaseButtonProps
       hoverUnderlineColor: theme.buttons.tertiaryBlack.textColor,
     }
   }
-)(({ theme }) => ({
-  backgroundColor: theme.designSystem.color.background.default,
-}))
+)({
+  backgroundColor: 'transparent',
+})
 
 const LoadingIndicator = styled(InitialLoadingIndicator).attrs(({ theme }) => ({
   color: theme.buttons.tertiaryBlack.loadingIconColor,

--- a/src/ui/components/buttons/ButtonTertiaryNeutralInfo.ts
+++ b/src/ui/components/buttons/ButtonTertiaryNeutralInfo.ts
@@ -35,9 +35,9 @@ export const ButtonTertiaryNeutralInfo = styledButton(AppButton).attrs<BaseButto
       hoverUnderlineColor: theme.designSystem.color.text.subtle,
     }
   }
-)(({ theme }) => ({
-  backgroundColor: theme.designSystem.color.background.default,
-}))
+)({
+  backgroundColor: 'transparent',
+})
 
 const LoadingIndicator = styled(InitialLoadingIndicator).attrs(({ theme }) => ({
   color: theme.buttons.tertiaryNeutralInfo.loadingIconColor,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7680,7 +7680,7 @@ __metadata:
     date-fns-tz: ^2.0.0
     deepmerge: ^4.2.2
     deprecated-react-native-prop-types: ^5.0.0
-    design-system: "https://github.com/pass-culture/design-system.git#v0.0.34"
+    design-system: "https://github.com/pass-culture/design-system.git#v0.0.42"
     dotenv: ^8.2.0
     dotenv-expand: ^5.1.0
     eslint: ^8.57.0
@@ -10918,10 +10918,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"design-system@https://github.com/pass-culture/design-system.git#v0.0.34":
-  version: 0.0.34
-  resolution: "design-system@https://github.com/pass-culture/design-system.git#commit=879cb9a6e27fae94e87ace74342b5dd332fcc9fc"
-  checksum: fe75e4904bd1932a5cfd8db689d0236bd2825a9a6604fd030467de147289f5f2bba81f0dc043f670b8a61aabe691e52a9fa9dc6732c7151207b81d84684d297b
+"design-system@https://github.com/pass-culture/design-system.git#v0.0.42":
+  version: 0.0.35
+  resolution: "design-system@https://github.com/pass-culture/design-system.git#commit=8108efcc3027157796f77279e6eb666f15d19061"
+  checksum: 944de8bf2f31d81ee0327c1a6dbd59d12846439a95c9769d668424e9dfbdf5918b124dea915fccb9cc2de49c6fa3596d7070e80367cc111b170736158b2217e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36434

Description : nous avons remontés un soucis de background en utilisant le background.default token sur des bouton étant donné que cela dépend de leur utilisation. 

![Capture d’écran 2025-06-05 à 14 21 09](https://github.com/user-attachments/assets/c95fff0c-da1b-44ea-b907-2bcada32e644)

Et dans la PR nous avons un update des valeurs des tokens notamment pour le token info qui renvoyait une couleur trop proche du token error 

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

<img width="432" alt="Capture d’écran 2025-06-05 à 18 17 23" src="https://github.com/user-attachments/assets/d0416dc1-afe2-472d-87a1-2cc83909984c" />
<img width="785" alt="Capture d’écran 2025-06-05 à 18 18 52" src="https://github.com/user-attachments/assets/2ef03dbb-6a66-45f5-aeee-2f52f41facd6" />


## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
