### PR TITLE
(PC-36420) fix(offer): prevent "Cannot read property 'searchGroupName' of undefined"

### DIFF
--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -65,7 +65,7 @@ export function Offer() {
 
   const { data } = useFetchHeadlineOffersCountQuery(offer)
 
-  if (!offer || !subcategories) return null
+  if (!offer || !subcategories || !subcategoriesMapping?.[offer?.subcategoryId]) return null
 
   const shouldFetchSearchVenueOffers = isMultiVenueCompatibleOffer(offer)
   const headlineOffersCount = shouldFetchSearchVenueOffers ? data?.headlineOffersCount : undefined

--- a/src/libs/subcategories/mappings.ts
+++ b/src/libs/subcategories/mappings.ts
@@ -57,7 +57,7 @@ export const useSubcategoryOfferLabelMapping = (): SubcategoryOfferLabelMapping 
   const { subcategories = [] } = data || {}
 
   return useMemo(() => {
-    const mapping = <SubcategoryOfferLabelMapping>{}
+    const mapping = {} as SubcategoryOfferLabelMapping
     subcategories.forEach((curr) => {
       mapping[curr.id] = curr.appLabel
     })


### PR DESCRIPTION
I search up in the code where is built this property and found it in Offer

if (!offer || !subcategories || !subcategoriesMapping?.[offer?.subcategoryId]) return null

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36420

