### PR TITLE
(PC-36077) refactor(offer): use search_group_names param rather than categories for similar offers api call

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -4056,6 +4056,11 @@ export interface SimilarOffersRequestQuery {
    * @type {Array<string>}
    * @memberof SimilarOffersRequestQuery
    */
+  search_group_names?: Array<string> | null
+  /**
+   * @type {Array<string>}
+   * @memberof SimilarOffersRequestQuery
+   */
   subcategories?: Array<string> | null
 }
 /**
@@ -5814,6 +5819,7 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
      * @param {number} [latitude]
      * @param {Array<string>} [categories]
      * @param {Array<string>} [subcategories]
+     * @param {Array<string>} [search_group_names]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -5823,6 +5829,7 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
       latitude?: number,
       categories?: Array<string>,
       subcategories?: Array<string>,
+      search_group_names?: Array<string>,
       options: any = {}
     ): Promise<FetchArgs> {
       // verify required parameter 'offer_id' is not null or undefined
@@ -5852,6 +5859,10 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
 
       if (subcategories != null) {
         queryParameters['subcategories'] = subcategories
+      }
+
+      if (search_group_names != null) {
+        queryParameters['search_group_names'] = search_group_names
       }
 
       const encodedQueryParams =
@@ -7760,6 +7771,7 @@ export const DefaultApiFp = function (api: DefaultApi, configuration?: Configura
      * @param {number} [latitude]
      * @param {Array<string>} [categories]
      * @param {Array<string>} [subcategories]
+     * @param {Array<string>} [search_group_names]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -7769,6 +7781,7 @@ export const DefaultApiFp = function (api: DefaultApi, configuration?: Configura
       latitude?: number,
       categories?: Array<string>,
       subcategories?: Array<string>,
+      search_group_names?: Array<string>,
       options?: any
     ): Promise<SimilarOffersResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(
@@ -7779,6 +7792,7 @@ export const DefaultApiFp = function (api: DefaultApi, configuration?: Configura
         latitude,
         categories,
         subcategories,
+        search_group_names,
         options
       )
       const response = await safeFetch(
@@ -9244,6 +9258,7 @@ export class DefaultApi extends BaseAPI {
    * @param {number} [latitude]
    * @param {Array<string>} [categories]
    * @param {Array<string>} [subcategories]
+   * @param {Array<string>} [search_group_names]
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof DefaultApi
@@ -9254,6 +9269,7 @@ export class DefaultApi extends BaseAPI {
     latitude?: number,
     categories?: Array<string>,
     subcategories?: Array<string>,
+    search_group_names?: Array<string>,
     options?: any
   ) {
     const configuration = this.getConfiguration()
@@ -9263,6 +9279,7 @@ export class DefaultApi extends BaseAPI {
       latitude,
       categories,
       subcategories,
+      search_group_names,
       options
     )
   }

--- a/src/features/offer/queries/useSimilarOffersQuery.native.test.ts
+++ b/src/features/offer/queries/useSimilarOffersQuery.native.test.ts
@@ -89,7 +89,7 @@ describe('useSimilarOffersQuery', () => {
       await waitFor(() => {
         expect(fetchApiRecoSpy).toHaveBeenNthCalledWith(
           1,
-          `${env.API_BASE_URL}/native/v1/recommendation/similar_offers/1?longitude=15&latitude=10&categories=CINEMA`,
+          `${env.API_BASE_URL}/native/v1/recommendation/similar_offers/1?longitude=15&latitude=10&search_group_names=CINEMA`,
           {
             credentials: 'omit',
             headers: {
@@ -123,7 +123,7 @@ describe('useSimilarOffersQuery', () => {
       await waitFor(() => {
         expect(fetchApiRecoSpy).toHaveBeenNthCalledWith(
           1,
-          `${env.API_BASE_URL}/native/v1/recommendation/similar_offers/1?categories=CINEMA`,
+          `${env.API_BASE_URL}/native/v1/recommendation/similar_offers/1?search_group_names=CINEMA`,
           {
             credentials: 'omit',
             headers: {
@@ -204,13 +204,13 @@ describe('useSimilarOffersQuery', () => {
         new Error('Error 400 with recommendation endpoint to get similar offers'),
         {
           extra: {
-            categories: '["CINEMA"]',
+            searchGroupNames: '["CINEMA"]',
             latitude: undefined,
             longitude: undefined,
             offerId: 1,
             statusCode: 400,
             errorMessage:
-              'Échec de la requête https://localhost/native/v1/recommendation/similar_offers/1?categories=CINEMA, code: 400',
+              'Échec de la requête https://localhost/native/v1/recommendation/similar_offers/1?search_group_names=CINEMA, code: 400',
           },
         }
       )

--- a/src/features/offer/queries/useSimilarOffersQuery.ts
+++ b/src/features/offer/queries/useSimilarOffersQuery.ts
@@ -56,20 +56,22 @@ export const useSimilarOffersQuery = ({
   categoryExcluded,
   searchGroupList,
 }: Props) => {
-  const categories: SearchGroupNameEnumv2[] = useMemo(
+  const searchGroupNames: SearchGroupNameEnumv2[] = useMemo(
     () => getCategories(searchGroupList, categoryIncluded, categoryExcluded),
     [categoryExcluded, categoryIncluded, searchGroupList]
   )
 
   const { data: apiRecoResponse } = useQuery(
-    [QueryKeys.SIMILAR_OFFERS_IDS, offerId, position, categories],
+    [QueryKeys.SIMILAR_OFFERS_IDS, offerId, position, searchGroupNames],
     async () => {
       try {
         return await api.getNativeV1RecommendationSimilarOffersofferId(
           offerId,
           position?.longitude,
           position?.latitude,
-          categories
+          undefined,
+          undefined,
+          searchGroupNames
         )
       } catch (err) {
         const statusCode = err instanceof ApiError ? err.statusCode : 'unknown'
@@ -86,7 +88,7 @@ export const useSimilarOffersQuery = ({
                 offerId,
                 longitude: position?.longitude,
                 latitude: position?.latitude,
-                categories: JSON.stringify(categories),
+                searchGroupNames: JSON.stringify(searchGroupNames),
                 statusCode,
                 errorMessage,
               },
@@ -99,7 +101,7 @@ export const useSimilarOffersQuery = ({
     },
     {
       staleTime: 1000 * 60 * 5,
-      enabled: !!categories && onlineManager.isOnline() && shouldFetch,
+      enabled: !!searchGroupNames && onlineManager.isOnline() && shouldFetch,
     }
   )
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36077

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
