### PR TITLE
(PC-36869) feat(offer): add offer video preview page

### DIFF
--- a/src/features/home/components/modules/video/YoutubePlayer/YoutubePlayer.tsx
+++ b/src/features/home/components/modules/video/YoutubePlayer/YoutubePlayer.tsx
@@ -144,12 +144,13 @@ const StyledAnimatedView = styled(Animated.View).attrs({
 }))
 
 const StyledPlayIcon = styled(Play).attrs(({ theme }) => ({
-  color: theme.designSystem.color.icon.lockedInverted,
+  color: theme.designSystem.color.icon.inverted,
+  color2: theme.designSystem.color.icon.default,
   size: getSpacing(14),
 }))``
 
 const IconContainer = styled.View(({ theme }) => ({
   borderRadius: theme.designSystem.size.borderRadius.xxl,
   padding: theme.designSystem.size.spacing.xxs,
-  backgroundColor: theme.designSystem.color.background.lockedInverted,
+  backgroundColor: theme.designSystem.color.background.default,
 }))

--- a/src/features/navigation/RootNavigator/RootStackNavigator.tsx
+++ b/src/features/navigation/RootNavigator/RootStackNavigator.tsx
@@ -56,6 +56,7 @@ import { TabNavigator } from 'features/navigation/TabBar/TabStackNavigator'
 import { VenueMapFiltersStackNavigator } from 'features/navigation/VenueMapFiltersStackNavigator/VenueMapFiltersStackNavigator'
 import { Offer } from 'features/offer/pages/Offer/Offer'
 import { OfferPreview } from 'features/offer/pages/OfferPreview/OfferPreview'
+import { OfferVideoPreview } from 'features/offer/pages/OfferVideoPreview/OfferVideoPreview'
 import { ChangeEmailExpiredLink } from 'features/profile/pages/ChangeEmail/ChangeEmailExpiredLink'
 import { SearchFilter } from 'features/search/pages/SearchFilter/SearchFilter'
 import { OnboardingSubscription } from 'features/subscription/page/OnboardingSubscription'
