### PR TITLE
(PC-36927) feat(offer): use small icon in chronicle variant to display chronicles counter

### DIFF
--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -12,6 +12,7 @@ import {
   SubcategoryIdEnumv2,
 } from 'api/gen'
 import { OfferBody } from 'features/offer/components/OfferBody/OfferBody'
+import { chronicleVariantInfoFixture } from 'features/offer/fixtures/chronicleVariantInfo'
 import { mockSubcategory, mockSubcategoryBook } from 'features/offer/fixtures/mockSubcategory'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { mockedAlgoliaOffersWithSameArtistResponse } from 'libs/algolia/fixtures/algoliaFixtures'
@@ -603,7 +604,11 @@ describe('<OfferBody />', () => {
   }: RenderOfferBodyType) {
     render(
       reactQueryProviderHOC(
-        <OfferBody offer={offer} subcategory={subcategory} distance={distance}>
+        <OfferBody
+          offer={offer}
+          subcategory={subcategory}
+          distance={distance}
+          chronicleVariantInfo={chronicleVariantInfoFixture}>
           {children}
         </OfferBody>
       ),

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -9,6 +9,7 @@ import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { OfferAbout } from 'features/offer/components/OfferAbout/OfferAbout'
 import { OfferArtists } from 'features/offer/components/OfferArtists/OfferArtists'
 import { ProposedBySection } from 'features/offer/components/OfferBody/ProposedBySection/ProposedBySection'
+import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
 import { VideoSection } from 'features/offer/components/OfferContent/VideoSection/VideoSection'
 import { OfferPlace } from 'features/offer/components/OfferPlace/OfferPlace'
 import { OfferReactionSection } from 'features/offer/components/OfferReactionSection/OfferReactionSection'
@@ -49,6 +50,7 @@ type Props = {
   distance?: string | null
   headlineOffersCount?: number
   videoData?: { videoId: string; thumbnailUri: string }
+  chronicleVariantInfo: ChronicleVariantInfo
 }
 
 export const OfferBody: FunctionComponent<Props> = ({
@@ -60,6 +62,7 @@ export const OfferBody: FunctionComponent<Props> = ({
   distance,
   headlineOffersCount,
   videoData,
+  chronicleVariantInfo,
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
 
@@ -157,6 +160,7 @@ export const OfferBody: FunctionComponent<Props> = ({
           likesCount={likesCount}
           chroniclesCount={chroniclesCount}
           headlineOffersCount={headlineOffersCount}
+          chronicleVariantInfo={chronicleVariantInfo}
         />
 
         <GroupWithSeparator

--- a/src/features/offer/components/OfferContent/ChronicleSection/types.ts
+++ b/src/features/offer/components/OfferContent/ChronicleSection/types.ts
@@ -23,6 +23,7 @@ export type ChronicleVariantInfo = {
   Icon?: React.ReactNode
   modalWording: string
   modalButtonLabel: string
+  SmallIcon?: React.ReactNode
 }
 
 export type BookClubSubcategoryId = (typeof BOOK_CLUB_SUBCATEGORIES)[number]

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -25,6 +25,7 @@ import { useFavorite } from 'features/favorites/hooks/useFavorite'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { OfferBody } from 'features/offer/components/OfferBody/OfferBody'
 import { ChronicleSection } from 'features/offer/components/OfferContent/ChronicleSection/ChronicleSection'
+import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
 import { OfferCTAButton } from 'features/offer/components/OfferCTAButton/OfferCTAButton'
 import { OfferFooter } from 'features/offer/components/OfferFooter/OfferFooter'
 import { OfferHeader } from 'features/offer/components/OfferHeader/OfferHeader'
@@ -69,6 +70,7 @@ type OfferContentBaseProps = OfferContentProps &
     onReactionButtonPress?: () => void
     contentContainerStyle?: StyleProp<ViewStyle>
     onLayout?: (params: LayoutChangeEvent) => void
+    chronicleVariantInfo?: ChronicleVariantInfo
   }>
 
 const DELAY_BEFORE_CONSIDERING_PAGE_SEEN = 5000
@@ -276,7 +278,8 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
               chroniclesCount={chronicles?.length}
               distance={distance}
               headlineOffersCount={headlineOffersCount}
-              videoData={videoData}>
+              videoData={videoData}
+              chronicleVariantInfo={chronicleVariantInfo}>
               {theme.isDesktopViewport ? offerCtaButton : null}
             </OfferBody>
           </BodyWrapper>

--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.native.test.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.native.test.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentProps } from 'react'
 
 import { OfferReactionSection } from 'features/offer/components/OfferReactionSection/OfferReactionSection'
+import { chronicleVariantInfoFixture } from 'features/offer/fixtures/chronicleVariantInfo'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -36,13 +37,6 @@ describe('<OfferReactionSection />', () => {
       renderOfferReactionSection({ chroniclesCount: 3 })
 
       expect(await screen.findByText('3 avis')).toBeOnTheScreen()
-      expect(screen.getByTestId('chroniclesCounterIcon')).toBeOnTheScreen()
-    })
-
-    it('should not display chronicles information when not exists', () => {
-      renderOfferReactionSection({ likesCount: 2 })
-
-      expect(screen.queryByTestId('chroniclesCounterIcon')).not.toBeOnTheScreen()
     })
 
     it('should display headline offers count when exist', async () => {
@@ -61,7 +55,6 @@ describe('<OfferReactionSection />', () => {
     it('should display nothing when there are not chronicles, likes information and headline offers count', async () => {
       renderOfferReactionSection({})
 
-      expect(screen.queryByTestId('chroniclesCounterIcon')).not.toBeOnTheScreen()
       expect(screen.queryByTestId('likesCounterIcon')).not.toBeOnTheScreen()
       expect(screen.queryByTestId('headlineOffersCounterIcon')).not.toBeOnTheScreen()
     })
@@ -81,6 +74,7 @@ function renderOfferReactionSection({
         chroniclesCount={chroniclesCount}
         likesCount={likesCount}
         headlineOffersCount={headlineOffersCount}
+        chronicleVariantInfo={chronicleVariantInfoFixture}
       />
     )
   )

--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
@@ -3,9 +3,9 @@ import { View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { InfoCounter } from 'features/offer/components/InfoCounter/InfoCounter'
+import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
 import { getRecommendationText } from 'features/offer/helpers/getRecommendationText/getRecommendationText'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
-import { BookClubCertification } from 'ui/svg/BookClubCertification'
 import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
 import { Star } from 'ui/svg/Star'
 
@@ -13,16 +13,18 @@ type Props = {
   likesCount?: number
   chroniclesCount?: number
   headlineOffersCount?: number
+  chronicleVariantInfo: ChronicleVariantInfo
 }
 
 export const OfferReactionSection: FunctionComponent<Props> = ({
   likesCount,
   chroniclesCount,
   headlineOffersCount,
+  chronicleVariantInfo,
 }) => {
   const likesCounterElement = likesCount ? <LikesInfoCounter text={`${likesCount} j’aime`} /> : null
   const chroniclesCounterElement = chroniclesCount ? (
-    <ChroniclesInfoCounter text={`${chroniclesCount} avis`} />
+    <ChroniclesInfoCounter text={`${chroniclesCount} avis`} icon={chronicleVariantInfo.SmallIcon} />
   ) : null
   const headlineOffersCounterElement = headlineOffersCount ? (
     <HeadlineOffersCount text={getRecommendationText(headlineOffersCount)} />
@@ -53,11 +55,6 @@ const ThumbUpIcon = styled(ThumbUpFilled).attrs(({ theme }) => ({
   color: theme.designSystem.color.icon.brandPrimary,
 }))``
 
-const BookClubIcon = styled(BookClubCertification).attrs(({ theme }) => ({
-  color: theme.designSystem.color.icon.bookclub,
-  size: theme.icons.sizes.small,
-}))``
-
 const StarIcon = styled(Star).attrs(({ theme }) => ({
   color: theme.designSystem.color.icon.headline,
 }))``
@@ -66,8 +63,8 @@ const LikesInfoCounter = styled(InfoCounter).attrs(() => ({
   icon: <ThumbUpIcon testID="likesCounterIcon" />,
 }))``
 
-const ChroniclesInfoCounter = styled(InfoCounter).attrs(() => ({
-  icon: <BookClubIcon testID="chroniclesCounterIcon" />,
+const ChroniclesInfoCounter = styled(InfoCounter).attrs<{ icon: React.ReactNode }>(({ icon }) => ({
+  icon,
 }))``
 
 const HeadlineOffersCount = styled(InfoCounter).attrs(() => ({

--- a/src/features/offer/constant.tsx
+++ b/src/features/offer/constant.tsx
@@ -9,8 +9,18 @@ const BookClubIcon = styled(BookClubCertification).attrs(({ theme }) => ({
   color: theme.designSystem.color.icon.bookclub,
 }))``
 
+const SmallBookClubIcon = styled(BookClubCertification).attrs(({ theme }) => ({
+  color: theme.designSystem.color.icon.bookclub,
+  size: theme.icons.sizes.small,
+}))``
+
 const CineClubIcon = styled(CineClubCertification).attrs(({ theme }) => ({
   color: theme.designSystem.color.icon.cineclub,
+}))``
+
+const SmallCineClubIcon = styled(CineClubCertification).attrs(({ theme }) => ({
+  color: theme.designSystem.color.icon.cineclub,
+  size: theme.icons.sizes.small,
 }))``
 
 export const BOOK_CLUB_SUBCATEGORIES = [
@@ -34,6 +44,7 @@ export const CHRONICLE_VARIANT_CONFIG = [
     subtitleSection: 'Notre communauté de lecteurs te partagent leurs avis sur ce livre\u00a0!',
     subtitleItem: 'Membre du Book Club',
     Icon: <BookClubIcon testID="bookClubIcon" />,
+    SmallIcon: <SmallBookClubIcon />,
     modalWording: 'Les avis du Book Club sont écrits par des jeunes passionnés de lecture.',
     modalButtonLabel: 'Voir toutes les recos du Book Club',
   },
@@ -43,6 +54,7 @@ export const CHRONICLE_VARIANT_CONFIG = [
     subtitleSection: 'Notre communauté de cinéphiles te partage leur avis sur ce film\u00a0!',
     subtitleItem: 'Membre du Ciné Club',
     Icon: <CineClubIcon testID="cineClubIcon" />,
+    SmallIcon: <SmallCineClubIcon />,
     modalWording: 'Les avis du Ciné Club sont écrits par des jeunes passionnés de cinéma.',
     modalButtonLabel: 'Voir toutes les recos du Ciné Club',
   },

--- a/src/features/offer/fixtures/chronicleVariantInfo.ts
+++ b/src/features/offer/fixtures/chronicleVariantInfo.ts
@@ -5,6 +5,7 @@ export const chronicleVariantInfoFixture: ChronicleVariantInfo = {
   subtitleSection: 'Notre communauté de lecteurs te partagent leurs avis sur ce livre\u00a0!',
   subtitleItem: 'Membre du Book Club',
   Icon: undefined,
+  SmallIcon: undefined,
   modalWording: 'Les avis du Book Club sont écrits par des jeunes passionnés de lecture.',
   modalButtonLabel: 'Voir toutes les recos du Book Club',
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36927

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
