### PR TITLE
(PC-36659) feat(a11y): add dynamic numberOfLines in AppButton compoared to font scale

### DIFF
--- a/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
@@ -1020,6 +1020,7 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
             {
               "alignItems": "center",
               "flexDirection": "row",
+              "flexWrap": "wrap",
               "gap": 4,
               "justifyContent": "center",
             },

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -676,6 +676,7 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "flexWrap": "wrap",
                   "gap": 4,
                   "justifyContent": "center",
                 },

--- a/__snapshots__/features/favorites/pages/NotConnectedFavorites.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/NotConnectedFavorites.native.test.tsx.native-snap
@@ -198,6 +198,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
           {
             "alignItems": "center",
             "flexDirection": "row",
+            "flexWrap": "wrap",
             "gap": 4,
             "justifyContent": "center",
           },

--- a/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
@@ -489,6 +489,7 @@ retrouver tes favoris
                       {
                         "alignItems": "center",
                         "flexDirection": "row",
+                        "flexWrap": "wrap",
                         "gap": 4,
                         "justifyContent": "center",
                       },

--- a/__snapshots__/features/offer/components/NotificationAuthModal/NotificationAuthModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/NotificationAuthModal/NotificationAuthModal.native.test.tsx.native-snap
@@ -516,6 +516,7 @@ activer un rappel
                       {
                         "alignItems": "center",
                         "flexDirection": "row",
+                        "flexWrap": "wrap",
                         "gap": 4,
                         "justifyContent": "center",
                       },

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingWelcome.native.test.tsx.native-snap
@@ -51,373 +51,389 @@ exports[`OnboardingWelcome should render correctly 1`] = `
       }
     />
   </View>
-  <View
-    style={
-      [
-        {
-          "flexBasis": 0,
-          "flexGrow": 1,
-          "flexShrink": 1,
-        },
-      ]
-    }
-  />
-  <BVLinearGradient
-    colors={
-      [
-        16777215,
-        4294967295,
-      ]
-    }
-    endPoint={
+  <RCTScrollView
+    contentContainerStyle={
       {
-        "x": 0.5,
-        "y": 1,
-      }
-    }
-    locations={
-      [
-        0,
-        0.85,
-      ]
-    }
-    startPoint={
-      {
-        "x": 0.5,
-        "y": 0,
+        "flexGrow": 1,
       }
     }
     style={
       [
-        {
-          "height": 200,
-        },
-      ]
-    }
-  />
-  <View
-    style={
-      [
-        {
-          "alignSelf": "center",
-          "backgroundColor": "#ffffff",
-          "bottom": 0,
-          "paddingBottom": 32,
-          "paddingHorizontal": 24,
-          "position": "static",
-          "width": "100%",
-        },
+        {},
       ]
     }
   >
-    <Text
-      style={
-        [
-          {
-            "color": "#161617",
-            "fontFamily": "Montserrat-Bold",
-            "fontSize": 28,
-            "lineHeight": 44.8,
-            "textAlign": "center",
-          },
-        ]
-      }
-    >
-      Bienvenue sur le pass Culture
-    </Text>
-    <View
-      numberOfSpaces={4}
-      style={
-        [
-          {
-            "height": 16,
-          },
-        ]
-      }
-    />
-    <Text
-      style={
-        [
-          {
-            "color": "#161617",
-            "fontFamily": "Montserrat-Medium",
-            "fontSize": 16,
-            "lineHeight": 25.6,
-            "textAlign": "center",
-          },
-        ]
-      }
-    >
-      Plus de 3 millions d’offres culturelles et un crédit à dépenser sur l’application si tu as 17 ou 18 ans.
-    </Text>
-    <View
-      numberOfSpaces={6}
-      style={
-        [
-          {
-            "height": 24,
-          },
-        ]
-      }
-    />
-    <View
-      accessibilityLabel="C’est parti !"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        [
-          [
-            {
-              "userSelect": "auto",
-            },
-            {
-              "alignItems": "center",
-              "backgroundColor": "#eb0055",
-              "borderRadius": 24,
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": 500,
-              "minHeight": 40,
-              "paddingBottom": 2,
-              "paddingLeft": 20,
-              "paddingRight": 20,
-              "paddingTop": 2,
-              "width": "100%",
-            },
-            {},
-          ],
-          {
-            "opacity": 1,
-          },
-        ]
-      }
-      testID="C’est parti !"
-    >
+    <View>
       <View
         style={
           [
             {
-              "alignItems": "center",
-              "flexDirection": "row",
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+            },
+          ]
+        }
+      />
+      <BVLinearGradient
+        colors={
+          [
+            16777215,
+            4294967295,
+          ]
+        }
+        endPoint={
+          {
+            "x": 0.5,
+            "y": 1,
+          }
+        }
+        locations={
+          [
+            0,
+            0.85,
+          ]
+        }
+        startPoint={
+          {
+            "x": 0.5,
+            "y": 0,
+          }
+        }
+        style={
+          [
+            {
+              "height": 200,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "alignSelf": "center",
+              "backgroundColor": "#ffffff",
+              "bottom": 0,
+              "paddingBottom": 32,
+              "paddingHorizontal": 24,
+              "position": "static",
+              "width": "100%",
             },
           ]
         }
       >
-        <View
+        <Text
           style={
             [
               {
-                "flexDirection": "row",
-                "flexShrink": 0,
+                "color": "#161617",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 28,
+                "lineHeight": 44.8,
+                "textAlign": "center",
               },
             ]
           }
         >
+          Bienvenue sur le pass Culture
+        </Text>
+        <View
+          numberOfSpaces={4}
+          style={
+            [
+              {
+                "height": 16,
+              },
+            ]
+          }
+        />
+        <Text
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          Plus de 3 millions d’offres culturelles et un crédit à dépenser sur l’application si tu as 17 ou 18 ans.
+        </Text>
+        <View
+          numberOfSpaces={6}
+          style={
+            [
+              {
+                "height": 24,
+              },
+            ]
+          }
+        />
+        <View
+          accessibilityLabel="C’est parti !"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            [
+              [
+                {
+                  "userSelect": "auto",
+                },
+                {
+                  "alignItems": "center",
+                  "backgroundColor": "#eb0055",
+                  "borderRadius": 24,
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                  "maxWidth": 500,
+                  "minHeight": 40,
+                  "paddingBottom": 2,
+                  "paddingLeft": 20,
+                  "paddingRight": 20,
+                  "paddingTop": 2,
+                  "width": "100%",
+                },
+                {},
+              ],
+              {
+                "opacity": 1,
+              },
+            ]
+          }
+          testID="C’est parti !"
+        >
           <View
-            height={24}
-            testID="button-icon-left"
-            width={24}
-          >
-            <Text>
-              button-icon-left-SVG-Mock
-            </Text>
-          </View>
-          <View
-            numberOfSpaces={2}
             style={
               [
                 {
-                  "width": 8,
+                  "alignItems": "center",
+                  "flexDirection": "row",
                 },
               ]
             }
-          />
+          >
+            <View
+              style={
+                [
+                  {
+                    "flexDirection": "row",
+                    "flexShrink": 0,
+                  },
+                ]
+              }
+            >
+              <View
+                height={24}
+                testID="button-icon-left"
+                width={24}
+              >
+                <Text>
+                  button-icon-left-SVG-Mock
+                </Text>
+              </View>
+              <View
+                numberOfSpaces={2}
+                style={
+                  [
+                    {
+                      "width": 8,
+                    },
+                  ]
+                }
+              />
+            </View>
+            <Text
+              adjustsFontSizeToFit={false}
+              numberOfLines={1}
+              style={
+                [
+                  {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat-Bold",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
+                    "maxWidth": "100%",
+                  },
+                ]
+              }
+            >
+              C’est parti !
+            </Text>
+          </View>
         </View>
-        <Text
-          adjustsFontSizeToFit={false}
-          numberOfLines={1}
+        <View
+          numberOfSpaces={4}
           style={
             [
               {
-                "color": "#ffffff",
-                "fontFamily": "Montserrat-Bold",
-                "fontSize": 16,
-                "lineHeight": 25.6,
-                "maxWidth": "100%",
+                "height": 16,
               },
             ]
           }
-        >
-          C’est parti !
-        </Text>
-      </View>
-    </View>
-    <View
-      numberOfSpaces={4}
-      style={
-        [
-          {
-            "height": 16,
-          },
-        ]
-      }
-    />
-    <View
-      style={
-        [
-          {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "gap": 4,
-            "justifyContent": "center",
-          },
-        ]
-      }
-    >
-      <Text
-        style={
-          [
-            {
-              "color": "#161617",
-              "fontFamily": "Montserrat-Medium",
-              "fontSize": 16,
-              "lineHeight": 25.6,
-              "textAlign": "center",
-            },
-          ]
-        }
-      >
-        Déjà un compte ?
-      </Text>
-      <View
-        accessibilityLabel="Se connecter"
-        accessibilityRole="link"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          [
-            [
-              {
-                "userSelect": "auto",
-              },
-            ],
-            {
-              "opacity": 1,
-            },
-          ]
-        }
-        testID="Se connecter"
-      >
+        />
         <View
-          paddingForIcon={0}
           style={
             [
               {
                 "alignItems": "center",
                 "flexDirection": "row",
-                "top": 0,
+                "flexWrap": "wrap",
+                "gap": 4,
+                "justifyContent": "center",
               },
             ]
           }
         >
-          <View
-            fill="#eb0055"
-            height={20}
-            testID="button-icon"
-            width={20}
-          >
-            <Text>
-              button-icon-SVG-Mock
-            </Text>
-          </View>
-          <View
-            numberOfSpaces={1}
-            style={
-              [
-                {
-                  "width": 4,
-                },
-              ]
-            }
-          />
           <Text
-            color="#eb0055"
             style={
               [
                 {
-                  "color": "#eb0055",
-                  "fontFamily": "Montserrat-Bold",
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Medium",
                   "fontSize": 16,
                   "lineHeight": 25.6,
+                  "textAlign": "center",
                 },
               ]
             }
-            typography="Button"
           >
-            Se connecter
+            Déjà un compte ?
           </Text>
+          <View
+            accessibilityLabel="Se connecter"
+            accessibilityRole="link"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Se connecter"
+          >
+            <View
+              paddingForIcon={0}
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "top": 0,
+                  },
+                ]
+              }
+            >
+              <View
+                fill="#eb0055"
+                height={20}
+                testID="button-icon"
+                width={20}
+              >
+                <Text>
+                  button-icon-SVG-Mock
+                </Text>
+              </View>
+              <View
+                numberOfSpaces={1}
+                style={
+                  [
+                    {
+                      "width": 4,
+                    },
+                  ]
+                }
+              />
+              <Text
+                color="#eb0055"
+                style={
+                  [
+                    {
+                      "color": "#eb0055",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
+                    },
+                  ]
+                }
+                typography="Button"
+              >
+                Se connecter
+              </Text>
+            </View>
+          </View>
         </View>
+        <View
+          customHeight={8}
+          enable={true}
+          style={
+            [
+              {
+                "height": 8,
+              },
+            ]
+          }
+        />
       </View>
     </View>
-    <View
-      customHeight={8}
-      enable={true}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
-  </View>
+  </RCTScrollView>
 </View>
 `;

