### PR TITLE
(PC-36675) feat(chronicle): custom modal for cine and book club

### DIFF
--- a/src/features/chronicle/pages/Chronicles/Chronicles.native.test.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.native.test.tsx
@@ -173,7 +173,7 @@ describe('Chronicles', () => {
       it('should navigate to recommandation thematic home when pressing button', async () => {
         render(reactQueryProviderHOC(<Chronicles />))
 
-        await user.press(await screen.findByText('Voir toutes les recos du book club'))
+        await user.press(await screen.findByText('Voir toutes les recos du Ciné Club'))
 
         await waitFor(async () => {
           expect(mockNavigate).toHaveBeenNthCalledWith(1, 'ThematicHome', {

--- a/src/features/chronicle/pages/Chronicles/Chronicles.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.tsx
@@ -29,7 +29,7 @@ export const Chronicles: FunctionComponent = () => {
       chronicleCardsData={chronicleCardsData}
       offerId={offer.id}
       offerName={offer.name}
-      cardIcon={chronicleVariantInfo.Icon}
+      variantInfo={chronicleVariantInfo}
     />
   )
 }

--- a/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
@@ -74,7 +74,7 @@ export const Chronicles: FunctionComponent = () => {
       <ChroniclesBase
         offerId={offer.id}
         offerName={offer.name}
-        cardIcon={chronicleVariantInfo.Icon}
+        variantInfo={chronicleVariantInfo}
         chronicleCardsData={chronicleCardsData}>
         {isDesktopViewport ? (
           <StyledChronicleOfferInfo

--- a/src/features/chronicle/pages/Chronicles/ChroniclesBase.tsx
+++ b/src/features/chronicle/pages/Chronicles/ChroniclesBase.tsx
@@ -12,6 +12,7 @@ import { ChroniclesWebMetaHeader } from 'features/chronicle/components/Chronicle
 import { ChroniclesWritersModal } from 'features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal'
 import { ChronicleCardData } from 'features/chronicle/type'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
+import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
 import { useModal } from 'ui/components/modals/useModal'
 import { getSpacing } from 'ui/theme'
@@ -20,14 +21,14 @@ type Props = PropsWithChildren<{
   offerId: number
   offerName: string
   chronicleCardsData: ChronicleCardData[]
-  cardIcon?: React.ReactNode
+  variantInfo: ChronicleVariantInfo
 }>
 
 export const ChroniclesBase: FunctionComponent<Props> = ({
   offerId,
   offerName,
   chronicleCardsData,
-  cardIcon,
+  variantInfo,
   children,
 }) => {
   const route = useRoute<UseRouteType<'Chronicles'>>()
@@ -98,13 +99,14 @@ export const ChroniclesBase: FunctionComponent<Props> = ({
                 }),
           }}
           onLayout={handleLayout}
-          cardIcon={cardIcon}
+          cardIcon={variantInfo.Icon}
         />
       </FullFlexRow>
       <ChroniclesWritersModal
         closeModal={hideModal}
         isVisible={visible}
         onShowRecoButtonPress={handleOnShowRecoButtonPress}
+        variantInfo={variantInfo}
       />
     </React.Fragment>
   )

--- a/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.native.test.tsx
+++ b/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.native.test.tsx
@@ -1,16 +1,22 @@
 import React from 'react'
 
 import { ChroniclesWritersModal } from 'features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal'
+import { chronicleVariantInfoFixture } from 'features/offer/fixtures/chronicleVariantInfo'
 import { render, screen } from 'tests/utils'
 
 describe('<ChroniclesWritersModal/>', () => {
   it('should render correctly', () => {
     render(
-      <ChroniclesWritersModal isVisible closeModal={jest.fn} onShowRecoButtonPress={jest.fn()} />
+      <ChroniclesWritersModal
+        isVisible
+        closeModal={jest.fn}
+        onShowRecoButtonPress={jest.fn()}
+        variantInfo={chronicleVariantInfoFixture}
+      />
     )
 
     expect(
-      screen.getByText('Les avis du book club sont écrits par des jeunes passionnés de lecture.')
+      screen.getByText('Les avis du Book Club sont écrits par des jeunes passionnés de lecture.')
     ).toBeOnTheScreen()
   })
 })

--- a/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.tsx
+++ b/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react'
 
+import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -10,12 +11,14 @@ type Props = {
   isVisible: boolean
   closeModal: VoidFunction
   onShowRecoButtonPress: VoidFunction
+  variantInfo: ChronicleVariantInfo
 }
 
 export const ChroniclesWritersModal: FunctionComponent<Props> = ({
   isVisible,
   closeModal,
   onShowRecoButtonPress,
+  variantInfo,
 }) => {
   return (
     <AppModal
@@ -26,18 +29,13 @@ export const ChroniclesWritersModal: FunctionComponent<Props> = ({
       rightIcon={Close}
       onRightIconPress={closeModal}>
       <ViewGap gap={6}>
-        <Typo.Body>
-          Les avis du book club sont écrits par des jeunes passionnés de lecture.
-        </Typo.Body>
+        <Typo.Body>{variantInfo.modalWording}</Typo.Body>
         <Typo.Body>
           Ils sont sélectionnés par le pass Culture pour te faire leurs meilleures recos tous les
           mois.
         </Typo.Body>
 
-        <ButtonPrimary
-          wording="Voir toutes les recos du book club"
-          onPress={onShowRecoButtonPress}
-        />
+        <ButtonPrimary wording={variantInfo.modalButtonLabel} onPress={onShowRecoButtonPress} />
       </ViewGap>
     </AppModal>
   )

--- a/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.web.test.tsx
+++ b/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.web.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { ChroniclesWritersModal } from 'features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal'
+import { chronicleVariantInfoFixture } from 'features/offer/fixtures/chronicleVariantInfo'
 import { act, checkAccessibilityFor, render } from 'tests/utils/web'
 
 describe('<ChroniclesWritersModal/>', () => {
@@ -11,6 +12,7 @@ describe('<ChroniclesWritersModal/>', () => {
           isVisible
           closeModal={jest.fn()}
           onShowRecoButtonPress={jest.fn()}
+          variantInfo={chronicleVariantInfoFixture}
         />
       )
       await act(async () => {

--- a/src/features/offer/components/OfferContent/ChronicleSection/types.ts
+++ b/src/features/offer/components/OfferContent/ChronicleSection/types.ts
@@ -20,4 +20,6 @@ export type ChronicleVariantInfo = {
   subtitleSection: string
   subtitleItem: string
   Icon?: React.ReactNode
+  modalWording: string
+  modalButtonLabel: string
 }

--- a/src/features/offer/constant.tsx
+++ b/src/features/offer/constant.tsx
@@ -34,6 +34,8 @@ export const CHRONICLE_VARIANT_CONFIG = [
     subtitleSection: 'Notre communauté de lecteurs te partagent leurs avis sur ce livre\u00a0!',
     subtitleItem: 'Membre du Book Club',
     Icon: <BookClubIcon testID="bookClubIcon" />,
+    modalWording: 'Les avis du Book Club sont écrits par des jeunes passionnés de lecture.',
+    modalButtonLabel: 'Voir toutes les recos du Book Club',
   },
   {
     subcategories: CINE_CLUB_SUBCATEGORIES,
@@ -41,5 +43,7 @@ export const CHRONICLE_VARIANT_CONFIG = [
     subtitleSection: 'Notre communauté de cinéphiles te partage leur avis sur ce film\u00a0!',
     subtitleItem: 'Membre du Ciné Club',
     Icon: <CineClubIcon testID="cineClubIcon" />,
+    modalWording: 'Les avis du Ciné Club sont écrits par des jeunes passionnés de cinéma.',
+    modalButtonLabel: 'Voir toutes les recos du Ciné Club',
   },
 ] as const

--- a/src/features/offer/fixtures/chronicleVariantInfo.ts
+++ b/src/features/offer/fixtures/chronicleVariantInfo.ts
@@ -5,4 +5,6 @@ export const chronicleVariantInfoFixture: ChronicleVariantInfo = {
   subtitleSection: 'Notre communauté de lecteurs te partagent leurs avis sur ce livre\u00a0!',
   subtitleItem: 'Membre du Book Club',
   Icon: undefined,
+  modalWording: 'Les avis du Book Club sont écrits par des jeunes passionnés de lecture.',
+  modalButtonLabel: 'Voir toutes les recos du Book Club',
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36675

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
