### PR TITLE
(PC-36679) feat(offer): scroll to cine sessions part when navigate from chronicles session button

### DIFF
--- a/src/features/chronicle/helpers/isBookClubSubcategory.test.ts
+++ b/src/features/chronicle/helpers/isBookClubSubcategory.test.ts
@@ -1,0 +1,12 @@
+import { SubcategoryIdEnum } from 'api/gen'
+import { isBookClubSubcategory } from 'features/chronicle/helpers/isBookClubSubcategory'
+
+describe('isBookClubSubcategory', () => {
+  it('should return true when subcategory includes in BOOK_CLUB_SUBCATEGORIES', () => {
+    expect(isBookClubSubcategory(SubcategoryIdEnum.LIVRE_AUDIO_PHYSIQUE)).toEqual(true)
+  })
+
+  it('should return false when subcategory not includes in BOOK_CLUB_SUBCATEGORIES', () => {
+    expect(isBookClubSubcategory(SubcategoryIdEnum.SEANCE_CINE)).toEqual(false)
+  })
+})

--- a/src/features/chronicle/helpers/isBookClubSubcategory.ts
+++ b/src/features/chronicle/helpers/isBookClubSubcategory.ts
@@ -1,0 +1,8 @@
+import { SubcategoryIdEnum } from 'api/gen'
+import { BookClubSubcategoryId } from 'features/offer/components/OfferContent/ChronicleSection/types'
+import { BOOK_CLUB_SUBCATEGORIES } from 'features/offer/constant'
+
+export const isBookClubSubcategory = (
+  subcategoryId: SubcategoryIdEnum
+): subcategoryId is BookClubSubcategoryId =>
+  BOOK_CLUB_SUBCATEGORIES.includes(subcategoryId as BookClubSubcategoryId)

--- a/src/features/chronicle/pages/Chronicles/Chronicles.web.test.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.web.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { useRoute } from '__mocks__/@react-navigation/native'
+import { SubcategoryIdEnum } from 'api/gen'
 import { offerChroniclesFixture } from 'features/chronicle/fixtures/offerChronicles.fixture'
 import { Chronicles } from 'features/chronicle/pages/Chronicles/Chronicles'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