@@ -195,6 +196,15 @@ const rootScreens: RouteConfig[] = [
     name: '_DeeplinkOnlyOfferPreview3',
     component: OfferPreview,
     options: { title: 'Aperçu de l’offre' },
+  },
+  {
+    name: 'OfferVideoPreview',
+    component: OfferVideoPreview,
+    options: {
+      title: 'Vidéo de l’offre',
+      presentation: 'modal',
+      ...FILTERS_MODAL_NAV_OPTIONS,
+    },
   },
   { name: 'BookingDetails', component: withAuthProtection(BookingDetails) },
   {

--- a/src/features/navigation/RootNavigator/linking/rootStackNavigatorPathConfig.ts
+++ b/src/features/navigation/RootNavigator/linking/rootStackNavigatorPathConfig.ts
@@ -204,6 +204,10 @@ export const rootStackNavigatorPathConfig = {
     path: 'offer/apercu',
     parse: screenParamsParser['OfferPreview'],
   },
+  OfferVideoPreview: {
+    path: 'offre/:id/video',
+    parse: screenParamsParser['OfferVideoPreview'],
+  },
   BookingDetails: {
     path: 'reservation/:id/details',
     parse: screenParamsParser['BookingDetails'],

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -204,6 +204,10 @@ type OfferPreviewParams = {
   defaultIndex?: number
 }
 
+type OfferVideoPreviewParams = {
+  id: number
+}
+
 type BookingDetailsParams = {
   id: number
 }
@@ -304,6 +308,7 @@ export type RootStackParamList = {
   _DeeplinkOnlyOfferPreview1: OfferPreviewParams
   _DeeplinkOnlyOfferPreview2: OfferPreviewParams
   _DeeplinkOnlyOfferPreview3: OfferPreviewParams
+  OfferVideoPreview: OfferVideoPreviewParams
   OnboardingSubscription: undefined
   PageNotFound: undefined
   Profile: undefined

--- a/src/features/navigation/screenParamsUtils.ts
+++ b/src/features/navigation/screenParamsUtils.ts
@@ -12,6 +12,7 @@ type ScreensRequiringParsing = Extract<
   | 'Login'
   | 'Offer'
   | 'OfferPreview'
+  | 'OfferVideoPreview'
   | 'ReinitializePassword'
   | 'ResetPasswordExpiredLink'
   | 'Venue'
@@ -121,6 +122,9 @@ export const screenParamsParser: ParamsParsers = {
   OfferPreview: {
     id: Number,
     defaultIndex: Number,
+  },
+  OfferVideoPreview: {
+    id: Number,
   },
   Home: {
     latitude: Number,

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -26,6 +26,7 @@ import { PlaylistType } from 'features/offer/enums'
 import { chronicleVariantInfoFixture } from 'features/offer/fixtures/chronicleVariantInfo'
 import { mockSubcategory } from 'features/offer/fixtures/mockSubcategory'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
+import { videoDataFixture } from 'features/offer/fixtures/videoDataFixture'
 import * as useSimilarOffersAPI from 'features/offer/queries/useSimilarOffersQuery'
 import { beneficiaryUser } from 'fixtures/user'
 import {
@@ -838,6 +839,36 @@ describe('<OfferContent />', () => {
       expect(screen.queryByTestId('coming-soon-footer-offset')).not.toBeOnTheScreen()
     })
   })
+
+  describe('See video button', () => {
+    it('should not display see video button when video data not defined', async () => {
+      renderOfferContent({})
+
+      await screen.findByText('Réserver l’offre')
+
+      expect(screen.queryByText('Voir la vidéo')).not.toBeOnTheScreen()
+    })
+
+    it('should display see video button when video data defined', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_OFFER_VIDEO_SECTION])
+      renderOfferContent({ videoData: videoDataFixture })
+
+      expect(await screen.findByText('Voir la vidéo')).toBeOnTheScreen()
+    })
+
+    it('should navigate to OfferVideoPreview screen when pressing see video button', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_OFFER_VIDEO_SECTION])
+      renderOfferContent({ videoData: videoDataFixture })
+
+      await screen.findByText('Réserver l’offre')
+
+      await user.press(screen.getByText('Voir la vidéo'))
+
+      expect(mockNavigate).toHaveBeenCalledWith('OfferVideoPreview', {
+        id: offerResponseSnap.id,
+      })
+    })
+  })
 })
 
 type RenderOfferContentType = Partial<ComponentProps<typeof OfferContent>> & {
@@ -849,6 +880,7 @@ function renderOfferContent({
   subcategory = mockSubcategory,
   isDesktopViewport,
   chronicles,
+  videoData,
 }: RenderOfferContentType) {
   const subtitle = 'Membre du Book Club'
   const chroniclesData =
@@ -863,6 +895,7 @@ function renderOfferContent({
           subcategory={subcategory}
           chronicles={chroniclesData}
           chronicleVariantInfo={chronicleVariantInfoFixture}
+          videoData={videoData}
         />
       </NavigationContainer>
     ),

--- a/src/features/offer/components/OfferContent/OfferContent.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.tsx
@@ -24,9 +24,14 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   onReactionButtonPress,
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
-  const handlePress = (defaultIndex = 0) => {
+
+  const handlePreviewPress = (defaultIndex = 0) => {
     if (!offer.images) return
     navigate('OfferPreview', { id: offer.id, defaultIndex })
+  }
+
+  const handleVideoPress = () => {
+    navigate('OfferVideoPreview', { id: offer.id })
   }
 
   const { onLayout, height: comingSoonFooterHeight } = useLayout()
@@ -37,7 +42,8 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
         offer={offer}
         searchGroupList={searchGroupList}
         contentContainerStyle={CONTENT_CONTAINER_STYLE}
-        onOfferPreviewPress={handlePress}
+        onOfferPreviewPress={handlePreviewPress}
+        onSeeVideoPress={videoData ? handleVideoPress : undefined}
         BodyWrapper={BodyWrapper}
         chronicles={chronicles}
         chronicleVariantInfo={chronicleVariantInfo}

--- a/src/features/offer/components/OfferContent/OfferContent.web.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.tsx
@@ -1,6 +1,8 @@
+import { useNavigation } from '@react-navigation/native'
 import React, { FunctionComponent, useMemo, useState } from 'react'
 import styled from 'styled-components/native'
 
+import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { OfferContentBase } from 'features/offer/components/OfferContent/OfferContentBase'
 import { OfferCTAProvider } from 'features/offer/components/OfferContent/OfferCTAProvider'
 import { OfferContentProps } from 'features/offer/types'
@@ -23,6 +25,7 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   onReactionButtonPress,
   headlineOffersCount,
 }) => {
+  const { navigate } = useNavigation<UseNavigationType>()
   const { visible, showModal, hideModal } = useModal(false)
   const headerHeight = useGetHeaderHeight()
   const [carouselDefaultIndex, setCarouselDefaultIndex] = useState(0)
@@ -34,10 +37,14 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
 
   const offerImagesUrl = useMemo(() => offerImages.map((image) => image.url), [offerImages])
 
-  const handlePress = (defaultIndex = 0) => {
+  const handlePreviewPress = (defaultIndex = 0) => {
     if (!offer.images) return
     setCarouselDefaultIndex(defaultIndex)
     showModal()
+  }
+
+  const handleVideoPress = () => {
+    navigate('OfferVideoPreview', { id: offer.id })
   }
 
   const BodyWrapper = useMemo(
@@ -66,7 +73,8 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
           subcategory={subcategory}
           chronicles={chronicles}
           chronicleVariantInfo={chronicleVariantInfo}
-          onOfferPreviewPress={handlePress}
+          onOfferPreviewPress={handlePreviewPress}
+          onSeeVideoPress={videoData ? handleVideoPress : undefined}
           BodyWrapper={BodyWrapper}
           videoData={videoData}
           defaultReaction={defaultReaction}

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -63,6 +63,7 @@ type OfferContentBaseProps = OfferContentProps &
   PropsWithChildren<{
     BodyWrapper: FunctionComponent
     onOfferPreviewPress: (index?: number) => void
+    onSeeVideoPress?: () => void
     chronicles?: ChronicleCardData[]
     videoData?: { videoId: string; thumbnailUri: string }
     likesCount?: number
@@ -83,6 +84,7 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
   chronicleVariantInfo,
   headlineOffersCount,
   onOfferPreviewPress,
+  onSeeVideoPress,
   contentContainerStyle,
   defaultReaction,
   onReactionButtonPress,
@@ -270,6 +272,7 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
               onPress={onOfferPreviewPress}
               placeholderImage={placeholderImage}
               imageDimensions={imageDimensions}
+              onSeeVideoPress={onSeeVideoPress}
             />
             <OfferBody
               offer={offer}

--- a/src/features/offer/components/OfferImageContainer/OfferImageContainer.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageContainer.tsx
@@ -15,6 +15,7 @@ type Props = {
   imageDimensions: OfferImageContainerDimensions
   images?: ImageWithCredit[]
   onPress?: (defaultIndex?: number) => void
+  onSeeVideoPress?: VoidFunction
   placeholderImage?: string
 }
 
@@ -24,6 +25,7 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
   categoryId,
   placeholderImage,
   imageDimensions,
+  onSeeVideoPress,
 }) => {
   const progressValue = useSharedValue<number>(0)
 
@@ -39,6 +41,7 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
         onPress={onPress}
         categoryId={categoryId}
         imageDimensions={imageDimensions}
+        onSeeVideoPress={onSeeVideoPress}
       />
     </OfferImageHeaderWrapper>
   )

--- a/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.tsx
@@ -18,6 +18,7 @@ type Props = {
   images?: ImageWithCredit[]
   onPress?: (defaultIndex?: number) => void
   placeholderImage?: string
+  onSeeVideoPress: VoidFunction
 }
 
 export const OfferImageContainer: FunctionComponent<Props> = ({
@@ -26,6 +27,7 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
   categoryId,
   placeholderImage,
   imageDimensions,
+  onSeeVideoPress,
 }) => {
   const { isDesktopViewport } = useTheme()
   const headerHeight = useGetHeaderHeight()
@@ -55,6 +57,7 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
         onPress={onPress}
         categoryId={categoryId}
         imageDimensions={imageDimensions}
+        onSeeVideoPress={onSeeVideoPress}
       />
     </Wrapper>
   )

--- a/src/features/offer/components/OfferImageContainer/OfferImageRenderer.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageRenderer.tsx
@@ -9,10 +9,14 @@ import { OfferImageCarousel } from 'features/offer/components/OfferImageCarousel
 import { OfferImageCarouselItem } from 'features/offer/components/OfferImageCarousel/OfferImageCarouselItem'
 import { OfferImageContainerDimensions } from 'features/offer/types'
 import { ImageWithCredit } from 'shared/types'
+import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
+import { Play } from 'ui/svg/icons/Play'
+import { getSpacing } from 'ui/theme'
 
 type Props = {
   categoryId: CategoryIdEnum | null
   imageDimensions: OfferImageContainerDimensions
+  onSeeVideoPress?: VoidFunction
   offerImages?: ImageWithCredit[]
   placeholderImage?: string
   progressValue: SharedValue<number>
@@ -27,6 +31,7 @@ export const OfferImageRenderer: FunctionComponent<Props> = ({
   placeholderImage,
   categoryId,
   onPress,
+  onSeeVideoPress,
   style,
 }) => {
   const [carouselReady, setCarouselReady] = useState(false)
@@ -56,6 +61,11 @@ export const OfferImageRenderer: FunctionComponent<Props> = ({
           </OfferImageCarouselItem>
         </AnimatedImageContainer>
       )}
+      {onSeeVideoPress ? (
+        <ButtonContainer>
+          <ButtonTertiaryBlack wording="Voir la vidéo" onPress={onSeeVideoPress} icon={Play} />
+        </ButtonContainer>
+      ) : null}
     </Animated.View>
   )
 }
@@ -71,4 +81,9 @@ const AnimatedImageContainer = styled(Animated.View)({
   position: 'absolute',
   top: 0,
   left: 0,
+})
+
+const ButtonContainer = styled.View({
+  alignItems: 'center',
+  marginTop: getSpacing(4),
 })

--- a/src/features/offer/fixtures/videoDataFixture.ts
+++ b/src/features/offer/fixtures/videoDataFixture.ts
@@ -1,0 +1,5 @@
+export const videoDataFixture = {
+  videoId: 'hCqdTGWspes',
+  thumbnailUri:
+    'https://rukminim2.flixcart.com/image/750/900/kgcl7680-0/poster/0/o/c/medium-sa-503-cartoon-sticker-poster-peppa-pig-wall-poster-original-imafwhuqjgjjtucs.jpeg?q=90&crop=false',
+}

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -7,6 +7,7 @@ import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { chroniclePreviewToChronicalCardData } from 'features/offer/adapters/chroniclePreviewToChronicleCardData'
 import { OfferContent } from 'features/offer/components/OfferContent/OfferContent'
 import { OfferContentPlaceholder } from 'features/offer/components/OfferContentPlaceholder/OfferContentPlaceholder'
+import { videoDataFixture } from 'features/offer/fixtures/videoDataFixture'
 import { chronicleVariant } from 'features/offer/helpers/chronicleVariant/chronicleVariant'
 import { useFetchHeadlineOffersCountQuery } from 'features/offer/queries/useFetchHeadlineOffersCountQuery'
 import { ReactionChoiceModal } from 'features/reactions/components/ReactionChoiceModal/ReactionChoiceModal'
@@ -53,13 +54,7 @@ export function Offer() {
   })
   const { mutate: saveReaction } = useReactionMutation()
 
-  const videoData = isVideoSectionEnabled
-    ? {
-        videoId: 'hCqdTGWspes',
-        thumbnailUri:
-          'https://rukminim2.flixcart.com/image/750/900/kgcl7680-0/poster/0/o/c/medium-sa-503-cartoon-sticker-poster-peppa-pig-wall-poster-original-imafwhuqjgjjtucs.jpeg?q=90&crop=false',
-      }
-    : undefined
+  const videoData = isVideoSectionEnabled ? videoDataFixture : undefined
 
   const handleSaveReaction = useCallback(
     ({ offerId, reactionType }: { offerId: number; reactionType: ReactionTypeEnum }) => {

--- a/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.native.test.tsx
+++ b/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.native.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import { OfferResponseV2 } from 'api/gen'
+import * as useGoBack from 'features/navigation/useGoBack'
+import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
+import { OfferVideoPreview } from 'features/offer/pages/OfferVideoPreview/OfferVideoPreview'
+import { render, screen, userEvent } from 'tests/utils'
+
+const mockOffer = jest.fn((): { data: OfferResponseV2 } => ({
+  data: offerResponseSnap,
+}))
+
+jest.mock('queries/offer/useOfferQuery', () => ({
+  useOfferQuery: () => mockOffer(),
+}))
+
+const mockGoBack = jest.fn()
+jest.spyOn(useGoBack, 'useGoBack').mockReturnValue({
+  goBack: mockGoBack,
+  canGoBack: jest.fn(() => true),
+})
+
+const user = userEvent.setup()
+jest.useFakeTimers()
+
+describe('<OfferPreview />', () => {
+  it('should display offer video preview page', () => {
+    render(<OfferVideoPreview />)
+
+    expect(screen.getByText('Vidéo Sous les étoiles de Paris - VF')).toBeOnTheScreen()
+  })
+
+  it('should execute go back when pressing go back button', async () => {
+    render(<OfferVideoPreview />)
+
+    await user.press(screen.getByLabelText('Revenir en arrière'))
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.tsx
+++ b/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.tsx
@@ -1,0 +1,60 @@
+import { useRoute } from '@react-navigation/native'
+import React, { FunctionComponent } from 'react'
+import { Animated, useWindowDimensions } from 'react-native'
+import styled from 'styled-components/native'
+
+import { RATIO169 } from 'features/home/components/helpers/getVideoPlayerDimensions'
+import { YoutubePlayer } from 'features/home/components/modules/video/YoutubePlayer/YoutubePlayer'
+import { UseRouteType } from 'features/navigation/RootNavigator/types'
+import { useGoBack } from 'features/navigation/useGoBack'
+import { videoDataFixture } from 'features/offer/fixtures/videoDataFixture'
+import { FastImage } from 'libs/resizing-image-on-demand/FastImage'
+import { useOfferQuery } from 'queries/offer/useOfferQuery'
+import { ContentHeader } from 'ui/components/headers/ContentHeader'
+
+const MAX_WIDTH = 800
+
+const animatedValue = new Animated.Value(1)
+const interpolated = animatedValue.interpolate({
+  inputRange: [0, 1],
+  outputRange: [0, 1],
+})
+
+export const OfferVideoPreview: FunctionComponent = () => {
+  const { params } = useRoute<UseRouteType<'OfferVideoPreview'>>()
+  const { goBack } = useGoBack('Offer', { id: params.id })
+  const { width: viewportWidth } = useWindowDimensions()
+  const videoHeight = Math.min(viewportWidth, MAX_WIDTH) * RATIO169
+  const { data: offer } = useOfferQuery({ offerId: params.id })
+
+  return (
+    <Container>
+      <ContentHeader
+        headerTitle={`Vidéo ${offer?.name ?? ''}`}
+        headerTransition={interpolated}
+        titleTestID="offerVideoPreviewHeader"
+        onBackPress={goBack}
+      />
+
+      <YoutubePlayer
+        videoId={videoDataFixture.videoId}
+        height={videoHeight}
+        width={viewportWidth < MAX_WIDTH ? undefined : MAX_WIDTH}
+        initialPlayerParams={{ autoplay: true }}
+        thumbnail={<VideoThumbnailImage url={videoDataFixture.thumbnailUri} resizeMode="cover" />}
+      />
+    </Container>
+  )
+}
+
+const Container = styled.View(({ theme }) => ({
+  flex: 1,
+  justifyContent: 'center',
+  alignItems: 'center',
+  backgroundColor: theme.designSystem.color.background.default,
+}))
+
+const VideoThumbnailImage = styled(FastImage)({
+  width: '100%',
+  height: '100%',
+})

--- a/src/ui/components/buttons/ButtonTertiaryBlack.ts
+++ b/src/ui/components/buttons/ButtonTertiaryBlack.ts
@@ -15,6 +15,9 @@ export const ButtonTertiaryBlack = styledButton(AppButton).attrs<BaseButtonProps
         color: disabled
           ? theme.designSystem.color.icon.disabled
           : theme.designSystem.color.icon.default,
+        color2: disabled
+          ? theme.designSystem.color.icon.disabled
+          : theme.designSystem.color.icon.inverted,
         size:
           buttonHeight === 'extraSmall'
             ? theme.icons.sizes.extraSmall

--- a/src/ui/svg/icons/Play.tsx
+++ b/src/ui/svg/icons/Play.tsx
@@ -24,9 +24,9 @@ const PlaySvg: React.FunctionComponent<PlayProps> = ({
       viewBox="0 0 48 48"
       accessibilityLabel={accessibilityLabel ?? `Jouer`}
       testID={testID}>
-      <Circle r={10} cx={24} cy={24} fill={color} />
+      <Circle r={10} cx={24} cy={24} fill={color2} />
       <Path
-        fill={color2}
+        fill={color}
         d="M24 44c11.046 0 20-8.954 20-20S35.046 4 24 4 4 12.954 4 24s8.954 20 20 20Zm-1.89-12.073 9.394-6.263a2 2 0 0 0 0-3.328l-9.395-6.263C20.78 15.187 19 16.14 19 17.737v12.526c0 1.597 1.78 2.55 3.11 1.664Z"
         clipRule="evenodd"
         fillRule="evenodd"
@@ -36,9 +36,9 @@ const PlaySvg: React.FunctionComponent<PlayProps> = ({
 }
 
 export const Play = styled(PlaySvg).attrs(
-  ({ color: playColor, color2: backgroundColor, size, theme }) => ({
-    color: playColor ?? theme.designSystem.color.icon.lockedInverted,
-    color2: backgroundColor ?? theme.designSystem.color.background.lockedInverted,
+  ({ color: backgroundColor, color2: playColor, size, theme }) => ({
+    color: backgroundColor ?? theme.designSystem.color.background.lockedInverted,
+    color2: playColor ?? theme.designSystem.color.icon.lockedInverted,
     size: size ?? theme.icons.sizes.smaller,
   })
 )``


### PR DESCRIPTION
Ajout du bouton Voir la vidéo sur la page offre + interaction du bouton qui ouvre une nouvelle page avec la vidéo associée à l'offre.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36869

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="296" alt="Capture d’écran 2025-07-08 à 17 46 00" src="https://github.com/user-attachments/assets/e096f232-8236-4dc3-aaf4-f1e25c7766a4" /> <img width="297" alt="Capture d’écran 2025-07-08 à 17 46 08" src="https://github.com/user-attachments/assets/172e5fc7-ca21-4d4a-92be-5ae16c3ad92f" />|<img width="423" alt="Capture d’écran 2025-07-08 à 17 50 43" src="https://github.com/user-attachments/assets/28245ad9-df35-4769-856f-ad0beb3b2f21" /> <img width="425" alt="Capture d’écran 2025-07-08 à 17 51 58" src="https://github.com/user-attachments/assets/5bfd8a43-8472-411f-9baf-f2998050a975" />|
| Android          |               |<img width="427" alt="Capture d’écran 2025-07-08 à 17 51 30" src="https://github.com/user-attachments/assets/7eaab30e-01a3-4df6-87b6-17e376db5292" /> <img width="412" alt="Capture d’écran 2025-07-08 à 17 51 40" src="https://github.com/user-attachments/assets/ffb2fab5-f16b-49e9-920b-594a887897d1" />|
| Phone - Chrome   |               |<img width="392" alt="Capture d’écran 2025-07-08 à 17 48 01" src="https://github.com/user-attachments/assets/464462d9-aa2f-482f-98d9-3980877717c8" /> <img width="398" alt="Capture d’écran 2025-07-08 à 17 48 07" src="https://github.com/user-attachments/assets/4f5a1572-0504-4656-8e80-2f379137fd20" />|
| Desktop - Chrome |<img width="616" alt="Capture d’écran 2025-07-08 à 17 45 41" src="https://github.com/user-attachments/assets/49ab731f-8347-42c6-9d15-ad8626a85790" />|<img width="1723" alt="Capture d’écran 2025-07-08 à 17 47 38" src="https://github.com/user-attachments/assets/7f257f57-e55b-47fd-b86d-83a40831e691" /> <img width="1726" alt="Capture d’écran 2025-07-08 à 17 47 45" src="https://github.com/user-attachments/assets/1bf4cb9d-0de4-4199-8c2a-97b7f752909c" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
