### PR TITLE
(PC-36907) feat(CalendarModal): add a blur on the bottom of the calendar

### DIFF
--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
@@ -1,9 +1,11 @@
 import { yupResolver } from '@hookform/resolvers/yup'
+import colorAlpha from 'color-alpha'
 import { addMonths, addYears, format } from 'date-fns'
 import React, { FunctionComponent, useCallback, useMemo, useRef } from 'react'
 import { SetValueConfig, useForm } from 'react-hook-form'
 import { View } from 'react-native'
 import { CalendarList, DateData, LocaleConfig } from 'react-native-calendars'
+import LinearGradient from 'react-native-linear-gradient'
 import styled, { useTheme } from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -250,13 +252,16 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
       rightIcon={Close}
       onRightIconPress={closeModal}
       fixedModalBottom={
-        <SearchFixedModalBottom
-          onSearchPress={onSubmit}
-          onResetPress={onResetPress}
-          isSearchDisabled={disabled}
-          filterBehaviour={filterBehaviour}
-          isResetDisabled={hasDefaultValues}
-        />
+        <React.Fragment>
+          <Gradient />
+          <SearchFixedModalBottom
+            onSearchPress={onSubmit}
+            onResetPress={onResetPress}
+            isSearchDisabled={disabled}
+            filterBehaviour={filterBehaviour}
+            isResetDisabled={hasDefaultValues}
+          />
+        </React.Fragment>
       }
       scrollEnabled={false}>
       <View>
@@ -292,10 +297,35 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
   )
 }
 
-const StyledCalendarList = styled(CalendarList).attrs({
+const StyledCalendarList = styled(CalendarList).attrs(({ theme }) => ({
   calendarStyle: {
     width: '100%',
+    backgroundColor: theme.designSystem.color.background.default,
   },
-})({
+  theme: {
+    calendarBackground: theme.designSystem.color.background.default,
+    dayTextColor: theme.designSystem.color.text.subtle,
+    monthTextColor: theme.designSystem.color.text.default,
+    textSectionTitleColor: theme.designSystem.color.text.subtle,
+  },
+}))({
   marginTop: getSpacing(4),
+})
+
+const Gradient = styled(LinearGradient).attrs(({ theme }) => ({
+  colors: [
+    colorAlpha(theme.designSystem.color.background.default, 0),
+    colorAlpha(theme.designSystem.color.background.default, 0.5),
+    theme.designSystem.color.background.default,
+  ],
+  locations: [0, 0.5, 1],
+  start: { x: 0, y: 0 },
+  end: { x: 0, y: 1 },
+}))({
+  position: 'absolute',
+  bottom: getSpacing(10),
+  left: 0,
+  right: 0,
+  height: getSpacing(23),
+  zIndex: 1,
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36907

Ajouter un blur sur le bas du Calendar et l'ajout des tokens sur des parties du Calendar pour prévoir la gestion du theme 

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

<img width="530" alt="Capture d’écran 2025-07-09 à 09 54 32" src="https://github.com/user-attachments/assets/9bddb1b7-4cac-46ee-94ee-a2de686472e5" />

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
