### PR TITLE
(PC-36424) refactor(ui): use design token for Banners

### DIFF
--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -46,12 +46,12 @@ exports[`<SetBirthday /> should render correctly 1`] = `
     }
   >
     <View
-      backgroundColor="#f3ecff"
+      backgroundColor="#f3edff"
       style={
         [
           {
             "alignItems": "center",
-            "backgroundColor": "#f3ecff",
+            "backgroundColor": "#f3edff",
             "borderRadius": 8,
             "flexDirection": "row",
             "justifyContent": "space-between",
@@ -422,12 +422,12 @@ exports[`<SetBirthday /> should render correctly when account creation token and
     }
   >
     <View
-      backgroundColor="#f3ecff"
+      backgroundColor="#f3edff"
       style={
         [
           {
             "alignItems": "center",
-            "backgroundColor": "#f3ecff",
+            "backgroundColor": "#f3edff",
             "borderRadius": 8,
             "flexDirection": "row",
             "justifyContent": "space-between",

--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
@@ -191,7 +191,7 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
       class="css-view-175oi2r r-alignItems-1awozwy r-width-13qz1uu"
     >
       <div
-        class="css-view-175oi2r r-alignItems-1awozwy r-backgroundColor-nyej4v r-borderRadius-1xfd6ze r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-paddingBottom-1l7z4oj r-paddingLeft-1qhn6m8 r-paddingRight-i023vh r-paddingTop-95jzfe"
+        class="css-view-175oi2r r-alignItems-1awozwy r-backgroundColor-1k962jn r-borderRadius-1xfd6ze r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-paddingBottom-1l7z4oj r-paddingLeft-1qhn6m8 r-paddingRight-i023vh r-paddingTop-95jzfe"
       >
         <div
           class="css-view-175oi2r r-paddingRight-i023vh"
@@ -1534,7 +1534,7 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
       class="css-view-175oi2r r-alignItems-1awozwy r-width-13qz1uu"
     >
       <div
-        class="css-view-175oi2r r-alignItems-1awozwy r-backgroundColor-nyej4v r-borderRadius-1xfd6ze r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-paddingBottom-1l7z4oj r-paddingLeft-1qhn6m8 r-paddingRight-i023vh r-paddingTop-95jzfe"
+        class="css-view-175oi2r r-alignItems-1awozwy r-backgroundColor-1k962jn r-borderRadius-1xfd6ze r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-paddingBottom-1l7z4oj r-paddingLeft-1qhn6m8 r-paddingRight-i023vh r-paddingTop-95jzfe"
       >
         <div
           class="css-view-175oi2r r-paddingRight-i023vh"

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -2265,12 +2265,12 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
           }
         >
           <View
-            backgroundColor="#f3ecff"
+            backgroundColor="#f3edff"
             style={
               [
                 {
                   "alignItems": "center",
-                  "backgroundColor": "#f3ecff",
+                  "backgroundColor": "#f3edff",
                   "borderRadius": 8,
                   "flexDirection": "row",
                   "justifyContent": "space-between",

--- a/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
@@ -816,12 +816,12 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                 }
               />
               <View
-                backgroundColor="#f3ecff"
+                backgroundColor="#f3edff"
                 style={
                   [
                     {
                       "alignItems": "center",
-                      "backgroundColor": "#f3ecff",
+                      "backgroundColor": "#f3edff",
                       "borderRadius": 8,
                       "flexDirection": "row",
                       "justifyContent": "space-between",

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
@@ -227,7 +227,7 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
                 class="css-view-175oi2r r-height-10ptun7"
               />
               <div
-                class="css-view-175oi2r r-alignItems-1awozwy r-backgroundColor-nyej4v r-borderRadius-1xfd6ze r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-paddingBottom-1l7z4oj r-paddingLeft-1qhn6m8 r-paddingRight-i023vh r-paddingTop-95jzfe"
+                class="css-view-175oi2r r-alignItems-1awozwy r-backgroundColor-1k962jn r-borderRadius-1xfd6ze r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-paddingBottom-1l7z4oj r-paddingLeft-1qhn6m8 r-paddingRight-i023vh r-paddingTop-95jzfe"
               >
                 <div
                   class="css-view-175oi2r r-paddingRight-i023vh"

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
@@ -295,12 +295,12 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
                   Saisis ton numéro de téléphone
                 </Text>
                 <View
-                  backgroundColor="#f3ecff"
+                  backgroundColor="#f3edff"
                   style={
                     [
                       {
                         "alignItems": "center",
-                        "backgroundColor": "#f3ecff",
+                        "backgroundColor": "#f3edff",
                         "borderRadius": 8,
                         "flexDirection": "row",
                         "justifyContent": "space-between",

--- a/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
@@ -302,12 +302,12 @@ exports[`<SetName/> should render correctly 1`] = `
                 }
               />
               <View
-                backgroundColor="#f3ecff"
+                backgroundColor="#f3edff"
                 style={
                   [
                     {
                       "alignItems": "center",
-                      "backgroundColor": "#f3ecff",
+                      "backgroundColor": "#f3edff",
                       "borderRadius": 8,
                       "flexDirection": "row",
                       "justifyContent": "space-between",

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
@@ -462,12 +462,12 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
               }
             >
               <View
-                backgroundColor="#f3ecff"
+                backgroundColor="#f3edff"
                 style={
                   [
                     {
                       "alignItems": "center",
-                      "backgroundColor": "#f3ecff",
+                      "backgroundColor": "#f3edff",
                       "borderRadius": 8,
                       "flexDirection": "row",
                       "justifyContent": "space-between",

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
@@ -342,12 +342,12 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
           , nous te conseillons de suspendre ton compte temporairement.
         </Text>
         <View
-          backgroundColor="#f3ecff"
+          backgroundColor="#f3edff"
           style={
             [
               {
                 "alignItems": "center",
-                "backgroundColor": "#f3ecff",
+                "backgroundColor": "#f3edff",
                 "borderRadius": 8,
                 "flexDirection": "row",
                 "justifyContent": "space-between",

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
@@ -323,12 +323,12 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
         }
       />
       <View
-        backgroundColor="#f3ecff"
+        backgroundColor="#f3edff"
         style={
           [
             {
               "alignItems": "center",
-              "backgroundColor": "#f3ecff",
+              "backgroundColor": "#f3edff",
               "borderRadius": 8,
               "flexDirection": "row",
               "justifyContent": "space-between",

--- a/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
@@ -380,12 +380,12 @@ exports[`<NewEmailSelection /> should match snapshot 1`] = `
           }
         >
           <View
-            backgroundColor="#f3ecff"
+            backgroundColor="#f3edff"
             style={
               [
                 {
                   "alignItems": "center",
-                  "backgroundColor": "#f3ecff",
+                  "backgroundColor": "#f3edff",
                   "borderRadius": 8,
                   "flexDirection": "row",
                   "justifyContent": "space-between",

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -750,12 +750,12 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
             }
           />
           <View
-            backgroundColor="#f3ecff"
+            backgroundColor="#f3edff"
             style={
               [
                 {
                   "alignItems": "center",
-                  "backgroundColor": "#f3ecff",
+                  "backgroundColor": "#f3edff",
                   "borderRadius": 8,
                   "flexDirection": "row",
                   "justifyContent": "space-between",
@@ -2589,12 +2589,12 @@ exports[`NotificationsSettings should render correctly when user is not logged i
         }
       >
         <View
-          backgroundColor="#f3ecff"
+          backgroundColor="#f3edff"
           style={
             [
               {
                 "alignItems": "center",
-                "backgroundColor": "#f3ecff",
+                "backgroundColor": "#f3edff",
                 "borderRadius": 8,
                 "flexDirection": "row",
                 "justifyContent": "space-between",

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -208,7 +208,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
           class="css-view-175oi2r r-alignSelf-1kihuf0 r-maxWidth-1ik5qf4 r-width-13qz1uu"
         >
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-backgroundColor-nyej4v r-borderRadius-1xfd6ze r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-paddingBottom-1l7z4oj r-paddingLeft-1qhn6m8 r-paddingRight-i023vh r-paddingTop-95jzfe"
+            class="css-view-175oi2r r-alignItems-1awozwy r-backgroundColor-1k962jn r-borderRadius-1xfd6ze r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-paddingBottom-1l7z4oj r-paddingLeft-1qhn6m8 r-paddingRight-i023vh r-paddingTop-95jzfe"
           >
             <div
               class="css-view-175oi2r r-paddingRight-i023vh"

--- a/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
@@ -1030,12 +1030,12 @@ exports[`PersonalData should render personal data success 1`] = `
         }
       >
         <View
-          backgroundColor="#f3ecff"
+          backgroundColor="#f3edff"
           style={
             [
               {
                 "alignItems": "center",
-                "backgroundColor": "#f3ecff",
+                "backgroundColor": "#f3edff",
                 "borderRadius": 8,
                 "flexDirection": "row",
                 "justifyContent": "space-between",

--- a/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
@@ -1043,12 +1043,12 @@ exports[`<ProfileTutorialAgeInformationCredit /> should render correctly 1`] = `
         }
       />
       <View
-        backgroundColor="#f3ecff"
+        backgroundColor="#f3edff"
         style={
           [
             {
               "alignItems": "center",
-              "backgroundColor": "#f3ecff",
+              "backgroundColor": "#f3edff",
               "borderRadius": 8,
               "flexDirection": "row",
               "justifyContent": "space-between",

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -387,12 +387,12 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                 }
               >
                 <View
-                  backgroundColor="#f3ecff"
+                  backgroundColor="#f3edff"
                   style={
                     [
                       {
                         "alignItems": "center",
-                        "backgroundColor": "#f3ecff",
+                        "backgroundColor": "#f3edff",
                         "borderRadius": 8,
                         "flexDirection": "row",
                         "justifyContent": "space-between",

--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -242,12 +242,12 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
         }
       />
       <View
-        backgroundColor="#f3ecff"
+        backgroundColor="#f3edff"
         style={
           [
             {
               "alignItems": "center",
-              "backgroundColor": "#f3ecff",
+              "backgroundColor": "#f3edff",
               "borderRadius": 8,
               "flexDirection": "row",
               "justifyContent": "space-between",
@@ -974,12 +974,12 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
         }
       />
       <View
-        backgroundColor="#f3ecff"
+        backgroundColor="#f3edff"
         style={
           [
             {
               "alignItems": "center",
-              "backgroundColor": "#f3ecff",
+              "backgroundColor": "#f3edff",
               "borderRadius": 8,
               "flexDirection": "row",
               "justifyContent": "space-between",
@@ -1616,12 +1616,12 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
         }
       />
       <View
-        backgroundColor="#f3ecff"
+        backgroundColor="#f3edff"
         style={
           [
             {
               "alignItems": "center",
-              "backgroundColor": "#f3ecff",
+              "backgroundColor": "#f3edff",
               "borderRadius": 8,
               "flexDirection": "row",
               "justifyContent": "space-between",

--- a/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.tsx
+++ b/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.tsx
@@ -12,7 +12,7 @@ import { useTimer } from 'libs/hooks/useTimer'
 import { LogTypeEnum } from 'libs/monitoring/errors'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { formatToHour } from 'libs/parsers/formatDates'
-import { AlertBanner } from 'ui/components/banners/AlertBanner'
+import { WarningBanner } from 'ui/components/banners/WarningBanner'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { Close } from 'ui/svg/icons/Close'
@@ -100,7 +100,7 @@ export const EmailResendModal = ({ email, visible, onDismiss }: Props) => {
           </React.Fragment>
         ) : (
           <React.Fragment>
-            <AlertBanner
+            <WarningBanner
               message={`Tu as dépassé le nombre de 3 demandes de lien autorisées.${retryMessage}`}
             />
             <Spacer.Column numberOfSpaces={6} />

--- a/src/ui/components/ModuleBanner/BannerWithBackground.tsx
+++ b/src/ui/components/ModuleBanner/BannerWithBackground.tsx
@@ -44,15 +44,18 @@ export const BannerWithBackground: FunctionComponent<BannerWithBackgroundProps> 
   const StyledLeftIcon =
     leftIcon &&
     styled(leftIcon).attrs(({ theme }) => ({
-      color: theme.colors.white,
+      color: theme.designSystem.color.icon.lockedInverted,
+      color2: theme.designSystem.color.icon.lockedInverted,
     }))``
   const StyledRightIcon = rightIcon
     ? styled(rightIcon).attrs(({ theme }) => ({
-        color: theme.colors.white,
+        color: theme.designSystem.color.icon.lockedInverted,
+        color2: theme.designSystem.color.icon.lockedInverted,
         size: theme.icons.sizes.small,
       }))``
     : styled(ArrowNext).attrs(({ theme }) => ({
-        color: theme.colors.white,
+        color: theme.designSystem.color.icon.lockedInverted,
+        color2: theme.designSystem.color.icon.lockedInverted,
         size: theme.icons.sizes.small,
       }))``
 
@@ -93,7 +96,7 @@ const ImageContainer = styled.View(({ theme }) => ({
 const ImageBackground = styled.ImageBackground(({ theme }) => ({
   width: '100%',
   justifyContent: 'center',
-  backgroundColor: theme.colors.primary,
+  backgroundColor: theme.designSystem.color.background.brandPrimary,
 }))
 
 const GenericBannerWithoutBorder = styled(GenericBanner)({

--- a/src/ui/components/banners/ErrorBanner.tsx
+++ b/src/ui/components/banners/ErrorBanner.tsx
@@ -19,8 +19,8 @@ export const ErrorBanner: FunctionComponent<Props> = ({ message, testID, childre
     <GenericColoredBanner
       message={message}
       Icon={Icon}
-      backgroundColor={theme.colors.errorLight}
-      textColor={theme.colors.error}
+      backgroundColor={theme.designSystem.color.background.error}
+      textColor={theme.designSystem.color.text.error}
       testID={testID}>
       {children}
     </GenericColoredBanner>
@@ -28,6 +28,7 @@ export const ErrorBanner: FunctionComponent<Props> = ({ message, testID, childre
 }
 
 const StyledErrorIcon = styled(Error).attrs(({ theme }) => ({
-  color: theme.colors.error,
+  color: theme.designSystem.color.icon.error,
+  color2: theme.designSystem.color.icon.error,
   size: theme.icons.sizes.small,
 }))``

--- a/src/ui/components/banners/GenericColoredBanner.stories.tsx
+++ b/src/ui/components/banners/GenericColoredBanner.stories.tsx
@@ -22,11 +22,11 @@ const variantConfig: Variants<typeof GenericColoredBanner> = [
   },
   {
     label: 'GenericColoredBanner with custom text color',
-    props: { message, textColor: theme.colors.error },
+    props: { message, textColor: theme.designSystem.color.text.error },
   },
   {
     label: 'GenericColoredBanner with custom background color',
-    props: { message, backgroundColor: theme.colors.attention },
+    props: { message, backgroundColor: theme.designSystem.color.background.warning },
   },
 ]
 

--- a/src/ui/components/banners/GenericColoredBanner.tsx
+++ b/src/ui/components/banners/GenericColoredBanner.tsx
@@ -46,7 +46,7 @@ const Container = styled.View<{ backgroundColor?: string }>(({ theme, background
   flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'space-between',
-  backgroundColor: backgroundColor || theme.colors.secondaryLight100,
+  backgroundColor: backgroundColor || theme.designSystem.color.background.info,
   borderRadius: getSpacing(2),
   padding: getSpacing(4),
 }))
@@ -60,5 +60,5 @@ const TextContainer = styled.View({
 })
 
 const Caption = styled(Typo.BodyAccentXs)<ColorMessageProps>(({ theme, textColor }) => ({
-  color: textColor || theme.colors.black,
+  color: textColor || theme.designSystem.color.text.default,
 }))

--- a/src/ui/components/banners/InfoBanner.tsx
+++ b/src/ui/components/banners/InfoBanner.tsx
@@ -34,18 +34,21 @@ export const InfoBanner: FunctionComponent<Props> = ({
   const Icon =
     icon &&
     styled(icon).attrs(({ theme }) => ({
-      color: theme.colors.greyDark,
-      color2: theme.colors.greyDark,
+      color: theme.designSystem.color.icon.info,
+      color2: theme.designSystem.color.icon.info,
       size: theme.icons.sizes.small,
     }))``
 
-  const textColor = withLightColorMessage ? theme.colors.greyDark : theme.colors.black
+  const textColor = withLightColorMessage
+    ? theme.designSystem.color.text.subtle
+    : theme.designSystem.color.text.default
+
   return (
     <GenericColoredBanner
       messageContainerStyle={messageContainerStyle}
       message={message}
       Icon={Icon}
-      backgroundColor={backgroundColor ?? theme.colors.secondaryLight100}
+      backgroundColor={backgroundColor ?? theme.designSystem.color.background.info}
       textColor={textColor}
       testID={testID}>
       {children}

--- a/src/ui/components/banners/WarningBanner.stories.tsx
+++ b/src/ui/components/banners/WarningBanner.stories.tsx
@@ -1,19 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import { AlertBanner } from './AlertBanner'
+import { WarningBanner } from './WarningBanner'
 
-const meta: Meta<typeof AlertBanner> = {
-  title: 'ui/banners/AlertBanner',
-  component: AlertBanner,
+const meta: Meta<typeof WarningBanner> = {
+  title: 'ui/banners/WarningBanner',
+  component: WarningBanner,
 }
 export default meta
 
-type Story = StoryObj<typeof AlertBanner>
+type Story = StoryObj<typeof WarningBanner>
 
 export const Default: Story = {
-  render: (props) => <AlertBanner {...props} />,
-  name: 'AlertBanner',
+  render: (props) => <WarningBanner {...props} />,
+  name: 'WarningBanner',
   args: {
     message:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.',

--- a/src/ui/components/banners/WarningBanner.tsx
+++ b/src/ui/components/banners/WarningBanner.tsx
@@ -11,15 +11,15 @@ type Props = {
   testID?: string
 }
 
-export const AlertBanner: FunctionComponent<Props> = ({ message, testID, children }) => {
+export const WarningBanner: FunctionComponent<Props> = ({ message, testID, children }) => {
   const theme = useTheme()
 
   return (
     <GenericColoredBanner
       message={message}
       Icon={GreyWarning}
-      backgroundColor={theme.colors.attentionLight}
-      textColor={theme.colors.black}
+      backgroundColor={theme.designSystem.color.background.warning}
+      textColor={theme.designSystem.color.text.warning}
       testID={testID}>
       {children}
     </GenericColoredBanner>
@@ -27,6 +27,7 @@ export const AlertBanner: FunctionComponent<Props> = ({ message, testID, childre
 }
 
 const GreyWarning = styled(Warning).attrs(({ theme }) => ({
-  color: theme.colors.greyDark,
+  color: theme.designSystem.color.icon.warning,
+  color2: theme.designSystem.color.icon.warning,
   size: theme.icons.sizes.small,
 }))``


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36424

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |        |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
