### PR TITLE
(PC-36308) feat(profile): add ChangeAddress screen

### DIFF
--- a/__snapshots__/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx.native-snap
@@ -1,0 +1,1315 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SetAddress/> from mandatory udpate personal data screen should render correctly 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "#ffffff",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      },
+    ]
+  }
+>
+  <View
+    accessibilityRole="header"
+    style={
+      [
+        {
+          "backgroundColor": "rgba(255,255,255,0)",
+          "borderBottomColor": "#cbcdd2",
+          "borderBottomWidth": 1,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1,
+        },
+      ]
+    }
+  >
+    <View
+      customHeight={16}
+      enable={true}
+      style={
+        [
+          {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "height": 48,
+            "justifyContent": "center",
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <View
+          positionInHeader="left"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-start",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="back-button-container"
+        >
+          <View
+            accessibilityLabel="Revenir en arrière"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "height": 40,
+                    "justifyContent": "center",
+                    "maxWidth": 40,
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Revenir en arrière"
+          >
+            <View
+              height={24}
+              testID="icon-back"
+              width={24}
+            >
+              <Text>
+                icon-back-SVG-Mock
+              </Text>
+            </View>
+            <Text
+              style={
+                [
+                  {
+                    "display": "none",
+                  },
+                ]
+              }
+            >
+              Retour
+            </Text>
+          </View>
+        </View>
+        <Text
+          numberOfLines={1}
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 17,
+                "lineHeight": 27.2,
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          Modifier mon adresse
+        </Text>
+        <View
+          positionInHeader="right"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-end",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="close-button-container"
+        />
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+        },
+      ]
+    }
+  >
+    <View
+      onLayout={[Function]}
+      style={
+        [
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderTopLeftRadius": 22,
+              "borderTopRightRadius": 22,
+              "display": "flex",
+              "flexBasis": 0,
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "height": "100%",
+              "overflow": "scroll",
+              "paddingTop": 32,
+            },
+          ],
+          {
+            "paddingBottom": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "maxWidth": 500,
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <RCTScrollView
+          bottomChildrenViewHeight={0}
+          contentContainerStyle={
+            {
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "paddingBottom": 0,
+              "paddingHorizontal": 20,
+            }
+          }
+          keyboardShouldPersistTaps="handled"
+          onContentSizeChange={[Function]}
+          onLayout={[Function]}
+          style={
+            [
+              {},
+            ]
+          }
+        >
+          <View>
+            <View
+              style={
+                {
+                  "height": 65,
+                }
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "maxWidth": 500,
+                    "width": "100%",
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 19,
+                      "lineHeight": 30.4,
+                    },
+                  ]
+                }
+              >
+                Renseigne ton adresse
+              </Text>
+              <View
+                style={
+                  [
+                    {
+                      "marginBottom": 8,
+                      "marginTop": 20,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "marginBottom": 8,
+                      },
+                    ]
+                  }
+                >
+                  <View>
+                    <View
+                      style={
+                        [
+                          {
+                            "alignItems": "flex-end",
+                            "flexDirection": "row",
+                            "justifyContent": "space-between",
+                            "width": "100%",
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Entre ton adresse
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+                <View
+                  style={
+                    [
+                      {
+                        "marginBottom": 8,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#696a6f",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Exemple : 34 avenue de l’Opéra
+                  </Text>
+                </View>
+                <View
+                  height="small"
+                  isDisabled={false}
+                  isError={false}
+                  isFocus={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#90949d",
+                        "borderRadius": 22,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "height": 40,
+                        "paddingBottom": 0,
+                        "paddingLeft": 17,
+                        "paddingRight": 17,
+                        "paddingTop": 0,
+                        "width": "100%",
+                      },
+                      {
+                        "borderRadius": 24,
+                        "outlineOffset": 0,
+                      },
+                    ]
+                  }
+                  testID="styled-input-container"
+                >
+                  <TextInput
+                    accessibilityDescribedBy="testUuidV4"
+                    accessibilityHidden={false}
+                    autoComplete="street-address"
+                    autoCorrect={false}
+                    editable={true}
+                    enablesReturnKeyAutomatically={true}
+                    focusable={true}
+                    isEmpty={false}
+                    multiline={false}
+                    nativeID="street-address-input"
+                    onBlur={[Function]}
+                    onChangeText={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    placeholderTextColor="#696a6f"
+                    returnKeyType="next"
+                    selectionColor="#696a6f"
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "flexBasis": 0,
+                          "flexGrow": 1,
+                          "flexShrink": 1,
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "height": "100%",
+                          "paddingBottom": 0,
+                          "paddingLeft": 0,
+                          "paddingRight": 0,
+                          "paddingTop": 0,
+                        },
+                        {},
+                      ]
+                    }
+                    testID="Entrée pour l’adresse"
+                    textAlignVertical="center"
+                    textContentType="fullStreetAddress"
+                    value="1 rue Poissonnière"
+                  />
+                  <View
+                    accessibilityLabel="Réinitialiser la recherche"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    focusable={true}
+                    hitSlop={
+                      {
+                        "bottom": 10,
+                        "left": 10,
+                        "right": 10,
+                        "top": 10,
+                      }
+                    }
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      [
+                        [
+                          {
+                            "userSelect": "auto",
+                          },
+                        ],
+                        {
+                          "opacity": 1,
+                        },
+                      ]
+                    }
+                    testID="Réinitialiser la recherche"
+                  >
+                    <View
+                      fill="#696a6f"
+                      height={20}
+                      width={20}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RCTScrollView>
+        <View
+          onLayout={[Function]}
+          style={
+            [
+              {
+                "backgroundColor": "#ffffff",
+                "bottom": 0,
+                "left": 0,
+                "paddingBottom": 20,
+                "paddingHorizontal": 20,
+                "paddingTop": 12,
+                "position": "absolute",
+                "right": 0,
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityLabel="Continuer"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#eb0055",
+                    "borderRadius": 24,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "maxWidth": 500,
+                    "minHeight": 40,
+                    "paddingBottom": 2,
+                    "paddingLeft": 20,
+                    "paddingRight": 20,
+                    "paddingTop": 2,
+                    "width": "100%",
+                  },
+                  {},
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Continuer"
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                adjustsFontSizeToFit={false}
+                numberOfLines={1}
+                style={
+                  [
+                    {
+                      "color": "#ffffff",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
+                      "maxWidth": "100%",
+                    },
+                  ]
+                }
+              >
+                Continuer
+              </Text>
+            </View>
+          </View>
+          <View
+            customHeight={8}
+            enable={true}
+            style={
+              [
+                {
+                  "height": 8,
+                },
+              ]
+            }
+          />
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    height={65}
+    style={
+      [
+        {
+          "backdropFilter": "blur(20px)",
+          "height": 65,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  >
+    <BlurView
+      blurAmount={8}
+      blurType="light"
+      style={
+        [
+          {
+            "backgroundColor": "transparent",
+          },
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+            },
+          ],
+        ]
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`<SetAddress/> without previous screen should render correctly 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "#ffffff",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      },
+    ]
+  }
+>
+  <View
+    accessibilityRole="header"
+    style={
+      [
+        {
+          "backgroundColor": "rgba(255,255,255,0)",
+          "borderBottomColor": "#cbcdd2",
+          "borderBottomWidth": 1,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1,
+        },
+      ]
+    }
+  >
+    <View
+      customHeight={16}
+      enable={true}
+      style={
+        [
+          {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "height": 48,
+            "justifyContent": "center",
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <View
+          positionInHeader="left"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-start",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="back-button-container"
+        >
+          <View
+            accessibilityLabel="Revenir en arrière"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "height": 40,
+                    "justifyContent": "center",
+                    "maxWidth": 40,
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Revenir en arrière"
+          >
+            <View
+              height={24}
+              testID="icon-back"
+              width={24}
+            >
+              <Text>
+                icon-back-SVG-Mock
+              </Text>
+            </View>
+            <Text
+              style={
+                [
+                  {
+                    "display": "none",
+                  },
+                ]
+              }
+            >
+              Retour
+            </Text>
+          </View>
+        </View>
+        <Text
+          numberOfLines={1}
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 17,
+                "lineHeight": 27.2,
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          Modifier mon adresse
+        </Text>
+        <View
+          positionInHeader="right"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-end",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="close-button-container"
+        />
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+        },
+      ]
+    }
+  >
+    <View
+      onLayout={[Function]}
+      style={
+        [
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderTopLeftRadius": 22,
+              "borderTopRightRadius": 22,
+              "display": "flex",
+              "flexBasis": 0,
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "height": "100%",
+              "overflow": "scroll",
+              "paddingTop": 32,
+            },
+          ],
+          {
+            "paddingBottom": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "maxWidth": 500,
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <RCTScrollView
+          bottomChildrenViewHeight={0}
+          contentContainerStyle={
+            {
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "paddingBottom": 0,
+              "paddingHorizontal": 20,
+            }
+          }
+          keyboardShouldPersistTaps="handled"
+          onContentSizeChange={[Function]}
+          onLayout={[Function]}
+          style={
+            [
+              {},
+            ]
+          }
+        >
+          <View>
+            <View
+              style={
+                {
+                  "height": 65,
+                }
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "maxWidth": 500,
+                    "width": "100%",
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 19,
+                      "lineHeight": 30.4,
+                    },
+                  ]
+                }
+              >
+                Renseigne ton adresse
+              </Text>
+              <View
+                style={
+                  [
+                    {
+                      "marginBottom": 8,
+                      "marginTop": 20,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "marginBottom": 8,
+                      },
+                    ]
+                  }
+                >
+                  <View>
+                    <View
+                      style={
+                        [
+                          {
+                            "alignItems": "flex-end",
+                            "flexDirection": "row",
+                            "justifyContent": "space-between",
+                            "width": "100%",
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Entre ton adresse
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+                <View
+                  style={
+                    [
+                      {
+                        "marginBottom": 8,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#696a6f",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Exemple : 34 avenue de l’Opéra
+                  </Text>
+                </View>
+                <View
+                  height="small"
+                  isDisabled={false}
+                  isError={false}
+                  isFocus={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#90949d",
+                        "borderRadius": 22,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "height": 40,
+                        "paddingBottom": 0,
+                        "paddingLeft": 17,
+                        "paddingRight": 17,
+                        "paddingTop": 0,
+                        "width": "100%",
+                      },
+                      {
+                        "borderRadius": 24,
+                        "outlineOffset": 0,
+                      },
+                    ]
+                  }
+                  testID="styled-input-container"
+                >
+                  <TextInput
+                    accessibilityDescribedBy="testUuidV4"
+                    accessibilityHidden={false}
+                    autoComplete="street-address"
+                    autoCorrect={false}
+                    editable={true}
+                    enablesReturnKeyAutomatically={true}
+                    focusable={true}
+                    isEmpty={false}
+                    multiline={false}
+                    nativeID="street-address-input"
+                    onBlur={[Function]}
+                    onChangeText={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    placeholderTextColor="#696a6f"
+                    returnKeyType="next"
+                    selectionColor="#696a6f"
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "flexBasis": 0,
+                          "flexGrow": 1,
+                          "flexShrink": 1,
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "height": "100%",
+                          "paddingBottom": 0,
+                          "paddingLeft": 0,
+                          "paddingRight": 0,
+                          "paddingTop": 0,
+                        },
+                        {},
+                      ]
+                    }
+                    testID="Entrée pour l’adresse"
+                    textAlignVertical="center"
+                    textContentType="fullStreetAddress"
+                    value="1 rue Poissonnière"
+                  />
+                  <View
+                    accessibilityLabel="Réinitialiser la recherche"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    focusable={true}
+                    hitSlop={
+                      {
+                        "bottom": 10,
+                        "left": 10,
+                        "right": 10,
+                        "top": 10,
+                      }
+                    }
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      [
+                        [
+                          {
+                            "userSelect": "auto",
+                          },
+                        ],
+                        {
+                          "opacity": 1,
+                        },
+                      ]
+                    }
+                    testID="Réinitialiser la recherche"
+                  >
+                    <View
+                      fill="#696a6f"
+                      height={20}
+                      width={20}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RCTScrollView>
+        <View
+          onLayout={[Function]}
+          style={
+            [
+              {
+                "backgroundColor": "#ffffff",
+                "bottom": 0,
+                "left": 0,
+                "paddingBottom": 20,
+                "paddingHorizontal": 20,
+                "paddingTop": 12,
+                "position": "absolute",
+                "right": 0,
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityLabel="Valider mon adresse"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#eb0055",
+                    "borderRadius": 24,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "maxWidth": 500,
+                    "minHeight": 40,
+                    "paddingBottom": 2,
+                    "paddingLeft": 20,
+                    "paddingRight": 20,
+                    "paddingTop": 2,
+                    "width": "100%",
+                  },
+                  {},
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Valider mon adresse"
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                adjustsFontSizeToFit={false}
+                numberOfLines={1}
+                style={
+                  [
+                    {
+                      "color": "#ffffff",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
+                      "maxWidth": "100%",
+                    },
+                  ]
+                }
+              >
+                Valider mon adresse
+              </Text>
+            </View>
+          </View>
+          <View
+            customHeight={8}
+            enable={true}
+            style={
+              [
+                {
+                  "height": 8,
+                },
+              ]
+            }
+          />
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    height={65}
+    style={
+      [
+        {
+          "backdropFilter": "blur(20px)",
+          "height": 65,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  >
+    <BlurView
+      blurAmount={8}
+      blurType="light"
+      style={
+        [
+          {
+            "backgroundColor": "transparent",
+          },
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+            },
+          ],
+        ]
+      }
+    />
+  </View>
+</View>
+`;

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ChangeCity should render correctly 1`] = `
+exports[`ChangeCity from mandatory udpate personal data screen should render correctly 1`] = `
 <View
   style={
     [
@@ -411,7 +411,7 @@ exports[`ChangeCity should render correctly 1`] = `
                     editable={true}
                     enablesReturnKeyAutomatically={true}
                     focusable={true}
-                    isEmpty={true}
+                    isEmpty={false}
                     keyboardType="number-pad"
                     multiline={false}
                     nativeID="postal-code-input"
@@ -429,7 +429,7 @@ exports[`ChangeCity should render correctly 1`] = `
                           "flexBasis": 0,
                           "flexGrow": 1,
                           "flexShrink": 1,
-                          "fontFamily": "Montserrat-MediumItalic",
+                          "fontFamily": "Montserrat-Medium",
                           "fontSize": 16,
                           "height": "100%",
                           "paddingBottom": 0,
@@ -443,8 +443,1511 @@ exports[`ChangeCity should render correctly 1`] = `
                     testID="Entrée pour la ville"
                     textAlignVertical="center"
                     textContentType="postalCode"
-                    value=""
+                    value="75001"
                   />
+                  <View
+                    accessibilityLabel="Réinitialiser la recherche"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    focusable={true}
+                    hitSlop={
+                      {
+                        "bottom": 10,
+                        "left": 10,
+                        "right": 10,
+                        "top": 10,
+                      }
+                    }
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      [
+                        [
+                          {
+                            "userSelect": "auto",
+                          },
+                        ],
+                        {
+                          "opacity": 1,
+                        },
+                      ]
+                    }
+                    testID="Réinitialiser la recherche"
+                  >
+                    <View
+                      fill="#696a6f"
+                      height={20}
+                      width={20}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  {
+                    "transform": [
+                      {
+                        "rotate": "0deg",
+                      },
+                    ],
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  height={32}
+                  width={32}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              accessibilityRole="radiogroup"
+              style={
+                [
+                  {
+                    "flexGrow": 1,
+                    "overflowY": "scroll",
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityRole="list"
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "paddingLeft": 0,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+        </RCTScrollView>
+        <View
+          onLayout={[Function]}
+          style={
+            [
+              {
+                "backgroundColor": "#ffffff",
+                "bottom": 0,
+                "left": 0,
+                "paddingBottom": 20,
+                "paddingHorizontal": 20,
+                "paddingTop": 12,
+                "position": "absolute",
+                "right": 0,
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityLabel="Continuer"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": true,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={false}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#f1f1f4",
+                    "borderRadius": 24,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "maxWidth": 500,
+                    "minHeight": 40,
+                    "paddingBottom": 2,
+                    "paddingLeft": 20,
+                    "paddingRight": 20,
+                    "paddingTop": 2,
+                    "width": "100%",
+                  },
+                  {},
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Continuer"
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                adjustsFontSizeToFit={false}
+                numberOfLines={1}
+                style={
+                  [
+                    {
+                      "color": "#696a6f",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
+                      "maxWidth": "100%",
+                    },
+                  ]
+                }
+              >
+                Continuer
+              </Text>
+            </View>
+          </View>
+          <View
+            customHeight={8}
+            enable={true}
+            style={
+              [
+                {
+                  "height": 8,
+                },
+              ]
+            }
+          />
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    height={65}
+    style={
+      [
+        {
+          "backdropFilter": "blur(20px)",
+          "height": 65,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  >
+    <BlurView
+      blurAmount={8}
+      blurType="light"
+      style={
+        [
+          {
+            "backgroundColor": "transparent",
+          },
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+            },
+          ],
+        ]
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`ChangeCity from profil personal data screen should render correctly 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "#ffffff",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      },
+    ]
+  }
+>
+  <View
+    accessibilityRole="header"
+    style={
+      [
+        {
+          "backgroundColor": "rgba(255,255,255,0)",
+          "borderBottomColor": "#cbcdd2",
+          "borderBottomWidth": 1,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1,
+        },
+      ]
+    }
+  >
+    <View
+      customHeight={16}
+      enable={true}
+      style={
+        [
+          {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "height": 48,
+            "justifyContent": "center",
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <View
+          positionInHeader="left"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-start",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="back-button-container"
+        >
+          <View
+            accessibilityLabel="Revenir en arrière"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "height": 40,
+                    "justifyContent": "center",
+                    "maxWidth": 40,
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Revenir en arrière"
+          >
+            <View
+              height={24}
+              testID="icon-back"
+              width={24}
+            >
+              <Text>
+                icon-back-SVG-Mock
+              </Text>
+            </View>
+            <Text
+              style={
+                [
+                  {
+                    "display": "none",
+                  },
+                ]
+              }
+            >
+              Retour
+            </Text>
+          </View>
+        </View>
+        <Text
+          numberOfLines={1}
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 17,
+                "lineHeight": 27.2,
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          Modifier ma ville de résidence
+        </Text>
+        <View
+          positionInHeader="right"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-end",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="close-button-container"
+        />
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+        },
+      ]
+    }
+  >
+    <View
+      onLayout={[Function]}
+      style={
+        [
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderTopLeftRadius": 22,
+              "borderTopRightRadius": 22,
+              "display": "flex",
+              "flexBasis": 0,
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "height": "100%",
+              "overflow": "scroll",
+              "paddingTop": 32,
+            },
+          ],
+          {
+            "paddingBottom": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "maxWidth": 500,
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <RCTScrollView
+          bottomChildrenViewHeight={0}
+          contentContainerStyle={
+            {
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "paddingBottom": 0,
+              "paddingHorizontal": 20,
+            }
+          }
+          keyboardShouldPersistTaps="handled"
+          onContentSizeChange={[Function]}
+          onLayout={[Function]}
+          style={
+            [
+              {},
+            ]
+          }
+        >
+          <View>
+            <View
+              style={
+                {
+                  "height": 65,
+                }
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "marginBottom": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 19,
+                      "lineHeight": 30.4,
+                    },
+                  ]
+                }
+              >
+                Renseigne ta ville de résidence
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "maxWidth": 500,
+                    "width": "100%",
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "marginBottom": 8,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "marginBottom": 8,
+                      },
+                    ]
+                  }
+                >
+                  <View>
+                    <View
+                      style={
+                        [
+                          {
+                            "alignItems": "flex-end",
+                            "flexDirection": "row",
+                            "justifyContent": "space-between",
+                            "width": "100%",
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Indique ton code postal et choisis ta ville
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+                <View
+                  style={
+                    [
+                      {
+                        "marginBottom": 8,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#696a6f",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Exemple : 75017
+                  </Text>
+                </View>
+                <View
+                  height="small"
+                  isDisabled={false}
+                  isError={false}
+                  isFocus={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#90949d",
+                        "borderRadius": 22,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "height": 40,
+                        "paddingBottom": 0,
+                        "paddingLeft": 17,
+                        "paddingRight": 17,
+                        "paddingTop": 0,
+                        "width": "100%",
+                      },
+                      {
+                        "borderRadius": 24,
+                        "outlineOffset": 0,
+                      },
+                    ]
+                  }
+                  testID="styled-input-container"
+                >
+                  <TextInput
+                    accessibilityDescribedBy="testUuidV4"
+                    accessibilityHidden={false}
+                    autoComplete="postal-code"
+                    autoCorrect={false}
+                    editable={true}
+                    enablesReturnKeyAutomatically={true}
+                    focusable={true}
+                    isEmpty={false}
+                    keyboardType="number-pad"
+                    multiline={false}
+                    nativeID="postal-code-input"
+                    onBlur={[Function]}
+                    onChangeText={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    placeholderTextColor="#696a6f"
+                    returnKeyType="search"
+                    selectionColor="#696a6f"
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "flexBasis": 0,
+                          "flexGrow": 1,
+                          "flexShrink": 1,
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "height": "100%",
+                          "paddingBottom": 0,
+                          "paddingLeft": 0,
+                          "paddingRight": 0,
+                          "paddingTop": 0,
+                        },
+                        {},
+                      ]
+                    }
+                    testID="Entrée pour la ville"
+                    textAlignVertical="center"
+                    textContentType="postalCode"
+                    value="75001"
+                  />
+                  <View
+                    accessibilityLabel="Réinitialiser la recherche"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    focusable={true}
+                    hitSlop={
+                      {
+                        "bottom": 10,
+                        "left": 10,
+                        "right": 10,
+                        "top": 10,
+                      }
+                    }
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      [
+                        [
+                          {
+                            "userSelect": "auto",
+                          },
+                        ],
+                        {
+                          "opacity": 1,
+                        },
+                      ]
+                    }
+                    testID="Réinitialiser la recherche"
+                  >
+                    <View
+                      fill="#696a6f"
+                      height={20}
+                      width={20}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  {
+                    "transform": [
+                      {
+                        "rotate": "0deg",
+                      },
+                    ],
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  height={32}
+                  width={32}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              accessibilityRole="radiogroup"
+              style={
+                [
+                  {
+                    "flexGrow": 1,
+                    "overflowY": "scroll",
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityRole="list"
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "paddingLeft": 0,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+        </RCTScrollView>
+        <View
+          onLayout={[Function]}
+          style={
+            [
+              {
+                "backgroundColor": "#ffffff",
+                "bottom": 0,
+                "left": 0,
+                "paddingBottom": 20,
+                "paddingHorizontal": 20,
+                "paddingTop": 12,
+                "position": "absolute",
+                "right": 0,
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityLabel="Continuer"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": true,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={false}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#f1f1f4",
+                    "borderRadius": 24,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "maxWidth": 500,
+                    "minHeight": 40,
+                    "paddingBottom": 2,
+                    "paddingLeft": 20,
+                    "paddingRight": 20,
+                    "paddingTop": 2,
+                    "width": "100%",
+                  },
+                  {},
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Continuer"
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                adjustsFontSizeToFit={false}
+                numberOfLines={1}
+                style={
+                  [
+                    {
+                      "color": "#696a6f",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
+                      "maxWidth": "100%",
+                    },
+                  ]
+                }
+              >
+                Continuer
+              </Text>
+            </View>
+          </View>
+          <View
+            customHeight={8}
+            enable={true}
+            style={
+              [
+                {
+                  "height": 8,
+                },
+              ]
+            }
+          />
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    height={65}
+    style={
+      [
+        {
+          "backdropFilter": "blur(20px)",
+          "height": 65,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  >
+    <BlurView
+      blurAmount={8}
+      blurType="light"
+      style={
+        [
+          {
+            "backgroundColor": "transparent",
+          },
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+            },
+          ],
+        ]
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`ChangeCity without previous screen should render correctly 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "#ffffff",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      },
+    ]
+  }
+>
+  <View
+    accessibilityRole="header"
+    style={
+      [
+        {
+          "backgroundColor": "rgba(255,255,255,0)",
+          "borderBottomColor": "#cbcdd2",
+          "borderBottomWidth": 1,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1,
+        },
+      ]
+    }
+  >
+    <View
+      customHeight={16}
+      enable={true}
+      style={
+        [
+          {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "height": 48,
+            "justifyContent": "center",
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <View
+          positionInHeader="left"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-start",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="back-button-container"
+        >
+          <View
+            accessibilityLabel="Revenir en arrière"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "height": 40,
+                    "justifyContent": "center",
+                    "maxWidth": 40,
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Revenir en arrière"
+          >
+            <View
+              height={24}
+              testID="icon-back"
+              width={24}
+            >
+              <Text>
+                icon-back-SVG-Mock
+              </Text>
+            </View>
+            <Text
+              style={
+                [
+                  {
+                    "display": "none",
+                  },
+                ]
+              }
+            >
+              Retour
+            </Text>
+          </View>
+        </View>
+        <Text
+          numberOfLines={1}
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 17,
+                "lineHeight": 27.2,
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          Modifier ma ville de résidence
+        </Text>
+        <View
+          positionInHeader="right"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-end",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="close-button-container"
+        />
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+        },
+      ]
+    }
+  >
+    <View
+      onLayout={[Function]}
+      style={
+        [
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderTopLeftRadius": 22,
+              "borderTopRightRadius": 22,
+              "display": "flex",
+              "flexBasis": 0,
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "height": "100%",
+              "overflow": "scroll",
+              "paddingTop": 32,
+            },
+          ],
+          {
+            "paddingBottom": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "maxWidth": 500,
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <RCTScrollView
+          bottomChildrenViewHeight={0}
+          contentContainerStyle={
+            {
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "paddingBottom": 0,
+              "paddingHorizontal": 20,
+            }
+          }
+          keyboardShouldPersistTaps="handled"
+          onContentSizeChange={[Function]}
+          onLayout={[Function]}
+          style={
+            [
+              {},
+            ]
+          }
+        >
+          <View>
+            <View
+              style={
+                {
+                  "height": 65,
+                }
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "marginBottom": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 19,
+                      "lineHeight": 30.4,
+                    },
+                  ]
+                }
+              >
+                Renseigne ta ville de résidence
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "maxWidth": 500,
+                    "width": "100%",
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "marginBottom": 8,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "marginBottom": 8,
+                      },
+                    ]
+                  }
+                >
+                  <View>
+                    <View
+                      style={
+                        [
+                          {
+                            "alignItems": "flex-end",
+                            "flexDirection": "row",
+                            "justifyContent": "space-between",
+                            "width": "100%",
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Indique ton code postal et choisis ta ville
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+                <View
+                  style={
+                    [
+                      {
+                        "marginBottom": 8,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#696a6f",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Exemple : 75017
+                  </Text>
+                </View>
+                <View
+                  height="small"
+                  isDisabled={false}
+                  isError={false}
+                  isFocus={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#90949d",
+                        "borderRadius": 22,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "height": 40,
+                        "paddingBottom": 0,
+                        "paddingLeft": 17,
+                        "paddingRight": 17,
+                        "paddingTop": 0,
+                        "width": "100%",
+                      },
+                      {
+                        "borderRadius": 24,
+                        "outlineOffset": 0,
+                      },
+                    ]
+                  }
+                  testID="styled-input-container"
+                >
+                  <TextInput
+                    accessibilityDescribedBy="testUuidV4"
+                    accessibilityHidden={false}
+                    autoComplete="postal-code"
+                    autoCorrect={false}
+                    editable={true}
+                    enablesReturnKeyAutomatically={true}
+                    focusable={true}
+                    isEmpty={false}
+                    keyboardType="number-pad"
+                    multiline={false}
+                    nativeID="postal-code-input"
+                    onBlur={[Function]}
+                    onChangeText={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    placeholderTextColor="#696a6f"
+                    returnKeyType="search"
+                    selectionColor="#696a6f"
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "flexBasis": 0,
+                          "flexGrow": 1,
+                          "flexShrink": 1,
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "height": "100%",
+                          "paddingBottom": 0,
+                          "paddingLeft": 0,
+                          "paddingRight": 0,
+                          "paddingTop": 0,
+                        },
+                        {},
+                      ]
+                    }
+                    testID="Entrée pour la ville"
+                    textAlignVertical="center"
+                    textContentType="postalCode"
+                    value="75001"
+                  />
+                  <View
+                    accessibilityLabel="Réinitialiser la recherche"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    focusable={true}
+                    hitSlop={
+                      {
+                        "bottom": 10,
+                        "left": 10,
+                        "right": 10,
+                        "top": 10,
+                      }
+                    }
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      [
+                        [
+                          {
+                            "userSelect": "auto",
+                          },
+                        ],
+                        {
+                          "opacity": 1,
+                        },
+                      ]
+                    }
+                    testID="Réinitialiser la recherche"
+                  >
+                    <View
+                      fill="#696a6f"
+                      height={20}
+                      width={20}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
                 </View>
               </View>
             </View>

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
@@ -285,25 +285,6 @@ exports[`ChangeCity should render correctly 1`] = `
                 </div>
               </form>
               <div
-                class="css-view-175oi2r r-alignItems-1awozwy"
-              >
-                <div
-                  class="css-view-175oi2r"
-                  style="width: 32px; transform: rotate(0deg);"
-                >
-                  <div
-                    class="css-view-175oi2r"
-                  >
-                    <div
-                      class="css-text-146c3p1"
-                      dir="ltr"
-                    >
-                      undefined-SVG-Mock
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
                 class="css-view-175oi2r r-boxSizing-1tjplnt r-flexGrow-16y2uox r-overflowY-17y9yhz"
                 role="radiogroup"
               >

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
@@ -213,14 +213,14 @@ exports[`ChangeCity should render correctly 1`] = `
               <div
                 class="css-view-175oi2r r-marginBottom-117bsoe"
               >
-                <h1
-                  aria-level="1"
+                <h2
+                  aria-level="2"
                   class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-19e3y8m r-lineHeight-1w51ilw"
                   dir="ltr"
                   role="heading"
                 >
                   Renseigne ta ville de résidence
-                </h1>
+                </h2>
               </div>
               <form
                 class="c2"

--- a/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ChangeStatus/> should render correctly 1`] = `
+exports[`<ChangeStatus/> from mandatory udpate personal data screen should render correctly 1`] = `
 [
   <View
     accessibilityRole="header"
@@ -741,7 +741,7 @@ exports[`<ChangeStatus/> should render correctly 1`] = `
                 accessibilityState={
                   {
                     "busy": undefined,
-                    "checked": false,
+                    "checked": true,
                     "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
@@ -773,16 +773,16 @@ exports[`<ChangeStatus/> should render correctly 1`] = `
                       {
                         "alignItems": "center",
                         "backgroundColor": "#ffffff",
-                        "borderColor": "#cbcdd2",
+                        "borderColor": "#90949d",
                         "borderRadius": 8,
                         "borderStyle": "solid",
-                        "borderWidth": 1,
+                        "borderWidth": 2,
                         "flexDirection": "row",
                         "flexGrow": 1,
-                        "paddingBottom": 16,
-                        "paddingLeft": 16,
-                        "paddingRight": 16,
-                        "paddingTop": 16,
+                        "paddingBottom": 15,
+                        "paddingLeft": 15,
+                        "paddingRight": 15,
+                        "paddingTop": 15,
                       },
                     ],
                     {
@@ -793,12 +793,12 @@ exports[`<ChangeStatus/> should render correctly 1`] = `
                 testID="Étudiant"
               >
                 <View
-                  isSelected={false}
+                  isSelected={true}
                   style={
                     [
                       {
                         "alignItems": "center",
-                        "borderColor": "#cbcdd2",
+                        "borderColor": "#eb0055",
                         "borderRadius": 8,
                         "borderStyle": "solid",
                         "borderWidth": 1,
@@ -811,11 +811,11 @@ exports[`<ChangeStatus/> should render correctly 1`] = `
                   }
                 >
                   <View
-                    isSelected={false}
+                    isSelected={true}
                     style={
                       [
                         {
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "#eb0055",
                           "borderRadius": 16,
                           "height": 8,
                           "width": 8,
@@ -2064,12 +2064,12 @@ exports[`<ChangeStatus/> should render correctly 1`] = `
       }
     >
       <View
-        accessibilityLabel="Valider mon statut"
+        accessibilityLabel="Continuer vers l’étape suivante"
         accessibilityState={
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": true,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }
@@ -2083,7 +2083,7 @@ exports[`<ChangeStatus/> should render correctly 1`] = `
           }
         }
         accessible={true}
-        focusable={false}
+        focusable={true}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -2099,7 +2099,7 @@ exports[`<ChangeStatus/> should render correctly 1`] = `
               },
               {
                 "alignItems": "center",
-                "backgroundColor": "#f1f1f4",
+                "backgroundColor": "#eb0055",
                 "borderRadius": 24,
                 "flexDirection": "row",
                 "justifyContent": "center",
@@ -2118,7 +2118,7 @@ exports[`<ChangeStatus/> should render correctly 1`] = `
             },
           ]
         }
-        testID="Valider mon statut"
+        testID="Continuer vers l’étape suivante"
       >
         <View
           style={
@@ -2136,7 +2136,7 @@ exports[`<ChangeStatus/> should render correctly 1`] = `
             style={
               [
                 {
-                  "color": "#696a6f",
+                  "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 16,
                   "lineHeight": 25.6,
@@ -2145,7 +2145,7 @@ exports[`<ChangeStatus/> should render correctly 1`] = `
               ]
             }
           >
-            Valider mon statut
+            Continuer
           </Text>
         </View>
       </View>
@@ -2200,7 +2200,7 @@ exports[`<ChangeStatus/> should render correctly 1`] = `
 ]
 `;
 
-exports[`<ChangeStatus/> should show loading component 1`] = `
+exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
 [
   <View
     accessibilityRole="header"
@@ -2941,7 +2941,7 @@ exports[`<ChangeStatus/> should show loading component 1`] = `
                 accessibilityState={
                   {
                     "busy": undefined,
-                    "checked": false,
+                    "checked": true,
                     "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
@@ -2973,16 +2973,16 @@ exports[`<ChangeStatus/> should show loading component 1`] = `
                       {
                         "alignItems": "center",
                         "backgroundColor": "#ffffff",
-                        "borderColor": "#cbcdd2",
+                        "borderColor": "#90949d",
                         "borderRadius": 8,
                         "borderStyle": "solid",
-                        "borderWidth": 1,
+                        "borderWidth": 2,
                         "flexDirection": "row",
                         "flexGrow": 1,
-                        "paddingBottom": 16,
-                        "paddingLeft": 16,
-                        "paddingRight": 16,
-                        "paddingTop": 16,
+                        "paddingBottom": 15,
+                        "paddingLeft": 15,
+                        "paddingRight": 15,
+                        "paddingTop": 15,
                       },
                     ],
                     {
@@ -2993,12 +2993,12 @@ exports[`<ChangeStatus/> should show loading component 1`] = `
                 testID="Étudiant"
               >
                 <View
-                  isSelected={false}
+                  isSelected={true}
                   style={
                     [
                       {
                         "alignItems": "center",
-                        "borderColor": "#cbcdd2",
+                        "borderColor": "#eb0055",
                         "borderRadius": 8,
                         "borderStyle": "solid",
                         "borderWidth": 1,
@@ -3011,11 +3011,11 @@ exports[`<ChangeStatus/> should show loading component 1`] = `
                   }
                 >
                   <View
-                    isSelected={false}
+                    isSelected={true}
                     style={
                       [
                         {
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "#eb0055",
                           "borderRadius": 16,
                           "height": 8,
                           "width": 8,
@@ -4264,12 +4264,12 @@ exports[`<ChangeStatus/> should show loading component 1`] = `
       }
     >
       <View
-        accessibilityLabel="Valider mon statut"
+        accessibilityLabel="Continuer vers l’étape suivante"
         accessibilityState={
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": true,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }
@@ -4283,7 +4283,7 @@ exports[`<ChangeStatus/> should show loading component 1`] = `
           }
         }
         accessible={true}
-        focusable={false}
+        focusable={true}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -4299,7 +4299,7 @@ exports[`<ChangeStatus/> should show loading component 1`] = `
               },
               {
                 "alignItems": "center",
-                "backgroundColor": "#f1f1f4",
+                "backgroundColor": "#eb0055",
                 "borderRadius": 24,
                 "flexDirection": "row",
                 "justifyContent": "center",
@@ -4318,7 +4318,7 @@ exports[`<ChangeStatus/> should show loading component 1`] = `
             },
           ]
         }
-        testID="Valider mon statut"
+        testID="Continuer vers l’étape suivante"
       >
         <View
           style={
@@ -4336,7 +4336,7 @@ exports[`<ChangeStatus/> should show loading component 1`] = `
             style={
               [
                 {
-                  "color": "#696a6f",
+                  "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 16,
                   "lineHeight": 25.6,
@@ -4345,7 +4345,2207 @@ exports[`<ChangeStatus/> should show loading component 1`] = `
               ]
             }
           >
-            Valider mon statut
+            Continuer
+          </Text>
+        </View>
+      </View>
+      <View
+        customHeight={8}
+        enable={true}
+        style={
+          [
+            {
+              "height": 8,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>,
+  <View
+    height={65}
+    style={
+      [
+        {
+          "backdropFilter": "blur(20px)",
+          "height": 65,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  >
+    <BlurView
+      blurAmount={8}
+      blurType="light"
+      style={
+        [
+          {
+            "backgroundColor": "transparent",
+          },
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+            },
+          ],
+        ]
+      }
+    />
+  </View>,
+]
+`;
+
+exports[`<ChangeStatus/> without previous screen should show loading component 1`] = `
+[
+  <View
+    accessibilityRole="header"
+    style={
+      [
+        {
+          "backgroundColor": "rgba(255,255,255,0)",
+          "borderBottomColor": "#cbcdd2",
+          "borderBottomWidth": 1,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1,
+        },
+      ]
+    }
+  >
+    <View
+      customHeight={16}
+      enable={true}
+      style={
+        [
+          {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "height": 48,
+            "justifyContent": "center",
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <View
+          positionInHeader="left"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-start",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="back-button-container"
+        >
+          <View
+            accessibilityLabel="Revenir en arrière"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "height": 40,
+                    "justifyContent": "center",
+                    "maxWidth": 40,
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Revenir en arrière"
+          >
+            <View
+              height={24}
+              testID="icon-back"
+              width={24}
+            >
+              <Text>
+                icon-back-SVG-Mock
+              </Text>
+            </View>
+            <Text
+              style={
+                [
+                  {
+                    "display": "none",
+                  },
+                ]
+              }
+            >
+              Retour
+            </Text>
+          </View>
+        </View>
+        <Text
+          numberOfLines={1}
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 17,
+                "lineHeight": 27.2,
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          Modifier mon statut
+        </Text>
+        <View
+          positionInHeader="right"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-end",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="close-button-container"
+        />
+      </View>
+    </View>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "#ffffff",
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+        ]
+      }
+    >
+      <RCTScrollView
+        ListHeaderComponent={
+          <React.Fragment>
+            <Styled(View)
+              headerHeight={65}
+            />
+            <Styled(View)
+              numberOfSpaces={2}
+            />
+            <Styled(Text)>
+              Sélectionne ton statut
+            </Styled(Text)>
+            <Styled(View)
+              numberOfSpaces={8}
+            />
+          </React.Fragment>
+        }
+        contentContainerStyle={
+          {
+            "alignSelf": "center",
+            "maxWidth": 500,
+            "paddingHorizontal": 24,
+            "paddingVertical": 24,
+            "width": "100%",
+          }
+        }
+        data={
+          [
+            {
+              "description": null,
+              "id": "MIDDLE_SCHOOL_STUDENT",
+              "label": "Collégien",
+            },
+            {
+              "description": null,
+              "id": "HIGH_SCHOOL_STUDENT",
+              "label": "Lycéen",
+            },
+            {
+              "description": null,
+              "id": "STUDENT",
+              "label": "Étudiant",
+            },
+            {
+              "description": null,
+              "id": "EMPLOYEE",
+              "label": "Employé",
+            },
+            {
+              "description": null,
+              "id": "APPRENTICE",
+              "label": "Apprenti",
+            },
+            {
+              "description": null,
+              "id": "APPRENTICE_STUDENT",
+              "label": "Alternant",
+            },
+            {
+              "description": "En service civique",
+              "id": "VOLUNTEER",
+              "label": "Volontaire",
+            },
+            {
+              "description": "En incapacité de travailler",
+              "id": "INACTIVE",
+              "label": "Inactif",
+            },
+            {
+              "description": "En recherche d’emploi",
+              "id": "UNEMPLOYED",
+              "label": "Chômeur",
+            },
+          ]
+        }
+        getItem={[Function]}
+        getItemCount={[Function]}
+        keyExtractor={[Function]}
+        listAs="ul"
+        onContentSizeChange={[Function]}
+        onLayout={[Function]}
+        onMomentumScrollBegin={[Function]}
+        onMomentumScrollEnd={[Function]}
+        onScroll={[Function]}
+        onScrollBeginDrag={[Function]}
+        onScrollEndDrag={[Function]}
+        onViewableItemsChanged={[Function]}
+        removeClippedSubviews={false}
+        renderItem={[Function]}
+        scrollEventThrottle={0.0001}
+        scrollIndicatorInsets={
+          {
+            "right": 1,
+          }
+        }
+        stickyHeaderIndices={[]}
+        viewabilityConfig={
+          {
+            "itemVisiblePercentThreshold": 100,
+          }
+        }
+        viewabilityConfigCallbackPairs={
+          [
+            {
+              "onViewableItemsChanged": [Function],
+              "viewabilityConfig": {
+                "itemVisiblePercentThreshold": 100,
+              },
+            },
+          ]
+        }
+      >
+        <View>
+          <View
+            collapsable={false}
+            onLayout={[Function]}
+          >
+            <View
+              headerHeight={65}
+              style={
+                [
+                  {
+                    "paddingTop": 65,
+                  },
+                ]
+              }
+            />
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "height": 8,
+                  },
+                ]
+              }
+            />
+            <Text
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Bold",
+                    "fontSize": 19,
+                    "lineHeight": 30.4,
+                  },
+                ]
+              }
+            >
+              Sélectionne ton statut
+            </Text>
+            <View
+              numberOfSpaces={8}
+              style={
+                [
+                  {
+                    "height": 32,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            onFocusCapture={[Function]}
+            onLayout={[Function]}
+            style={null}
+          >
+            <View
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityRole="none"
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityLabel="Collégien"
+                accessibilityRole="radio"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "flexGrow": 1,
+                        "paddingBottom": 16,
+                        "paddingLeft": 16,
+                        "paddingRight": 16,
+                        "paddingTop": 16,
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Collégien"
+              >
+                <View
+                  isSelected={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "height": 16,
+                        "justifyContent": "center",
+                        "marginRight": 16,
+                        "width": 16,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    isSelected={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderRadius": 16,
+                          "height": 8,
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
+                </View>
+                <View
+                  contentDirection="row"
+                  style={
+                    [
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    gap={4}
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 16,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        isHover={false}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Collégien
+                      </Text>
+                    </View>
+                    <View
+                      style={
+                        [
+                          {},
+                        ]
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+              <View
+                numberOfSpaces={3}
+                style={
+                  [
+                    {
+                      "height": 12,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            onFocusCapture={[Function]}
+            onLayout={[Function]}
+            style={null}
+          >
+            <View
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityRole="none"
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityLabel="Lycéen"
+                accessibilityRole="radio"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "flexGrow": 1,
+                        "paddingBottom": 16,
+                        "paddingLeft": 16,
+                        "paddingRight": 16,
+                        "paddingTop": 16,
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Lycéen"
+              >
+                <View
+                  isSelected={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "height": 16,
+                        "justifyContent": "center",
+                        "marginRight": 16,
+                        "width": 16,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    isSelected={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderRadius": 16,
+                          "height": 8,
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
+                </View>
+                <View
+                  contentDirection="row"
+                  style={
+                    [
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    gap={4}
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 16,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        isHover={false}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Lycéen
+                      </Text>
+                    </View>
+                    <View
+                      style={
+                        [
+                          {},
+                        ]
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+              <View
+                numberOfSpaces={3}
+                style={
+                  [
+                    {
+                      "height": 12,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            onFocusCapture={[Function]}
+            onLayout={[Function]}
+            style={null}
+          >
+            <View
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityRole="none"
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityLabel="Étudiant"
+                accessibilityRole="radio"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": true,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#90949d",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 2,
+                        "flexDirection": "row",
+                        "flexGrow": 1,
+                        "paddingBottom": 15,
+                        "paddingLeft": 15,
+                        "paddingRight": 15,
+                        "paddingTop": 15,
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Étudiant"
+              >
+                <View
+                  isSelected={true}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "borderColor": "#eb0055",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "height": 16,
+                        "justifyContent": "center",
+                        "marginRight": 16,
+                        "width": 16,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    isSelected={true}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#eb0055",
+                          "borderRadius": 16,
+                          "height": 8,
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
+                </View>
+                <View
+                  contentDirection="row"
+                  style={
+                    [
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    gap={4}
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 16,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        isHover={false}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Étudiant
+                      </Text>
+                    </View>
+                    <View
+                      style={
+                        [
+                          {},
+                        ]
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+              <View
+                numberOfSpaces={3}
+                style={
+                  [
+                    {
+                      "height": 12,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            onFocusCapture={[Function]}
+            onLayout={[Function]}
+            style={null}
+          >
+            <View
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityRole="none"
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityLabel="Employé"
+                accessibilityRole="radio"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "flexGrow": 1,
+                        "paddingBottom": 16,
+                        "paddingLeft": 16,
+                        "paddingRight": 16,
+                        "paddingTop": 16,
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Employé"
+              >
+                <View
+                  isSelected={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "height": 16,
+                        "justifyContent": "center",
+                        "marginRight": 16,
+                        "width": 16,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    isSelected={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderRadius": 16,
+                          "height": 8,
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
+                </View>
+                <View
+                  contentDirection="row"
+                  style={
+                    [
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    gap={4}
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 16,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        isHover={false}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Employé
+                      </Text>
+                    </View>
+                    <View
+                      style={
+                        [
+                          {},
+                        ]
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+              <View
+                numberOfSpaces={3}
+                style={
+                  [
+                    {
+                      "height": 12,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            onFocusCapture={[Function]}
+            onLayout={[Function]}
+            style={null}
+          >
+            <View
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityRole="none"
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityLabel="Apprenti"
+                accessibilityRole="radio"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "flexGrow": 1,
+                        "paddingBottom": 16,
+                        "paddingLeft": 16,
+                        "paddingRight": 16,
+                        "paddingTop": 16,
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Apprenti"
+              >
+                <View
+                  isSelected={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "height": 16,
+                        "justifyContent": "center",
+                        "marginRight": 16,
+                        "width": 16,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    isSelected={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderRadius": 16,
+                          "height": 8,
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
+                </View>
+                <View
+                  contentDirection="row"
+                  style={
+                    [
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    gap={4}
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 16,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        isHover={false}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Apprenti
+                      </Text>
+                    </View>
+                    <View
+                      style={
+                        [
+                          {},
+                        ]
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+              <View
+                numberOfSpaces={3}
+                style={
+                  [
+                    {
+                      "height": 12,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            onFocusCapture={[Function]}
+            onLayout={[Function]}
+            style={null}
+          >
+            <View
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityRole="none"
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityLabel="Alternant"
+                accessibilityRole="radio"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "flexGrow": 1,
+                        "paddingBottom": 16,
+                        "paddingLeft": 16,
+                        "paddingRight": 16,
+                        "paddingTop": 16,
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Alternant"
+              >
+                <View
+                  isSelected={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "height": 16,
+                        "justifyContent": "center",
+                        "marginRight": 16,
+                        "width": 16,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    isSelected={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderRadius": 16,
+                          "height": 8,
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
+                </View>
+                <View
+                  contentDirection="row"
+                  style={
+                    [
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    gap={4}
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 16,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        isHover={false}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Alternant
+                      </Text>
+                    </View>
+                    <View
+                      style={
+                        [
+                          {},
+                        ]
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+              <View
+                numberOfSpaces={3}
+                style={
+                  [
+                    {
+                      "height": 12,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            onFocusCapture={[Function]}
+            onLayout={[Function]}
+            style={null}
+          >
+            <View
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityRole="none"
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityLabel="Volontaire"
+                accessibilityRole="radio"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "flexGrow": 1,
+                        "paddingBottom": 16,
+                        "paddingLeft": 16,
+                        "paddingRight": 16,
+                        "paddingTop": 16,
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Volontaire"
+              >
+                <View
+                  isSelected={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "height": 16,
+                        "justifyContent": "center",
+                        "marginRight": 16,
+                        "width": 16,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    isSelected={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderRadius": 16,
+                          "height": 8,
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
+                </View>
+                <View
+                  contentDirection="row"
+                  style={
+                    [
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    gap={4}
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 16,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        isHover={false}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Volontaire
+                      </Text>
+                      <Text
+                        style={
+                          [
+                            {
+                              "color": "#696a6f",
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 12,
+                              "lineHeight": 19.2,
+                              "marginTop": 4,
+                            },
+                          ]
+                        }
+                      >
+                        En service civique
+                      </Text>
+                    </View>
+                    <View
+                      style={
+                        [
+                          {},
+                        ]
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+              <View
+                numberOfSpaces={3}
+                style={
+                  [
+                    {
+                      "height": 12,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            onFocusCapture={[Function]}
+            onLayout={[Function]}
+            style={null}
+          >
+            <View
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityRole="none"
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityLabel="Inactif"
+                accessibilityRole="radio"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "flexGrow": 1,
+                        "paddingBottom": 16,
+                        "paddingLeft": 16,
+                        "paddingRight": 16,
+                        "paddingTop": 16,
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Inactif"
+              >
+                <View
+                  isSelected={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "height": 16,
+                        "justifyContent": "center",
+                        "marginRight": 16,
+                        "width": 16,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    isSelected={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderRadius": 16,
+                          "height": 8,
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
+                </View>
+                <View
+                  contentDirection="row"
+                  style={
+                    [
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    gap={4}
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 16,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        isHover={false}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Inactif
+                      </Text>
+                      <Text
+                        style={
+                          [
+                            {
+                              "color": "#696a6f",
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 12,
+                              "lineHeight": 19.2,
+                              "marginTop": 4,
+                            },
+                          ]
+                        }
+                      >
+                        En incapacité de travailler
+                      </Text>
+                    </View>
+                    <View
+                      style={
+                        [
+                          {},
+                        ]
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+              <View
+                numberOfSpaces={3}
+                style={
+                  [
+                    {
+                      "height": 12,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            onFocusCapture={[Function]}
+            onLayout={[Function]}
+            style={null}
+          >
+            <View
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityRole="none"
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityLabel="Chômeur"
+                accessibilityRole="radio"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "flexGrow": 1,
+                        "paddingBottom": 16,
+                        "paddingLeft": 16,
+                        "paddingRight": 16,
+                        "paddingTop": 16,
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Chômeur"
+              >
+                <View
+                  isSelected={false}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "borderColor": "#cbcdd2",
+                        "borderRadius": 8,
+                        "borderStyle": "solid",
+                        "borderWidth": 1,
+                        "height": 16,
+                        "justifyContent": "center",
+                        "marginRight": 16,
+                        "width": 16,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    isSelected={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderRadius": 16,
+                          "height": 8,
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
+                </View>
+                <View
+                  contentDirection="row"
+                  style={
+                    [
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    gap={4}
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 16,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        isHover={false}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Chômeur
+                      </Text>
+                      <Text
+                        style={
+                          [
+                            {
+                              "color": "#696a6f",
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 12,
+                              "lineHeight": 19.2,
+                              "marginTop": 4,
+                            },
+                          ]
+                        }
+                      >
+                        En recherche d’emploi
+                      </Text>
+                    </View>
+                    <View
+                      style={
+                        [
+                          {},
+                        ]
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+              <View
+                numberOfSpaces={3}
+                style={
+                  [
+                    {
+                      "height": 12,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </RCTScrollView>
+    </View>
+    <BVLinearGradient
+      bottomViewHeight={0}
+      colors={
+        [
+          16777215,
+          4294967295,
+        ]
+      }
+      endPoint={
+        {
+          "x": 0.5,
+          "y": 1,
+        }
+      }
+      locations={
+        [
+          0,
+          1,
+        ]
+      }
+      pointerEvents="none"
+      startPoint={
+        {
+          "x": 0.5,
+          "y": 0,
+        }
+      }
+      style={
+        [
+          [
+            {
+              "bottom": 0,
+              "height": 120,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+            },
+          ],
+          {},
+          {},
+        ]
+      }
+    />
+    <View
+      onLayout={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "backgroundColor": "#ffffff",
+            "paddingBottom": 20,
+            "paddingHorizontal": 20,
+            "paddingTop": 12,
+          },
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="Continuer vers l’étape suivante"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            [
+              {
+                "userSelect": "auto",
+              },
+              {
+                "alignItems": "center",
+                "backgroundColor": "#eb0055",
+                "borderRadius": 24,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": 500,
+                "minHeight": 40,
+                "paddingBottom": 2,
+                "paddingLeft": 20,
+                "paddingRight": 20,
+                "paddingTop": 2,
+                "width": "100%",
+              },
+              {},
+            ],
+            {
+              "opacity": 1,
+            },
+          ]
+        }
+        testID="Continuer vers l’étape suivante"
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+            ]
+          }
+        >
+          <Text
+            adjustsFontSizeToFit={false}
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "color": "#ffffff",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                  "maxWidth": "100%",
+                },
+              ]
+            }
+          >
+            Continuer
           </Text>
         </View>
       </View>

--- a/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
@@ -840,7 +840,7 @@ exports[`PersonalData should render personal data success 1`] = `
           ]
         }
       >
-        Ville de résidence
+        Adresse de résidence
       </Text>
       <View
         style={
@@ -868,10 +868,10 @@ exports[`PersonalData should render personal data success 1`] = `
             ]
           }
         >
-          75001, Paris
+          10 rue de Bohneur, 75001, Paris
         </Text>
         <View
-          accessibilityLabel="Modifier la ville de résidence"
+          accessibilityLabel="Modifier mon adresse de résidence"
           accessibilityState={
             {
               "busy": undefined,
@@ -928,7 +928,7 @@ exports[`PersonalData should render personal data success 1`] = `
               },
             ]
           }
-          testID="Modifier la ville de résidence"
+          testID="Modifier mon adresse de résidence"
         >
           <View
             style={

--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -4650,6 +4650,11 @@ export interface UserProfilePatchRequest {
    * @type {string}
    * @memberof UserProfilePatchRequest
    */
+  address?: string | null
+  /**
+   * @type {string}
+   * @memberof UserProfilePatchRequest
+   */
   city?: string | null
   /**
    * @type {string}

--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -4823,6 +4823,11 @@ export interface UserProfileResponse {
    */
   status: YoungStatusResponse
   /**
+   * @type {string}
+   * @memberof UserProfileResponse
+   */
+  street?: string | null
+  /**
    * @type {SubscriptionMessage}
    * @memberof UserProfileResponse
    */

--- a/src/cheatcodes/pages/features/profile/CheatcodesNavigationProfile.tsx
+++ b/src/cheatcodes/pages/features/profile/CheatcodesNavigationProfile.tsx
@@ -32,6 +32,11 @@ const profileCheatcodeCategory: CheatcodeCategory = {
     },
     {
       id: uuidv4(),
+      title: 'ChangeAddress',
+      navigationTarget: getProfileNavConfig('ChangeAddress'),
+    },
+    {
+      id: uuidv4(),
       title: 'ChangeEmail',
       navigationTarget: getProfileNavConfig('ChangeEmail'),
     },

--- a/src/features/identityCheck/pages/profile/SetCity.web.test.tsx
+++ b/src/features/identityCheck/pages/profile/SetCity.web.test.tsx
@@ -4,7 +4,7 @@ import { useRoute } from '__mocks__/@react-navigation/native'
 import { ProfileTypes } from 'features/identityCheck/pages/profile/enums'
 import { SetCity } from 'features/identityCheck/pages/profile/SetCity'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { checkAccessibilityFor, render, screen, waitFor } from 'tests/utils/web'
+import { checkAccessibilityFor, render } from 'tests/utils/web'
 
 jest.mock('uuid', () => ({
   v1: jest.fn(),
@@ -22,10 +22,6 @@ describe('<SetCity/>', () => {
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = renderSetCity()
-
-      await waitFor(() => {
-        expect(screen.getByTestId('Entrée pour la ville')).toHaveFocus()
-      })
 
       const results = await checkAccessibilityFor(container)
 

--- a/src/features/navigation/ProfileStackNavigator/ProfileStackNavigator.tsx
+++ b/src/features/navigation/ProfileStackNavigator/ProfileStackNavigator.tsx
@@ -13,6 +13,7 @@ import { AccessibilityDeclarationWeb } from 'features/profile/pages/Accessibilit
 import { AccessibilityEngagement } from 'features/profile/pages/Accessibility/AccessibilityEngagement'
 import { RecommendedPaths } from 'features/profile/pages/Accessibility/RecommendedPaths'
 import { SiteMapScreen } from 'features/profile/pages/Accessibility/SiteMapScreen'
+import { ChangeAddress } from 'features/profile/pages/ChangeAddress/ChangeAddress'
 import { ChangeCity } from 'features/profile/pages/ChangeCity/ChangeCity'
 import { ChangeEmail } from 'features/profile/pages/ChangeEmail/ChangeEmail'
 import { ChangeEmailSetPassword } from 'features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword'
@@ -140,6 +141,11 @@ const profileScreens: ProfileRouteConfig[] = [
     name: 'ChangeCity',
     component: withAuthProtection(ChangeCity),
     options: { title: 'Ton code postal | Profil' },
+  },
+  {
+    name: 'ChangeAddress',
+    component: withAuthProtection(ChangeAddress),
+    options: { title: 'Ton adresse | Profil' },
   },
   {
     name: 'ChangeEmail',

--- a/src/features/navigation/ProfileStackNavigator/ProfileStackTypes.ts
+++ b/src/features/navigation/ProfileStackNavigator/ProfileStackTypes.ts
@@ -1,6 +1,7 @@
 import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
 import { AccessibilityRootStackParamList } from 'features/navigation/RootNavigator/types'
-export interface PersonalDataType {
+
+interface PersonalDataType {
   type: PersonalDataTypes.PROFIL_PERSONAL_DATA | PersonalDataTypes.MANDATORY_UPDATE_PERSONAL_DATA
 }
 

--- a/src/features/navigation/ProfileStackNavigator/ProfileStackTypes.ts
+++ b/src/features/navigation/ProfileStackNavigator/ProfileStackTypes.ts
@@ -1,7 +1,19 @@
+import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
 import { AccessibilityRootStackParamList } from 'features/navigation/RootNavigator/types'
+export interface PersonalDataType {
+  type: PersonalDataTypes.PROFIL_PERSONAL_DATA | PersonalDataTypes.MANDATORY_UPDATE_PERSONAL_DATA
+}
 
 export type ProfileStackParamList = {
-  NotificationsSettings: undefined
+  ChangeAddress: PersonalDataType | undefined
+  ChangeCity: PersonalDataType | undefined
+  ChangeEmail: { showModal: boolean } | undefined
+  ChangePassword: undefined
+  ChangeStatus: PersonalDataType | undefined
+  ConfirmChangeEmail: { token: string; expiration_timestamp: number } | undefined
+  ConfirmDeleteProfile: undefined
+  ConsentSettings: { onGoBack?: () => void } | undefined
+  DeactivateProfileSuccess: undefined
   DebugScreen: undefined
   DeleteProfileAccountHacked: undefined
   DeleteProfileAccountNotDeletable: undefined
@@ -10,23 +22,16 @@ export type ProfileStackParamList = {
   DeleteProfileEmailHacked: undefined
   DeleteProfileReason: undefined
   DeleteProfileSuccess: undefined
-  ConfirmDeleteProfile: undefined
-  DeactivateProfileSuccess: undefined
-  SuspendAccountConfirmationWithoutAuthentication: undefined
-  ChangeStatus: undefined
-  ChangeCity: undefined
-  ChangeEmail: { showModal: boolean } | undefined
-  TrackEmailChange: undefined
-  LegalNotices: undefined
-  PersonalData: undefined
-  ValidateEmailChange: { token: string } | undefined
-  ChangePassword: undefined
-  SuspendAccountConfirmation: { token: string } | undefined
-  FeedbackInApp: undefined
-  ProfileTutorialAgeInformationCredit: undefined
   DisplayPreference: undefined
-  ConsentSettings: { onGoBack?: () => void } | undefined
-  ConfirmChangeEmail: { token: string; expiration_timestamp: number } | undefined
+  FeedbackInApp: undefined
+  LegalNotices: undefined
+  NotificationsSettings: undefined
+  PersonalData: undefined
+  ProfileTutorialAgeInformationCredit: undefined
+  SuspendAccountConfirmation: { token: string } | undefined
+  SuspendAccountConfirmationWithoutAuthentication: undefined
+  TrackEmailChange: undefined
+  ValidateEmailChange: { token: string } | undefined
   ChangeEmailSetPassword:
     | { token: string | null | undefined; emailSelectionToken: string | null | undefined }
     | undefined

--- a/src/features/navigation/ProfileStackNavigator/enums.ts
+++ b/src/features/navigation/ProfileStackNavigator/enums.ts
@@ -1,0 +1,4 @@
+export enum PersonalDataTypes {
+  PROFIL_PERSONAL_DATA = 'profilPersonalData',
+  MANDATORY_UPDATE_PERSONAL_DATA = 'mandatoryUpdatePersonalData',
+}

--- a/src/features/navigation/ProfileStackNavigator/profileStackNavigatorPathConfig.ts
+++ b/src/features/navigation/ProfileStackNavigator/profileStackNavigatorPathConfig.ts
@@ -67,6 +67,9 @@ export const profileStackNavigatorPathConfig = {
       ChangeCity: {
         path: 'profil/modification-ville',
       },
+      ChangeAddress: {
+        path: 'profil/modification-adresse',
+      },
       ChangeEmail: {
         path: 'profil/modification-email',
       },

--- a/src/features/profile/components/CitySearchInput/CitySearchInput.tsx
+++ b/src/features/profile/components/CitySearchInput/CitySearchInput.tsx
@@ -40,7 +40,11 @@ export const CitySearchInput = ({ city, onCitySelected }: CitySearchInputProps) 
   const [postalCodeQuery, setPostalCodeQuery] = useState<string>(city?.postalCode ?? '')
   const [isPostalCodeIneligible, setIsPostalCodeIneligible] = useState(false)
   const debouncedSetPostalCode = useRef(debounce(setPostalCodeQuery, 500)).current
-  const { data: cities = [], isLoading } = useCities(postalCodeQuery, {
+  const {
+    data: cities = [],
+    isLoading,
+    isInitialLoading,
+  } = useCities(postalCodeQuery, {
     onError: () => {
       showErrorSnackBar({
         message:
@@ -153,7 +157,7 @@ export const CitySearchInput = ({ city, onCitySelected }: CitySearchInputProps) 
         </InfoBannerContainer>
       ) : (
         <React.Fragment>
-          {isLoading ? <Spinner /> : null}
+          {isLoading && isInitialLoading ? <Spinner /> : null}
           <CitiesContainer accessibilityRole={AccessibilityRole.RADIOGROUP}>
             <VerticalUl>
               {cities.map((cityOption, index) => (

--- a/src/features/profile/components/CitySearchInput/CitySearchInput.tsx
+++ b/src/features/profile/components/CitySearchInput/CitySearchInput.tsx
@@ -122,7 +122,6 @@ export const CitySearchInput = ({ city, onCitySelected }: CitySearchInputProps) 
           render={({ field: { value, onChange }, fieldState: { error } }) => (
             <StyledView>
               <SearchInput
-                autoFocus
                 onChangeText={(text) => {
                   onChange(text)
                   handlePostalCodeChange(text)

--- a/src/features/profile/components/EditableFiled/EditableField.tsx
+++ b/src/features/profile/components/EditableFiled/EditableField.tsx
@@ -10,6 +10,7 @@ type EditableFieldProps = {
   label: string
   value?: string | null
   navigateTo?: ProfileNavigateParams[0]
+  navigateParams?: ProfileNavigateParams[1]
   onBeforeNavigate?: () => void
   accessibilityLabel?: string
 }
@@ -18,6 +19,7 @@ export function EditableField({
   label,
   value,
   navigateTo,
+  navigateParams,
   onBeforeNavigate,
   accessibilityLabel,
 }: EditableFieldProps) {
@@ -36,7 +38,7 @@ export function EditableField({
         )}
         {showButton ? (
           <EditButton
-            navigateTo={getProfileNavConfig(navigateTo)}
+            navigateTo={getProfileNavConfig(navigateTo, navigateParams)}
             onPress={onBeforeNavigate}
             wording={isCompleted ? 'Modifier' : 'Compléter'}
             accessibilityLabel={accessibilityLabel}

--- a/src/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx
+++ b/src/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx
@@ -1,0 +1,184 @@
+import { FeatureCollection, Point } from 'geojson'
+import React from 'react'
+
+import { navigate, useRoute } from '__mocks__/@react-navigation/native'
+import { SettingsResponse, UserProfileResponse } from 'api/gen'
+import { SettingsWrapper } from 'features/auth/context/SettingsContext'
+import { defaultSettings } from 'features/auth/fixtures/fixtures'
+import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
+import { ChangeAddress } from 'features/profile/pages/ChangeAddress/ChangeAddress'
+import { beneficiaryUser } from 'fixtures/user'
+import { analytics } from 'libs/analytics/provider'
+import { mockedSuggestedPlaces } from 'libs/place/fixtures/mockedSuggestedPlaces'
+import { Properties } from 'libs/place/types'
+import { mockServer } from 'tests/mswServer'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { fireEvent, render, screen, userEvent, waitFor } from 'tests/utils'
+import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
+
+jest.mock('libs/jwt/jwt')
+jest.mock('libs/network/NetInfoWrapper')
+
+const QUERY_ADDRESS = '1 rue Poissonnière'
+
+const mockShowSuccessSnackBar = jest.fn()
+const mockShowErrorSnackBar = jest.fn()
+jest.mock('ui/components/snackBar/SnackBarContext', () => ({
+  useSnackBarContext: () => ({
+    showSuccessSnackBar: mockShowSuccessSnackBar,
+    showErrorSnackBar: mockShowErrorSnackBar,
+  }),
+}))
+
+jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
+  return function createAnimatedComponent(Component: unknown) {
+    return Component
+  }
+})
+
+const user = userEvent.setup()
+jest.useFakeTimers()
+
+describe('<SetAddress/>', () => {
+  beforeEach(() => {
+    mockServer.patchApi<UserProfileResponse>('/v1/profile', beneficiaryUser)
+    mockServer.getApi<SettingsResponse>('/v1/settings', defaultSettings)
+    mockServer.universalGet<FeatureCollection<Point, Properties>>(
+      'https://api-adresse.data.gouv.fr/search',
+      mockedSuggestedPlaces
+    )
+  })
+
+  describe('without previous screen', () => {
+    beforeEach(() => {
+      useRoute.mockReturnValue({ params: { type: undefined } })
+    })
+
+    it('should render correctly', async () => {
+      renderSetAddress()
+      await screen.findByText('Modifier mon adresse')
+      const input = screen.getByTestId('Entrée pour l’adresse')
+      fireEvent.changeText(input, QUERY_ADDRESS)
+
+      expect(screen).toMatchSnapshot()
+    })
+
+    it('should display a list of addresses when user add an address', async () => {
+      renderSetAddress()
+
+      const input = screen.getByTestId('Entrée pour l’adresse')
+      fireEvent.changeText(input, QUERY_ADDRESS)
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(mockedSuggestedPlaces.features[0].properties.name)
+        ).toBeOnTheScreen()
+        expect(
+          screen.getByText(mockedSuggestedPlaces.features[1].properties.name)
+        ).toBeOnTheScreen()
+        expect(
+          screen.getByText(mockedSuggestedPlaces.features[2].properties.name)
+        ).toBeOnTheScreen()
+      })
+    })
+
+    it('should navigate to PersonalData when clicking on "Valider mon adresse"', async () => {
+      renderSetAddress()
+
+      const input = screen.getByTestId('Entrée pour l’adresse')
+      fireEvent.changeText(input, QUERY_ADDRESS)
+
+      await user.press(await screen.findByText(mockedSuggestedPlaces.features[1].properties.name))
+      await user.press(screen.getByText('Valider mon adresse'))
+
+      expect(navigate).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
+        params: undefined,
+        screen: 'PersonalData',
+      })
+    })
+
+    it('should show snackbar on success when clicking on "Valider mon adresse"', async () => {
+      renderSetAddress()
+
+      const input = screen.getByTestId('Entrée pour l’adresse')
+      fireEvent.changeText(input, QUERY_ADDRESS)
+
+      await user.press(await screen.findByText(mockedSuggestedPlaces.features[1].properties.name))
+      await user.press(screen.getByText('Valider mon adresse'))
+
+      expect(mockShowSuccessSnackBar).toHaveBeenCalledWith({
+        message: 'Ton adresse de résidence a bien été modifiée\u00a0!',
+        timeout: SNACK_BAR_TIME_OUT,
+      })
+    })
+
+    it('should send analytics when success', async () => {
+      renderSetAddress()
+
+      const input = screen.getByTestId('Entrée pour l’adresse')
+      fireEvent.changeText(input, QUERY_ADDRESS)
+
+      await user.press(await screen.findByText(mockedSuggestedPlaces.features[1].properties.name))
+      await user.press(screen.getByText('Valider mon adresse'))
+
+      expect(analytics.logUpdateAddress).toHaveBeenCalledWith({
+        newAddress: mockedSuggestedPlaces.features[1].properties.name,
+        oldAddress: '',
+      })
+    })
+  })
+
+  describe('from mandatory udpate personal data screen', () => {
+    beforeEach(() => {
+      useRoute.mockReturnValue({
+        params: { type: PersonalDataTypes.MANDATORY_UPDATE_PERSONAL_DATA },
+      })
+    })
+
+    it('should render correctly', async () => {
+      renderSetAddress()
+      await screen.findByText('Modifier mon adresse')
+      const input = screen.getByTestId('Entrée pour l’adresse')
+      fireEvent.changeText(input, QUERY_ADDRESS)
+
+      expect(screen).toMatchSnapshot()
+    })
+
+    it('should not show snackbar on success when clicking on "Continuer"', async () => {
+      renderSetAddress()
+
+      const input = screen.getByTestId('Entrée pour l’adresse')
+      fireEvent.changeText(input, QUERY_ADDRESS)
+
+      await user.press(await screen.findByText(mockedSuggestedPlaces.features[1].properties.name))
+      await user.press(screen.getByText('Continuer'))
+
+      expect(mockShowSuccessSnackBar).not.toHaveBeenCalled()
+    })
+
+    it('should navigate to ChangeStatus when clicking on "Continuer"', async () => {
+      renderSetAddress()
+
+      const input = screen.getByTestId('Entrée pour l’adresse')
+      fireEvent.changeText(input, QUERY_ADDRESS)
+
+      await user.press(await screen.findByText(mockedSuggestedPlaces.features[1].properties.name))
+      await user.press(screen.getByText('Continuer'))
+
+      expect(navigate).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
+        params: { type: PersonalDataTypes.MANDATORY_UPDATE_PERSONAL_DATA },
+        screen: 'ChangeStatus',
+      })
+    })
+  })
+})
+
+const renderSetAddress = () => {
+  return render(
+    reactQueryProviderHOC(
+      <SettingsWrapper>
+        <ChangeAddress />
+      </SettingsWrapper>
+    )
+  )
+}

--- a/src/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx
+++ b/src/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx
@@ -2,6 +2,7 @@ import { FeatureCollection, Point } from 'geojson'
 import React from 'react'
 
 import { navigate, useRoute } from '__mocks__/@react-navigation/native'
+import * as API from 'api/api'
 import { SettingsResponse, UserProfileResponse } from 'api/gen'
 import { SettingsWrapper } from 'features/auth/context/SettingsContext'
 import { defaultSettings } from 'features/auth/fixtures/fixtures'
@@ -18,6 +19,8 @@ import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 
 jest.mock('libs/jwt/jwt')
 jest.mock('libs/network/NetInfoWrapper')
+
+const patchProfileSpy = jest.spyOn(API.api, 'patchNativeV1Profile')
 
 const QUERY_ADDRESS = '1 rue Poissonnière'
 
@@ -79,6 +82,20 @@ describe('<SetAddress/>', () => {
         expect(
           screen.getByText(mockedSuggestedPlaces.features[2].properties.name)
         ).toBeOnTheScreen()
+      })
+    })
+
+    it('should update profile when clicking on "Valider mon adresse"', async () => {
+      renderSetAddress()
+
+      const input = screen.getByTestId('Entrée pour l’adresse')
+      fireEvent.changeText(input, QUERY_ADDRESS)
+
+      await user.press(await screen.findByText(mockedSuggestedPlaces.features[1].properties.name))
+      await user.press(screen.getByText('Valider mon adresse'))
+
+      expect(patchProfileSpy).toHaveBeenNthCalledWith(1, {
+        address: mockedSuggestedPlaces.features[1].properties.name,
       })
     })
 

--- a/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
+++ b/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
@@ -50,7 +50,6 @@ export const ChangeAddress = () => {
                 name="address"
                 render={({ field: { value, onChange } }) => (
                   <SearchInput
-                    autoFocus
                     onChangeText={(text) => {
                       onChangeAddress(text)
                       onChange(text)

--- a/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
+++ b/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import { Controller } from 'react-hook-form'
+import { Platform } from 'react-native'
+import styled from 'styled-components/native'
+import { v4 as uuidv4 } from 'uuid'
+
+import { AddressOption } from 'features/identityCheck/components/AddressOption'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { Form } from 'ui/components/Form'
+import { InputError } from 'ui/components/inputs/InputError'
+import { SearchInput } from 'ui/components/inputs/SearchInput'
+import { Spinner } from 'ui/components/Spinner'
+import { PageWithHeader } from 'ui/pages/PageWithHeader'
+import { Typo, getSpacing } from 'ui/theme'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+
+import { useSubmitChangeAddress } from './useSubmitChangeAddress'
+
+export const ChangeAddress = () => {
+  const {
+    control,
+    handleSubmit,
+    onSubmit,
+    isValid,
+    label,
+    onChangeAddress,
+    resetSearch,
+    addresses,
+    isLoading,
+    shouldShowAddressResults,
+    onAddressSelection,
+    selectedAddress,
+    hasError,
+    buttonWording,
+  } = useSubmitChangeAddress()
+
+  const addressInputErrorId = uuidv4()
+
+  return (
+    <PageWithHeader
+      title="Modifier mon adresse"
+      scrollChildren={
+        <React.Fragment>
+          <Form.MaxWidth>
+            <Typo.Title3 {...getHeadingAttrs(2)}>Renseigne ton adresse</Typo.Title3>
+            <Container>
+              <Controller
+                control={control}
+                name="address"
+                render={({ field: { value, onChange } }) => (
+                  <SearchInput
+                    autoFocus
+                    onChangeText={(text) => {
+                      onChangeAddress(text)
+                      onChange(text)
+                    }}
+                    value={value}
+                    label={label}
+                    format="34 avenue de l’Opéra"
+                    autoComplete="street-address"
+                    textContentType="fullStreetAddress"
+                    accessibilityDescribedBy={addressInputErrorId}
+                    onPressRightIcon={resetSearch}
+                    returnKeyType="next"
+                    testID="Entrée pour l’adresse"
+                    searchInputID="street-address-input"
+                  />
+                )}
+              />
+              <InputError
+                visible={hasError}
+                messageId="Ton adresse ne doit pas contenir de caractères spéciaux ou n’être composée que d’espaces."
+                numberOfSpacesTop={2}
+                relatedInputId={addressInputErrorId}
+              />
+            </Container>
+          </Form.MaxWidth>
+          {shouldShowAddressResults ? (
+            <React.Fragment>
+              {isLoading ? <Spinner /> : null}
+              <AdressesContainer accessibilityRole={AccessibilityRole.RADIOGROUP}>
+                {addresses.map((address, index) => (
+                  <AddressOption
+                    label={address}
+                    selected={address === selectedAddress}
+                    onPressOption={onAddressSelection}
+                    optionKey={address}
+                    key={address}
+                    accessibilityLabel={`Proposition d’adresse ${index + 1}\u00a0: ${address}`}
+                  />
+                ))}
+              </AdressesContainer>
+            </React.Fragment>
+          ) : null}
+        </React.Fragment>
+      }
+      fixedBottomChildren={
+        <ButtonPrimary
+          type="submit"
+          onPress={handleSubmit(onSubmit)}
+          wording={buttonWording}
+          disabled={!isValid}
+        />
+      }
+    />
+  )
+}
+
+const AdressesContainer = styled.View({
+  flexGrow: 1,
+  overflowY: 'scroll',
+  ...(Platform.OS === 'web' ? { boxSizing: 'content-box' } : {}),
+})
+
+const Container = styled.View({
+  marginTop: getSpacing(5),
+  marginBottom: getSpacing(2),
+})

--- a/src/features/profile/pages/ChangeAddress/useSubmitChangeAddress.ts
+++ b/src/features/profile/pages/ChangeAddress/useSubmitChangeAddress.ts
@@ -1,0 +1,159 @@
+import { useNavigation, useRoute } from '@react-navigation/native'
+import { debounce } from 'lodash'
+import { useEffect, useRef, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { Keyboard } from 'react-native'
+
+import { useAuthContext } from 'features/auth/context/AuthContext'
+import { useSettingsContext } from 'features/auth/context/SettingsContext'
+import { IdentityCheckError } from 'features/identityCheck/pages/profile/errors'
+import { addressActions, useAddress } from 'features/identityCheck/pages/profile/store/addressStore'
+import { useCity } from 'features/identityCheck/pages/profile/store/cityStore'
+import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
+import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
+import { analytics } from 'libs/analytics/provider'
+import { eventMonitoring } from 'libs/monitoring/services'
+import { useAddresses } from 'libs/place/useAddresses'
+import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation'
+import { isAddressValid } from 'ui/components/inputs/addressCheck'
+import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
+import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
+
+const snackbarMessage =
+  'Nous avons eu un problème pour trouver l’adresse associée à ton code postal. Réessaie plus tard.'
+const exception = 'Failed to fetch data from API: https://api-adresse.data.gouv.fr/search'
+
+type AddressForm = {
+  address: string
+}
+
+export const useSubmitChangeAddress = () => {
+  const { params } = useRoute<UseRouteType<'ChangeAddress'>>()
+  const type = params?.type
+  const isMandatoryUpdatePersonalData = type === PersonalDataTypes.MANDATORY_UPDATE_PERSONAL_DATA
+  const buttonWording = isMandatoryUpdatePersonalData ? 'Continuer' : 'Valider mon adresse'
+
+  const { user } = useAuthContext()
+  const { data: settings } = useSettingsContext()
+  const { showErrorSnackBar, showSuccessSnackBar } = useSnackBarContext()
+  const { setAddress: setStoreAddress } = addressActions
+  const storedCity = useCity()
+  const storedAddress = useAddress()
+  const { navigate } = useNavigation<UseNavigationType>()
+
+  const {
+    control,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { isValid },
+  } = useForm<AddressForm>({
+    mode: 'onChange',
+    defaultValues: { address: storedAddress ?? user?.street ?? '' },
+  })
+
+  const query = watch('address')
+  const [selectedAddress, setSelectedAddress] = useState<string | null>(null)
+
+  const debouncedSetQuery = useRef(
+    debounce((value: string) => setDebouncedQuery(value), 500)
+  ).current
+  const [debouncedQuery, setDebouncedQuery] = useState(query)
+
+  const idCheckAddressAutocompletion = !!settings?.idCheckAddressAutocompletion
+  const shouldShowAddressResults = idCheckAddressAutocompletion && debouncedQuery.length > 0
+
+  const {
+    data: addresses = [],
+    isLoading,
+    isError,
+  } = useAddresses({
+    query: debouncedQuery,
+    cityCode: storedCity?.code ?? '',
+    postalCode: storedCity?.postalCode ?? '',
+    enabled: shouldShowAddressResults,
+    limit: 10,
+  })
+
+  useEffect(() => {
+    if (isError) {
+      showErrorSnackBar({ message: snackbarMessage, timeout: SNACK_BAR_TIME_OUT })
+      eventMonitoring.captureException(new IdentityCheckError(exception))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isError])
+
+  const onChangeAddress = (value: string) => {
+    setSelectedAddress(null)
+    setValue('address', value)
+    debouncedSetQuery(value)
+  }
+
+  const onAddressSelection = (address: string) => {
+    setSelectedAddress(address)
+    setValue('address', address)
+    Keyboard.dismiss()
+  }
+
+  const resetSearch = () => {
+    setSelectedAddress(null)
+    setValue('address', '')
+    debouncedSetQuery('')
+  }
+
+  const { mutate: patchProfile } = usePatchProfileMutation({
+    onSuccess: (_, variables) => {
+      if (isMandatoryUpdatePersonalData) {
+        navigate(...getProfileStackConfig('ChangeStatus', { type }))
+      } else {
+        navigate(...getProfileStackConfig('PersonalData'))
+        showSuccessSnackBar({
+          message: 'Ton adresse de résidence a bien été modifiée\u00a0!',
+          timeout: SNACK_BAR_TIME_OUT,
+        })
+      }
+      analytics.logUpdateAddress({
+        newAddress: variables.address ?? '',
+        oldAddress: user?.street ?? '',
+      })
+    },
+    onError: () => {
+      showErrorSnackBar({
+        message: 'Une erreur est survenue',
+        timeout: SNACK_BAR_TIME_OUT,
+      })
+    },
+  })
+
+  const onSubmit = ({ address }: AddressForm) => {
+    const finalAddress = selectedAddress ?? address
+    setStoreAddress(finalAddress)
+    patchProfile({ address: finalAddress })
+  }
+
+  useEnterKeyAction(isValid ? handleSubmit(onSubmit) : undefined)
+
+  const isValidAddress = isAddressValid(query)
+  const label = idCheckAddressAutocompletion
+    ? 'Recherche et sélectionne ton adresse'
+    : 'Entre ton adresse'
+  const hasError = !isValidAddress && query.length > 0
+
+  return {
+    control,
+    handleSubmit,
+    onSubmit,
+    isValid,
+    label,
+    onChangeAddress,
+    resetSearch,
+    addresses,
+    isLoading,
+    shouldShowAddressResults,
+    onAddressSelection,
+    selectedAddress,
+    hasError,
+    buttonWording,
+  }
+}

--- a/src/features/profile/pages/ChangeCity/ChangeCity.tsx
+++ b/src/features/profile/pages/ChangeCity/ChangeCity.tsx
@@ -1,64 +1,18 @@
-import { yupResolver } from '@hookform/resolvers/yup'
-import { useNavigation } from '@react-navigation/native'
 import React from 'react'
-import { Controller, useForm } from 'react-hook-form'
+import { Controller } from 'react-hook-form'
 import styled from 'styled-components/native'
 
-import { useAuthContext } from 'features/auth/context/AuthContext'
-import { CityForm, cityResolver } from 'features/identityCheck/pages/profile/SetCity'
-import { cityActions, useCity } from 'features/identityCheck/pages/profile/store/cityStore'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
-import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { CitySearchInput } from 'features/profile/components/CitySearchInput/CitySearchInput'
-import { analytics } from 'libs/analytics/provider'
-import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
-import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo, getSpacing } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
-export const ChangeCity = () => {
-  const { user } = useAuthContext()
-  const { navigate } = useNavigation<UseNavigationType>()
-  const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()
-  const storedCity = useCity()
-  const { setCity } = cityActions
-  const {
-    control,
-    formState: { isValid },
-    handleSubmit,
-  } = useForm<CityForm>({
-    mode: 'onChange',
-    resolver: yupResolver(cityResolver),
-    defaultValues: { city: storedCity ?? undefined },
-  })
-  const { mutate: patchProfile } = usePatchProfileMutation({
-    onSuccess: (_, variables) => {
-      analytics.logUpdatePostalCode({
-        newCity: variables.city ?? '',
-        oldCity: user?.city ?? '',
-        newPostalCode: variables.postalCode ?? '',
-        oldPostalCode: user?.postalCode ?? '',
-      })
-      showSuccessSnackBar({
-        message: 'Ta ville de résidence a bien été modifiée\u00a0!',
-        timeout: SNACK_BAR_TIME_OUT,
-      })
-    },
-    onError: () => {
-      showErrorSnackBar({
-        message: 'Une erreur est survenue',
-        timeout: SNACK_BAR_TIME_OUT,
-      })
-    },
-  })
+import { useSubmitChangeCity } from './useSubmitChangeCity'
 
-  const onSubmit = ({ city }: CityForm) => {
-    setCity(city)
-    patchProfile({ city: city.name, postalCode: city.postalCode })
-    navigate(...getProfileStackConfig('PersonalData'))
-  }
+export const ChangeCity = () => {
+  const { control, handleSubmit, onSubmit, isValid, buttonWording, isLoading } =
+    useSubmitChangeCity()
 
   return (
     <PageWithHeader
@@ -66,7 +20,7 @@ export const ChangeCity = () => {
       scrollChildren={
         <React.Fragment>
           <Container>
-            <Typo.Title3 {...getHeadingAttrs(1)}>Renseigne ta ville de résidence</Typo.Title3>
+            <Typo.Title3 {...getHeadingAttrs(2)}>Renseigne ta ville de résidence</Typo.Title3>
           </Container>
           <Controller
             control={control}
@@ -81,12 +35,15 @@ export const ChangeCity = () => {
         <ButtonPrimary
           type="submit"
           onPress={handleSubmit(onSubmit)}
-          wording="Valider ma ville de résidence"
+          wording={buttonWording}
           disabled={!isValid}
+          isLoading={isLoading}
         />
       }
     />
   )
 }
 
-const Container = styled.View({ marginBottom: getSpacing(5) })
+const Container = styled.View({
+  marginBottom: getSpacing(5),
+})

--- a/src/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx
+++ b/src/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { ChangeCity } from 'features/profile/pages/ChangeCity/ChangeCity'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, checkAccessibilityFor, render, screen, waitFor } from 'tests/utils/web'
+import { act, checkAccessibilityFor, render } from 'tests/utils/web'
 
 jest.mock('uuid', () => ({
   v1: jest.fn(),
@@ -23,10 +23,6 @@ describe('ChangeCity', () => {
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = await renderAccessibility()
-
-      await waitFor(() => {
-        expect(screen.getByTestId('Entrée pour la ville')).toHaveFocus()
-      })
 
       const results = await checkAccessibilityFor(container)
 

--- a/src/features/profile/pages/ChangeCity/useSubmitChangeCity.ts
+++ b/src/features/profile/pages/ChangeCity/useSubmitChangeCity.ts
@@ -1,0 +1,86 @@
+import { yupResolver } from '@hookform/resolvers/yup'
+import { useNavigation, useRoute } from '@react-navigation/native'
+import { useForm } from 'react-hook-form'
+
+import { useAuthContext } from 'features/auth/context/AuthContext'
+import { CityForm, cityResolver } from 'features/identityCheck/pages/profile/SetCity'
+import { cityActions, useCity } from 'features/identityCheck/pages/profile/store/cityStore'
+import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
+import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
+import { analytics } from 'libs/analytics/provider'
+import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation'
+import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
+
+export const useSubmitChangeCity = () => {
+  const { user } = useAuthContext()
+  const userCity = {
+    name: user?.city ?? undefined,
+    postalCode: user?.postalCode ?? undefined,
+    code: undefined,
+  }
+
+  const storedCity = useCity()
+  const { setCity } = cityActions
+
+  const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()
+  const { navigate } = useNavigation<UseNavigationType>()
+  const { params } = useRoute<UseRouteType<'ChangeCity'>>()
+  const type = params?.type
+
+  const isFromProfileUpdateFlow =
+    type === PersonalDataTypes.PROFIL_PERSONAL_DATA ||
+    type === PersonalDataTypes.MANDATORY_UPDATE_PERSONAL_DATA
+
+  const {
+    control,
+    formState: { isValid },
+    handleSubmit,
+  } = useForm<CityForm>({
+    mode: 'onChange',
+    resolver: yupResolver(cityResolver),
+    defaultValues: { city: storedCity ?? userCity },
+  })
+
+  const { mutate: patchProfile, isLoading } = usePatchProfileMutation({
+    onSuccess: (_, variables) => {
+      if (isFromProfileUpdateFlow) {
+        navigate(...getProfileStackConfig('ChangeAddress', { type }))
+      } else {
+        navigate(...getProfileStackConfig('PersonalData'))
+        showSuccessSnackBar({
+          message: 'Ta ville de résidence a bien été modifiée\u00a0!',
+          timeout: SNACK_BAR_TIME_OUT,
+        })
+      }
+      analytics.logUpdatePostalCode({
+        newCity: variables.city ?? '',
+        oldCity: user?.city ?? '',
+        newPostalCode: variables.postalCode ?? '',
+        oldPostalCode: user?.postalCode ?? '',
+      })
+    },
+    onError: () => {
+      showErrorSnackBar({
+        message: 'Une erreur est survenue',
+        timeout: SNACK_BAR_TIME_OUT,
+      })
+    },
+  })
+
+  const onSubmit = ({ city }: CityForm) => {
+    setCity(city)
+    patchProfile({ city: city.name, postalCode: city.postalCode })
+  }
+
+  const buttonWording = isFromProfileUpdateFlow ? 'Continuer' : 'Valider ma ville de résidence'
+
+  return {
+    control,
+    isValid,
+    handleSubmit,
+    onSubmit,
+    buttonWording,
+    isLoading,
+  }
+}

--- a/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
@@ -4,6 +4,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { UpdateEmailTokenExpiration, UserProfileResponse } from 'api/gen'
 import * as Auth from 'features/auth/context/AuthContext'
 import * as OpenUrlAPI from 'features/navigation/helpers/openUrl'
+import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
 import { beneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/fixtures'
@@ -34,6 +35,7 @@ const mockedUser: UserProfileResponse = {
   lastName: 'Bonheur',
   email: 'rosa.bonheur@gmail.com',
   phoneNumber: '+33685974563',
+  street: '10 rue de Bohneur',
 }
 
 const initialAuthContext = {
@@ -113,10 +115,10 @@ describe('PersonalData', () => {
 
     render(reactQueryProviderHOC(<PersonalData />))
 
-    await user.press(screen.getByTestId('Modifier la ville de résidence'))
+    await user.press(screen.getByTestId('Modifier mon adresse de résidence'))
 
     expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
-      params: undefined,
+      params: { type: PersonalDataTypes.PROFIL_PERSONAL_DATA },
       screen: 'ChangeCity',
     })
   })
@@ -159,28 +161,5 @@ describe('PersonalData', () => {
     await user.press(screen.getByTestId('Modifier e-mail'))
 
     expect(analytics.logModifyMail).toHaveBeenCalledTimes(1)
-  })
-
-  //TODO(PC-36587): unskip this test
-  it.skip('should not show password field when user has no password', async () => {
-    mockedUseAuthContext
-      .mockReturnValueOnce({
-        ...initialAuthContext,
-        user: {
-          ...mockedUser,
-          hasPassword: false,
-        },
-      })
-      .mockReturnValueOnce({
-        ...initialAuthContext,
-        user: {
-          ...mockedUser,
-          hasPassword: false,
-        },
-      })
-    render(reactQueryProviderHOC(<PersonalData />))
-    await screen.findByText('Adresse e-mail')
-
-    expect(screen.queryByText('Mot de passe')).not.toBeOnTheScreen()
   })
 })

--- a/src/features/profile/pages/PersonalData/PersonalData.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { getActivityLabel } from 'features/identityCheck/helpers/getActivityLabel'
+import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
 import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
 import { ProfileNavigateParams } from 'features/navigation/RootNavigator/types'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
@@ -33,7 +34,10 @@ export function PersonalData() {
 
   const fullname = String(user?.firstName + ' ' + user?.lastName).trim()
   const hasCity = user?.postalCode && user?.city
-  const city = hasCity && user?.postalCode && user?.city ? `${user.postalCode}, ${user.city}` : ''
+  const city =
+    hasCity && user?.postalCode && user?.city && user?.street
+      ? `${user.street}, ${user.postalCode}, ${user.city}`
+      : ''
 
   const { hasCurrentEmailChange } = useCheckHasCurrentEmailChange()
 
@@ -71,10 +75,11 @@ export function PersonalData() {
       />
       <StyledSeparator />
       <EditableField
-        label="Ville de résidence"
+        label="Adresse de résidence"
         value={city}
         navigateTo="ChangeCity"
-        accessibilityLabel="Modifier la ville de résidence"
+        navigateParams={{ type: PersonalDataTypes.PROFIL_PERSONAL_DATA }}
+        accessibilityLabel="Modifier mon adresse de résidence"
       />
       <StyledSeparator />
       <ViewGap gap={8}>

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -190,6 +190,7 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logTrendsBlockClicked: jest.fn(),
   logTrySelectDeposit: jest.fn(),
   logUpdatePostalCode: jest.fn(),
+  logUpdateAddress: jest.fn(),
   logUpdateStatus: jest.fn(),
   logUserSetLocation: jest.fn(),
   logUserSetVenue: jest.fn(),

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -692,6 +692,8 @@ export const logEventAnalytics = {
   }) => analytics.logEvent({ firebase: AnalyticsEvent.TRENDS_BLOCK_CLICKED }, params),
   logTrySelectDeposit: (age: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.TRY_SELECT_DEPOSIT }, { age }),
+  logUpdateAddress: (params: { newAddress: string; oldAddress: string }) =>
+    analytics.logEvent({ firebase: AnalyticsEvent.UPDATE_ADDRESS }, params),
   logUpdatePostalCode: (params: {
     oldCity: string
     oldPostalCode: string

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -177,6 +177,7 @@ export enum AnalyticsEvent {
   TRENDS_BLOCK_CLICKED = 'TrendsBlockClicked',
   TRY_SELECT_DEPOSIT = 'TrySelectDeposit',
   UPDATE_POSTAL_CODE = 'UpdatePostalCode',
+  UPDATE_ADDRESS = 'UpdateAddress',
   UPDATE_STATUS = 'UpdateStatus',
   USE_FILTER = 'UseFilter',
   USER_SET_LOCATION = 'UserSetLocation',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36308

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
