### PR TITLE
(PC-36329) feat(venue): Hide hour label when no opening hours

### DIFF
--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -213,7 +213,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                   style={
                     [
                       {
-                        "color": "#b60025",
+                        "color": "#a20121",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
@@ -3207,7 +3207,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                   style={
                     [
                       {
-                        "color": "#b60025",
+                        "color": "#a20121",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
@@ -6527,7 +6527,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                   style={
                     [
                       {
-                        "color": "#b60025",
+                        "color": "#a20121",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,

--- a/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.native.test.tsx
+++ b/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.native.test.tsx
@@ -13,11 +13,9 @@ const TIMEZONE = 'UTC'
 jest.useFakeTimers().setSystemTime(CURRENT_DATE)
 
 describe('<OpeningHoursStatus />', () => {
-  it('should update state automatically when state change is in less than 30 minutes', async () => {
-    const openingHours = {
-      FRIDAY: [{ open: '09:00', close: '19:00' }],
-    }
-    render(
+  it('should render nothing if text is falsy (empty string)', () => {
+    const openingHours = { FRIDAY: undefined }
+    const { toJSON } = render(
       <OpeningHoursStatus
         openingHours={openingHours}
         currentDate={CURRENT_DATE}
@@ -25,11 +23,28 @@ describe('<OpeningHoursStatus />', () => {
       />
     )
 
-    expect(screen.getByText('Ouvre bientôt - 9h')).toBeOnTheScreen()
+    expect(toJSON()).toBeNull()
+  })
 
-    await act(async () => jest.advanceTimersByTime(30 * 60 * 1000))
+  it('should render nothing if state is "not-applicable"', () => {
+    const openingHours = { SUNDAY: undefined }
+    jest.mock('./getOpeningHoursStatus', () => ({
+      getOpeningHoursStatus: jest.fn(() => ({
+        openingState: 'not-applicable',
+        openingLabel: 'Label',
+        nextChangeTime: null,
+      })),
+    }))
 
-    expect(await screen.findByText('Ouvert jusqu’à 19h')).toBeOnTheScreen()
+    const { toJSON } = render(
+      <OpeningHoursStatus
+        openingHours={openingHours}
+        currentDate={CURRENT_DATE}
+        timezone={TIMEZONE}
+      />
+    )
+
+    expect(toJSON()).toBeNull()
   })
 
   it('should not update state automatically when state change is in more than 30 minutes', async () => {

--- a/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.tsx
+++ b/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.tsx
@@ -50,6 +50,8 @@ export const OpeningHoursStatus: FC<Props> = ({ openingHours, currentDate, timez
 
   useAppStateChange(() => setDate(new Date()), undefined)
 
+  if (!text || state === 'not-applicable') return null
+
   return (
     <Container>
       <StyledClock state={state} />
@@ -58,25 +60,36 @@ export const OpeningHoursStatus: FC<Props> = ({ openingHours, currentDate, timez
   )
 }
 
-const getColorFromState = (theme: DefaultTheme) => (state: OpeningHoursStatusState) => {
+const getIconColorFromState = (theme: DefaultTheme) => (state: OpeningHoursStatusState) => {
   return {
-    open: theme.colors.greenValid,
-    close: theme.colors.error,
-    'open-soon': theme.colors.goldDark,
-    'close-soon': theme.colors.goldDark,
+    open: theme.designSystem.color.icon.success,
+    close: theme.designSystem.color.icon.error,
+    'open-soon': theme.designSystem.color.icon.warning,
+    'close-soon': theme.designSystem.color.icon.warning,
+    'not-applicable': theme.designSystem.color.icon.default,
   }[state]
 }
 
 const StyledClock = styled(ClockFilled).attrs<{ state: OpeningHoursStatusState }>(
   ({ theme, state }) => ({
-    color: getColorFromState(theme)(state),
+    color: getIconColorFromState(theme)(state),
     size: theme.icons.sizes.extraSmall,
   })
 )<{ state: OpeningHoursStatusState }>``
 
+const getTextColorFromState = (theme: DefaultTheme) => (state: OpeningHoursStatusState) => {
+  return {
+    open: theme.designSystem.color.text.success,
+    close: theme.designSystem.color.text.error,
+    'open-soon': theme.colors.goldDark,
+    'close-soon': theme.colors.goldDark,
+    'not-applicable': theme.designSystem.color.text.default,
+  }[state]
+}
+
 const StyledText = styled(Typo.BodyAccentXs)<{ state: OpeningHoursStatusState }>(
   ({ state, theme }) => ({
-    color: getColorFromState(theme)(state),
+    color: getTextColorFromState(theme)(state),
   })
 )
 

--- a/src/features/venue/components/OpeningHoursStatus/getOpeningHoursStatus.native.test.ts
+++ b/src/features/venue/components/OpeningHoursStatus/getOpeningHoursStatus.native.test.ts
@@ -112,6 +112,18 @@ describe('OpeningHoursStatusViewModel', () => {
         },
         expected: 'Ouvert jusqu’à 19h30',
       },
+      {
+        openingHours: {
+          SUNDAY: undefined,
+          MONDAY: undefined,
+          TUESDAY: undefined,
+          WEDNESDAY: undefined,
+          THURSDAY: undefined,
+          FRIDAY: undefined,
+          SATURDAY: undefined,
+        },
+        expected: null,
+      },
     ])('should have correct text $expected', ({ openingHours, expected }) => {
       const viewModel = getOpeningHoursStatus({
         openingHours,
@@ -322,12 +334,6 @@ describe('OpeningHoursStatusViewModel', () => {
       },
       {
         openingHours: {
-          MONDAY: undefined,
-        },
-        currentDate: paris.monday('20:00:00'),
-      },
-      {
-        openingHours: {
           MONDAY: [{ open: '09:00', close: '19:00' }],
         },
         currentDate: paris.monday('07:00:00'),
@@ -343,11 +349,6 @@ describe('OpeningHoursStatusViewModel', () => {
     })
 
     it.each([
-      {
-        openingHours: { MONDAY: undefined },
-        currentDate: paris.monday('20:00:00'),
-        expectText: 'Fermé',
-      },
       {
         openingHours: { MONDAY: [{ open: '09:00', close: '19:00' }] },
         currentDate: paris.monday('20:00:00'),
@@ -479,6 +480,32 @@ describe('OpeningHoursStatusViewModel', () => {
         expect(viewModel.nextChangeTime).toEqual(expectedNextChange)
       }
     )
+  })
+
+  describe('Venue is not-applicable hours', () => {
+    it('should return not-applicable state', () => {
+      const openingHours = { MONDAY: undefined }
+      const currentDate = paris.monday('20:00:00')
+      const viewModel = getOpeningHoursStatus({
+        openingHours,
+        currentDate,
+        timezone: PARIS_TIMEZONE,
+      })
+
+      expect(viewModel.openingState).toEqual('not-applicable')
+    })
+
+    it('should not return text', () => {
+      const openingHours = { MONDAY: undefined }
+      const currentDate = paris.monday('20:00:00')
+      const viewModel = getOpeningHoursStatus({
+        openingHours,
+        currentDate,
+        timezone: PARIS_TIMEZONE,
+      })
+
+      expect(viewModel.openingLabel).toEqual(null)
+    })
   })
 
   describe('Venue is not on same timezone', () => {

--- a/src/features/venue/components/OpeningHoursStatus/getOpeningHoursStatus.ts
+++ b/src/features/venue/components/OpeningHoursStatus/getOpeningHoursStatus.ts
@@ -21,7 +21,7 @@ type OpeningHoursStatusParams = {
 
 type OpeningHoursStatus = {
   openingState: OpeningHoursStatusState
-  openingLabel: string
+  openingLabel: string | null
   nextChangeTime?: Date
 }
 
@@ -31,6 +31,10 @@ export const getOpeningHoursStatus = ({
   timezone,
 }: OpeningHoursStatusParams): OpeningHoursStatus => {
   const currentDateAtVenueTimezone = utcToZonedTime(currentDate, timezone)
+
+  const hasOpenDay = Object.values(openingHours).some((value) => !!value && value.length > 0)
+  if (!hasOpenDay) return { openingState: 'not-applicable', openingLabel: null }
+
   const currentOpeningPeriod = getCurrentOpeningPeriod(openingHours, currentDateAtVenueTimezone)
   const nextOpeningPeriod = getNextOpeningPeriod(openingHours, currentDateAtVenueTimezone)
   const { openingState, openingLabel } = computeOpeningState(

--- a/src/features/venue/types.ts
+++ b/src/features/venue/types.ts
@@ -45,7 +45,12 @@ export type OpeningHour = {
   close: string
 }
 
-export type OpeningHoursStatusState = 'open' | 'open-soon' | 'close-soon' | 'close'
+export type OpeningHoursStatusState =
+  | 'open'
+  | 'open-soon'
+  | 'close-soon'
+  | 'close'
+  | 'not-applicable'
 
 export type PastilleType = {
   label: string


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36329

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |     ![Capture d’écran 2025-06-10 à 15 30 06](https://github.com/user-attachments/assets/790bf490-7024-4a7c-a6df-35da9543d93b)    |   ![Capture d’écran 2025-06-10 à 15 30 16](https://github.com/user-attachments/assets/77480d6a-f5f8-4119-9f87-e51fc71a6d50)  |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