@@ -21,34 +22,114 @@ jest.mock('features/navigation/helpers/openUrl')
 
 describe('Chronicles', () => {
   beforeEach(() => {
-    mockServer.getApi(`/v2/offer/${offerResponseSnap.id}`, offerResponseSnap)
     mockServer.getApi(`/v1/offer/${offerResponseSnap.id}/chronicles`, offerChroniclesFixture)
     mockServer.getApi('/v1/subcategories/v2', subcategoriesDataTest)
   })
 
-  it('should render correctly in mobile', async () => {
-    render(reactQueryProviderHOC(<Chronicles />), {
-      theme: {
-        isDesktopViewport: false,
-      },
+  describe('Mobile displaying', () => {
+    describe('Book Club subcategory', () => {
+      beforeEach(() => {
+        mockServer.getApi(`/v2/offer/${offerResponseSnap.id}`, {
+          ...offerResponseSnap,
+          subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
+        })
+      })
+
+      it('should render correctly', async () => {
+        render(reactQueryProviderHOC(<Chronicles />), {
+          theme: {
+            isDesktopViewport: false,
+          },
+        })
+
+        expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
+        expect(screen.getAllByTestId(/chronicle-*/).length).toBeGreaterThan(0)
+      })
+
+      it('should not display booking button when offer subscategory is in book club subcategories', async () => {
+        render(reactQueryProviderHOC(<Chronicles />), {
+          theme: {
+            isDesktopViewport: false,
+          },
+        })
+
+        expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
+        expect(screen.queryByText("Réserver l'offre")).not.toBeInTheDocument()
+      })
     })
 
-    expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
-    expect(screen.queryByText("Réserver l'offre")).not.toBeInTheDocument()
-    expect(screen.getAllByTestId(/chronicle-*/).length).toBeGreaterThan(0)
+    describe('Cine Club subcategory', () => {
+      beforeEach(() => {
+        mockServer.getApi(`/v2/offer/${offerResponseSnap.id}`, {
+          ...offerResponseSnap,
+          subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
+        })
+      })
+
+      it('should not display session button when offer subscategory is in cine club subcategories', async () => {
+        render(reactQueryProviderHOC(<Chronicles />), {
+          theme: {
+            isDesktopViewport: false,
+          },
+        })
+
+        expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
+        expect(screen.queryByText('Trouve ta séance')).not.toBeInTheDocument()
+      })
+    })
   })
 
-  it('should render correctly in desktop', async () => {
-    render(reactQueryProviderHOC(<Chronicles />), {
-      theme: {
-        isDesktopViewport: true,
-      },
+  describe('Desktop displaying', () => {
+    describe('Cine Club subcategory', () => {
+      beforeEach(() => {
+        mockServer.getApi(`/v2/offer/${offerResponseSnap.id}`, {
+          ...offerResponseSnap,
+          subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
+        })
+      })
+
+      it('should render correctly', async () => {
+        render(reactQueryProviderHOC(<Chronicles />), {
+          theme: {
+            isDesktopViewport: true,
+          },
+        })
+
+        expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
+        expect(screen.getByText('Sous les étoiles de Paris - VF')).toBeInTheDocument()
+        expect(screen.getByText('Dès 5,00 €')).toBeInTheDocument()
+        expect(screen.getAllByTestId(/chronicle-*/).length).toBeGreaterThan(0)
+      })
+
+      it('should display session button when offer subscategory is in cine club subcategories', async () => {
+        render(reactQueryProviderHOC(<Chronicles />), {
+          theme: {
+            isDesktopViewport: true,
+          },
+        })
+
+        expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
+        expect(screen.getByText('Trouve ta séance')).toBeInTheDocument()
+      })
     })
 
-    expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
-    expect(screen.getByText('Sous les étoiles de Paris - VF')).toBeInTheDocument()
-    expect(screen.getByText('Dès 5,00 €')).toBeInTheDocument()
-    expect(screen.getByTestId('booking-button')).toBeInTheDocument()
-    expect(screen.getAllByTestId(/chronicle-*/).length).toBeGreaterThan(0)
+    describe('Book Club subcategory', () => {
+      beforeEach(() => {
+        mockServer.getApi(`/v2/offer/${offerResponseSnap.id}`, {
+          ...offerResponseSnap,
+          subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
+        })
+      })
+
+      it('should display booking button when offer subscategory is in book club subcategories', async () => {
+        render(reactQueryProviderHOC(<Chronicles />), {
+          theme: {
+            isDesktopViewport: true,
+          },
+        })
+
+        expect(await screen.findByText('Réserver l’offre')).toBeInTheDocument()
+      })
+    })
   })
 })

--- a/src/features/chronicle/pages/Chronicles/Chronicles.web.test.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.web.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useRoute } from '__mocks__/@react-navigation/native'
+import { navigate, useRoute } from '__mocks__/@react-navigation/native'
 import { SubcategoryIdEnum } from 'api/gen'
 import { offerChroniclesFixture } from 'features/chronicle/fixtures/offerChronicles.fixture'
 import { Chronicles } from 'features/chronicle/pages/Chronicles/Chronicles'
@@ -8,7 +8,7 @@ import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render, screen } from 'tests/utils/web'
+import { fireEvent, render, screen } from 'tests/utils/web'
 
 useRoute.mockReturnValue({
   params: {
@@ -110,6 +110,23 @@ describe('Chronicles', () => {
 
         expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
         expect(screen.getByText('Trouve ta séance')).toBeInTheDocument()
+      })
+
+      it('should redirect to offer page when pressing session button and offer subscategory is in cine club subcategories', async () => {
+        render(reactQueryProviderHOC(<Chronicles />), {
+          theme: {
+            isDesktopViewport: true,
+          },
+        })
+
+        await screen.findByText('Tous les avis')
+
+        fireEvent.click(screen.getByText('Trouve ta séance'))
+
+        expect(navigate).toHaveBeenCalledWith('Offer', {
+          id: offerResponseSnap.id,
+          from: 'chronicles',
+        })
       })
     })
 

--- a/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
@@ -1,4 +1,4 @@
-import { useRoute } from '@react-navigation/native'
+import { useNavigation, useRoute } from '@react-navigation/native'
 import React, { FunctionComponent } from 'react'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled, { useTheme } from 'styled-components/native'
@@ -8,9 +8,10 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { offerChroniclesToChronicleCardData } from 'features/chronicle/adapters/offerChroniclesToChronicleCardData/offerChroniclesToChronicleCardData'
 import { useChronicles } from 'features/chronicle/api/useChronicles/useChronicles'
 import { ChronicleOfferInfo } from 'features/chronicle/components/ChronicleOfferInfo/ChronicleOfferInfo.web'
+import { isBookClubSubcategory } from 'features/chronicle/helpers/isBookClubSubcategory'
 import { ChroniclesBase } from 'features/chronicle/pages/Chronicles/ChroniclesBase'
 import { ChronicleCardData } from 'features/chronicle/type'
-import { UseRouteType } from 'features/navigation/RootNavigator/types'
+import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { OfferCTAButton } from 'features/offer/components/OfferCTAButton/OfferCTAButton'
 import { chronicleVariant } from 'features/offer/helpers/chronicleVariant/chronicleVariant'
 import { getOfferPrices } from 'features/offer/helpers/getOfferPrice/getOfferPrice'
@@ -25,10 +26,12 @@ import { useSubcategoriesMapping } from 'libs/subcategories'
 import { useOfferQuery } from 'queries/offer/useOfferQuery'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { useGetPacificFrancToEuroRate } from 'shared/exchangeRates/useGetPacificFrancToEuroRate'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 
 export const Chronicles: FunctionComponent = () => {
   const route = useRoute<UseRouteType<'Chronicles'>>()
   const offerId = route.params?.offerId
+  const { navigate } = useNavigation<UseNavigationType>()
   const { data: offer } = useOfferQuery({ offerId })
   const subcategoriesMapping = useSubcategoriesMapping()
   const chronicleVariantInfo =
@@ -67,6 +70,10 @@ export const Chronicles: FunctionComponent = () => {
     }
   )
 
+  const onPress = () => {
+    navigate('Offer', { id: offerId, openModalOnNavigation: undefined, from: 'chronicles' })
+  }
+
   if (!offer || !chronicleCardsData) return null
 
   return (
@@ -84,11 +91,15 @@ export const Chronicles: FunctionComponent = () => {
             categoryId={subcategory.categoryId}
             paddingTop={headerHeight}
             imageDimensions={imageDimensions}>
-            <OfferCTAButton
-              offer={offer}
-              subcategory={subcategoriesMapping[offer.subcategoryId]}
-              trackEventHasSeenOfferOnce={trackEventHasSeenOfferOnce}
-            />
+            {isBookClubSubcategory(offer.subcategoryId) ? (
+              <OfferCTAButton
+                offer={offer}
+                subcategory={subcategoriesMapping[offer.subcategoryId]}
+                trackEventHasSeenOfferOnce={trackEventHasSeenOfferOnce}
+              />
+            ) : (
+              <ButtonPrimary wording="Trouve ta séance" onPress={onPress} />
+            )}
           </StyledChronicleOfferInfo>
         ) : null}
       </ChroniclesBase>

--- a/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
@@ -71,7 +71,7 @@ export const Chronicles: FunctionComponent = () => {
   )
 
   const onPress = () => {
-    navigate('Offer', { id: offerId, openModalOnNavigation: undefined, from: 'chronicles' })
+    navigate('Offer', { id: offerId, from: 'chronicles' })
   }
 
   if (!offer || !chronicleCardsData) return null

--- a/src/features/offer/components/OfferCine/OfferCineBlock.tsx
+++ b/src/features/offer/components/OfferCine/OfferCineBlock.tsx
@@ -1,9 +1,11 @@
-import React, { FC, useEffect } from 'react'
+import { useRoute } from '@react-navigation/native'
+import React, { FC, useCallback, useEffect } from 'react'
 import { ViewStyle } from 'react-native'
 import { InView } from 'react-native-intersection-observer'
 import styled, { useTheme } from 'styled-components/native'
 
 import { OfferResponseV2 } from 'api/gen'
+import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { MovieCalendarProvider } from 'features/offer/components/MoviesScreeningCalendar/MovieCalendarContext'
 import { OfferCineContent } from 'features/offer/components/OfferCine/OfferCineContent'
 import { useOfferCTA } from 'features/offer/components/OfferContent/OfferCTAProvider'
@@ -26,6 +28,8 @@ const cinemaCTAButtonName = 'Accéder aux séances'
 
 export const OfferCineBlock: FC<Props> = ({ title, onSeeVenuePress, offer, distance }) => {
   const theme = useTheme()
+  const route = useRoute<UseRouteType<'Chronicles'>>()
+  const from = route.params?.from
   const { setButton, showButton } = useOfferCTA()
   const scrollToAnchor = useScrollToAnchor()
 
@@ -40,8 +44,14 @@ export const OfferCineBlock: FC<Props> = ({ title, onSeeVenuePress, offer, dista
   }, [scrollToAnchor, setButton])
   const next15Dates = getDates(new Date(), 15)
 
+  const handleLayout = useCallback(() => {
+    if (from === 'chronicles') {
+      scrollToAnchor('offer-cine-availabilities')
+    }
+  }, [from, scrollToAnchor])
+
   return (
-    <Container testID="offer-new-xp-cine-block" gap={4}>
+    <Container testID="offer-new-xp-cine-block" gap={4} onLayout={handleLayout}>
       <Anchor name="offer-cine-availabilities">
         <InView
           onChange={(inView) => {

--- a/src/features/offer/components/OfferContent/ChronicleSection/types.ts
+++ b/src/features/offer/components/OfferContent/ChronicleSection/types.ts
@@ -2,6 +2,7 @@ import { ReactNode } from 'react'
 import { StyleProp, ViewStyle } from 'react-native'
 
 import { ChronicleCardData } from 'features/chronicle/type'
+import { BOOK_CLUB_SUBCATEGORIES } from 'features/offer/constant'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 
 export type ChronicleSectionProps = {
@@ -23,3 +24,5 @@ export type ChronicleVariantInfo = {
   modalWording: string
   modalButtonLabel: string
 }
+
+export type BookClubSubcategoryId = (typeof BOOK_CLUB_SUBCATEGORIES)[number]


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36679

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

https://github.com/user-attachments/assets/fe766dff-5949-42e8-971b-28294649f0c1


**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |<img width="375" alt="Capture d’écran 2025-07-07 à 14 19 11" src="https://github.com/user-attachments/assets/9fbd9afb-fd4b-433f-b71a-292aa11c091f" />|
| Desktop - Chrome |               |<img width="1724" alt="Capture d’écran 2025-07-07 à 14 19 01" src="https://github.com/user-attachments/assets/e4df1c2d-fd57-4052-89d2-93528b4ac63f" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
