### PR TITLE
(PC-36508) fix(searchFilter): ensure correct value for predefined and…

### DIFF
--- a/src/libs/analytics/utils.ts
+++ b/src/libs/analytics/utils.ts
@@ -94,7 +94,16 @@ const buildSearchDate = (searchState: SearchState) => {
   const startDate =
     searchState.date?.selectedDate ?? searchState.timeRange?.[0] ?? searchState.beginningDatetime
   const endDate = searchState.timeRange?.[1] ?? searchState.endingDatetime ?? null
-  const searchFilter = searchState.date?.option ?? searchState.calendarFilterId ?? null
+
+  let searchFilter: string | null = null
+  const filterId = searchState.date?.option ?? searchState.calendarFilterId ?? null
+  if (filterId) {
+    searchFilter = filterId
+  } else if (startDate && endDate && startDate !== endDate) {
+    searchFilter = 'dateInterval'
+  } else if (startDate && (!endDate || startDate === endDate)) {
+    searchFilter = 'specificDate'
+  }
 
   if (startDate) {
     return JSON.stringify({ startDate, endDate, searchFilter })

--- a/src/libs/firebase/analytics/utils.test.ts
+++ b/src/libs/firebase/analytics/utils.test.ts
@@ -90,7 +90,7 @@ describe('[Analytics utils]', () => {
       })
     })
 
-    it('with single date selected (no filter)', () => {
+    it('with single date selected (should return specificDate)', () => {
       const partialSearchState = buildPerformSearchState(
         {
           ...initialSearchState,
@@ -106,13 +106,13 @@ describe('[Analytics utils]', () => {
         searchDate: JSON.stringify({
           startDate: TODAY.toISOString(),
           endDate: null,
-          searchFilter: null,
+          searchFilter: 'specificDate',
         }),
         searchView: SearchView.Results,
       })
     })
 
-    it('with date range selected (no filter)', () => {
+    it('with date range selected (should return dateInterval)', () => {
       const partialSearchState = buildPerformSearchState(
         {
           ...initialSearchState,
@@ -128,7 +128,7 @@ describe('[Analytics utils]', () => {
         searchDate: JSON.stringify({
           startDate: TODAY.toISOString(),
           endDate: endOfMonth(TODAY).toISOString(),
-          searchFilter: null,
+          searchFilter: 'dateInterval',
         }),
         searchView: SearchView.Results,
       })


### PR DESCRIPTION
## Context
https://passculture.atlassian.net/browse/PC-36407
https://www.notion.so/passcultureapp/searchDate-20aad4e0ff988000a8c8dd4e9978f4de

## Objectif
Corriger la logique d’attribution du champ searchFilter dans les analytics de recherche pour qu’elle reflète correctement le filtre appliqué par l’utilisateur, qu’il soit prédéfini ou personnalisé.
Ce qui a été fait :
- Correction de la logique de sélection du searchFilter :
	- Si un filtre prédéfini (ex : today, thisMonth, thisWeekend, etc.) est sélectionné (calendarFilterId ou date.option), il est utilisé en priorité comme valeur de searchFilter.
	- Si aucun filtre prédéfini n’est sélectionné :
		- searchFilter prend la valeur dateInterval si un intervalle de dates personnalisé est choisi.
		- searchFilter prend la valeur specificDate si une date unique personnalisée est choisie.
	- Sinon, searchFilter reste à null.