### PR TITLE
(BSR) refactor(ui): use design token for theme.colors.greyDark

### DIFF
--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -1174,7 +1174,7 @@ exports[`BookingDetails OldBookingDetails : when FF WIP_NEW_BOOKING_PAGE is off 
               style={
                 [
                   {
-                    "color": "#696A6F",
+                    "color": "#696a6f",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
                     "lineHeight": 19.2,

--- a/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
@@ -414,7 +414,7 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
               style={
                 [
                   {
-                    "color": "#696A6F",
+                    "color": "#696a6f",
                     "fontFamily": "Montserrat-Medium",
                     "fontSize": 16,
                     "lineHeight": 25.6,
@@ -576,7 +576,7 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
                           },
                           [
                             {
-                              "backgroundColor": "#F1F1F4",
+                              "backgroundColor": "#f1f1f4",
                               "borderColor": "#696A6F",
                               "borderRadius": 5,
                               "borderWidth": 1,

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -506,7 +506,7 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                   style={
                     [
                       {
-                        "color": "#696A6F",
+                        "color": "#696a6f",
                         "flexShrink": 1,
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -3987,7 +3987,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                                   },
                                   [
                                     {
-                                      "backgroundColor": "#F1F1F4",
+                                      "backgroundColor": "#f1f1f4",
                                       "borderRadius": 4,
                                       "height": 96,
                                       "width": 64,

--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -317,7 +317,7 @@ const Separator = styled.View(({ theme }) => ({
 const Caption = styled(Typo.BodyAccentXs)(({ theme }) => ({
   marginTop: getSpacing(1),
   textAlign: 'center',
-  color: theme.colors.greyDark,
+  color: theme.designSystem.color.text.subtle,
 }))
 
 const VenueTitleContainer = styled.View({

--- a/src/features/bookOffer/components/Calendar/DayComponent.tsx
+++ b/src/features/bookOffer/components/Calendar/DayComponent.tsx
@@ -79,7 +79,7 @@ function getStatusColor({ colors }: DefaultTheme, status: OfferStatus) {
 }
 
 const Body = styled(Typo.Body)(({ theme }) => ({
-  color: theme.colors.greyDark,
+  color: theme.designSystem.color.text.subtle,
 }))
 
 const Day = styled(Typo.Button)<{ status: OfferStatus }>(({ theme, status }) => ({

--- a/src/features/bookings/components/BookingDetailsCancelButton.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.tsx
@@ -68,5 +68,5 @@ export const BookingDetailsCancelButton = (props: BookingDetailsCancelButtonProp
 
 const StyledCaption = styled(Typo.BodyAccentXs)(({ theme }) => ({
   textAlign: 'center',
-  color: theme.colors.greyDark,
+  color: theme.designSystem.color.text.subtle,
 }))

--- a/src/features/bookings/components/BookingPrecision.tsx
+++ b/src/features/bookings/components/BookingPrecision.tsx
@@ -41,5 +41,5 @@ const EmailContainer = styled(ViewGap)({
 })
 
 const CaptionNeutralInfo = styled(Typo.BodyAccentS)(({ theme }) => ({
-  color: theme.colors.greyDark,
+  color: theme.designSystem.color.text.subtle,
 }))

--- a/src/features/bookings/components/OldBookingDetails/BookingDetailsCancelButton.tsx
+++ b/src/features/bookings/components/OldBookingDetails/BookingDetailsCancelButton.tsx
@@ -68,7 +68,7 @@ export const BookingDetailsCancelButton = (props: BookingDetailsCancelButtonProp
 
 const StyledCaption = styled(Typo.BodyAccentXs)(({ theme }) => ({
   textAlign: 'center',
-  color: theme.colors.greyDark,
+  color: theme.designSystem.color.text.subtle,
 }))
 
 const StyledViewGap = styled(ViewGap)({

--- a/src/features/home/components/modules/video/VideoModal.tsx
+++ b/src/features/home/components/modules/video/VideoModal.tsx
@@ -156,7 +156,7 @@ const StyledCaptionDate = styled(Typo.BodyAccentXs)(({ theme }) => ({
 }))
 
 const StyledBody = styled(Typo.Body)(({ theme }) => ({
-  color: theme.colors.greyDark,
+  color: theme.designSystem.color.text.subtle,
 }))
 
 const StyledScrollView = styled.ScrollView({

--- a/src/features/home/components/modules/video/VideoModal.web.tsx
+++ b/src/features/home/components/modules/video/VideoModal.web.tsx
@@ -154,7 +154,7 @@ const StyledCaptionDate = styled(Typo.BodyAccentXs)(({ theme }) => ({
 }))
 
 const StyledBody = styled(Typo.Body)(({ theme }) => ({
-  color: theme.colors.greyDark,
+  color: theme.designSystem.color.text.subtle,
 }))
 
 const StyledScrollView = styled.ScrollView({

--- a/src/features/offer/components/VenueDetails/VenueDetails.tsx
+++ b/src/features/offer/components/VenueDetails/VenueDetails.tsx
@@ -54,15 +54,15 @@ const Title = styled(Typo.BodyAccent).attrs({
   numberOfLines: 1,
   ellipsizeMode: 'tail',
 })<{ isHover?: boolean }>(({ theme, isHover }) => ({
-  ...getHoverStyle(theme.colors.black, isHover),
+  ...getHoverStyle(theme.designSystem.color.text.default, isHover),
 }))
 
 const VenueAddress = styled(Typo.BodyAccentXs).attrs({
   numberOfLines: 2,
   ellipsizeMode: 'tail',
 })<{ isHover?: boolean }>(({ theme, isHover }) => ({
-  color: theme.colors.greyDark,
-  ...getHoverStyle(theme.colors.black, isHover),
+  color: theme.designSystem.color.text.subtle,
+  ...getHoverStyle(theme.designSystem.color.text.subtle, isHover),
 }))
 
 const StyledTag = styled(Tag)({

--- a/src/features/search/components/FilterRow/FilterRow.tsx
+++ b/src/features/search/components/FilterRow/FilterRow.tsx
@@ -77,7 +77,7 @@ const Title = styled(Typo.BodyAccent)({
 
 const Description = styled(Typo.BodyAccentXs)(({ theme }) => ({
   flexShrink: 1,
-  color: theme.colors.greyDark,
+  color: theme.designSystem.color.text.subtle,
 }))
 
 const ArrowNext = styled(DefaultArrowNext).attrs(({ theme }) => ({

--- a/src/features/search/components/NoSearchResults/NoSearchResult.tsx
+++ b/src/features/search/components/NoSearchResults/NoSearchResult.tsx
@@ -30,7 +30,7 @@ export const NoSearchResult: React.FC<NoSearchResultProps> = ({
       </ContainerNoOffer>
       <ContainerText>
         <Title>{title}</Title>
-        {subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
+        {subtitle ? <Typo.Body>{subtitle}</Typo.Body> : null}
         <ErrorDescriptionContainer>
           <ErrorDescription accessibilityLiveRegion="assertive">
             {errorDescription}
@@ -71,17 +71,12 @@ const ContainerText = styled.View(({ theme }) => ({
 
 const Title = styled(Typo.Title4).attrs({
   ...getHeadingAttrs(2),
-})(({ theme }) => ({
-  color: theme.colors.black,
+})({
   marginTop: getSpacing(4),
-}))
-
-const Subtitle = styled(Typo.Body)(({ theme }) => ({
-  color: theme.colors.black,
-}))
+})
 
 const ErrorDescription = styled(Typo.Body)(({ theme }) => ({
-  color: theme.colors.greyDark,
+  color: theme.designSystem.color.text.subtle,
 }))
 
 const ErrorDescriptionContainer = styled(Typo.Body)({

--- a/src/features/search/pages/SuggestedPlacesOrVenues/SuggestedPlaces.tsx
+++ b/src/features/search/pages/SuggestedPlacesOrVenues/SuggestedPlaces.tsx
@@ -95,7 +95,7 @@ const ListIconWrapper = styled.View({
 })
 
 const StyledBody = styled(Typo.Body)(({ theme }) => ({
-  color: theme.colors.greyDark,
+  color: theme.designSystem.color.text.subtle,
 }))
 
 const ListLocationPointer = styled(DefaultLocationPointer).attrs(({ theme }) => ({

--- a/src/features/search/pages/SuggestedPlacesOrVenues/SuggestedVenues.tsx
+++ b/src/features/search/pages/SuggestedPlacesOrVenues/SuggestedVenues.tsx
@@ -85,7 +85,9 @@ const DescriptionErrorTextContainer = styled(Typo.Body)({
   textAlign: 'center',
 })
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({ color: theme.colors.greyDark }))
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.designSystem.color.text.subtle,
+}))
 
 const BuildingIcon = styled(LocationBuildingFilled).attrs(({ theme }) => ({
   size: theme.icons.sizes.smaller,

--- a/src/ui/components/PassPlaylist.tsx
+++ b/src/ui/components/PassPlaylist.tsx
@@ -124,7 +124,7 @@ const StyledSubtitle = styled(Typo.BodyAccentXs).attrs({
   numberOfLines: 2,
 })(({ theme }) => ({
   marginHorizontal: theme.contentPage.marginHorizontal,
-  color: theme.colors.greyDark,
+  color: theme.designSystem.color.text.subtle,
 }))
 
 const StyledView = styled.View({

--- a/src/ui/components/ValidationMark.tsx
+++ b/src/ui/components/ValidationMark.tsx
@@ -21,7 +21,7 @@ export const ValidationMark: React.FC<Props> = ({ isValid, size }) => {
 }
 
 const ValidateGreenValid = styled(Validate).attrs(({ theme }) => ({
-  color: theme.colors.greenValid,
+  color: theme.designSystem.color.icon.success,
   accessibilityLabel: 'Accessible',
 }))``
 

--- a/src/ui/components/tiles/HorizontalOfferTile.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.tsx
@@ -187,7 +187,7 @@ const Container = styled(InternalTouchableLink)({
 })
 
 const Body = styled(Typo.Body)(({ theme }) => ({
-  color: theme.colors.greyDark,
+  color: theme.designSystem.color.text.subtle,
 }))
 
 const Flex = styled.View<FlexStyle>(({ flex, justifyContent, alignItems, gap, flexDirection }) => ({

--- a/src/ui/components/tiles/OfferImage.tsx
+++ b/src/ui/components/tiles/OfferImage.tsx
@@ -65,7 +65,7 @@ export const OfferImage: React.FC<Props> = ({
 const StyledFastImage = styled(ResizedFastImage).attrs<StyleProps>(({ theme, size }) => ({
   ...theme.tiles.sizes[size],
 }))<StyleProps>(({ theme, size, borderRadius, withStroke }) => ({
-  backgroundColor: theme.colors.greyLight,
+  backgroundColor: theme.designSystem.color.background.subtle,
   ...theme.tiles.sizes[size],
   borderRadius: borderRadius || theme.tiles.borderRadius,
   ...(withStroke


### PR DESCRIPTION
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
