### PR TITLE
(BSR) fix(vite): fix build with react-native-reanimated

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,7 @@ const libsThatHaveJSFilesContainingJSX = [
   'node_modules/react-native-calendars',
   'node_modules/react-native-swipe-gestures',
   'node_modules/@react-native/assets-registry',
+  'node_modules/react-native-reanimated',
 ]
 
 const packageJson = require('./package.json')


### PR DESCRIPTION
Fix `yarn build:testing` broken after `react-native@0.75`
