### PR TITLE
(PC-36961) fix(app): use isInitialLoading instead of isLoading

### DIFF
--- a/src/cheatcodes/queries/useCheatcodesFeatureFlagQuery.ts
+++ b/src/cheatcodes/queries/useCheatcodesFeatureFlagQuery.ts
@@ -27,7 +27,7 @@ export const useCheatcodesFeatureFlagQuery = () => {
   const appBuildVersion = getAppBuildVersion()
   const {
     data: docSnapshot,
-    isLoading,
+    isInitialLoading: isLoading,
     error,
   } = useQuery(['FEATURE_FLAGS'], getAllFeatureFlags, {
     staleTime: 1000 * 30,

--- a/src/features/auth/context/SettingsContext.tsx
+++ b/src/features/auth/context/SettingsContext.tsx
@@ -25,7 +25,7 @@ export const SettingsWrapper = memo(function SettingsWrapper({
 }: {
   children: React.JSX.Element
 }) {
-  const { data, isLoading } = useAppSettings()
+  const { data, isInitialLoading: isLoading } = useAppSettings()
 
   const value = useMemo(() => ({ data, isLoading }), [data, isLoading])
 

--- a/src/features/favorites/hooks/useFavorite.ts
+++ b/src/features/favorites/hooks/useFavorite.ts
@@ -7,7 +7,7 @@ export const useFavorite = ({
 }: {
   offerId?: number
 }): FavoriteResponse | undefined | null => {
-  const { data, isLoading } = useFavoritesQuery()
+  const { data, isInitialLoading: isLoading } = useFavoritesQuery()
   if (isLoading) return undefined
   const favorites = data?.favorites ?? []
   return favorites.find((favorite) => favorite.offer.id === offerId) ?? null

--- a/src/features/forceUpdate/helpers/useMinimalBuildNumber.ts
+++ b/src/features/forceUpdate/helpers/useMinimalBuildNumber.ts
@@ -6,7 +6,7 @@ import { QueryKeys } from 'libs/queryKeys'
 export const useMinimalBuildNumber = () => {
   const {
     data: minimalBuildNumber,
-    isLoading,
+    isInitialLoading: isLoading,
     error,
   } = useQuery([QueryKeys.MINIMAL_BUILD_NUMBER], getMinimalBuildNumber, {
     staleTime: 1000 * 30,

--- a/src/features/search/pages/ThematicSearch/api/useThematicSearchPlaylists.ts
+++ b/src/features/search/pages/ThematicSearch/api/useThematicSearchPlaylists.ts
@@ -27,7 +27,11 @@ export function useThematicSearchPlaylists({
   const transformHits = useTransformOfferHits()
 
   const { userLocation } = useLocation()
-  const { data, refetch, isLoading } = useQuery({
+  const {
+    data,
+    refetch,
+    isInitialLoading: isLoading,
+  } = useQuery({
     queryKey: [queryKey],
     queryFn: async (): Promise<SearchResponse<Offer>[]> => {
       return fetchMethod(userLocation)

--- a/src/libs/firebase/firestore/featureFlags/useFeatureFlagOptions.ts
+++ b/src/libs/firebase/firestore/featureFlags/useFeatureFlagOptions.ts
@@ -20,10 +20,14 @@ export type FeatureFlagOptions = {
 // firestore feature flag documentation:
 // https://www.notion.so/passcultureapp/Feature-Flag-e7b0da7946f64020b8403e3581b4ed42#fff5fb17737240c9996c432117acacd8
 export const useFeatureFlagOptions = (featureFlag: RemoteStoreFeatureFlags): FeatureFlagOptions => {
-  const { data: docSnapshot, isLoading } = useQuery([QueryKeys.FEATURE_FLAGS], getAllFeatureFlags, {
-    staleTime: 1000 * 60 * 60 * 24, // 24h (re-renders whole app because of usage of feature flag in the ThemeWrapper)
-    enabled: onlineManager.isOnline(),
-  })
+  const { data: docSnapshot, isInitialLoading: isLoading } = useQuery(
+    [QueryKeys.FEATURE_FLAGS],
+    getAllFeatureFlags,
+    {
+      staleTime: 1000 * 60 * 60 * 24, // 24h (re-renders whole app because of usage of feature flag in the ThemeWrapper)
+      enabled: onlineManager.isOnline(),
+    }
+  )
   const { logType } = useLogTypeFromRemoteConfig()
 
   if (isLoading || !docSnapshot) return { isFeatureFlagActive: false }

--- a/src/libs/react-query/usePersistQuery.ts
+++ b/src/libs/react-query/usePersistQuery.ts
@@ -33,12 +33,12 @@ function useSetPersistQuery<TData, TError, TQueryKey>(
   queryKey: TQueryKey
 ) {
   useEffect(() => {
-    if (!query.isLoading && query.data) {
+    if (!query.isInitialLoading && query.data) {
       AsyncStorage.setItem(String(queryKey), JSON.stringify(query.data)).catch((error) => {
         eventMonitoring.captureException(error, { extra: { queryKey, data: query.data } })
       })
     }
-  }, [query.data, query.isLoading, queryKey])
+  }, [query.data, query.isInitialLoading, queryKey])
 }
 
 type UsePersistQueryResult<TData, TError> = UseQueryResult<TData, TError> & {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36961

### ⚖️ Comparatif `isLoading` et `isInitialLoading` (React Query v3 vs v4 vs v5)

| ⚙️ Version | 🏷️ Propriété        | 📖 Description                                                                                     |
|-----------|---------------------|-----------------------------------------------------------------------------------------------------|
| v3        | `isLoading`         | Vrai lors du tout premier chargement, quand `status === 'loading'`                            |
| v3        | `isFetching`        | Vrai à chaque fetch en cours, y compris lors d’un refetch avec cache                        |
| v3        | *(Pas de `isInitialLoading`)* | -                                                                                      |
| v4        | `isLoading`         | Toujours dérivé de `status === 'loading'` |
| v4        | `isFetching`        | Identique à v3                      |
| v4        | `isInitialLoading`  | Vrai uniquement lors du tout premier fetch, équivaut à `isLoading && isFetching`               |
| v5        | `isLoading`          | Vrai pendant le **premier fetch**, équivaut à `isFetching && isPending`                          |
| v5        | `isFetching`         | Alias de `isLoading`, basé sur `fetchStatus`    |
| v5        | `isPending`          | Nouveau. Dérivé de `status === 'pending'`. Utile pour gérer l’état "aucun résultat encore"    |
| v5        | `isInitialLoading`   | ⚠️ **Déprécié.** Remplacé par `isLoading`                                           |