### PR TITLE
(PC-36322) fix(searchResults): artist search results

### DIFF
--- a/src/features/search/api/useSearchResults/useSearchResults.native.test.ts
+++ b/src/features/search/api/useSearchResults/useSearchResults.native.test.ts
@@ -126,14 +126,11 @@ describe('useSearchResults', () => {
           {
             indexName: 'algoliaOffersIndexName',
             params: {
-              attributesToHighlight: [],
               attributesToRetrieve: ['artists'],
-              clickAnalytics: true,
               facetFilters: [['offer.isEducational:false']],
               hitsPerPage: 100,
               numericFilters: [['offer.prices: 0 TO 300']],
               tagFilters: '["-is_future"]',
-              page: 0,
             },
             query: '',
           },

--- a/src/features/search/api/useSearchResults/useSearchResults.ts
+++ b/src/features/search/api/useSearchResults/useSearchResults.ts
@@ -122,7 +122,7 @@ export const useSearchInfiniteQuery = (searchState: SearchState) => {
         pages[0]?.offerArtists.hits
           .filter((offer) => offer.artists?.length)
           .flatMap((offer) => offer.artists ?? []),
-        'name'
+        (artist) => artist.name.toLowerCase()
       ),
     }
   }, [data, transformHits, userLocation])

--- a/src/libs/algolia/enums/facetsEnums.ts
+++ b/src/libs/algolia/enums/facetsEnums.ts
@@ -1,5 +1,6 @@
 // Taken from https://www.algolia.com/apps/E2IKXJ325N/explorer/configuration/PRODUCTION/facets
 export enum FACETS_FILTERS_ENUM {
+  ARTISTS_NAME = 'artists.name',
   OBJECT_ID = 'objectID',
   OFFER_ALLOCINE_ID = 'offer.allocineId',
   OFFER_BOOK_TYPE = 'offer.bookMacroSection',

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildFacetFilters.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildFacetFilters.ts
@@ -3,6 +3,7 @@ import { FACETS_FILTERS_ENUM } from 'libs/algolia/enums/facetsEnums'
 import {
   buildAccessibiltyFiltersPredicate,
   buildAllocineIdPredicate,
+  buildArtistNamePredicate,
   buildEanPredicate,
   buildHeadlinePredicate,
   buildObjectIdsPredicate,
@@ -23,6 +24,7 @@ const defaultFilter = [[`${FACETS_FILTERS_ENUM.OFFER_IS_EDUCATIONAL}:false`]]
 export const buildFacetFilters = ({
   venue,
   eanList,
+  artistName,
   allocineId,
   isUserUnderage,
   objectIds,
@@ -56,6 +58,7 @@ export const buildFacetFilters = ({
   isUserUnderage: boolean
   objectIds?: string[]
   eanList?: string[]
+  artistName?: string
   allocineId?: number
   disabilitiesProperties: DisabilitiesProperties
 }): null | {
@@ -97,6 +100,11 @@ export const buildFacetFilters = ({
   if (eanList && eanList?.length > 0) {
     const eanIdsPredicate = buildEanPredicate(eanList)
     facetFilters.push(eanIdsPredicate)
+  }
+
+  if (artistName) {
+    const artistNamePredicate = buildArtistNamePredicate(artistName)
+    facetFilters.push([artistNamePredicate])
   }
 
   if (allocineId) {

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildOfferSearchParameters.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildOfferSearchParameters.ts
@@ -21,6 +21,7 @@ type Parameters = SearchQueryParameters & {
 export const buildOfferSearchParameters = (
   {
     allocineId = undefined,
+    artistName = undefined,
     beginningDatetime = undefined,
     date = null,
     eanList = [],
@@ -61,8 +62,9 @@ export const buildOfferSearchParameters = (
 
   return {
     ...buildFacetFilters({
-      eanList,
       allocineId,
+      artistName,
+      eanList,
       isUserUnderage,
       venue,
       objectIds,

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/helpers/buildFacetFiltersHelpers/buildFacetFiltersHelpers.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/helpers/buildFacetFiltersHelpers/buildFacetFiltersHelpers.ts
@@ -68,6 +68,9 @@ export const buildObjectIdsPredicate = (objectIds: string[]) => {
 export const buildEanPredicate = (eanList: string[]) =>
   eanList.map((ean) => `${FACETS_FILTERS_ENUM.OFFER_EAN}:${ean}`)
 
+export const buildArtistNamePredicate = (artistName: string) =>
+  `${FACETS_FILTERS_ENUM.ARTISTS_NAME}:${artistName}`
+
 export const buildAllocineIdPredicate = (allocineId: number) => [
   `${FACETS_FILTERS_ENUM.OFFER_ALLOCINE_ID}:${allocineId}`,
 ]

--- a/src/libs/algolia/fetchAlgolia/fetchSearchResults/fetchSearchResults.test.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchSearchResults/fetchSearchResults.test.ts
@@ -130,16 +130,13 @@ describe('fetchSearchResults', () => {
       {
         indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
         params: {
-          attributesToHighlight: [],
           attributesToRetrieve: ['artists'],
-          clickAnalytics: true,
-          facetFilters: [['offer.isEducational:false']],
+          facetFilters: [['offer.isEducational:false'], ['artists.name:searched query']],
           numericFilters: [['offer.prices: 0 TO 300']],
           tagFilters: '["-is_future"]',
-          page: 0,
           hitsPerPage: 100,
         },
-        query: 'searched query',
+        query: '',
       },
     ]
 
@@ -209,16 +206,13 @@ describe('fetchSearchResults', () => {
       {
         indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
         params: {
-          attributesToHighlight: [],
           attributesToRetrieve: ['artists'],
-          clickAnalytics: true,
-          facetFilters: [['offer.isEducational:false']],
+          facetFilters: [['offer.isEducational:false'], ['artists.name:searched query']],
           numericFilters: [['offer.prices: 0 TO 300']],
           tagFilters: '["-is_future"]',
-          page: 0,
           hitsPerPage: 100,
         },
-        query: 'searched query',
+        query: '',
       },
     ]
 
@@ -299,18 +293,15 @@ describe('fetchSearchResults', () => {
       {
         indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
         params: {
-          aroundLatLng: '42, 43',
-          aroundRadius: 'all',
-          attributesToHighlight: [],
           attributesToRetrieve: ['artists'],
-          clickAnalytics: true,
-          facetFilters: [['offer.isEducational:false']],
+          facetFilters: [['offer.isEducational:false'], ['artists.name:searched query']],
           numericFilters: [['offer.prices: 0 TO 300']],
           tagFilters: '["-is_future"]',
-          page: 0,
           hitsPerPage: 100,
+          aroundLatLng: '42, 43',
+          aroundRadius: 'all',
         },
-        query: 'searched query',
+        query: '',
       },
     ]
 
@@ -392,18 +383,15 @@ describe('fetchSearchResults', () => {
       {
         indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
         params: {
-          aroundLatLng: '42, 43',
-          aroundRadius: 100000,
-          attributesToHighlight: [],
           attributesToRetrieve: ['artists'],
-          clickAnalytics: true,
-          facetFilters: [['offer.isEducational:false']],
+          facetFilters: [['offer.isEducational:false'], ['artists.name:searched query']],
           numericFilters: [['offer.prices: 0 TO 300']],
           tagFilters: '["-is_future"]',
-          page: 0,
           hitsPerPage: 100,
+          aroundLatLng: '42, 43',
+          aroundRadius: 100000,
         },
-        query: 'searched query',
+        query: '',
       },
     ]
 
@@ -485,18 +473,15 @@ describe('fetchSearchResults', () => {
       {
         indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
         params: {
-          aroundLatLng: '5.16176, -52.669726',
-          aroundRadius: 100000,
-          attributesToHighlight: [],
           attributesToRetrieve: ['artists'],
-          clickAnalytics: true,
-          facetFilters: [['offer.isEducational:false']],
+          facetFilters: [['offer.isEducational:false'], ['artists.name:searched query']],
           numericFilters: [['offer.prices: 0 TO 300']],
           tagFilters: '["-is_future"]',
-          page: 0,
           hitsPerPage: 100,
+          aroundLatLng: '5.16176, -52.669726',
+          aroundRadius: 100000,
         },
-        query: 'searched query',
+        query: '',
       },
     ]
 
@@ -578,18 +563,15 @@ describe('fetchSearchResults', () => {
       {
         indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
         params: {
-          aroundLatLng: '5.16176, -52.669726',
-          aroundRadius: 100000,
-          attributesToHighlight: [],
           attributesToRetrieve: ['artists'],
-          clickAnalytics: true,
-          facetFilters: [['offer.isEducational:false']],
+          facetFilters: [['offer.isEducational:false'], ['artists.name:searched query']],
           numericFilters: [['offer.prices: 0 TO 300']],
           tagFilters: '["-is_future"]',
-          page: 0,
           hitsPerPage: 100,
+          aroundLatLng: '5.16176, -52.669726',
+          aroundRadius: 100000,
         },
-        query: 'searched query',
+        query: '',
       },
     ]
 
@@ -668,16 +650,17 @@ describe('fetchSearchResults', () => {
       {
         indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
         params: {
-          attributesToHighlight: [],
           attributesToRetrieve: ['artists'],
-          clickAnalytics: true,
-          facetFilters: [['offer.isEducational:false'], ['venue.id:5543']],
+          facetFilters: [
+            ['offer.isEducational:false'],
+            ['artists.name:searched query'],
+            ['venue.id:5543'],
+          ],
           numericFilters: [['offer.prices: 0 TO 300']],
           tagFilters: '["-is_future"]',
-          page: 0,
           hitsPerPage: 100,
         },
-        query: 'searched query',
+        query: '',
       },
     ]
 
@@ -756,16 +739,17 @@ describe('fetchSearchResults', () => {
       {
         indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
         params: {
-          attributesToHighlight: [],
           attributesToRetrieve: ['artists'],
-          clickAnalytics: true,
-          facetFilters: [['offer.isEducational:false'], ['venue.id:5543']],
+          facetFilters: [
+            ['offer.isEducational:false'],
+            ['artists.name:searched query'],
+            ['venue.id:5543'],
+          ],
           numericFilters: [['offer.prices: 0 TO 300']],
           tagFilters: '["-is_future"]',
-          page: 0,
           hitsPerPage: 100,
         },
-        query: 'searched query',
+        query: '',
       },
     ]
 
@@ -858,20 +842,18 @@ describe('fetchSearchResults', () => {
       {
         indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
         params: {
-          attributesToHighlight: [],
           attributesToRetrieve: ['artists'],
-          clickAnalytics: true,
           facetFilters: [
             ['offer.isEducational:false'],
+            ['artists.name:searched query'],
             ['venue.isAudioDisabilityCompliant:true'],
             ['venue.isMentalDisabilityCompliant:true'],
           ],
           numericFilters: [['offer.prices: 0 TO 300']],
           tagFilters: '["-is_future"]',
-          page: 0,
           hitsPerPage: 100,
         },
-        query: 'searched query',
+        query: '',
       },
     ]
 
@@ -951,21 +933,13 @@ describe('fetchSearchResults', () => {
       {
         indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
         params: {
-          attributesToHighlight: [],
           attributesToRetrieve: ['artists'],
-          clickAnalytics: true,
-          facetFilters: [['offer.isEducational:false']],
+          facetFilters: [['offer.isEducational:false'], ['artists.name:searched query']],
           numericFilters: [['offer.prices: 0 TO 300']],
           tagFilters: '["-is_future"]',
-          page: 0,
           hitsPerPage: 100,
-          aroundPrecision: [
-            { from: 0, value: 1000 },
-            { from: 1000, value: 4000 },
-            { from: 5000, value: 10000 },
-          ],
         },
-        query: 'searched query',
+        query: '',
       },
     ]
 
@@ -1034,18 +1008,15 @@ describe('fetchSearchResults', () => {
         query: 'searched query',
       },
       {
-        indexName: 'algoliaOffersIndexName',
+        indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
         params: {
-          attributesToHighlight: [],
           attributesToRetrieve: ['artists'],
-          clickAnalytics: true,
-          facetFilters: [['offer.isEducational:false']],
-          hitsPerPage: 100,
+          facetFilters: [['offer.isEducational:false'], ['artists.name:searched query']],
           numericFilters: [['offer.prices: 0 TO 300']],
           tagFilters: '["-is_future"]',
-          page: 0,
+          hitsPerPage: 100,
         },
-        query: 'searched query',
+        query: '',
       },
     ]
 

--- a/src/libs/algolia/fetchAlgolia/fetchSearchResults/fetchSearchResults.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchSearchResults/fetchSearchResults.ts
@@ -142,12 +142,18 @@ export const fetchSearchResults = async ({
     },
     // Artists in offers
     {
-      ...offersQuery,
+      indexName: offersIndex,
+      query: '',
       params: {
-        ...offersQuery.params,
+        ...buildOfferSearchParameters(
+          { ...parameters, artistName: parameters.query },
+          buildLocationParameterParams,
+          isUserUnderage,
+          disabilitiesProperties,
+          true
+        ),
         attributesToRetrieve: ['artists'],
         ...buildHitsPerPage(100),
-        ...(aroundPrecision && { aroundPrecision }),
       },
     },
   ]

--- a/src/libs/algolia/types.ts
+++ b/src/libs/algolia/types.ts
@@ -130,6 +130,7 @@ export type SearchQueryParameters = {
   beginningDatetime?: string
   date: SelectedDate | null
   eanList?: string[]
+  artistName?: string
   endingDatetime?: string
   hitsPerPage: number | null
   isFullyDigitalOffersCategory?: boolean


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36322

Modification de la query Algolia pour afficher les artistes dans les résultats de recherche

On utilise un attribut `facetFilter` pour récupérer l'artiste correspondant. L'inconvénient de cette technique est qu'il n'y a pas de tolérance d'erreur possible 

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
