### PR TITLE
(PC-36210) feat(OfferPage): users not logged in, users with not enough credit, users with expired credit should have CTA "acceder au site partenaire" if offer has an external url

### DIFF
--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
@@ -49,7 +49,23 @@ const setFreeOfferIdSpy = jest.spyOn(freeOfferIdActions, 'setFreeOfferId')
 
 describe('getCtaWordingAndAction', () => {
   describe('Logged out user', () => {
-    it('should display "Réserver l’offre" wording and modal "authentication"', () => {
+    it('should display "Accéder au site partenaire" wording and redirect to external link when offer has external url', () => {
+      const result = getCtaWordingAndAction({
+        ...defaultParameters,
+        isLoggedIn: false,
+        user: undefined,
+        offer: buildOffer({ externalTicketOfficeUrl: 'https://url-externe' }),
+        subcategory: buildSubcategory({}),
+      })
+
+      expect(result).toEqual({
+        wording: 'Accéder au site partenaire',
+        externalNav: { url: 'https://url-externe' },
+        isDisabled: false,
+      })
+    })
+
+    it('should display "Réserver l’offre" wording and modal "authentication" when offer has no external url', () => {
       const result = getCtaWordingAndAction({
         ...defaultParameters,
         isLoggedIn: false,
@@ -304,6 +320,23 @@ describe('getCtaWordingAndAction', () => {
         expect(result?.modalToDisplay).toEqual(modalToDisplay)
       }
     )
+
+    describe('ex-beneficiary', () => {
+      it('should display "Accéder au site partenaire" wording and redirect to external link when offer has external url', () => {
+        const result = getCtaWordingAndAction({
+          ...defaultParameters,
+          user: { ...beneficiaryUser, depositExpirationDate: '2021-01-01T11:00:00Z' },
+          offer: buildOffer({ externalTicketOfficeUrl: 'https://url-externe' }),
+          subcategory: buildSubcategory({}),
+        })
+
+        expect(result).toEqual({
+          wording: 'Accéder au site partenaire',
+          externalNav: { url: 'https://url-externe' },
+          isDisabled: false,
+        })
+      })
+    })
   })
 
   // same as non beneficiary use cases, beneficiary users should not be able to book educational offers
@@ -439,6 +472,22 @@ describe('getCtaWordingAndAction', () => {
         modalToDisplay: OfferModal.BOOKING,
         isDisabled: false,
         ...result,
+      })
+    })
+
+    it('CTA="Accéder au site partenaire" when user does not have enough credit and offer has external url', () => {
+      const result = getCta(
+        { isDigital: true },
+        {
+          hasEnoughCredit: false,
+          offer: buildOffer({ externalTicketOfficeUrl: 'https://url-externe' }),
+        }
+      )
+
+      expect(result).toEqual({
+        wording: 'Accéder au site partenaire',
+        externalNav: { url: 'https://url-externe' },
+        isDisabled: false,
       })
     })
 
@@ -612,7 +661,7 @@ describe('getCtaWordingAndAction', () => {
       const { onPress } =
         getCtaWordingAndAction({
           ...defaultParameters,
-          user: { ...beneficiaryUser },
+          user: { ...beneficiaryUser, depositExpirationDate: '2023-11-19T11:00:00Z' },
           userStatus: { statusType: YoungStatusType.beneficiary },
           isBeneficiary: true,
           offer,
@@ -720,7 +769,7 @@ describe('getCtaWordingAndAction', () => {
         getCtaWordingAndAction({
           ...defaultParameters,
           isLoggedIn: true,
-          user: { ...beneficiaryUser },
+          user: { ...beneficiaryUser, depositExpirationDate: '2023-11-19T11:00:00Z' },
           userStatus: { statusType: YoungStatusType.beneficiary },
           isBeneficiary: true,
           offer,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36210

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| case         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
|user not connected           |  ![not connected](https://github.com/user-attachments/assets/08fe09fe-641d-4ca5-8f60-d46c1e20a034) |  ![not connected new](https://github.com/user-attachments/assets/d3fb627c-4fa8-440f-80b6-466e0b0978e7)  |
| user not eligible          |    ![Screenshot 2025-06-24 at 11 06 07](https://github.com/user-attachments/assets/c59ed5de-e17c-4f5e-94d2-8e4d385774d9)| ![Screenshot 2025-06-24 at 11 07 02](https://github.com/user-attachments/assets/c9315ee7-1109-4076-a6f3-167e125f378a)|
| ex beneficiary user   |               |       |
| user with not enough credit |      ![not enough credit](https://github.com/user-attachments/assets/cdd9c68a-df0f-43c8-9194-c520fc2ee458) |     ![not enough credit ](https://github.com/user-attachments/assets/7c949895-8d44-4702-8357-9dd6fff574bc)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
