### PR TITLE
(PC-36419) fix(venue): avoid to catch Sentry error

### DIFF
--- a/src/features/venue/queries/useVenueQuery.native.test.ts
+++ b/src/features/venue/queries/useVenueQuery.native.test.ts
@@ -1,0 +1,56 @@
+import { api } from 'api/api'
+import { ApiError } from 'api/ApiError'
+import { VenueResponse } from 'api/gen'
+import { venueDataTest } from 'features/venue/fixtures/venueDataTest'
+import { VenueNotFound } from 'features/venue/pages/VenueNotFound/VenueNotFound'
+import { LogTypeEnum, VenueNotFoundError } from 'libs/monitoring/errors'
+import { mockServer } from 'tests/mswServer'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { act, renderHook } from 'tests/utils'
+
+import { useVenueQuery } from './useVenueQuery'
+
+jest.mock('libs/network/NetInfoWrapper')
+jest.mock('libs/firebase/analytics/analytics')
+
+const spyApiGetVenue = jest.spyOn(api, 'getNativeV1VenuevenueId')
+
+describe('useVenueQuery', () => {
+  it('should call API otherwise', async () => {
+    mockServer.getApi<VenueResponse>(`/v1/venue/${venueDataTest.id}`, venueDataTest)
+    const { result } = renderHook(() => useVenueQuery(venueDataTest.id), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+
+    await act(async () => {})
+
+    expect(JSON.stringify(result.current.data)).toEqual(JSON.stringify(venueDataTest))
+  })
+
+  it('should trigger VenueNotFoundError when error is an ApiError and status code is 404', async () => {
+    spyApiGetVenue.mockRejectedValueOnce(new ApiError(404, 'Venue not found'))
+    const { result } = renderHook(() => useVenueQuery(venueDataTest.id), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+
+    await act(async () => {})
+
+    expect(result.current.error).toEqual(
+      new VenueNotFoundError(venueDataTest.id, {
+        Screen: VenueNotFound,
+        logType: LogTypeEnum.IGNORED,
+      })
+    )
+  })
+
+  it('should trigger ApiError when error is an ApiError and status code is 400', async () => {
+    spyApiGetVenue.mockRejectedValueOnce(new ApiError(400, 'Bad request'))
+    const { result } = renderHook(() => useVenueQuery(venueDataTest.id), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+
+    await act(async () => {})
+
+    expect(result.current.error).toEqual(new ApiError(400, 'Bad request'))
+  })
+})

--- a/src/features/venue/queries/useVenueQuery.ts
+++ b/src/features/venue/queries/useVenueQuery.ts
@@ -1,25 +1,34 @@
 import { useQuery } from 'react-query'
 
 import { api } from 'api/api'
+import { ApiError } from 'api/ApiError'
 import { VenueResponse } from 'api/gen'
 import { VenueNotFound } from 'features/venue/pages/VenueNotFound/VenueNotFound'
 import { useLogTypeFromRemoteConfig } from 'libs/hooks/useLogTypeFromRemoteConfig'
-import { VenueNotFoundError } from 'libs/monitoring/errors'
+import { LogTypeEnum, VenueNotFoundError } from 'libs/monitoring/errors'
 import { QueryKeys } from 'libs/queryKeys'
+
+const getVenueById = async (venueId: number, logType: LogTypeEnum) => {
+  try {
+    return await api.getNativeV1VenuevenueId(venueId)
+  } catch (error) {
+    if (error instanceof ApiError && error.statusCode === 404) {
+      throw new VenueNotFoundError(venueId, {
+        Screen: VenueNotFound,
+        logType,
+      })
+    }
+    throw error
+  }
+}
 
 export const useVenueQuery = (venueId: number, options?: { enabled?: boolean }) => {
   const { logType } = useLogTypeFromRemoteConfig()
 
   return useQuery<VenueResponse | undefined>(
     [QueryKeys.VENUE, venueId],
-    () => api.getNativeV1VenuevenueId(venueId),
+    () => getVenueById(venueId, logType),
     {
-      onError: (_error) => {
-        throw new VenueNotFoundError(venueId, {
-          Screen: VenueNotFound,
-          logType,
-        })
-      },
       enabled: options?.enabled ?? true,
     }
   )


### PR DESCRIPTION
onError est exécutée à la fin du cycle de la requête. À ce moment, l’erreur est déjà gérée par React Query. Si on throw à ce moment, on crée une deuxième erreur asynchrone que React Query ne gère pas et Sentry la capture.

=> Du coup j'ai à peu près repris le code tel qu'il était avant la refacto de Xavier

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36419

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |<img width="1721" alt="Capture d’écran 2025-06-23 à 14 23 21" src="https://github.com/user-attachments/assets/6a9e6ba8-f316-4d50-b994-93fb09afee73" />|<img width="1721" alt="Capture d’écran 2025-06-23 à 14 23 03" src="https://github.com/user-attachments/assets/d295bc76-ce8d-422a-93d9-1c03ee058d11" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
