### PR TITLE
(PC-36672) feat(Chronicles): refacto and add Ciné club

### DIFF
--- a/src/features/chronicle/adapters/offerChroniclesToChronicleCardData/offerChroniclesToChronicleCardData.test.ts
+++ b/src/features/chronicle/adapters/offerChroniclesToChronicleCardData/offerChroniclesToChronicleCardData.test.ts
@@ -1,10 +1,12 @@
 import { offerChroniclesToChronicleCardData } from 'features/chronicle/adapters/offerChroniclesToChronicleCardData/offerChroniclesToChronicleCardData'
 import { chroniclesFixture } from 'features/chronicle/fixtures/offerChronicles.fixture'
 
+const subtitle = 'Membre du Book Club'
+
 describe('transformOfferChroniclesToChronicleCardData', () => {
   it('should transform offer chronicles to chronicle card data', () => {
     const chronicles = [...chroniclesFixture]
-    const result = offerChroniclesToChronicleCardData(chronicles)
+    const result = offerChroniclesToChronicleCardData(chronicles, subtitle)
 
     expect(result).toEqual([
       {

--- a/src/features/chronicle/adapters/offerChroniclesToChronicleCardData/offerChroniclesToChronicleCardData.ts
+++ b/src/features/chronicle/adapters/offerChroniclesToChronicleCardData/offerChroniclesToChronicleCardData.ts
@@ -4,12 +4,13 @@ import { getChronicleCardTitle } from 'shared/chronicle/getChronicleCardTitle/ge
 import { getFormattedChronicleDate } from 'shared/chronicle/getFormattedChronicleDate/getFormattedChronicleDate'
 
 export function offerChroniclesToChronicleCardData(
-  chronicles: OfferChronicle[]
+  chronicles: OfferChronicle[],
+  subtitleItem: string
 ): ChronicleCardData[] {
   return chronicles.map(({ id, author, content, dateCreated }) => ({
     id,
-    title: getChronicleCardTitle(author),
-    subtitle: author?.firstName ? 'Membre du Book Club' : '',
+    title: getChronicleCardTitle(subtitleItem, author),
+    subtitle: author?.firstName ? subtitleItem : '',
     description: content,
     date: getFormattedChronicleDate(dateCreated),
   }))

--- a/src/features/chronicle/api/useChronicles/useChronicles.test.ts
+++ b/src/features/chronicle/api/useChronicles/useChronicles.test.ts
@@ -8,6 +8,8 @@ import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, renderHook, waitFor } from 'tests/utils'
 
+const subtitle = 'Membre du Book Club'
+
 describe('useChronicles', () => {
   beforeEach(() =>
     mockServer.getApi(`/v1/offer/${offerResponseSnap.id}/chronicles`, offerChroniclesFixture)
@@ -34,7 +36,7 @@ describe('useChronicles', () => {
       () =>
         useChronicles<ChronicleCardData[]>({
           offerId: offerResponseSnap.id,
-          select: (data) => offerChroniclesToChronicleCardData(data.chronicles),
+          select: (data) => offerChroniclesToChronicleCardData(data.chronicles, subtitle),
         }),
       {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
@@ -45,9 +47,10 @@ describe('useChronicles', () => {
 
     expect(JSON.stringify(result.current.data)).toEqual(
       JSON.stringify(
-        offerChroniclesToChronicleCardData([
-          ...offerChroniclesFixture.chronicles,
-        ] as OfferChronicle[])
+        offerChroniclesToChronicleCardData(
+          [...offerChroniclesFixture.chronicles] as OfferChronicle[],
+          subtitle
+        )
       )
     )
   })

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.stories.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.stories.tsx
@@ -25,7 +25,7 @@ const baseProps = {
   description:
     'Pour moi, cette biographie n’est pas comme une autre. Cela concerne le créateur de Star Wars, le premier film...',
   date: 'Juin 2024',
-  chronicleIcon: <BookClubIcon />,
+  icon: <BookClubIcon />,
 }
 
 const variantConfig: Variants<typeof ChronicleCard> = [

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.stories.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.stories.tsx
@@ -1,16 +1,22 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 import { View } from 'react-native'
+import styled from 'styled-components/native'
 
 import { ChronicleCard } from 'features/chronicle/components/ChronicleCard/ChronicleCard'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
 import { VariantsTemplate, type Variants } from 'ui/storybook/VariantsTemplate'
+import { BookClubCertification } from 'ui/svg/BookClubCertification'
 
 const meta: Meta<typeof ChronicleCard> = {
   title: 'ui/ChronicleCard',
   component: ChronicleCard,
 }
 export default meta
+
+const BookClubIcon = styled(BookClubCertification).attrs(({ theme }) => ({
+  color: theme.designSystem.color.icon.bookclub,
+}))``
 
 const baseProps = {
   id: 1,
@@ -19,6 +25,7 @@ const baseProps = {
   description:
     'Pour moi, cette biographie n’est pas comme une autre. Cela concerne le créateur de Star Wars, le premier film...',
   date: 'Juin 2024',
+  chronicleIcon: <BookClubIcon />,
 }
 
 const variantConfig: Variants<typeof ChronicleCard> = [

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, PropsWithChildren, useState } from 'react'
+import React, { FunctionComponent, PropsWithChildren, ReactNode, useState } from 'react'
 import { LayoutChangeEvent, Platform } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -6,7 +6,6 @@ import { ChronicleCardData } from 'features/chronicle/type'
 import { InfoHeader } from 'ui/components/InfoHeader/InfoHeader'
 import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
-import { BookClubCertification } from 'ui/svg/BookClubCertification'
 import { Typo, getShadow, getSpacing } from 'ui/theme'
 import { REM_TO_PX } from 'ui/theme/constants'
 
@@ -16,6 +15,7 @@ type Props = PropsWithChildren<
   ChronicleCardData & {
     cardWidth?: number
     shouldTruncate?: boolean
+    chronicleIcon?: ReactNode
   }
 >
 
@@ -30,6 +30,7 @@ export const ChronicleCard: FunctionComponent<Props> = ({
   date,
   cardWidth,
   children,
+  chronicleIcon,
   shouldTruncate = false,
 }) => {
   const theme = useTheme()
@@ -61,7 +62,7 @@ export const ChronicleCard: FunctionComponent<Props> = ({
         title={title}
         subtitle={subtitle}
         defaultThumbnailSize={CHRONICLE_THUMBNAIL_SIZE}
-        thumbnailComponent={<BookClubIcon />}
+        thumbnailComponent={chronicleIcon}
       />
       <Separator.Horizontal />
       <DescriptionContainer defaultHeight={defaultHeight} shouldTruncate={shouldTruncate}>
@@ -97,10 +98,6 @@ const Container = styled(ViewGap)<{ width?: number; shouldTruncate?: boolean }>(
     }),
   })
 )
-
-const BookClubIcon = styled(BookClubCertification).attrs(({ theme }) => ({
-  color: theme.designSystem.color.icon.bookclub,
-}))``
 
 const DescriptionContainer = styled.View<{ defaultHeight: number; shouldTruncate?: boolean }>(
   ({ defaultHeight, shouldTruncate }) =>

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
@@ -15,7 +15,7 @@ type Props = PropsWithChildren<
   ChronicleCardData & {
     cardWidth?: number
     shouldTruncate?: boolean
-    chronicleIcon?: ReactNode
+    icon?: ReactNode
   }
 >
 
@@ -30,7 +30,7 @@ export const ChronicleCard: FunctionComponent<Props> = ({
   date,
   cardWidth,
   children,
-  chronicleIcon,
+  icon,
   shouldTruncate = false,
 }) => {
   const theme = useTheme()
@@ -62,7 +62,7 @@ export const ChronicleCard: FunctionComponent<Props> = ({
         title={title}
         subtitle={subtitle}
         defaultThumbnailSize={CHRONICLE_THUMBNAIL_SIZE}
-        thumbnailComponent={chronicleIcon}
+        thumbnailComponent={icon}
       />
       <Separator.Horizontal />
       <DescriptionContainer defaultHeight={defaultHeight} shouldTruncate={shouldTruncate}>

--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.tsx
@@ -33,7 +33,7 @@ export const ChronicleCardList = forwardRef<
     onSeeMoreButtonPress,
     onLayout,
     shouldTruncate,
-    chronicleIcon,
+    icon,
   },
   ref
 ) {
@@ -105,7 +105,7 @@ export const ChronicleCardList = forwardRef<
         onSeeMoreButtonPress={onSeeMoreButtonPress}
         onLayout={onLayout}
         shouldTruncate={shouldTruncate}
-        chronicleIcon={chronicleIcon}
+        icon={icon}
       />
     </View>
   )

--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.tsx
@@ -33,6 +33,7 @@ export const ChronicleCardList = forwardRef<
     onSeeMoreButtonPress,
     onLayout,
     shouldTruncate,
+    chronicleIcon,
   },
   ref
 ) {
@@ -104,6 +105,7 @@ export const ChronicleCardList = forwardRef<
         onSeeMoreButtonPress={onSeeMoreButtonPress}
         onLayout={onLayout}
         shouldTruncate={shouldTruncate}
+        chronicleIcon={chronicleIcon}
       />
     </View>
   )

--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardListBase.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardListBase.tsx
@@ -1,5 +1,6 @@
 import React, {
   ReactElement,
+  ReactNode,
   forwardRef,
   useCallback,
   useEffect,
@@ -39,6 +40,7 @@ export type ChronicleCardListProps = Pick<
   style?: StyleProp<ViewStyle>
   onSeeMoreButtonPress?: (chronicleId: number) => void
   shouldTruncate?: boolean
+  chronicleIcon?: ReactNode
 }
 
 export const ChronicleCardListBase = forwardRef<
@@ -60,6 +62,7 @@ export const ChronicleCardListBase = forwardRef<
     onSeeMoreButtonPress,
     onLayout,
     shouldTruncate,
+    chronicleIcon,
   },
   ref
 ) {
@@ -89,6 +92,7 @@ export const ChronicleCardListBase = forwardRef<
     ({ item }) => {
       return (
         <ChronicleCard
+          chronicleIcon={chronicleIcon}
           id={item.id}
           title={item.title}
           subtitle={item.subtitle}
@@ -107,7 +111,7 @@ export const ChronicleCardListBase = forwardRef<
         </ChronicleCard>
       )
     },
-    [cardWidth, onSeeMoreButtonPress, shouldTruncate]
+    [cardWidth, onSeeMoreButtonPress, shouldTruncate, chronicleIcon]
   )
 
   return (

--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardListBase.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardListBase.tsx
@@ -40,7 +40,7 @@ export type ChronicleCardListProps = Pick<
   style?: StyleProp<ViewStyle>
   onSeeMoreButtonPress?: (chronicleId: number) => void
   shouldTruncate?: boolean
-  chronicleIcon?: ReactNode
+  icon?: ReactNode
 }
 
 export const ChronicleCardListBase = forwardRef<
@@ -62,7 +62,7 @@ export const ChronicleCardListBase = forwardRef<
     onSeeMoreButtonPress,
     onLayout,
     shouldTruncate,
-    chronicleIcon,
+    icon,
   },
   ref
 ) {
@@ -92,7 +92,7 @@ export const ChronicleCardListBase = forwardRef<
     ({ item }) => {
       return (
         <ChronicleCard
-          chronicleIcon={chronicleIcon}
+          icon={icon}
           id={item.id}
           title={item.title}
           subtitle={item.subtitle}
@@ -111,7 +111,7 @@ export const ChronicleCardListBase = forwardRef<
         </ChronicleCard>
       )
     },
-    [cardWidth, onSeeMoreButtonPress, shouldTruncate, chronicleIcon]
+    [cardWidth, onSeeMoreButtonPress, shouldTruncate, icon]
   )
 
   return (

--- a/src/features/chronicle/pages/Chronicles/Chronicles.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.tsx
@@ -1,20 +1,25 @@
 import { useRoute } from '@react-navigation/native'
 import React, { FunctionComponent } from 'react'
 
+import { SubcategoryIdEnum } from 'api/gen'
 import { offerChroniclesToChronicleCardData } from 'features/chronicle/adapters/offerChroniclesToChronicleCardData/offerChroniclesToChronicleCardData'
 import { useChronicles } from 'features/chronicle/api/useChronicles/useChronicles'
 import { ChroniclesBase } from 'features/chronicle/pages/Chronicles/ChroniclesBase'
 import { ChronicleCardData } from 'features/chronicle/type'
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
+import { chronicleVariant } from 'features/offer/helpers/chronicleVariant/chronicleVariant'
 import { useOfferQuery } from 'queries/offer/useOfferQuery'
 
 export const Chronicles: FunctionComponent = () => {
   const route = useRoute<UseRouteType<'Chronicles'>>()
   const offerId = route.params?.offerId
   const { data: offer } = useOfferQuery({ offerId })
+  const chronicleVariantInfo =
+    chronicleVariant[offer?.subcategoryId ?? SubcategoryIdEnum.LIVRE_PAPIER]
   const { data: chronicleCardsData } = useChronicles<ChronicleCardData[]>({
     offerId,
-    select: ({ chronicles }) => offerChroniclesToChronicleCardData(chronicles),
+    select: ({ chronicles }) =>
+      offerChroniclesToChronicleCardData(chronicles, chronicleVariantInfo.subtitleItem),
   })
 
   if (!offer || !chronicleCardsData) return null

--- a/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent } from 'react'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled, { useTheme } from 'styled-components/native'
 
-import { SubcategoryIdEnumv2 } from 'api/gen'
+import { SubcategoryIdEnum, SubcategoryIdEnumv2 } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { offerChroniclesToChronicleCardData } from 'features/chronicle/adapters/offerChroniclesToChronicleCardData/offerChroniclesToChronicleCardData'
 import { useChronicles } from 'features/chronicle/api/useChronicles/useChronicles'
@@ -12,6 +12,7 @@ import { ChroniclesBase } from 'features/chronicle/pages/Chronicles/ChroniclesBa
 import { ChronicleCardData } from 'features/chronicle/type'
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { OfferCTAButton } from 'features/offer/components/OfferCTAButton/OfferCTAButton'
+import { chronicleVariant } from 'features/offer/helpers/chronicleVariant/chronicleVariant'
 import { getOfferPrices } from 'features/offer/helpers/getOfferPrice/getOfferPrice'
 import { useOfferBatchTracking } from 'features/offer/helpers/useOfferBatchTracking/useOfferBatchTracking'
 import { useOfferImageContainerDimensions } from 'features/offer/helpers/useOfferImageContainerDimensions'
@@ -30,10 +31,12 @@ export const Chronicles: FunctionComponent = () => {
   const offerId = route.params?.offerId
   const { data: offer } = useOfferQuery({ offerId })
   const subcategoriesMapping = useSubcategoriesMapping()
-
+  const chronicleVariantInfo =
+    chronicleVariant[offer?.subcategoryId ?? SubcategoryIdEnum.LIVRE_PAPIER]
   const { data: chronicleCardsData } = useChronicles<ChronicleCardData[]>({
     offerId,
-    select: ({ chronicles }) => offerChroniclesToChronicleCardData(chronicles),
+    select: ({ chronicles }) =>
+      offerChroniclesToChronicleCardData(chronicles, chronicleVariantInfo.subtitleItem),
   })
 
   const { user } = useAuthContext()

--- a/src/features/offer/adapters/chroniclePreviewToChronicleCardData.test.ts
+++ b/src/features/offer/adapters/chroniclePreviewToChronicleCardData.test.ts
@@ -13,9 +13,11 @@ const CHRONICLE_PREVIEW: ChroniclePreview = {
   },
 }
 
+const subtitle = 'Membre du Book Club'
+
 describe('chroniclePreviewToChronicleCardData', () => {
   it('should convert ChroniclePreview to ChronicleCardData with Author', () => {
-    expect(chroniclePreviewToChronicalCardData(CHRONICLE_PREVIEW)).toStrictEqual({
+    expect(chroniclePreviewToChronicalCardData(CHRONICLE_PREVIEW, subtitle)).toStrictEqual({
       date: 'Janvier 2025',
       description: 'lorem ipsum dolor',
       id: 1,
@@ -27,7 +29,7 @@ describe('chroniclePreviewToChronicleCardData', () => {
   it('should convert ChroniclePreview to ChronicleCardData with no Author', () => {
     const data = { ...CHRONICLE_PREVIEW, author: null }
 
-    expect(chroniclePreviewToChronicalCardData(data)).toStrictEqual({
+    expect(chroniclePreviewToChronicalCardData(data, subtitle)).toStrictEqual({
       date: 'Janvier 2025',
       description: 'lorem ipsum dolor',
       id: 1,
@@ -51,7 +53,7 @@ describe('chroniclePreviewToChronicleCardData', () => {
       author: { ...CHRONICLE_PREVIEW.author, age: null, firstName: null },
     }
 
-    expect(chroniclePreviewToChronicalCardData(dataWithoutName)).toStrictEqual({
+    expect(chroniclePreviewToChronicalCardData(dataWithoutName, subtitle)).toStrictEqual({
       date: 'Janvier 2025',
       description: 'lorem ipsum dolor',
       id: 1,
@@ -59,7 +61,7 @@ describe('chroniclePreviewToChronicleCardData', () => {
       title: 'Membre du Book Club',
     })
 
-    expect(chroniclePreviewToChronicalCardData(dataWithoutAge)).toStrictEqual({
+    expect(chroniclePreviewToChronicalCardData(dataWithoutAge, subtitle)).toStrictEqual({
       date: 'Janvier 2025',
       description: 'lorem ipsum dolor',
       id: 1,
@@ -67,7 +69,7 @@ describe('chroniclePreviewToChronicleCardData', () => {
       title: 'John',
     })
 
-    expect(chroniclePreviewToChronicalCardData(dataWithEmptyAuthor)).toStrictEqual({
+    expect(chroniclePreviewToChronicalCardData(dataWithEmptyAuthor, subtitle)).toStrictEqual({
       date: 'Janvier 2025',
       description: 'lorem ipsum dolor',
       id: 1,

--- a/src/features/offer/adapters/chroniclePreviewToChronicleCardData.ts
+++ b/src/features/offer/adapters/chroniclePreviewToChronicleCardData.ts
@@ -3,12 +3,15 @@ import { ChronicleCardData } from 'features/chronicle/type'
 import { getChronicleCardTitle } from 'shared/chronicle/getChronicleCardTitle/getChronicleCardTitle'
 import { getFormattedChronicleDate } from 'shared/chronicle/getFormattedChronicleDate/getFormattedChronicleDate'
 
-export const chroniclePreviewToChronicalCardData = (data: ChroniclePreview): ChronicleCardData => {
+export const chroniclePreviewToChronicalCardData = (
+  data: ChroniclePreview,
+  subtitle: string
+): ChronicleCardData => {
   return {
     date: getFormattedChronicleDate(data.dateCreated),
     description: data.contentPreview,
     id: data.id,
-    subtitle: data.author?.firstName ? 'Membre du Book Club' : '',
-    title: getChronicleCardTitle(data.author),
+    subtitle: data.author?.firstName ? subtitle : '',
+    title: getChronicleCardTitle(subtitle, data.author),
   }
 }

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.tsx
@@ -16,16 +16,7 @@ import { ChronicleSectionProps } from './types'
 
 export const ChronicleSection = (props: ChronicleSectionProps) => {
   const { isDesktopViewport } = useTheme()
-  const {
-    data,
-    title,
-    subtitle,
-    ctaLabel,
-    navigateTo,
-    style,
-    onSeeMoreButtonPress,
-    chronicleIcon,
-  } = props
+  const { data, title, subtitle, ctaLabel, navigateTo, style, onSeeMoreButtonPress, icon } = props
 
   return isDesktopViewport ? (
     <View style={style}>
@@ -48,7 +39,7 @@ export const ChronicleSection = (props: ChronicleSectionProps) => {
         data={data}
         onSeeMoreButtonPress={onSeeMoreButtonPress}
         shouldTruncate
-        chronicleIcon={chronicleIcon}
+        icon={icon}
       />
     </View>
   ) : (

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.tsx
@@ -16,7 +16,16 @@ import { ChronicleSectionProps } from './types'
 
 export const ChronicleSection = (props: ChronicleSectionProps) => {
   const { isDesktopViewport } = useTheme()
-  const { data, title, subtitle, ctaLabel, navigateTo, style, onSeeMoreButtonPress } = props
+  const {
+    data,
+    title,
+    subtitle,
+    ctaLabel,
+    navigateTo,
+    style,
+    onSeeMoreButtonPress,
+    chronicleIcon,
+  } = props
 
   return isDesktopViewport ? (
     <View style={style}>
@@ -39,6 +48,7 @@ export const ChronicleSection = (props: ChronicleSectionProps) => {
         data={data}
         onSeeMoreButtonPress={onSeeMoreButtonPress}
         shouldTruncate
+        chronicleIcon={chronicleIcon}
       />
     </View>
   ) : (

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSectionBase.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSectionBase.tsx
@@ -19,7 +19,7 @@ export const ChronicleSectionBase = ({
   navigateTo,
   onSeeMoreButtonPress,
   style,
-  chronicleIcon,
+  icon,
 }: ChronicleSectionProps) => {
   return (
     <View style={style}>
@@ -31,7 +31,7 @@ export const ChronicleSectionBase = ({
         data={data}
         onSeeMoreButtonPress={onSeeMoreButtonPress}
         shouldTruncate
-        chronicleIcon={chronicleIcon}
+        icon={icon}
       />
       <Gutter>
         <InternalTouchableLink

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSectionBase.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSectionBase.tsx
@@ -19,6 +19,7 @@ export const ChronicleSectionBase = ({
   navigateTo,
   onSeeMoreButtonPress,
   style,
+  chronicleIcon,
 }: ChronicleSectionProps) => {
   return (
     <View style={style}>
@@ -30,6 +31,7 @@ export const ChronicleSectionBase = ({
         data={data}
         onSeeMoreButtonPress={onSeeMoreButtonPress}
         shouldTruncate
+        chronicleIcon={chronicleIcon}
       />
       <Gutter>
         <InternalTouchableLink

--- a/src/features/offer/components/OfferContent/ChronicleSection/types.ts
+++ b/src/features/offer/components/OfferContent/ChronicleSection/types.ts
@@ -14,4 +14,10 @@ export type ChronicleSectionProps = {
   style?: StyleProp<ViewStyle>
   chronicleIcon?: ReactNode
 }
+
+export type ChronicleVariantInfo = {
+  titleSection: string
+  subtitleSection: string
+  subtitleItem: string
+  Icon?: React.ReactNode
 }

--- a/src/features/offer/components/OfferContent/ChronicleSection/types.ts
+++ b/src/features/offer/components/OfferContent/ChronicleSection/types.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react'
 import { StyleProp, ViewStyle } from 'react-native'
 
 import { ChronicleCardData } from 'features/chronicle/type'
@@ -11,4 +12,6 @@ export type ChronicleSectionProps = {
   navigateTo: InternalNavigationProps['navigateTo']
   onSeeMoreButtonPress?: (chronicleId: number) => void
   style?: StyleProp<ViewStyle>
+  chronicleIcon?: ReactNode
+}
 }

--- a/src/features/offer/components/OfferContent/ChronicleSection/types.ts
+++ b/src/features/offer/components/OfferContent/ChronicleSection/types.ts
@@ -12,7 +12,7 @@ export type ChronicleSectionProps = {
   navigateTo: InternalNavigationProps['navigateTo']
   onSeeMoreButtonPress?: (chronicleId: number) => void
   style?: StyleProp<ViewStyle>
-  chronicleIcon?: ReactNode
+  icon?: ReactNode
 }
 
 export type ChronicleVariantInfo = {

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -23,6 +23,7 @@ import * as useGoBack from 'features/navigation/useGoBack'
 import { chroniclePreviewToChronicalCardData } from 'features/offer/adapters/chroniclePreviewToChronicleCardData'
 import { CineContentCTAID } from 'features/offer/components/OfferCine/CineContentCTA'
 import { PlaylistType } from 'features/offer/enums'
+import { chronicleVariantInfo } from 'features/offer/fixtures/chronicleVariantInfo'
 import { mockSubcategory } from 'features/offer/fixtures/mockSubcategory'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import * as useSimilarOffersAPI from 'features/offer/queries/useSimilarOffersQuery'
@@ -849,8 +850,10 @@ function renderOfferContent({
   isDesktopViewport,
   chronicles,
 }: RenderOfferContentType) {
+  const subtitle = 'Membre du Book Club'
   const chroniclesData =
-    chronicles || offer.chronicles.map((data) => chroniclePreviewToChronicalCardData(data))
+    chronicles ||
+    offer.chronicles.map((data) => chroniclePreviewToChronicalCardData(data, subtitle))
   render(
     reactQueryProviderHOC(
       <NavigationContainer>
@@ -859,6 +862,7 @@ function renderOfferContent({
           searchGroupList={subcategoriesDataTest.searchGroups}
           subcategory={subcategory}
           chronicles={chroniclesData}
+          chronicleVariantInfo={chronicleVariantInfo}
         />
       </NavigationContainer>
     ),

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -23,7 +23,7 @@ import * as useGoBack from 'features/navigation/useGoBack'
 import { chroniclePreviewToChronicalCardData } from 'features/offer/adapters/chroniclePreviewToChronicleCardData'
 import { CineContentCTAID } from 'features/offer/components/OfferCine/CineContentCTA'
 import { PlaylistType } from 'features/offer/enums'
-import { chronicleVariantInfo } from 'features/offer/fixtures/chronicleVariantInfo'
+import { chronicleVariantInfoFixture } from 'features/offer/fixtures/chronicleVariantInfo'
 import { mockSubcategory } from 'features/offer/fixtures/mockSubcategory'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import * as useSimilarOffersAPI from 'features/offer/queries/useSimilarOffersQuery'
@@ -862,7 +862,7 @@ function renderOfferContent({
           searchGroupList={subcategoriesDataTest.searchGroups}
           subcategory={subcategory}
           chronicles={chroniclesData}
-          chronicleVariantInfo={chronicleVariantInfo}
+          chronicleVariantInfo={chronicleVariantInfoFixture}
         />
       </NavigationContainer>
     ),

--- a/src/features/offer/components/OfferContent/OfferContent.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.tsx
@@ -17,6 +17,7 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   searchGroupList,
   subcategory,
   chronicles,
+  chronicleVariantInfo,
   defaultReaction,
   headlineOffersCount,
   onReactionButtonPress,
@@ -38,6 +39,7 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
         onOfferPreviewPress={handlePress}
         BodyWrapper={BodyWrapper}
         chronicles={chronicles}
+        chronicleVariantInfo={chronicleVariantInfo}
         headlineOffersCount={headlineOffersCount}
         subcategory={subcategory}
         defaultReaction={defaultReaction}

--- a/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
@@ -2,6 +2,7 @@ import React, { ComponentProps } from 'react'
 import * as ReactQueryAPI from 'react-query'
 
 import { OfferResponseV2, SubcategoriesResponseModelv2 } from 'api/gen'
+import { chronicleVariantInfo } from 'features/offer/fixtures/chronicleVariantInfo'
 import { mockSubcategory } from 'features/offer/fixtures/mockSubcategory'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import * as useSimilarOffersAPI from 'features/offer/queries/useSimilarOffersQuery'
@@ -172,6 +173,7 @@ const renderOfferContent = ({
         offer={offer}
         searchGroupList={PLACEHOLDER_DATA.searchGroups}
         subcategory={subcategory}
+        chronicleVariantInfo={chronicleVariantInfo}
       />
     ),
     {

--- a/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
@@ -2,7 +2,7 @@ import React, { ComponentProps } from 'react'
 import * as ReactQueryAPI from 'react-query'
 
 import { OfferResponseV2, SubcategoriesResponseModelv2 } from 'api/gen'
-import { chronicleVariantInfo } from 'features/offer/fixtures/chronicleVariantInfo'
+import { chronicleVariantInfoFixture } from 'features/offer/fixtures/chronicleVariantInfo'
 import { mockSubcategory } from 'features/offer/fixtures/mockSubcategory'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import * as useSimilarOffersAPI from 'features/offer/queries/useSimilarOffersQuery'
@@ -173,7 +173,7 @@ const renderOfferContent = ({
         offer={offer}
         searchGroupList={PLACEHOLDER_DATA.searchGroups}
         subcategory={subcategory}
-        chronicleVariantInfo={chronicleVariantInfo}
+        chronicleVariantInfo={chronicleVariantInfoFixture}
       />
     ),
     {

--- a/src/features/offer/components/OfferContent/OfferContent.web.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.tsx
@@ -17,6 +17,7 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   searchGroupList,
   subcategory,
   chronicles,
+  chronicleVariantInfo,
   defaultReaction,
   onReactionButtonPress,
   headlineOffersCount,
@@ -63,6 +64,7 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
           searchGroupList={searchGroupList}
           subcategory={subcategory}
           chronicles={chronicles}
+          chronicleVariantInfo={chronicleVariantInfo}
           onOfferPreviewPress={handlePress}
           BodyWrapper={BodyWrapper}
           defaultReaction={defaultReaction}

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -77,6 +77,7 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
   searchGroupList,
   subcategory,
   chronicles,
+  chronicleVariantInfo,
   headlineOffersCount,
   onOfferPreviewPress,
   contentContainerStyle,
@@ -279,9 +280,10 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
           {chronicles?.length ? (
             <StyledSectionWithDivider visible testID="chronicles-section" gap={8}>
               <ChronicleSection
-                title="La reco du Book Club"
+                title={chronicleVariantInfo.titleSection}
                 ctaLabel="Voir tous les avis"
-                subtitle="Notre communauté de lecteurs te partagent leurs avis sur ce livre&nbsp;!"
+                subtitle={chronicleVariantInfo.subtitleSection}
+                chronicleIcon={chronicleVariantInfo.Icon}
                 data={chronicles}
                 // It's dirty but necessary to use from parameter for the logs
                 navigateTo={{

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -283,7 +283,7 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
                 title={chronicleVariantInfo.titleSection}
                 ctaLabel="Voir tous les avis"
                 subtitle={chronicleVariantInfo.subtitleSection}
-                chronicleIcon={chronicleVariantInfo.Icon}
+                icon={chronicleVariantInfo.Icon}
                 data={chronicles}
                 // It's dirty but necessary to use from parameter for the logs
                 navigateTo={{

--- a/src/features/offer/constant.tsx
+++ b/src/features/offer/constant.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { SubcategoryIdEnum } from 'api/gen'
+import { BookClubCertification } from 'ui/svg/BookClubCertification'
+import { CineClubCertification } from 'ui/svg/CineClubCertification'
+
+const BookClubIcon = styled(BookClubCertification).attrs(({ theme }) => ({
+  color: theme.designSystem.color.icon.bookclub,
+}))``
+
+const CineClubIcon = styled(CineClubCertification).attrs(({ theme }) => ({
+  color: theme.designSystem.color.icon.cineclub,
+}))``
+
+export const BOOK_CLUB_SUBCATEGORIES = [
+  SubcategoryIdEnum.LIVRE_AUDIO_PHYSIQUE,
+  SubcategoryIdEnum.LIVRE_NUMERIQUE,
+  SubcategoryIdEnum.LIVRE_PAPIER,
+] as const
+
+export const CINE_CLUB_SUBCATEGORIES = [
+  SubcategoryIdEnum.SEANCE_CINE,
+  SubcategoryIdEnum.SUPPORT_PHYSIQUE_FILM,
+  SubcategoryIdEnum.AUTRE_SUPPORT_NUMERIQUE,
+  SubcategoryIdEnum.VOD,
+  SubcategoryIdEnum.CINE_PLEIN_AIR,
+] as const
+
+export const CHRONICLE_VARIANT_CONFIG = [
+  {
+    subcategories: BOOK_CLUB_SUBCATEGORIES,
+    titleSection: 'La reco du Book Club',
+    subtitleSection: 'Notre communauté de lecteurs te partagent leurs avis sur ce livre\u00a0!',
+    subtitleItem: 'Membre du Book Club',
+    Icon: <BookClubIcon />,
+  },
+  {
+    subcategories: CINE_CLUB_SUBCATEGORIES,
+    titleSection: 'La reco du Ciné Club',
+    subtitleSection: 'Des avis de jeunes passionnés sélectionnés par le pass Culture\u00a0!',
+    subtitleItem: 'Membre du Ciné Club',
+    Icon: <CineClubIcon />,
+  },
+] as const

--- a/src/features/offer/fixtures/chronicleVariantInfo.ts
+++ b/src/features/offer/fixtures/chronicleVariantInfo.ts
@@ -1,0 +1,8 @@
+import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
+
+export const chronicleVariantInfo: ChronicleVariantInfo = {
+  titleSection: 'La reco du Book Club',
+  subtitleSection: 'Notre communauté de lecteurs te partagent leurs avis sur ce livre\u00a0!',
+  subtitleItem: 'Membre du Book Club',
+  Icon: undefined,
+}

--- a/src/features/offer/fixtures/chronicleVariantInfo.ts
+++ b/src/features/offer/fixtures/chronicleVariantInfo.ts
@@ -1,6 +1,6 @@
 import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
 
-export const chronicleVariantInfo: ChronicleVariantInfo = {
+export const chronicleVariantInfoFixture: ChronicleVariantInfo = {
   titleSection: 'La reco du Book Club',
   subtitleSection: 'Notre communauté de lecteurs te partagent leurs avis sur ce livre\u00a0!',
   subtitleItem: 'Membre du Book Club',

--- a/src/features/offer/helpers/chronicleVariant/chronicleVariant.native.test.ts
+++ b/src/features/offer/helpers/chronicleVariant/chronicleVariant.native.test.ts
@@ -6,10 +6,8 @@ describe('chronicleVariant', () => {
     BOOK_CLUB_SUBCATEGORIES.forEach((subcategoryId) => {
       const variant = chronicleVariant[subcategoryId]
 
-      expect(variant).toBeDefined()
       expect(variant.titleSection).toEqual('La reco du Book Club')
       expect(variant.subtitleItem).toEqual('Membre du Book Club')
-      expect(variant.Icon).toBeTruthy()
     })
   })
 
@@ -17,10 +15,8 @@ describe('chronicleVariant', () => {
     CINE_CLUB_SUBCATEGORIES.forEach((subcategoryId) => {
       const variant = chronicleVariant[subcategoryId]
 
-      expect(variant).toBeDefined()
       expect(variant.titleSection).toEqual('La reco du Ciné Club')
       expect(variant.subtitleItem).toEqual('Membre du Ciné Club')
-      expect(variant.Icon).toBeTruthy()
     })
   })
 })

--- a/src/features/offer/helpers/chronicleVariant/chronicleVariant.native.test.ts
+++ b/src/features/offer/helpers/chronicleVariant/chronicleVariant.native.test.ts
@@ -1,0 +1,26 @@
+import { BOOK_CLUB_SUBCATEGORIES, CINE_CLUB_SUBCATEGORIES } from 'features/offer/constant'
+import { chronicleVariant } from 'features/offer/helpers/chronicleVariant/chronicleVariant'
+
+describe('chronicleVariant', () => {
+  it('should define all Book Club subcategories', () => {
+    BOOK_CLUB_SUBCATEGORIES.forEach((subcategoryId) => {
+      const variant = chronicleVariant[subcategoryId]
+
+      expect(variant).toBeDefined()
+      expect(variant.titleSection).toEqual('La reco du Book Club')
+      expect(variant.subtitleItem).toEqual('Membre du Book Club')
+      expect(variant.Icon).toBeTruthy()
+    })
+  })
+
+  it('should define all Ciné Club subcategories', () => {
+    CINE_CLUB_SUBCATEGORIES.forEach((subcategoryId) => {
+      const variant = chronicleVariant[subcategoryId]
+
+      expect(variant).toBeDefined()
+      expect(variant.titleSection).toEqual('La reco du Ciné Club')
+      expect(variant.subtitleItem).toEqual('Membre du Ciné Club')
+      expect(variant.Icon).toBeTruthy()
+    })
+  })
+})

--- a/src/features/offer/helpers/chronicleVariant/chronicleVariant.ts
+++ b/src/features/offer/helpers/chronicleVariant/chronicleVariant.ts
@@ -1,0 +1,9 @@
+import { SubcategoryIdEnum } from 'api/gen'
+import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
+import { CHRONICLE_VARIANT_CONFIG } from 'features/offer/constant'
+
+export const chronicleVariant: Record<SubcategoryIdEnum, ChronicleVariantInfo> = Object.fromEntries(
+  CHRONICLE_VARIANT_CONFIG.map(({ subcategories, ...variant }) =>
+    subcategories.map((id) => [id, variant] as const)
+  ).flat()
+)

--- a/src/features/offer/pages/Offer/Offer.native.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.native.test.tsx
@@ -211,7 +211,7 @@ describe('<Offer />', () => {
 
     renderOfferPage({ mockOffer: offerResponseSnap })
 
-    expect(await screen.findByText('La reco du Book Club')).toBeOnTheScreen()
+    expect(await screen.findByText('La reco du Ciné Club')).toBeOnTheScreen()
   })
 
   it('should display offer placeholder on init', async () => {

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -7,6 +7,7 @@ import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { chroniclePreviewToChronicalCardData } from 'features/offer/adapters/chroniclePreviewToChronicleCardData'
 import { OfferContent } from 'features/offer/components/OfferContent/OfferContent'
 import { OfferContentPlaceholder } from 'features/offer/components/OfferContentPlaceholder/OfferContentPlaceholder'
+import { chronicleVariant } from 'features/offer/helpers/chronicleVariant/chronicleVariant'
 import { useFetchHeadlineOffersCountQuery } from 'features/offer/queries/useFetchHeadlineOffersCountQuery'
 import { ReactionChoiceModal } from 'features/reactions/components/ReactionChoiceModal/ReactionChoiceModal'
 import { ReactionChoiceModalBodyEnum, ReactionFromEnum } from 'features/reactions/enum'
@@ -59,13 +60,18 @@ export function Offer() {
     [hideModal, saveReaction]
   )
 
-  const chronicles = hasOfferChronicleSection
-    ? offer?.chronicles?.map((value) => chroniclePreviewToChronicalCardData(value))
-    : undefined
-
   const { data } = useFetchHeadlineOffersCountQuery(offer)
 
   if (!offer || !subcategories || !subcategoriesMapping?.[offer?.subcategoryId]) return null
+
+  const subcategory = subcategoriesMapping[offer?.subcategoryId]
+  const chronicleVariantInfo = chronicleVariant[subcategory.id]
+
+  const chronicles = hasOfferChronicleSection
+    ? offer?.chronicles?.map((value) =>
+        chroniclePreviewToChronicalCardData(value, chronicleVariantInfo.subtitleItem)
+      )
+    : undefined
 
   const shouldFetchSearchVenueOffers = isMultiVenueCompatibleOffer(offer)
   const headlineOffersCount = shouldFetchSearchVenueOffers ? data?.headlineOffersCount : undefined
@@ -88,6 +94,7 @@ export function Offer() {
       <OfferContent
         offer={offer}
         chronicles={chronicles}
+        chronicleVariantInfo={chronicleVariantInfo}
         headlineOffersCount={headlineOffersCount}
         searchGroupList={subcategories.searchGroups}
         subcategory={subcategoriesMapping[offer.subcategoryId]}

--- a/src/features/offer/types.ts
+++ b/src/features/offer/types.ts
@@ -11,6 +11,7 @@ import {
 } from 'api/gen'
 import { ChronicleCardData } from 'features/chronicle/type'
 import { Referrals } from 'features/navigation/RootNavigator/types'
+import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
 import { PlaylistType } from 'features/offer/enums'
 import { AlgoliaGeoloc } from 'libs/algolia/types'
 import { Subcategory } from 'libs/subcategories/types'
@@ -70,6 +71,7 @@ export interface VenueDetail {
 export type OfferContentProps = {
   offer: OfferResponseV2
   searchGroupList: SearchGroupResponseModelv2[]
+  chronicleVariantInfo: ChronicleVariantInfo
   subcategory: Subcategory
   chronicles?: ChronicleCardData[]
   headlineOffersCount?: number

--- a/src/shared/chronicle/getChronicleCardTitle/getChronicleCardTitle.test.ts
+++ b/src/shared/chronicle/getChronicleCardTitle/getChronicleCardTitle.test.ts
@@ -1,27 +1,31 @@
 import { getChronicleCardTitle } from 'shared/chronicle/getChronicleCardTitle/getChronicleCardTitle'
 
+const subtitle = 'Membre du Book Club'
+
 describe('getChronicleCardTitle', () => {
   it('should return "Membre du Book Club" when author not defined', () => {
-    expect(getChronicleCardTitle()).toEqual('Membre du Book Club')
+    expect(getChronicleCardTitle(subtitle)).toEqual('Membre du Book Club')
   })
 
   it('should return "Membre du Book Club" when author is null', () => {
-    expect(getChronicleCardTitle(null)).toEqual('Membre du Book Club')
+    expect(getChronicleCardTitle(subtitle, null)).toEqual('Membre du Book Club')
   })
 
   it('should return "Membre du Book Club" when author has only an age', () => {
-    expect(getChronicleCardTitle({ age: 18 })).toEqual('Membre du Book Club')
+    expect(getChronicleCardTitle(subtitle, { age: 18 })).toEqual('Membre du Book Club')
   })
 
   it('should return author firstname when defined', () => {
-    expect(getChronicleCardTitle({ firstName: 'Alice' })).toEqual('Alice')
+    expect(getChronicleCardTitle(subtitle, { firstName: 'Alice' })).toEqual('Alice')
   })
 
   it('should return author age and firstname when defined', () => {
-    expect(getChronicleCardTitle({ firstName: 'Alice', age: 18 })).toEqual('Alice, 18 ans')
+    expect(getChronicleCardTitle(subtitle, { firstName: 'Alice', age: 18 })).toEqual(
+      'Alice, 18 ans'
+    )
   })
 
   it('should return "Membre du Book Club" when author firstname is an empty string', () => {
-    expect(getChronicleCardTitle({ firstName: '', age: 18 })).toBe('Membre du Book Club')
+    expect(getChronicleCardTitle(subtitle, { firstName: '', age: 18 })).toBe('Membre du Book Club')
   })
 })

--- a/src/shared/chronicle/getChronicleCardTitle/getChronicleCardTitle.ts
+++ b/src/shared/chronicle/getChronicleCardTitle/getChronicleCardTitle.ts
@@ -1,8 +1,8 @@
 import { ChronicleAuthor } from 'api/gen'
 
-export function getChronicleCardTitle(author?: ChronicleAuthor | null) {
+export function getChronicleCardTitle(subtitle: string, author?: ChronicleAuthor | null) {
   if (!author?.firstName) {
-    return 'Membre du Book Club'
+    return subtitle
   }
   if (author?.age) {
     return `${author.firstName}, ${author.age} ans`

--- a/src/ui/svg/CineClubCertification.tsx
+++ b/src/ui/svg/CineClubCertification.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Path } from 'react-native-svg'
+import styled from 'styled-components/native'
+
+import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
+import { AccessibleIcon } from 'ui/svg/icons/types'
+
+const CineClubCertificationSvg: React.FunctionComponent<AccessibleIcon> = ({
+  size,
+  color,
+  accessibilityLabel,
+  testID,
+}) => {
+  return (
+    <AccessibleSvg
+      width={size}
+      height={size}
+      viewBox="0 0 48 48"
+      fill="none"
+      testID={testID}
+      accessibilityLabel={accessibilityLabel}>
+      <Path
+        d="M45.6875 20.5982L46.9375 16.6034L43.5625 14.1066V9.92458L39.5625 8.61379L38.25 4.61899H34.0625L31.5625 1.24838L27.5625 2.49675L24.0625 0L20.625 2.43433L16.625 1.18596L14.125 4.55657H9.9375L8.625 8.55137L4.625 9.86216V14.0442L1.25 16.541L2.5 20.5358L0 24.0312L2.4375 27.4643L1.1875 31.4591L4.5625 33.9558V38.1379L8.5625 39.4487L9.875 43.4435H14.0625L16.5625 46.8141L20.5625 45.5657L24 48L27.4375 45.5657L31.4375 46.8141L33.9375 43.4435H38.125L39.4375 39.4487L43.4375 38.1379V33.9558L46.8125 31.4591L45.5625 27.4643L48 24.0312L45.6875 20.5982Z"
+        fill={color}
+      />
+      <Path
+        d="M34.1821 33.0467C34.1821 34.1234 33.1771 34.9978 31.9428 34.9979H15.9848C14.7452 34.9979 13.7446 34.1234 13.7446 33.0467V27.7098H34.1821V33.0467ZM19.9741 22.2586L18.7553 22.5291H31.9428C33.1823 22.5292 34.1821 23.4036 34.1821 24.4803V26.6746H13.7446V24.4803C13.7446 23.4036 14.7504 22.5291 15.9848 22.5291H16.2221L19.1928 17.0623L23.2915 16.1473L19.9741 22.2586ZM14.2915 22.8621V22.8573C14.0831 22.6596 13.9266 22.3992 13.8588 22.0975L13.3588 19.8768C13.1818 19.0811 13.682 18.2853 14.4838 18.1082L17.1977 17.5047L14.2915 22.8621ZM26.0415 20.9012L21.9692 21.8114L25.2866 15.7L29.354 14.7899L26.0415 20.9012ZM31.8911 14.2274C32.6878 14.0507 33.4845 14.5505 33.6616 15.3514L34.1616 17.5721C34.3387 18.3679 33.8387 19.1638 33.0366 19.3407L28.0366 20.4588L31.3491 14.3475L31.8911 14.2274Z"
+        fill="white"
+      />
+    </AccessibleSvg>
+  )
+}
+
+export const CineClubCertification = styled(CineClubCertificationSvg).attrs(
+  ({ color, size, theme }) => ({
+    color: color ?? theme.designSystem.color.icon.default,
+    size: size ?? theme.icons.sizes.standard,
+  })
+)``


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36672

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

![Capture d’écran 2025-07-01 à 15 55 36](https://github.com/user-attachments/assets/c0baea0e-f00e-49b9-9353-c96091e1db47)
<img width="1194" alt="Capture d’écran 2025-07-02 à 09 41 42" src="https://github.com/user-attachments/assets/2022de8c-8407-429b-812a-0b062cf23b54" />


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
