### PR TITLE
(PC-36997) fix(activation): fix useNavigateForwardToStepper

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2494,10 +2494,10 @@ SPEC CHECKSUMS:
   Base64: cecfb41a004124895a7bcee567a89bae5a89d49b
   Batch: 5910c05091914c3ca415ca8793e5ce6fcc36cfee
   BatchFirebaseDispatcher: 1711b32884f4b6b3513553beab4c766056794ae1
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
+  boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
   CodePush: d892f13c5012e9e2cb36640f4929654b7be21fe5
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 7605ea4810e0e10ae4815292433c09bf4324ba45
   Firebase: 3435bc66b4d494c2f22c79fd3aae4c1db6662327
@@ -2521,7 +2521,7 @@ SPEC CHECKSUMS:
   FirebaseSessions: eaa8ec037e7793769defe4201c20bd4d976f9677
   FirebaseSharedSwift: aca73668bc95e8efccb618e0167eab05d19d3a75
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
   GoogleAppMeasurement: 0dfca1a4b534d123de3945e28f77869d10d0d600
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db

--- a/src/features/identityCheck/helpers/useNavigateForwardToStepper.ts
+++ b/src/features/identityCheck/helpers/useNavigateForwardToStepper.ts
@@ -17,7 +17,15 @@ export const useNavigateForwardToStepper = () => {
     dispatch(
       CommonActions.reset({
         index: 1,
-        routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }],
+        routes: [
+          { name: 'TabNavigator' },
+          {
+            name: 'SubscriptionStackNavigator',
+            state: {
+              routes: [{ name: 'Stepper' }],
+            },
+          },
+        ],
       })
     )
 

--- a/src/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx
@@ -43,7 +43,22 @@ describe('<EduConnectValidation />', () => {
     await user.press(validateButton)
 
     expect(dispatch).toHaveBeenCalledWith({
-      payload: { index: 1, routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }] },
+      payload: {
+        index: 1,
+        routes: [
+          { name: 'TabNavigator' },
+          {
+            name: 'SubscriptionStackNavigator',
+            state: {
+              routes: [
+                {
+                  name: 'Stepper',
+                },
+              ],
+            },
+          },
+        ],
+      },
       type: 'RESET',
     })
   })

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx
@@ -103,7 +103,22 @@ describe('SetPhoneNumberWithoutValidation', () => {
 
         await act(() => {
           expect(dispatch).toHaveBeenCalledWith({
-            payload: { index: 1, routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }] },
+            payload: {
+              index: 1,
+              routes: [
+                { name: 'TabNavigator' },
+                {
+                  name: 'SubscriptionStackNavigator',
+                  state: {
+                    routes: [
+                      {
+                        name: 'Stepper',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
             type: 'RESET',
           })
         })

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx
@@ -159,7 +159,22 @@ describe('SetPhoneValidationCode', () => {
     await user.press(screen.getByTestId('Continuer'))
 
     expect(dispatch).toHaveBeenCalledWith({
-      payload: { index: 1, routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }] },
+      payload: {
+        index: 1,
+        routes: [
+          { name: 'TabNavigator' },
+          {
+            name: 'SubscriptionStackNavigator',
+            state: {
+              routes: [
+                {
+                  name: 'Stepper',
+                },
+              ],
+            },
+          },
+        ],
+      },
       type: 'RESET',
     })
   })

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -66,6 +66,7 @@ export const SetAddress = () => {
   const {
     data: addresses = [],
     isLoading,
+    isInitialLoading,
     isError,
   } = useAddresses({
     query: debouncedQuery,
@@ -148,7 +149,7 @@ export const SetAddress = () => {
               />
             </Container>
           </Form.MaxWidth>
-          {isLoading ? <Spinner /> : null}
+          {isLoading && isInitialLoading ? <Spinner /> : null}
           <AdressesContainer accessibilityRole={AccessibilityRole.RADIOGROUP}>
             {addresses.map((address, index) => (
               <AddressOption

--- a/src/features/identityCheck/pages/profile/SetStatus.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/SetStatus.native.test.tsx
@@ -159,7 +159,22 @@ describe('<SetStatus/>', () => {
     await user.press(screen.getByText('Continuer'))
 
     expect(dispatch).toHaveBeenCalledWith({
-      payload: { index: 1, routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }] },
+      payload: {
+        index: 1,
+        routes: [
+          { name: 'TabNavigator' },
+          {
+            name: 'SubscriptionStackNavigator',
+            state: {
+              routes: [
+                {
+                  name: 'Stepper',
+                },
+              ],
+            },
+          },
+        ],
+      },
       type: 'RESET',
     })
   })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36997

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
