### PR TITLE
(PC-36098) fix(achievements): allow undefined 'from' queryparam for achievements page

### DIFF
--- a/src/cheatcodes/pages/features/achievements/CheatcodesNavigationAchievements.tsx
+++ b/src/cheatcodes/pages/features/achievements/CheatcodesNavigationAchievements.tsx
@@ -27,7 +27,6 @@ const achievementCheatcodeCategory: CheatcodeCategory = {
       title: 'Liste des achievements',
       navigationTarget: {
         screen: 'Achievements',
-        params: { from: 'cheatcodes' },
       },
     },
     // These are "ContainerButtons". They exist for search but have no action here.

--- a/src/features/achievements/helpers/getAchievements.ts
+++ b/src/features/achievements/helpers/getAchievements.ts
@@ -18,7 +18,7 @@ type Categories = {
 
 type GetAchievements = {
   categories: Categories
-  track: (from: 'profile' | 'success' | 'cheatcodes') => void
+  track: (from: 'profile' | 'success') => void
 }
 
 export type GetAchivementsParams = {
@@ -34,7 +34,7 @@ export const getAchievements = ({
     createCategory(achievements, completedAchievements)
   )
 
-  const track = (from: 'profile' | 'success' | 'cheatcodes') => {
+  const track = (from: 'profile' | 'success') => {
     analytics.logDisplayAchievements({ from, numberUnlocked: completedAchievements.length })
   }
 

--- a/src/features/achievements/pages/Achievements.tsx
+++ b/src/features/achievements/pages/Achievements.tsx
@@ -29,9 +29,7 @@ const emptyAchievement = {
 }
 
 export const Achievements = () => {
-  const {
-    params: { from },
-  } = useRoute<UseRouteType<'Achievements'>>()
+  const { params } = useRoute<UseRouteType<'Achievements'>>()
   const { user } = useAuthContext()
   const { categories, track } = getAchievements({
     achievements: achievementData,
@@ -39,8 +37,10 @@ export const Achievements = () => {
   })
 
   useEffect(() => {
-    track(from)
-  }, [from, track])
+    if (params?.from) {
+      track(params.from)
+    }
+  }, [params?.from, track])
 
   return (
     <SecondaryPageWithBlurHeader title="Mes succès">

--- a/src/features/navigation/RootNavigator/linking/rootStackNavigatorPathConfig.ts
+++ b/src/features/navigation/RootNavigator/linking/rootStackNavigatorPathConfig.ts
@@ -366,7 +366,7 @@ export const rootStackNavigatorPathConfig = {
     parse: screenParamsParser['ThematicHome'],
   },
   Achievements: {
-    path: 'profile/achievements',
+    path: 'profil/succes',
   },
   Chronicles: {
     path: 'avis-du-book-club/:offerId/:chronicleId',

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -211,7 +211,7 @@ export type RootStackParamList = {
   AccountCreated: undefined
   AccountReactivationSuccess: undefined
   AccountStatusScreenHandler: undefined
-  Achievements: { from: 'profile' | 'success' | 'cheatcodes' }
+  Achievements: { from?: 'profile' | 'success' }
   AfterSignupEmailValidationBuffer: AfterSignupEmailValidationBufferParams
   _DeeplinkOnlyAfterSignupEmailValidationBuffer1: AfterSignupEmailValidationBufferParams
   Artist: ArtistParams


### PR DESCRIPTION

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36098

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |       <img width="712" height="539" alt="Capture d’écran 2025-07-18 à 10 16 47" src="https://github.com/user-attachments/assets/d2fa8583-26ff-4a36-94fa-1ddf482afc10" />        |   <img width="739" height="529" alt="Capture d’écran 2025-07-18 à 10 17 55" src="https://github.com/user-attachments/assets/524da5be-3ece-48ae-bce7-aaf9176ec4f9" />    |
|                  |       <img width="742" height="696" alt="Capture d’écran 2025-07-18 à 10 17 16" src="https://github.com/user-attachments/assets/aa0a0298-8253-4fc7-bf31-68304fb54891" />        |   <img width="765" height="528" alt="Capture d’écran 2025-07-18 à 10 18 17" src="https://github.com/user-attachments/assets/6147c53a-880d-4f4e-9d7e-b12742e035d9" />    |


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