--- a/__snapshots__/features/profile/pages/Profile.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/Profile.web.test.tsx.web-snap
@@ -277,7 +277,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
                   class="css-view-175oi2r r-borderRightColor-q65h00 r-borderRightWidth-13l2t4g r-marginInline-14mg64r"
                 />
                 <div
-                  class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-9aw3ui r-justifyContent-1777fci"
+                  class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-flexWrap-1w6e6rj r-gap-9aw3ui r-justifyContent-1777fci"
                 >
                   <div
                     class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm r-textAlign-q4m81j"
@@ -1423,7 +1423,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
                   class="css-view-175oi2r r-height-z80fyv"
                 />
                 <div
-                  class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-9aw3ui r-justifyContent-1777fci"
+                  class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-flexWrap-1w6e6rj r-gap-9aw3ui r-justifyContent-1777fci"
                 >
                   <div
                     class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm r-textAlign-q4m81j"

--- a/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
@@ -514,6 +514,7 @@ exports[`<NotificationsLoggedOutModal /> should render correctly 1`] = `
                         {
                           "alignItems": "center",
                           "flexDirection": "row",
+                          "flexWrap": "wrap",
                           "gap": 4,
                           "justifyContent": "center",
                         },

--- a/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
@@ -531,6 +531,7 @@ pour réserver l’offre
                       {
                         "alignItems": "center",
                         "flexDirection": "row",
+                        "flexWrap": "wrap",
                         "gap": 4,
                         "justifyContent": "center",
                       },

--- a/jest/jest.setup.ts
+++ b/jest/jest.setup.ts
@@ -30,3 +30,8 @@ jest.unmock('react-native-modal')
 // The issue comes from Jest trying to parse a module (react-native-orientation-locker) that uses ESModule syntax (import/export) without being processed by Babel
 // A common problem with some React Native libraries not properly packaged for Node.
 jest.mock('react-native-orientation-locker')
+
+// useGetFontScale is used in AppButton, so it impacts all buttons like ButtonPrimary, ButtonSecondary, etc.
+jest.mock('shared/accessibility/useGetFontScale', () => ({
+  useGetFontScale: () => ({ fontScale: 1 }),
+}))

--- a/src/features/auth/components/AuthenticationButton/AuthenticationButton.tsx
+++ b/src/features/auth/components/AuthenticationButton/AuthenticationButton.tsx
@@ -91,6 +91,7 @@ const AuthenticationContainer = styled.View({
   flexDirection: 'row',
   justifyContent: 'center',
   gap: getSpacing(1),
+  flexWrap: 'wrap',
 })
 
 const StyledBody = styled(Typo.Body)({

--- a/src/features/onboarding/pages/onboarding/OnboardingWelcome.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingWelcome.tsx
@@ -1,5 +1,6 @@
 import colorAlpha from 'color-alpha'
 import React, { FunctionComponent } from 'react'
+import { ScrollView } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
 
@@ -31,35 +32,41 @@ export const OnboardingWelcome: FunctionComponent = () => {
   return (
     <Page>
       <ImageBackground source={WELCOME_BACKGROUND_SOURCE} />
-      <Spacer.Flex />
-      <Gradient />
-      <Content>
-        <StyledTitle1>Bienvenue sur&nbsp;le&nbsp;pass&nbsp;Culture</StyledTitle1>
-        <Spacer.Column numberOfSpaces={4} />
-        <StyledBody>
-          Plus de 3 millions d’offres culturelles et un crédit à dépenser sur l’application si tu as
-          17 ou 18 ans.
-        </StyledBody>
-        <Spacer.Column numberOfSpaces={6} />
-        <InternalTouchableLink
-          as={ButtonPrimary}
-          wording="C’est parti&nbsp;!"
-          icon={PlainArrowNext}
-          iconAfterWording
-          navigateTo={getOnboardingNavConfig('OnboardingGeolocation')}
-          onBeforeNavigate={onStartPress}
-        />
-        <Spacer.Column numberOfSpaces={4} />
-        <StyledAuthenticationButton
-          type="login"
-          onAdditionalPress={onLoginPress}
-          params={{ from: StepperOrigin.ONBOARDING_WELCOME }}
-        />
-        <Spacer.BottomScreen />
-      </Content>
+      <StyledScrollView>
+        <Spacer.Flex />
+        <Gradient />
+        <Content>
+          <StyledTitle1>Bienvenue sur&nbsp;le&nbsp;pass&nbsp;Culture</StyledTitle1>
+          <Spacer.Column numberOfSpaces={4} />
+          <StyledBody>
+            Plus de 3 millions d’offres culturelles et un crédit à dépenser sur l’application si tu
+            as 17 ou 18 ans.
+          </StyledBody>
+          <Spacer.Column numberOfSpaces={6} />
+          <InternalTouchableLink
+            as={ButtonPrimary}
+            wording="C’est parti&nbsp;!"
+            icon={PlainArrowNext}
+            iconAfterWording
+            navigateTo={getOnboardingNavConfig('OnboardingGeolocation')}
+            onBeforeNavigate={onStartPress}
+          />
+          <Spacer.Column numberOfSpaces={4} />
+          <StyledAuthenticationButton
+            type="login"
+            onAdditionalPress={onLoginPress}
+            params={{ from: StepperOrigin.ONBOARDING_WELCOME }}
+          />
+          <Spacer.BottomScreen />
+        </Content>
+      </StyledScrollView>
     </Page>
   )
 }
+
+const StyledScrollView = styled(ScrollView).attrs({
+  contentContainerStyle: { flexGrow: 1 },
+})``
 
 const Content = styled.View(({ theme }) => ({
   width: '100%',

--- a/src/features/trustedDevice/helpers/useDeviceInfo.ts
+++ b/src/features/trustedDevice/helpers/useDeviceInfo.ts
@@ -8,9 +8,9 @@ import { TrustedDevice } from 'api/gen'
 import { getDeviceId } from 'libs/react-native-device-info/getDeviceId'
 
 export type DeviceInformation = TrustedDevice & {
-  resolution?: string
+  resolution: string
+  fontScale: number
   screenZoomLevel?: number
-  fontScale?: number
 }
 
 const isWeb = Platform.OS === 'web'

--- a/src/features/trustedDevice/helpers/useDeviceInfo.web.test.ts
+++ b/src/features/trustedDevice/helpers/useDeviceInfo.web.test.ts
@@ -10,8 +10,12 @@ jest.spyOn(DeviceInfo, 'getModel')
 jest.spyOn(DeviceInfo, 'getBaseOs')
 jest.spyOn(DeviceInfo, 'getSystemName')
 
-jest.mock('react-device-detect', () => ({ browserName: undefined }))
-jest.requireMock('react-device-detect').browserName = 'Chrome'
+jest.mock('react-device-detect', () => ({ browserName: 'Chrome' }))
+
+jest.mock('react-native', () => {
+  const RN = jest.requireActual('react-native')
+  return { ...RN, useWindowDimensions: jest.fn(() => ({ width: 700, height: 1000 })) }
+})
 
 describe('useDeviceInfo', () => {
   it('returns informations about the device for web', async () => {
@@ -23,6 +27,7 @@ describe('useDeviceInfo', () => {
       os: 'unknown',
       fontScale: 1,
       screenZoomLevel: 1,
+      resolution: '700x1000',
     }
     await act(async () => {})
 

--- a/src/shared/accessibility/useGetFontScale.ts
+++ b/src/shared/accessibility/useGetFontScale.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { PixelRatio, Platform } from 'react-native'
+import DeviceInfo from 'react-native-device-info'
+
+import { eventMonitoring } from 'libs/monitoring/services'
+import { getErrorMessage } from 'shared/getErrorMessage/getErrorMessage'
+
+const DEFAULT_FONT_SCALE = 1
+const isWeb = Platform.OS === 'web'
+
+export const useGetFontScale = (): { fontScale: number } => {
+  const [fontScale, setFontScale] = useState<number>(DEFAULT_FONT_SCALE)
+
+  useEffect(() => {
+    const fetchFontScale = async () => {
+      try {
+        const rawFontScale = isWeb ? PixelRatio.getFontScale() : await DeviceInfo.getFontScale()
+        setFontScale(parseFloat(rawFontScale.toFixed(3)))
+      } catch (error) {
+        eventMonitoring.captureException(
+          `Failed to get fontScale in useGetFontScale: ${getErrorMessage(error)}`,
+          { extra: { error }, level: 'info' }
+        )
+        setFontScale(DEFAULT_FONT_SCALE)
+      }
+    }
+
+    fetchFontScale()
+  }, [])
+
+  return { fontScale }
+}

--- a/src/ui/components/buttons/AppButton/AppButton.tsx
+++ b/src/ui/components/buttons/AppButton/AppButton.tsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react'
 import { StyleProp, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
+import { useGetFontScale } from 'shared/accessibility/useGetFontScale'
 import { AppButtonInner } from 'ui/components/buttons/AppButton/AppButtonInner'
 import { DefaultLoadingIndicator } from 'ui/components/buttons/AppButton/DefaultLoadingIndicator'
 import { appButtonStyles } from 'ui/components/buttons/AppButton/styleUtils'
@@ -38,10 +39,15 @@ const _AppButton = <T extends AppButtonProps>({
   ellipsizeMode,
   backgroundColor,
 }: OnlyBaseButtonProps<T>) => {
+  const { fontScale } = useGetFontScale()
+  const numberOfLinesComparedToFontScale = fontScale > 1 ? 2 : 1
+
   const pressHandler: AppButtonEventNative =
     disabled || isLoading ? undefined : (onPress as AppButtonEventNative)
+
   const longPressHandler: AppButtonEventNative =
     disabled || isLoading ? undefined : (onLongPress as AppButtonEventNative)
+
   return (
     <TouchableOpacityButton
       accessibilityLabel={accessibilityLabel || wording}
@@ -54,7 +60,7 @@ const _AppButton = <T extends AppButtonProps>({
       inline={inline}
       inlineHeight={inlineHeight}
       justifyContent={justifyContent}
-      numberOfLines={numberOfLines}
+      numberOfLines={numberOfLines ?? numberOfLinesComparedToFontScale}
       style={style as StyleProp<ViewStyle>}
       center={center}
       backgroundColor={backgroundColor}
@@ -66,7 +72,7 @@ const _AppButton = <T extends AppButtonProps>({
         iconPosition={iconPosition}
         title={Title}
         adjustsFontSizeToFit={adjustsFontSizeToFit}
-        numberOfLines={numberOfLines}
+        numberOfLines={numberOfLines ?? numberOfLinesComparedToFontScale}
         wording={wording}
         ellipsizeMode={ellipsizeMode}
       />

--- a/src/ui/components/buttons/AppButton/styleUtils.ts
+++ b/src/ui/components/buttons/AppButton/styleUtils.ts
@@ -45,7 +45,7 @@ export const appButtonStyles: ButtonStyles = ({
   mediumWidth,
   fullWidth,
   justifyContent,
-  numberOfLines,
+  numberOfLines = 1,
   center,
   backgroundColor,
 }: ButtonStylesArgs) => {
@@ -90,7 +90,7 @@ export const appButtonStyles: ButtonStyles = ({
         }
       : {}),
     ...(justifyContent === 'flex-start' ? { paddingRight: 0, paddingLeft: 0 } : {}),
-    ...(numberOfLines ? { height: 'auto' } : {}),
+    ...(numberOfLines > 1 ? { height: 'auto' } : {}),
   }
 }
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36659

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |      ![Simulator Screenshot - iPhone 15 - 2025-06-25 at 16 45 38](https://github.com/user-attachments/assets/308a9901-60d7-4f8f-af7f-21b7264c298d) ![Simulator Screenshot - iPhone 15 - 2025-06-26 at 09 05 33](https://github.com/user-attachments/assets/3c41f46f-03cc-4b71-aa2a-2db462fb9be9) ![Simulator Screenshot - iPhone 15 - 2025-06-26 at 09 08 33](https://github.com/user-attachments/assets/3ab3751a-e4f3-4ce9-8ba2-b0a73f1ba477) |  ![Simulator Screenshot - iPhone 15 - 2025-06-25 at 16 45 21](https://github.com/user-attachments/assets/22a9316b-1561-4c50-9538-675d33f66080) ![Simulator Screenshot - iPhone 15 - 2025-06-25 at 16 48 18](https://github.com/user-attachments/assets/b14133d1-471b-42d3-b49f-4eb6f0ad248e) ![Simulator Screenshot - iPhone 15 - 2025-06-26 at 09 08 15](https://github.com/user-attachments/assets/77fbfa04-0972-4d0a-8af0-cd1930eff9dd) |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
