### PR TITLE
(PC-36690) feat(BookingDetails): add external bookings tickets

### DIFF
--- a/src/features/bookings/components/Ticket/Ticket.tsx
+++ b/src/features/bookings/components/Ticket/Ticket.tsx
@@ -109,6 +109,7 @@ export const Ticket = ({
           isDigital={properties.isDigital ?? false}
           isEvent={properties.isEvent ?? false}
           expirationDate={expirationDateFormated({ prefix: `avant le ` })}
+          beginningDateTime={booking.stock.beginningDatetime ?? undefined}
         />
       }
       infoBanner={

--- a/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/ExternalBookingTicket.native.test.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/ExternalBookingTicket.native.test.tsx
@@ -5,21 +5,46 @@ import { ExternalBookingTicket } from 'features/bookings/components/Ticket/Ticke
 import { render, screen } from 'tests/utils'
 
 describe('ExternalBookingTicket', () => {
-  it('should not display anything when data is empty', async () => {
-    renderExternalBookingTicket({ data: [] })
+  it('should display hidden ticket when data is empty', async () => {
+    renderExternalBookingTicket({ data: [], beginningDateTime: '2025-07-21T20:00:00' })
 
-    expect(screen.queryByTestId('external-booking-ticket-container')).not.toBeOnTheScreen()
+    expect(
+      await screen.findByText('Ton billet sera disponible ici le 19 juillet 2025 à 22h00')
+    ).toBeOnTheScreen()
   })
 
-  it('should display container when data is present', async () => {
+  it('should display ticket when data is present', async () => {
     renderExternalBookingTicket({
       data: [{ barcode: '1234', seat: 'B2' }],
+      beginningDateTime: undefined,
     })
 
-    expect(screen.getByTestId('external-booking-ticket-container')).toBeOnTheScreen()
+    expect(await screen.findByText('RÉF 1234')).toBeOnTheScreen()
+    expect(await screen.findByText('Siège B2')).toBeOnTheScreen()
+  })
+
+  it('should display tickets in carousel when multiple external bookings', async () => {
+    renderExternalBookingTicket({
+      data: [
+        { barcode: '1234', seat: 'B2' },
+        { barcode: '999', seat: 'A02' },
+      ],
+      beginningDateTime: undefined,
+    })
+
+    expect(await screen.findByText('RÉF 1234')).toBeOnTheScreen()
+    expect(await screen.findByText('Siège B2')).toBeOnTheScreen()
+    expect(await screen.findByText('RÉF 999')).toBeOnTheScreen()
+    expect(await screen.findByText('Siège A02')).toBeOnTheScreen()
   })
 })
 
-const renderExternalBookingTicket = ({ data }: { data: ExternalBookingDataResponseV2[] }) => {
-  return render(<ExternalBookingTicket data={data} />)
+const renderExternalBookingTicket = ({
+  data,
+  beginningDateTime,
+}: {
+  data: ExternalBookingDataResponseV2[]
+  beginningDateTime: string | undefined
+}) => {
+  return render(<ExternalBookingTicket data={data} beginningDatetime={beginningDateTime} />)
 }

--- a/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/ExternalBookingTicket.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/ExternalBookingTicket.tsx
@@ -1,13 +1,80 @@
 import React from 'react'
-import { View } from 'react-native'
+import { Platform } from 'react-native'
+import styled from 'styled-components/native'
 
 import { ExternalBookingDataResponseV2 } from 'api/gen'
+import { getHiddenQRCodeTextInfos } from 'features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/getHiddenQRCodeTextInfos'
+import { TicketSwiper } from 'features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/TicketSwiper'
+import { TicketText } from 'features/bookings/components/Ticket/TicketBottomPart/TicketText'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import genericQrCode from 'ui/images/generic-qr-code.png'
+import { BarCode } from 'ui/svg/icons/BarCode'
+import { getSpacing } from 'ui/theme'
 
 type props = {
-  data: ExternalBookingDataResponseV2[]
+  data?: ExternalBookingDataResponseV2[]
+  beginningDatetime: string | undefined
+  timezone?: string
 }
 
-export const ExternalBookingTicket = ({ data }: props) => {
-  if (data.length) return <View testID="external-booking-ticket-container" />
-  return null
+export const ExternalBookingTicket = ({ data, beginningDatetime, timezone }: props) => {
+  const { day, time } = getHiddenQRCodeTextInfos(beginningDatetime, 48, timezone)
+  const hiddenTicketText = `Ton billet sera disponible ici le ${day} à ${time}`
+
+  return (
+    <StyledViewGap gap={4} testID="external-booking-ticket-container">
+      {data?.length ? (
+        <TicketSwiper data={data} />
+      ) : (
+        <React.Fragment>
+          <DashedContainer>
+            <BlurredQrCodeContainer>
+              <BlurredQrCode />
+              <ContentContainer>
+                <BarCode />
+              </ContentContainer>
+            </BlurredQrCodeContainer>
+          </DashedContainer>
+          <TicketText>{hiddenTicketText}</TicketText>
+        </React.Fragment>
+      )}
+    </StyledViewGap>
+  )
 }
+
+const StyledViewGap = styled(ViewGap)({
+  justifyContent: 'center',
+  minHeight: getSpacing(25),
+  width: '100%',
+})
+
+const BlurredQrCodeContainer = styled.View({
+  position: 'relative',
+})
+
+const BlurredQrCode = styled.ImageBackground.attrs({
+  blurRadius: Platform.OS === 'android' ? 15 : 4,
+  source: genericQrCode,
+})(({ theme }) => ({
+  width: theme.ticket.qrCodeSize,
+  height: theme.ticket.qrCodeSize,
+  opacity: 0.1,
+}))
+
+const ContentContainer = styled.View({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  justifyContent: 'space-evenly',
+  alignItems: 'center',
+})
+
+const DashedContainer = styled.View(({ theme }) => ({
+  borderWidth: 2,
+  borderColor: theme.designSystem.color.border.default,
+  borderRadius: 8,
+  borderStyle: 'dashed',
+  alignSelf: 'center',
+}))

--- a/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/HiddenExternalBookingTicket.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/HiddenExternalBookingTicket.tsx
@@ -1,6 +1,0 @@
-import React from 'react'
-import { View } from 'react-native'
-
-export const HiddenExternalBookingTicket = () => {
-  return <View testID="hidden-external-booking-ticket-container" />
-}

--- a/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/TicketSwiper.native.test.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/TicketSwiper.native.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+
+import type { BookingsResponse } from 'api/gen'
+import { TicketSwiper } from 'features/bookings/components/OldBookingDetails/Ticket/TicketSwiper'
+import { bookingsSnap } from 'features/bookings/fixtures'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { render, screen } from 'tests/utils'
+
+jest.mock('libs/subcategories/useCategoryId')
+jest.mock('libs/subcategories/useSubcategory')
+
+const booking: BookingsResponse['ongoing_bookings'][number] = bookingsSnap.ongoing_bookings[1]
+
+jest.mock('libs/firebase/analytics/analytics')
+
+describe('<TicketSwiper/>', () => {
+  beforeEach(() => setFeatureFlags())
+
+  it('should display ticket without external bookings information if there are no external bookings (externalBookings is null)', () => {
+    booking.externalBookings = null
+
+    render(<TicketSwiper booking={booking} />)
+
+    expect(
+      screen.queryByTestId('ticket-without-external-bookings-information')
+    ).not.toBeOnTheScreen()
+    expect(screen.queryByTestId('ticket-with-external-bookings-information')).not.toBeOnTheScreen()
+  })
+
+  it('should display ticket without external bookings information if there are no external bookings (empty externalBookings array)', () => {
+    booking.externalBookings = []
+
+    render(<TicketSwiper booking={booking} />)
+
+    expect(screen.getByTestId('ticket-without-external-bookings-information')).toBeOnTheScreen()
+  })
+
+  it('should display one ticket with external bookings information if there are one external booking', () => {
+    booking.externalBookings = [{ barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A12' }]
+
+    render(<TicketSwiper booking={booking} />)
+
+    expect(screen.getByTestId('ticket-with-external-bookings-information')).toBeOnTheScreen()
+  })
+
+  it('should display as many tickets as the number of tickets', () => {
+    booking.externalBookings = [
+      { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A12' },
+      { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A13' },
+    ]
+
+    render(<TicketSwiper booking={booking} />)
+
+    expect(screen.queryAllByTestId('ticket-with-external-bookings-information')).toHaveLength(2)
+  })
+
+  describe('Swiper ticket controls', () => {
+    it('should not show if number of ticket is equal to one', () => {
+      booking.externalBookings = [{ barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A12' }]
+
+      render(<TicketSwiper booking={booking} />)
+
+      expect(screen.queryByTestId('swiper-tickets-controls')).not.toBeOnTheScreen()
+    })
+
+    it('should show if number of ticket is greater than one', () => {
+      booking.externalBookings = [
+        { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A12' },
+        { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A13' },
+      ]
+
+      render(<TicketSwiper booking={booking} />)
+
+      expect(screen.getByTestId('swiper-tickets-controls')).toBeOnTheScreen()
+    })
+  })
+})

--- a/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/TicketSwiper.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/TicketSwiper.tsx
@@ -1,0 +1,116 @@
+import React, { useRef, useState } from 'react'
+import {
+  FlatList,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  StyleProp,
+  ViewStyle,
+} from 'react-native'
+import styled, { useTheme } from 'styled-components/native'
+
+import { QrCodeWithSeat } from 'features/bookings/components/OldBookingDetails/TicketBody/QrCodeWithSeat/QrCodeWithSeat'
+import {
+  getTickets,
+  TicketsProps,
+} from 'features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/getTickets'
+import { TicketSwiperControls } from 'features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/TicketSwiperControls'
+import { TicketText } from 'features/bookings/components/Ticket/TicketBottomPart/TicketText'
+import { getSpacing } from 'ui/theme'
+
+const SEPARATOR_VALUE = 0
+const INTERVAL = getSpacing(SEPARATOR_VALUE)
+
+export const TicketSwiper = ({ data }: TicketsProps) => {
+  const { isTouch, appContentWidth, ticket } = useTheme()
+  const flatListRef = useRef<FlatList>(null)
+  const { tickets } = getTickets({ data })
+  const [currentIndex, setCurrentIndex] = useState(1)
+
+  const NUMBER_OF_TICKETS = tickets.length ?? 0
+  const TICKET_WIDTH = isTouch ? appContentWidth * ticket.sizeRatio : ticket.maxWidth
+  const TICKET_SPACING = (appContentWidth - TICKET_WIDTH) / 2
+
+  const renderItem = ({ item }) => (
+    <TicketsContainer key={item.key} width={TICKET_WIDTH}>
+      {item}
+    </TicketsContainer>
+  )
+
+  const nextItemPosition = (TICKET_WIDTH + INTERVAL) * currentIndex
+  const prevItemPosition = nextItemPosition - TICKET_SPACING + INTERVAL - TICKET_WIDTH * 2
+  const moveTo = (direction: 'prev' | 'next') => {
+    if (flatListRef.current) {
+      if (direction === 'prev') {
+        flatListRef.current.scrollToOffset({
+          offset: prevItemPosition,
+          animated: true,
+        })
+      } else {
+        flatListRef.current.scrollToOffset({
+          offset: nextItemPosition,
+          animated: true,
+        })
+      }
+    }
+  }
+
+  const onScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const xPos = event.nativeEvent.contentOffset.x
+    const xPosWithSpacing = xPos + TICKET_SPACING
+    const index = Math.floor(xPosWithSpacing / TICKET_WIDTH) + 1
+    setCurrentIndex(index)
+  }
+
+  const displaySideBySideTickets = false
+  const showControls = !displaySideBySideTickets && NUMBER_OF_TICKETS > 1
+  const contentContainerStyle: StyleProp<ViewStyle> = {
+    ...(displaySideBySideTickets ? { flex: 1, justifyContent: 'center' } : {}),
+  }
+
+  return data && data.length === 1 && data[0] ? (
+    <React.Fragment key={data[0].barcode}>
+      <QrCodeWithSeat seat={data[0].seat ?? undefined} barcode={data[0].barcode} />
+      <TicketText>{`RÉF ${data[0].barcode}`}</TicketText>
+    </React.Fragment>
+  ) : (
+    <React.Fragment>
+      <FlatList
+        ref={flatListRef}
+        data={tickets}
+        horizontal
+        bounces={false}
+        showsHorizontalScrollIndicator={false}
+        snapToInterval={TICKET_WIDTH + INTERVAL}
+        decelerationRate="fast"
+        contentContainerStyle={contentContainerStyle}
+        onScroll={onScroll}
+        renderItem={renderItem}
+        scrollEnabled
+      />
+      {showControls ? (
+        <SwiperTicketsControlsContainer>
+          <TicketSwiperControls
+            numberOfSteps={NUMBER_OF_TICKETS}
+            currentStep={currentIndex}
+            prevTitle="Revenir au ticket précédent"
+            nextTitle="Voir le ticket suivant"
+            onPressPrev={() => moveTo('prev')}
+            onPressNext={() => moveTo('next')}
+          />
+        </SwiperTicketsControlsContainer>
+      ) : null}
+    </React.Fragment>
+  )
+}
+
+const TicketsContainer = styled.View<{ width: number }>(({ width }) => ({
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+  paddingTop: getSpacing(2),
+  paddingBottom: getSpacing(6),
+  width,
+}))
+
+const SwiperTicketsControlsContainer = styled.View({
+  alignItems: 'center',
+})

--- a/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/TicketSwiperControls.native.test.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/TicketSwiperControls.native.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+
+import { TicketSwiperControls } from 'features/bookings/components/OldBookingDetails/Ticket/TicketSwiperControls'
+import { render, screen } from 'tests/utils'
+
+const props = {
+  prevTitle: 'prev',
+  nextTitle: 'next',
+  onPressPrev: jest.fn(),
+  onPressNext: jest.fn(),
+  numberOfSteps: 4,
+  currentStep: 1,
+}
+
+describe('<TicketSwiperControls/>', () => {
+  it('should hide prev button if currentStep === 1', () => {
+    render(<TicketSwiperControls {...props} />)
+
+    expect(screen.queryByTestId('Revenir à l’étape précédente')).not.toBeOnTheScreen()
+
+    screen.queryByTestId('control-component-spacing-prev')
+  })
+
+  it('should show prev button if currentStep > 1', () => {
+    props.currentStep = 2
+    render(<TicketSwiperControls {...props} />)
+    screen.queryByTestId('Revenir à l’étape précédente')
+
+    expect(screen.queryByTestId('control-component-spacing-prev')).not.toBeOnTheScreen()
+  })
+
+  it('should hide next button if currentStep === numberOfSteps', () => {
+    props.currentStep = 4
+    render(<TicketSwiperControls {...props} />)
+
+    expect(screen.queryByTestId('Continuer vers l’étape suivante')).not.toBeOnTheScreen()
+
+    screen.queryByTestId('control-component-spacing-next')
+  })
+
+  it('should show prev button if currentStep !== 1', () => {
+    props.currentStep = 2
+    render(<TicketSwiperControls {...props} />)
+    screen.queryByTestId('Continuer vers l’étape suivante')
+
+    expect(screen.queryByTestId('control-component-spacing-next')).not.toBeOnTheScreen()
+  })
+})

--- a/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/TicketSwiperControls.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/TicketSwiperControls.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { ControlComponent } from 'features/bookings/components/OldBookingDetails/Ticket/ControlComponent'
+import { StepDots } from 'ui/components/StepDots'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { getSpacing } from 'ui/theme'
+
+type Props = {
+  numberOfSteps: number
+  currentStep: number
+  prevTitle: string
+  nextTitle: string
+  onPressPrev: () => void
+  onPressNext: () => void
+}
+
+export function TicketSwiperControls({
+  numberOfSteps,
+  currentStep,
+  prevTitle,
+  nextTitle,
+  onPressPrev,
+  onPressNext,
+}: Props) {
+  const showPrevButton = currentStep > 1
+  const showNextButton = currentStep !== numberOfSteps
+
+  return (
+    <DotsContainer gap={2} testID="swiper-tickets-controls">
+      {showPrevButton ? (
+        <ControlComponent type="prev" title={prevTitle} onPress={onPressPrev} />
+      ) : (
+        <ControlComponentSpacing testID="control-component-spacing-prev" />
+      )}
+      <StepDots
+        numberOfSteps={numberOfSteps}
+        currentStep={currentStep}
+        withNeutralPreviousStepsColor
+      />
+      {showNextButton ? (
+        <ControlComponent type="next" title={nextTitle} onPress={onPressNext} />
+      ) : (
+        <ControlComponentSpacing testID="control-component-spacing-next" />
+      )}
+    </DotsContainer>
+  )
+}
+
+const DotsContainer = styled(ViewGap)({
+  marginTop: getSpacing(3),
+  flexDirection: 'row',
+})
+
+const ControlComponentSpacing = styled.View(({ theme }) => ({
+  width: theme.controlComponent.size,
+}))

--- a/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/getHiddenQRCodeTextInfos.ts
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/getHiddenQRCodeTextInfos.ts
@@ -1,0 +1,22 @@
+import { subHours } from 'date-fns'
+
+import {
+  formatToCompleteFrenchDate,
+  formatToHour,
+  getTimeZonedDate,
+} from 'libs/parsers/formatDates'
+
+export const getHiddenQRCodeTextInfos = (
+  beginningDatetime = new Date().toISOString(),
+  qrCodeVisibilityHoursBeforeEvent = 48,
+  timezone = 'Europe/Paris'
+) => {
+  const timezonedDate = getTimeZonedDate({
+    date: subHours(new Date(beginningDatetime), qrCodeVisibilityHoursBeforeEvent),
+    timezone,
+  })
+  const day = formatToCompleteFrenchDate({ date: timezonedDate, shouldDisplayWeekDay: false })
+  const time = formatToHour(timezonedDate)
+
+  return { day, time }
+}

--- a/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/getTickets.test.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/getTickets.test.tsx
@@ -1,0 +1,93 @@
+import { BookingsResponse } from 'api/gen'
+import { getTickets } from 'features/bookings/components/OldBookingDetails/Ticket/getTickets'
+import { bookingsSnap } from 'features/bookings/fixtures'
+
+const booking: BookingsResponse['ongoing_bookings'][number] = bookingsSnap.ongoing_bookings[1]
+
+jest.mock('libs/firebase/analytics/analytics')
+
+describe('getTickets', () => {
+  it('should not display any ticket when external bookings is null', () => {
+    booking.externalBookings = null
+
+    const { tickets } = getTickets({ booking })
+
+    expect(tickets).toEqual([])
+  })
+
+  it('should display ticket without external booking when there is no external bookings', () => {
+    booking.externalBookings = []
+
+    const { tickets } = getTickets({ booking })
+
+    expect(tickets).toHaveLength(1)
+  })
+
+  it('should display as many tickets as there are external bookings', () => {
+    booking.externalBookings = [
+      { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A12' },
+      { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A13' },
+    ]
+
+    const { tickets } = getTickets({ booking })
+
+    expect(tickets).toHaveLength(2)
+  })
+
+  it('should not display the seat number if there are one external bookings', () => {
+    booking.externalBookings = [{ barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A12' }]
+
+    const { tickets } = getTickets({ booking })
+    const ticket = tickets[0]
+
+    expect(ticket?.props.externalBookings.seatIndex).toEqual(undefined)
+  })
+
+  it('should display the seat number on the total number of seats', () => {
+    booking.externalBookings = [
+      { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A12' },
+      { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: null },
+    ]
+
+    const { tickets } = getTickets({ booking })
+
+    const firstTicket = tickets[0]
+    const secondTicket = tickets[1]
+
+    expect(firstTicket?.props.externalBookings.seatIndex).toEqual('1/2')
+
+    expect(secondTicket?.props.externalBookings.seatIndex).toEqual('2/2')
+  })
+
+  it('should display only 2 tickets according to the default value (2) of max number of seats to display', () => {
+    booking.externalBookings = [
+      { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A12' },
+      { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A13' },
+      { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A14' },
+    ]
+
+    const { tickets } = getTickets({
+      booking,
+    })
+
+    expect(tickets).toHaveLength(2)
+  })
+
+  it('should display the number of seats according to the value of max number of seats to display', () => {
+    const maxNumberOfTicketsToDisplay = 3
+
+    booking.externalBookings = [
+      { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A12' },
+      { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A13' },
+      { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A14' },
+      { barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A15' },
+    ]
+
+    const { tickets } = getTickets({
+      booking,
+      maxNumberOfTicketsToDisplay,
+    })
+
+    expect(tickets).toHaveLength(maxNumberOfTicketsToDisplay)
+  })
+})

--- a/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/getTickets.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/getTickets.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+import { ExternalBookingDataResponseV2 } from 'api/gen'
+import { QrCodeWithSeat } from 'features/bookings/components/OldBookingDetails/TicketBody/QrCodeWithSeat/QrCodeWithSeat'
+import { TicketText } from 'features/bookings/components/Ticket/TicketBottomPart/TicketText'
+
+export type TicketsProps = {
+  data?: ExternalBookingDataResponseV2[]
+  maxNumberOfTicketsToDisplay?: number
+}
+
+export const getTickets = ({ data, maxNumberOfTicketsToDisplay = 2 }: TicketsProps) => {
+  if (!data) return { tickets: [] }
+
+  const externalBookings = data.slice(0, maxNumberOfTicketsToDisplay)
+
+  return {
+    tickets: externalBookings.map(({ seat, barcode }) => {
+      const seatNumber = seat ?? undefined
+      return (
+        <React.Fragment key={barcode}>
+          <QrCodeWithSeat seat={seatNumber} barcode={barcode} />
+          <TicketText>{`RÉF ${barcode}`}</TicketText>
+        </React.Fragment>
+      )
+    }),
+  }
+}

--- a/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/index.ts
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket/index.ts
@@ -1,2 +1,1 @@
-export { HiddenExternalBookingTicket } from './HiddenExternalBookingTicket'
 export { ExternalBookingTicket } from './ExternalBookingTicket'

--- a/src/features/bookings/components/Ticket/TicketBottomPart/TicketBottomPart.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/TicketBottomPart.tsx
@@ -4,10 +4,7 @@ import { TicketResponse, UserProfileResponse } from 'api/gen'
 import { TicketCode } from 'features/bookings/components/OldBookingDetails/TicketCode'
 import { CinemaBookingTicket } from 'features/bookings/components/Ticket/TicketBottomPart/CinemaBookingTicket/CinemaBookingTicket'
 import { EmailWithdrawal } from 'features/bookings/components/Ticket/TicketBottomPart/EmailWithdrawal/EmailWithdrawal'
-import {
-  ExternalBookingTicket,
-  HiddenExternalBookingTicket,
-} from 'features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket'
+import { ExternalBookingTicket } from 'features/bookings/components/Ticket/TicketBottomPart/ExternalBookingTicket'
 import { NoTicket } from 'features/bookings/components/Ticket/TicketBottomPart/NoTicket/NoTicket'
 import { OnSiteWithdrawal } from 'features/bookings/components/Ticket/TicketBottomPart/OnSiteWithdrawal/OnSiteWithdrawal'
 import { PhysicalGoodBookingTicket } from 'features/bookings/components/Ticket/TicketBottomPart/PhysicalGoodBookingTicket/PhysicalGoodBookingTicket'
@@ -19,6 +16,7 @@ export const TicketBottomPart = ({
   userEmail,
   ticket,
   expirationDate,
+  beginningDateTime,
 }: {
   isDuo: boolean
   isDigital: boolean
@@ -26,6 +24,7 @@ export const TicketBottomPart = ({
   userEmail: UserProfileResponse['email']
   ticket: TicketResponse
   expirationDate?: string
+  beginningDateTime: string | undefined
 }) => {
   if (ticket.noTicket) return <NoTicket />
 
@@ -38,14 +37,14 @@ export const TicketBottomPart = ({
         userEmail={userEmail}
       />
     )
-
   if (ticket.activationCode) return <TicketCode code={ticket.activationCode.code} />
 
   if (ticket.externalBooking)
-    return ticket.externalBooking.data ? (
-      <ExternalBookingTicket data={ticket.externalBooking.data} />
-    ) : (
-      <HiddenExternalBookingTicket />
+    return (
+      <ExternalBookingTicket
+        data={ticket.externalBooking.data ?? undefined}
+        beginningDatetime={beginningDateTime}
+      />
     )
 
   if (ticket.voucher?.data) {

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
@@ -815,28 +815,6 @@ describe('BookingDetails', () => {
         expect(screen.getByTestId('external-booking-ticket-container')).toBeOnTheScreen()
       })
 
-      it('should render Hidden External Booking Component when no externalbooking data', async () => {
-        renderBookingDetailsV2({
-          ...ongoingBookingV2,
-          stock: {
-            ...ongoingBookingV2.stock,
-            offer: {
-              ...ongoingBookingV2.stock.offer,
-              isDigital: false,
-            },
-          },
-          ticket: {
-            ...ongoingBookingV2.ticket,
-            noTicket: false,
-            withdrawal: {},
-            externalBooking: {},
-          },
-        })
-        await screen.findAllByText(ongoingBookingV2.stock.offer.name)
-
-        expect(screen.getByTestId('hidden-external-booking-ticket-container')).toBeOnTheScreen()
-      })
-
       it('should render cinema booking ticket if voucher is present', async () => {
         renderBookingDetailsV2({
           ...ongoingBookingV2,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36690

Sonarcloud n'est pas content pour des problèmes de couverture de code, mais le code va être refacto dans le ticket [suivant](https://passculture.atlassian.net/browse/PC-36879) donc on merge en l'état. 


## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
