### PR TITLE
(PC-36773) fix(sonar): Utilisation de la date comme flag pour le cache

### DIFF
--- a/src/features/forceUpdate/helpers/onPressStoreLink.ts
+++ b/src/features/forceUpdate/helpers/onPressStoreLink.ts
@@ -13,7 +13,7 @@ const clearStorageAndReload = (): void => {
 
   const location = globalThis.window.location
   const url = new URL(location.href)
-  url.searchParams.set(QUERY_PARAMETER_THAT_CLEAR_STUFF, Math.random().toString()) // force to bypass HTML cache
+  url.searchParams.set(QUERY_PARAMETER_THAT_CLEAR_STUFF, Date.now().toString()) // force to bypass HTML cache
   location.assign(url)
 }
 


### PR DESCRIPTION
Problème remonté par Sonar sur l'utilisation de Math.random()

Je l'ai remplacé par Date.now() qui est safe.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36773

