### PR TITLE
(PC-36608) feat(ui): use design token in some components

### DIFF
--- a/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
@@ -206,10 +206,11 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
         style={
           [
             {
-              "color": "#ffffff",
+              "color": "#161617",
               "fontFamily": "Montserrat-Medium",
               "fontSize": 16,
               "lineHeight": 25.6,
+              "textAlign": "center",
             },
           ]
         }
@@ -230,10 +231,11 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
         style={
           [
             {
-              "color": "#ffffff",
+              "color": "#161617",
               "fontFamily": "Montserrat-Medium",
               "fontSize": 16,
               "lineHeight": 25.6,
+              "textAlign": "center",
             },
           ]
         }

--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -71,7 +71,36 @@ exports[`BookingDetails OldBookingDetails : when FF WIP_NEW_BOOKING_PAGE is off 
               ]
             }
             width={960}
-          />
+          >
+            <BVLinearGradient
+              colors={
+                [
+                  1447447,
+                  437655063,
+                ]
+              }
+              endPoint={
+                {
+                  "x": 0.5,
+                  "y": 1,
+                }
+              }
+              locations={null}
+              startPoint={
+                {
+                  "x": 0.5,
+                  "y": 0,
+                }
+              }
+              style={
+                [
+                  {
+                    "height": "100%",
+                  },
+                ]
+              }
+            />
+          </View>
         </View>
       </View>
       <RCTScrollView

--- a/src/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.tsx
+++ b/src/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.tsx
@@ -19,6 +19,6 @@ const onBeforeNavigateContactFraudTeam = () => {
   analytics.logContactFraudTeam({ from: 'fraudulentsuspendedaccount' })
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
-  color: theme.colors.white,
-}))
+const StyledBody = styled(Typo.Body)({
+  textAlign: 'center',
+})

--- a/src/features/bookOffer/components/Calendar/DayComponent.tsx
+++ b/src/features/bookOffer/components/Calendar/DayComponent.tsx
@@ -68,14 +68,14 @@ export const DayComponent: React.FC<Props> = ({ status, selected, date }) => {
   )
 }
 
-function getStatusColor({ colors }: DefaultTheme, status: OfferStatus) {
+function getStatusColor({ designSystem }: DefaultTheme, status: OfferStatus) {
   if (status === OfferStatus.BOOKABLE) {
-    return colors.primary
+    return designSystem.color.text.brandPrimary
   }
   if (status === OfferStatus.NOT_BOOKABLE) {
-    return colors.greyDark
+    return designSystem.color.text.disabled
   }
-  return colors.greyDark
+  return designSystem.color.text.subtle
 }
 
 const Body = styled(Typo.Body)(({ theme }) => ({

--- a/src/features/bookOffer/components/Calendar/DiagonalStripe.tsx
+++ b/src/features/bookOffer/components/Calendar/DiagonalStripe.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components/native'
 
 export const DiagonalStripe = styled(LinearGradient).attrs(({ theme }) => ({
   colors: [
-    theme.designSystem.color.background.locked,
-    theme.designSystem.color.background.subtle,
-    theme.designSystem.color.background.locked,
+    theme.designSystem.color.text.inverted,
+    theme.designSystem.color.text.disabled,
+    theme.designSystem.color.text.inverted,
   ],
   start: { x: 0.0, y: 0.0 },
   end: { x: 1.0, y: 1.0 },

--- a/src/features/bookings/components/OldBookingDetails/ThreeShapesTicket.tsx
+++ b/src/features/bookings/components/OldBookingDetails/ThreeShapesTicket.tsx
@@ -34,7 +34,7 @@ const Container = styled.View(({ theme }) => {
         height: 2,
       },
       shadowRadius: 3,
-      shadowColor: theme.colors.black,
+      shadowColor: theme.designSystem.color.background.lockedInverted,
       shadowOpacity: 0.1,
     })
   }

--- a/src/features/bookings/helpers/useReactionIcon/useReactionIcon.tsx
+++ b/src/features/bookings/helpers/useReactionIcon/useReactionIcon.tsx
@@ -16,26 +16,18 @@ export const useReactionIcon = (reaction?: ReactionTypeEnum | null) => {
     [iconFactory]
   )
 
-  const ReactionDislikeIcon = useMemo(
-    () =>
-      styled(iconFactory.getIcon('dislike-filled')).attrs(({ theme }) => ({
-        color: theme.designSystem.color.icon.default,
-      }))``,
-    [iconFactory]
-  )
-
   const getCustomReactionIcon = useCallback(
     (reaction?: ReactionTypeEnum | null): React.FC<AccessibleIcon> => {
       switch (reaction) {
         case ReactionTypeEnum.LIKE:
           return ReactionLikeIcon
         case ReactionTypeEnum.DISLIKE:
-          return ReactionDislikeIcon
+          return iconFactory.getIcon('dislike-filled')
         default:
           return iconFactory.getIcon('like')
       }
     },
-    [ReactionLikeIcon, ReactionDislikeIcon, iconFactory]
+    [ReactionLikeIcon, iconFactory]
   )
 
   return getCustomReactionIcon(reaction)

--- a/src/features/location/components/LocationWidgetWrapperDesktop.tsx
+++ b/src/features/location/components/LocationWidgetWrapperDesktop.tsx
@@ -120,12 +120,12 @@ const NotShrunk = styled.View({
 const LocationPointerFilled = styled(LocationPointerAppV2).attrs(({ theme }) => ({
   color: theme.designSystem.color.icon.brandPrimary,
   size: theme.icons.sizes.small,
-}))({})
+}))``
 
 const LocationPointerNotFilled = styled(LocationPointerAppV2).attrs(({ theme }) => ({
   color: theme.designSystem.color.icon.subtle,
   size: theme.icons.sizes.small,
-}))({})
+}))``
 
 const LocationTitle = styled(Typo.BodyAccent).attrs({
   numberOfLines: 1,

--- a/src/features/navigation/RootNavigator/withWebWrapper.web.tsx
+++ b/src/features/navigation/RootNavigator/withWebWrapper.web.tsx
@@ -18,7 +18,7 @@ const SiteWrapper = styled.View(({ theme }) => ({
   flex: 1,
   margin: 'auto',
   width: '100%',
-  backgroundColor: theme.colors.greyLight,
+  backgroundColor: theme.designSystem.color.background.subtle,
 }))
 
 const SiteContainer = styled.View(({ theme }) => ({

--- a/src/features/navigation/TabBar/TabBarContainer.tsx
+++ b/src/features/navigation/TabBar/TabBarContainer.tsx
@@ -31,7 +31,7 @@ const MainContainer = styled.View(({ theme }) => ({
   backgroundColor: theme.designSystem.color.background.default,
   borderTopStyle: 'solid',
   borderTopWidth: getSpacing(1 / 4),
-  borderTopColor: theme.colors.greyMedium,
+  borderTopColor: theme.designSystem.color.border.default,
   width: '100%',
   position: 'absolute',
   bottom: 0,
@@ -39,6 +39,6 @@ const MainContainer = styled.View(({ theme }) => ({
     shadowOffset: { width: 0, height: getSpacing(1 / 4) },
     shadowRadius: getSpacing(1),
     shadowColor: theme.colors.black,
-    shadowOpacity: 0.2,
+    shadowOpacity: 1,
   }),
 }))

--- a/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
+++ b/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
@@ -58,11 +58,7 @@ export const ProposedBySection: FunctionComponent<ProposedBySectionProps> = ({
   return (
     <Wrapper>
       {navigateTo ? (
-        <InternalTouchableLink
-          navigateTo={navigateTo}
-          hoverUnderlineColor={theme.designSystem.color.text.inverted}>
-          {content}
-        </InternalTouchableLink>
+        <InternalTouchableLink navigateTo={navigateTo}>{content}</InternalTouchableLink>
       ) : (
         content
       )}

--- a/src/features/offer/components/OfferContent/StickyFooterContent/StickyFooterContentBase.tsx
+++ b/src/features/offer/components/OfferContent/StickyFooterContent/StickyFooterContentBase.tsx
@@ -81,7 +81,6 @@ const StickyFooterWrapper = styled(StickyBottomWrapper)(({ theme }) => ({
   }),
 }))
 
-const Caption = styled(Typo.BodyAccentXs)(({ theme }) => ({
+const Caption = styled(Typo.BodyAccentXs)({
   textAlign: 'center',
-  color: theme.designSystem.color.text.default,
-}))
+})

--- a/src/features/search/components/SelectionLabel/SelectionLabel.tsx
+++ b/src/features/search/components/SelectionLabel/SelectionLabel.tsx
@@ -34,7 +34,7 @@ export const SelectionLabel: React.FC<Props> = ({ label, selected, onPress }) =>
 }
 
 const ValidateWhite = styled(Validate).attrs(({ theme }) => ({
-  color: theme.designSystem.color.icon.lockedInverted,
+  color: theme.designSystem.color.icon.inverted,
   size: theme.icons.sizes.smaller,
 }))``
 

--- a/src/libs/itinerary/components/SeeItineraryButton.tsx
+++ b/src/libs/itinerary/components/SeeItineraryButton.tsx
@@ -26,10 +26,9 @@ export function SeeItineraryButton(props: Props) {
   )
 }
 
-const Icon = styled(LocationPointer).attrs(({ theme }) => ({
-  color: theme.colors.black,
+const Icon = styled(LocationPointer).attrs({
   accessibilityLabel: 'Nouvelle fenêtre',
-}))``
+})``
 
 const Container = styled.View({
   alignItems: 'flex-start',

--- a/src/ui/components/headers/HeaderWithImage.tsx
+++ b/src/ui/components/headers/HeaderWithImage.tsx
@@ -1,5 +1,7 @@
+import colorAlpha from 'color-alpha'
 import React, { FunctionComponent } from 'react'
 import { Platform, ViewStyle } from 'react-native'
+import LinearGradient from 'react-native-linear-gradient'
 import styled, { useTheme } from 'styled-components/native'
 
 import { Image } from 'libs/resizing-image-on-demand/Image'
@@ -39,7 +41,9 @@ export const HeaderWithImage: FunctionComponent<Props> = ({
             {...blurImageTransform}
           />
         ) : (
-          <DefaultImagePlaceholderOfferV2 width={appContentWidth} height={imageHeight} />
+          <DefaultImagePlaceholderOfferV2 width={appContentWidth} height={imageHeight}>
+            <BlackGradient />
+          </DefaultImagePlaceholderOfferV2>
         )}
       </ImageContainer>
       {children}
@@ -64,3 +68,10 @@ const DefaultImagePlaceholderOfferV2 = styled.View<{ width: number; height: numb
     height,
   })
 )
+
+const BlackGradient = styled(LinearGradient).attrs(({ theme }) => ({
+  colors: [
+    colorAlpha(theme.designSystem.color.background.lockedInverted, 0),
+    colorAlpha(theme.designSystem.color.background.lockedInverted, 0.1),
+  ],
+}))({ height: '100%' })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36608

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
