### PR TITLE
(PC-36935) feat(profile): hide data when null or undefined

### DIFF
--- a/src/features/profile/components/EditableFiled/EditableField.stories.tsx
+++ b/src/features/profile/components/EditableFiled/EditableField.stories.tsx
@@ -21,10 +21,6 @@ export default meta
 
 const variantConfig: Variants<typeof EditableField> = [
   {
-    label: 'EditableField default',
-    props: { label: 'Label' },
-  },
-  {
     label: 'EditableField with value',
     props: { label: 'Label', value: 'Value' },
   },

--- a/src/features/profile/components/EditableFiled/EditableField.tsx
+++ b/src/features/profile/components/EditableFiled/EditableField.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
 import { ProfileNavigateParams } from 'features/navigation/RootNavigator/types'
 import { EditButton } from 'features/profile/components/Buttons/EditButton/EditButton'
+import { Separator } from 'ui/components/Separator'
 import { getSpacing, Typo } from 'ui/theme'
 
 type EditableFieldProps = {
@@ -27,6 +28,8 @@ export function EditableField({
   const isCompleted = !!displayValue
   const showButton = !!navigateTo
 
+  if (!displayValue && !navigateTo) return null
+
   return (
     <React.Fragment>
       <StyledBodyAccentXs>{label}</StyledBodyAccentXs>
@@ -45,6 +48,7 @@ export function EditableField({
           />
         ) : null}
       </EditContainer>
+      <StyledSeparator />
     </React.Fragment>
   )
 }
@@ -67,3 +71,7 @@ const EditText = styled(Typo.Body)({
 const NoEditText = styled(Typo.BodyItalic)(({ theme }) => ({
   color: theme.designSystem.color.text.subtle,
 }))
+
+const StyledSeparator = styled(Separator.Horizontal)({
+  marginVertical: getSpacing(4),
+})

--- a/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
@@ -62,6 +62,17 @@ describe('PersonalData', () => {
     expect(screen).toMatchSnapshot()
   })
 
+  it('should not display name section when first name and last name not provided', async () => {
+    mockedUseAuthContext.mockReturnValueOnce({
+      ...initialAuthContext,
+      user: { ...mockedUser, firstName: null, lastName: null },
+    })
+    render(reactQueryProviderHOC(<PersonalData />))
+    await screen.findByText('Informations personnelles')
+
+    expect(screen.queryByText('Prénom et nom')).not.toBeOnTheScreen()
+  })
+
   it('should redirect to ChangeEmail when clicking on modify email button', async () => {
     mockedUseAuthContext.mockReturnValueOnce({
       ...initialAuthContext,

--- a/src/features/profile/pages/PersonalData/PersonalData.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react'
-import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { getActivityLabel } from 'features/identityCheck/helpers/getActivityLabel'
@@ -15,13 +14,12 @@ import { env } from 'libs/environment/env'
 import { InfoBanner } from 'ui/components/banners/InfoBanner'
 import { ButtonQuaternarySecondary } from 'ui/components/buttons/ButtonQuaternarySecondary'
 import { SectionRow } from 'ui/components/SectionRow'
-import { Separator } from 'ui/components/Separator'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { SecondaryPageWithBlurHeader } from 'ui/pages/SecondaryPageWithBlurHeader'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Trash } from 'ui/svg/icons/Trash'
-import { getSpacing, Spacer } from 'ui/theme'
+import { Spacer } from 'ui/theme'
 import { SECTION_ROW_ICON_SIZE } from 'ui/theme/constants'
 
 function onEmailChangeClick() {
@@ -32,7 +30,7 @@ export function PersonalData() {
   const { user } = useAuthContext()
   const { goBack } = useGoBack(...getTabNavConfig('Profile'))
 
-  const fullname = String(user?.firstName + ' ' + user?.lastName).trim()
+  const fullname = [user?.firstName, user?.lastName].filter(Boolean).join(' ').trim()
   const hasCity = user?.postalCode && user?.city
   const city =
     hasCity && user?.postalCode && user?.city && user?.street
@@ -49,7 +47,6 @@ export function PersonalData() {
   return (
     <SecondaryPageWithBlurHeader onGoBack={goBack} title="Informations personnelles">
       <EditableField label="Prénom et nom" value={fullname} />
-      <StyledSeparator />
       <EditableField
         label="Adresse e-mail"
         value={user?.email}
@@ -57,23 +54,19 @@ export function PersonalData() {
         onBeforeNavigate={onEmailChangeClick}
         accessibilityLabel="Modifier e-mail"
       />
-      <StyledSeparator />
       <EditableField label="Numéro de téléphone" value={user?.phoneNumber} />
-      <StyledSeparator />
       <EditableField
         label="Mot de passe"
         value={'*'.repeat(12)}
         navigateTo="ChangePassword"
         accessibilityLabel="Modifier mot de passe"
       />
-      <StyledSeparator />
       <EditableField
         label="Statut"
         value={getActivityLabel(user?.activityId)}
         navigateTo="ChangeStatus"
         accessibilityLabel="Modifier le statut"
       />
-      <StyledSeparator />
       <EditableField
         label="Adresse de résidence"
         value={city}
@@ -81,7 +74,6 @@ export function PersonalData() {
         navigateParams={{ type: PersonalDataTypes.PROFIL_PERSONAL_DATA }}
         accessibilityLabel="Modifier mon adresse de résidence"
       />
-      <StyledSeparator />
       <ViewGap gap={8}>
         <InfoBanner message="Le pass Culture traite tes données pour la gestion de ton compte et pour l’inscription à la newsletter.">
           <Spacer.Column numberOfSpaces={3} />
@@ -106,7 +98,3 @@ export function PersonalData() {
     </SecondaryPageWithBlurHeader>
   )
 }
-
-const StyledSeparator = styled(Separator.Horizontal)({
-  marginVertical: getSpacing(4),
-})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36935

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |   <img width="516" height="933" alt="Capture d’écran 2025-07-17 à 15 38 57" src="https://github.com/user-attachments/assets/190982e2-c8d1-45e0-8a54-aa21d554e7ae" />      |   <img width="515" height="933" alt="Capture d’écran 2025-07-17 à 15 38 29" src="https://github.com/user-attachments/assets/e43fb0f2-bcc6-4107-a7c4-fb7dac706ac1" />   |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
