### PR TITLE
(PC-36320) feat(identityCheck): update suggested address in SetAddress

### DIFF
--- a/src/features/identityCheck/components/AddressOption.tsx
+++ b/src/features/identityCheck/components/AddressOption.tsx
@@ -6,6 +6,7 @@ import { Separator } from 'ui/components/Separator'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { Validate as DefaultValidate } from 'ui/svg/icons/Validate'
 import { getSpacing, Typo } from 'ui/theme'
+
 interface Props {
   onPressOption: (optionKey: string) => void
   optionKey: string

--- a/src/features/identityCheck/pages/profile/SetAddress.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.native.test.tsx
@@ -36,7 +36,6 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 })
 
 const user = userEvent.setup()
-
 jest.useFakeTimers()
 
 useRoute.mockReturnValue({
@@ -89,9 +88,9 @@ describe('<SetAddress/>', () => {
     fireEvent.changeText(input, QUERY_ADDRESS)
 
     await waitFor(() => {
-      expect(screen.getByText(mockedSuggestedPlaces.features[0].properties.label)).toBeOnTheScreen()
-      expect(screen.getByText(mockedSuggestedPlaces.features[1].properties.label)).toBeOnTheScreen()
-      expect(screen.getByText(mockedSuggestedPlaces.features[2].properties.label)).toBeOnTheScreen()
+      expect(screen.getByText(mockedSuggestedPlaces.features[0].properties.name)).toBeOnTheScreen()
+      expect(screen.getByText(mockedSuggestedPlaces.features[1].properties.name)).toBeOnTheScreen()
+      expect(screen.getByText(mockedSuggestedPlaces.features[2].properties.name)).toBeOnTheScreen()
     })
   })
 
@@ -101,7 +100,7 @@ describe('<SetAddress/>', () => {
     const input = screen.getByTestId('Entrée pour l’adresse')
     fireEvent.changeText(input, QUERY_ADDRESS)
 
-    await user.press(await screen.findByText(mockedSuggestedPlaces.features[1].properties.label))
+    await user.press(await screen.findByText(mockedSuggestedPlaces.features[1].properties.name))
     await user.press(screen.getByText('Continuer'))
 
     expect(navigate).toHaveBeenNthCalledWith(1, 'SetStatus', {
@@ -115,12 +114,12 @@ describe('<SetAddress/>', () => {
     const input = screen.getByTestId('Entrée pour l’adresse')
     fireEvent.changeText(input, QUERY_ADDRESS)
 
-    await user.press(await screen.findByText(mockedSuggestedPlaces.features[1].properties.label))
+    await user.press(await screen.findByText(mockedSuggestedPlaces.features[1].properties.name))
     await user.press(screen.getByText('Continuer'))
 
     expect(await storage.readObject('profile-address')).toMatchObject({
       state: {
-        address: mockedSuggestedPlaces.features[1].properties.label,
+        address: mockedSuggestedPlaces.features[1].properties.name,
       },
     })
   })

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -100,14 +100,7 @@ export const SetAddress = () => {
 
   const isValidAddress = isAddressValid(query)
 
-  // The button is enabled only when the user has selected an address
-  // if suggested addresses are available. Otherwise, if the user has
-  // typed something and either the FF doesn't allow suggested addresses
-  // or the API call fails, then the button is enabled
-  const enabled =
-    !isError && idCheckAddressAutocompletion && query.length > 0
-      ? !!selectedAddress
-      : isValidAddress
+  const enabled = query.trim().length > 0
 
   const label = idCheckAddressAutocompletion
     ? 'Recherche et sélectionne ton adresse'

--- a/src/libs/place/fetchAddresses.ts
+++ b/src/libs/place/fetchAddresses.ts
@@ -2,7 +2,7 @@ import { buildPlaceUrl, BuildSearchAddressProps } from 'libs/place/buildUrl'
 import { Collection } from 'libs/place/types'
 
 const buildSuggestedAddresses = (collection: Collection): string[] =>
-  collection.features.map(({ properties }) => properties.label)
+  collection.features.map(({ properties }) => properties.name)
 
 export const fetchAddresses = async ({
   query,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36320

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |    ![Capture d’écran 2025-06-27 à 16 12 23](https://github.com/user-attachments/assets/35dbcce8-fa8e-46d8-80d8-04d887671408)  |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
