### PR TITLE
(PC-36999) fix(navigation): replace navigate by push

### DIFF
--- a/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
@@ -247,7 +247,7 @@ exports[`Accessibility should render correctly 1`] = `
         >
           <View
             accessibilityLabel="Plan du site"
-            accessibilityRole="link"
+            accessibilityRole="button"
             accessibilityState={
               {
                 "busy": undefined,
@@ -280,7 +280,6 @@ exports[`Accessibility should render correctly 1`] = `
                   {
                     "userSelect": "auto",
                   },
-                  {},
                 ],
                 {
                   "opacity": 1,
@@ -379,7 +378,7 @@ exports[`Accessibility should render correctly 1`] = `
         >
           <View
             accessibilityLabel="Les engagements du pass Culture"
-            accessibilityRole="link"
+            accessibilityRole="button"
             accessibilityState={
               {
                 "busy": undefined,
@@ -412,7 +411,6 @@ exports[`Accessibility should render correctly 1`] = `
                   {
                     "userSelect": "auto",
                   },
-                  {},
                 ],
                 {
                   "opacity": 1,
@@ -511,7 +509,7 @@ exports[`Accessibility should render correctly 1`] = `
         >
           <View
             accessibilityLabel="Schéma pluriannuel"
-            accessibilityRole="link"
+            accessibilityRole="button"
             accessibilityState={
               {
                 "busy": undefined,
@@ -544,7 +542,6 @@ exports[`Accessibility should render correctly 1`] = `
                   {
                     "userSelect": "auto",
                   },
-                  {},
                 ],
                 {
                   "opacity": 1,
@@ -643,7 +640,7 @@ exports[`Accessibility should render correctly 1`] = `
         >
           <View
             accessibilityLabel="Déclaration d’accessibilité des applications iOS et Android"
-            accessibilityRole="link"
+            accessibilityRole="button"
             accessibilityState={
               {
                 "busy": undefined,
@@ -676,7 +673,6 @@ exports[`Accessibility should render correctly 1`] = `
                   {
                     "userSelect": "auto",
                   },
-                  {},
                 ],
                 {
                   "opacity": 1,
@@ -775,7 +771,7 @@ exports[`Accessibility should render correctly 1`] = `
         >
           <View
             accessibilityLabel="Déclaration d’accessibilité de la version web"
-            accessibilityRole="link"
+            accessibilityRole="button"
             accessibilityState={
               {
                 "busy": undefined,
@@ -808,7 +804,6 @@ exports[`Accessibility should render correctly 1`] = `
                   {
                     "userSelect": "auto",
                   },
-                  {},
                 ],
                 {
                   "opacity": 1,
@@ -907,7 +902,7 @@ exports[`Accessibility should render correctly 1`] = `
         >
           <View
             accessibilityLabel="Parcours recommandés de la version web"
-            accessibilityRole="link"
+            accessibilityRole="button"
             accessibilityState={
               {
                 "busy": undefined,
@@ -940,7 +935,6 @@ exports[`Accessibility should render correctly 1`] = `
                   {
                     "userSelect": "auto",
                   },
-                  {},
                 ],
                 {
                   "opacity": 1,

--- a/src/cheatcodes/pages/features/achievements/CheatcodesNavigationAchievements.tsx
+++ b/src/cheatcodes/pages/features/achievements/CheatcodesNavigationAchievements.tsx
@@ -10,7 +10,7 @@ import {
   userCompletedMovieBooking,
 } from 'features/achievements/data/AchievementData'
 import { AchievementSuccessModal } from 'features/achievements/pages/AchievementSuccessModal'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { useModal } from 'ui/components/modals/useModal'
 
@@ -49,7 +49,7 @@ export const cheatcodesNavigationAchievementsButtons: CheatcodeCategory[] = [
 ]
 
 export function CheatcodesNavigationAchievements(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
   const {
     visible: visibleOneAchievement,
     showModal: showModalOneAchievement,

--- a/src/cheatcodes/pages/features/culturalSurvey/CheatcodesNavigationCulturalSurvey.tsx
+++ b/src/cheatcodes/pages/features/culturalSurvey/CheatcodesNavigationCulturalSurvey.tsx
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { CheatcodeCategory } from 'cheatcodes/types'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { getSubscriptionPropConfig } from 'features/navigation/SubscriptionStackNavigator/getSubscriptionPropConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 
@@ -39,7 +39,7 @@ export const cheatcodesNavigationCulturalSurveyButtons: CheatcodeCategory[] = [
 ]
 
 export function CheatcodesNavigationCulturalSurvey(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
 
   return (
     <CheatcodesTemplateScreen title={culturalSurveyCheatcodeCategory.title} onGoBack={goBack}>

--- a/src/cheatcodes/pages/features/forceUpdate/CheatcodesNavigationForceUpdate.tsx
+++ b/src/cheatcodes/pages/features/forceUpdate/CheatcodesNavigationForceUpdate.tsx
@@ -6,7 +6,7 @@ import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTempla
 import { LinkToCheatcodesScreen } from 'cheatcodes/components/LinkToCheatcodesScreen'
 import { CheatcodeCategory } from 'cheatcodes/types'
 import { ForceUpdateWithResetErrorBoundary } from 'features/forceUpdate/pages/ForceUpdateWithResetErrorBoundary'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { useLogTypeFromRemoteConfig } from 'libs/hooks/useLogTypeFromRemoteConfig'
 import { ScreenError } from 'libs/monitoring/errors'
@@ -32,7 +32,7 @@ export const cheatcodesNavigationForceUpdateButtons: CheatcodeCategory[] = [
 ]
 
 export function CheatcodesNavigationForceUpdate(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
 
   const [screenError, setScreenError] = useState<ScreenError | undefined>(undefined)
   const { logType } = useLogTypeFromRemoteConfig()

--- a/src/cheatcodes/pages/features/home/CheatcodesNavigationHome.tsx
+++ b/src/cheatcodes/pages/features/home/CheatcodesNavigationHome.tsx
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { CheatcodeCategory } from 'cheatcodes/types'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 
 const homeCheatcodeCategory: CheatcodeCategory = {
@@ -45,7 +45,7 @@ const homeCheatcodeCategory: CheatcodeCategory = {
 export const cheatcodesNavigationHomeButtons: CheatcodeCategory[] = [homeCheatcodeCategory]
 
 export function CheatcodesNavigationHome(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
 
   return (
     <CheatcodesTemplateScreen title={homeCheatcodeCategory.title} onGoBack={goBack}>

--- a/src/cheatcodes/pages/features/home/CheatcodesScreenCategoryThematicHomeHeader.tsx
+++ b/src/cheatcodes/pages/features/home/CheatcodesScreenCategoryThematicHomeHeader.tsx
@@ -6,13 +6,13 @@ import { CategoryThematicHomeHeader } from 'features/home/components/headers/Cat
 import { ThematicHomeHeader } from 'features/home/components/headers/ThematicHomeHeader'
 import { CategoryThematicHeader, Color, ThematicHeaderType } from 'features/home/types'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
 
 export const CheatcodesScreenCategoryThematicHomeHeader: FunctionComponent = () => {
   const { headerTransition } = useOpacityTransition()
   const { navigate } = useNavigation<UseNavigationType>()
-  const handleBackPress = () => navigate(...homeNavConfig)
+  const handleBackPress = () => navigate(...homeNavigationConfig)
 
   const thematicHomeHeader: CategoryThematicHeader = {
     type: ThematicHeaderType.Category,

--- a/src/cheatcodes/pages/features/home/CheatcodesScreenDefaultThematicHomeHeader.tsx
+++ b/src/cheatcodes/pages/features/home/CheatcodesScreenDefaultThematicHomeHeader.tsx
@@ -6,13 +6,13 @@ import { DefaultThematicHomeHeader } from 'features/home/components/headers/Defa
 import { ThematicHomeHeader } from 'features/home/components/headers/ThematicHomeHeader'
 import { CategoryThematicHeader, Color, ThematicHeaderType } from 'features/home/types'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
 
 export const CheatcodesScreenDefaultThematicHomeHeader: FunctionComponent = () => {
   const { headerTransition, onScroll } = useOpacityTransition()
   const { navigate } = useNavigation<UseNavigationType>()
-  const handleBackPress = () => navigate(...homeNavConfig)
+  const handleBackPress = () => navigate(...homeNavigationConfig)
 
   const thematicHomeHeader: CategoryThematicHeader = {
     type: ThematicHeaderType.Category,

--- a/src/cheatcodes/pages/features/home/CheatcodesScreenHighlightThematicHomeHeader.tsx
+++ b/src/cheatcodes/pages/features/home/CheatcodesScreenHighlightThematicHomeHeader.tsx
@@ -6,13 +6,13 @@ import { HighlightThematicHomeHeader } from 'features/home/components/headers/Hi
 import { ThematicHomeHeader } from 'features/home/components/headers/ThematicHomeHeader'
 import { CategoryThematicHeader, Color, ThematicHeaderType } from 'features/home/types'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
 
 export const CheatcodesScreenHighlightThematicHomeHeader: FunctionComponent = () => {
   const { headerTransition } = useOpacityTransition()
   const { navigate } = useNavigation<UseNavigationType>()
-  const handleBackPress = () => navigate(...homeNavConfig)
+  const handleBackPress = () => navigate(...homeNavigationConfig)
 
   const thematicHomeHeader: CategoryThematicHeader = {
     type: ThematicHeaderType.Category,

--- a/src/cheatcodes/pages/features/identityCheck/CheatcodesNavigationIdentityCheck.tsx
+++ b/src/cheatcodes/pages/features/identityCheck/CheatcodesNavigationIdentityCheck.tsx
@@ -10,7 +10,7 @@ import { NotEligibleEduConnect } from 'features/identityCheck/pages/identificati
 import { EduConnectErrorMessageEnum } from 'features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData'
 import { PhoneValidationTipsModal } from 'features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal'
 import { ProfileTypes } from 'features/identityCheck/pages/profile/enums'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getSubscriptionPropConfig } from 'features/navigation/SubscriptionStackNavigator/getSubscriptionPropConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
@@ -205,7 +205,7 @@ export const cheatcodesNavigationIdentityCheckButtons: CheatcodeCategory[] = [
 ]
 
 export function CheatcodesNavigationIdentityCheck(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
   const [screenError, setScreenError] = useState<ScreenError | undefined>(undefined)
   const [phoneValidationTipsModalVisible, setPhoneValidationTipsModalVisible] = useState(false)
   const { navigate } = useNavigation<UseNavigationType>()

--- a/src/cheatcodes/pages/features/identityCheck/CheatcodesNavigationNewIdentificationFlow.tsx
+++ b/src/cheatcodes/pages/features/identityCheck/CheatcodesNavigationNewIdentificationFlow.tsx
@@ -4,12 +4,12 @@ import { v4 as uuidv4 } from 'uuid'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToCheatcodesScreen } from 'cheatcodes/components/LinkToCheatcodesScreen'
 import { CheatcodeButton } from 'cheatcodes/types'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { getSubscriptionPropConfig } from 'features/navigation/SubscriptionStackNavigator/getSubscriptionPropConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 
 export function CheatcodesNavigationNewIdentificationFlow(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
 
   const navigationButtons: CheatcodeButton[] = [
     {

--- a/src/cheatcodes/pages/features/internal/CheatcodesNavigationInternal.tsx
+++ b/src/cheatcodes/pages/features/internal/CheatcodesNavigationInternal.tsx
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { CheatcodeCategory } from 'cheatcodes/types'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 
 const internalCheatcodeCategory: CheatcodeCategory = {
@@ -31,7 +31,7 @@ const internalCheatcodeCategory: CheatcodeCategory = {
 export const cheatcodesNavigationInternalButtons: CheatcodeCategory[] = [internalCheatcodeCategory]
 
 export function CheatcodesNavigationInternal(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
 
   return (
     <CheatcodesTemplateScreen title={internalCheatcodeCategory.title} onGoBack={goBack}>

--- a/src/cheatcodes/pages/features/onboarding/CheatcodesNavigationOnboarding.tsx
+++ b/src/cheatcodes/pages/features/onboarding/CheatcodesNavigationOnboarding.tsx
@@ -6,8 +6,8 @@ import { v4 as uuidv4 } from 'uuid'
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { CheatcodeCategory } from 'cheatcodes/types'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
-import { getOnboardingNavConfig } from 'features/navigation/OnboardingStackNavigator/getOnboardingNavConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
+import { getOnboardingPropConfig } from 'features/navigation/OnboardingStackNavigator/getOnboardingPropConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 
 const onboardingCheatcodeCategory: CheatcodeCategory = {
@@ -21,37 +21,37 @@ const onboardingCheatcodeCategory: CheatcodeCategory = {
     {
       id: uuidv4(),
       title: 'OnboardingNotEligible',
-      navigationTarget: getOnboardingNavConfig('OnboardingNotEligible'),
+      navigationTarget: getOnboardingPropConfig('OnboardingNotEligible'),
     },
     {
       id: uuidv4(),
       title: 'OnboardingGeneralPublicWelcome',
-      navigationTarget: getOnboardingNavConfig('OnboardingGeneralPublicWelcome'),
+      navigationTarget: getOnboardingPropConfig('OnboardingGeneralPublicWelcome'),
     },
     {
       id: uuidv4(),
       title: 'OnboardingWelcome',
-      navigationTarget: getOnboardingNavConfig('OnboardingWelcome'),
+      navigationTarget: getOnboardingPropConfig('OnboardingWelcome'),
     },
     {
       id: uuidv4(),
       title: 'OnboardingGeolocation',
-      navigationTarget: getOnboardingNavConfig('OnboardingGeolocation'),
+      navigationTarget: getOnboardingPropConfig('OnboardingGeolocation'),
     },
     {
       id: uuidv4(),
       title: 'OnboardingAgeSelectionFork',
-      navigationTarget: getOnboardingNavConfig('OnboardingAgeSelectionFork'),
+      navigationTarget: getOnboardingPropConfig('OnboardingAgeSelectionFork'),
     },
     {
       id: uuidv4(),
       title: 'OnboardingAgeInformation (age: 17)',
-      navigationTarget: getOnboardingNavConfig('OnboardingAgeInformation', { age: 17 }),
+      navigationTarget: getOnboardingPropConfig('OnboardingAgeInformation', { age: 17 }),
     },
     {
       id: uuidv4(),
       title: 'OnboardingAgeInformation (age: 18)',
-      navigationTarget: getOnboardingNavConfig('OnboardingAgeInformation', { age: 18 }),
+      navigationTarget: getOnboardingPropConfig('OnboardingAgeInformation', { age: 18 }),
     },
   ],
 }
@@ -68,7 +68,7 @@ export function CheatcodesNavigationOnboarding(): React.JSX.Element {
     }, [])
   )
 
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
 
   return (
     <CheatcodesTemplateScreen title={onboardingCheatcodeCategory.title} onGoBack={goBack}>

--- a/src/cheatcodes/pages/features/profile/CheatcodesNavigationProfile.tsx
+++ b/src/cheatcodes/pages/features/profile/CheatcodesNavigationProfile.tsx
@@ -5,8 +5,8 @@ import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/Cheatcodes
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToCheatcodesScreen } from 'cheatcodes/components/LinkToCheatcodesScreen'
 import { CheatcodeCategory } from 'cheatcodes/types'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { ExpiredCreditModal } from 'features/profile/components/Modals/ExpiredCreditModal'
 import { useModal } from 'ui/components/modals/useModal'
@@ -28,67 +28,67 @@ const profileCheatcodeCategory: CheatcodeCategory = {
     {
       id: uuidv4(),
       title: 'ChangeCity',
-      navigationTarget: getProfileNavConfig('ChangeCity'),
+      navigationTarget: getProfilePropConfig('ChangeCity'),
     },
     {
       id: uuidv4(),
       title: 'ChangeAddress',
-      navigationTarget: getProfileNavConfig('ChangeAddress'),
+      navigationTarget: getProfilePropConfig('ChangeAddress'),
     },
     {
       id: uuidv4(),
       title: 'ChangeEmail',
-      navigationTarget: getProfileNavConfig('ChangeEmail'),
+      navigationTarget: getProfilePropConfig('ChangeEmail'),
     },
     {
       id: uuidv4(),
       title: 'ChangeStatus',
-      navigationTarget: getProfileNavConfig('ChangeStatus'),
+      navigationTarget: getProfilePropConfig('ChangeStatus'),
     },
     {
       id: uuidv4(),
       title: 'ConsentSettings',
-      navigationTarget: getProfileNavConfig('ConsentSettings'),
+      navigationTarget: getProfilePropConfig('ConsentSettings'),
     },
     {
       id: uuidv4(),
       title: 'DeactivateProfileSuccess',
-      navigationTarget: getProfileNavConfig('DeactivateProfileSuccess'),
+      navigationTarget: getProfilePropConfig('DeactivateProfileSuccess'),
     },
     {
       id: uuidv4(),
       title: 'DeleteProfileReason',
-      navigationTarget: getProfileNavConfig('DeleteProfileReason'),
+      navigationTarget: getProfilePropConfig('DeleteProfileReason'),
     },
     {
       id: uuidv4(),
       title: 'FeedbackInApp',
-      navigationTarget: getProfileNavConfig('FeedbackInApp'),
+      navigationTarget: getProfilePropConfig('FeedbackInApp'),
     },
     {
       id: uuidv4(),
       title: 'NotificationsSettings',
-      navigationTarget: getProfileNavConfig('NotificationsSettings'),
+      navigationTarget: getProfilePropConfig('NotificationsSettings'),
     },
     {
       id: uuidv4(),
       title: 'SuspendAccountConfirmation',
-      navigationTarget: getProfileNavConfig('SuspendAccountConfirmation'),
+      navigationTarget: getProfilePropConfig('SuspendAccountConfirmation'),
     },
     {
       id: uuidv4(),
       title: 'ProfileTutorialAgeInformationCredit',
-      navigationTarget: getProfileNavConfig('ProfileTutorialAgeInformationCredit'),
+      navigationTarget: getProfilePropConfig('ProfileTutorialAgeInformationCredit'),
     },
     {
       id: uuidv4(),
       title: 'SuspendAccountConfirmationWithoutAuthentication',
-      navigationTarget: getProfileNavConfig('SuspendAccountConfirmationWithoutAuthentication'),
+      navigationTarget: getProfilePropConfig('SuspendAccountConfirmationWithoutAuthentication'),
     },
     {
       id: uuidv4(),
       title: 'ChangeEmailSetPassword',
-      navigationTarget: getProfileNavConfig('ChangeEmailSetPassword', {
+      navigationTarget: getProfilePropConfig('ChangeEmailSetPassword', {
         token: 'token',
         emailSelectionToken: 'token',
       }),
@@ -101,17 +101,17 @@ const profileCheatcodeCategory: CheatcodeCategory = {
     {
       id: uuidv4(),
       title: 'MandatoryUpdatePersonalData',
-      navigationTarget: getProfileNavConfig('MandatoryUpdatePersonalData'),
+      navigationTarget: getProfilePropConfig('MandatoryUpdatePersonalData'),
     },
     {
       id: uuidv4(),
       title: 'UpdatePersonalDataConfirmation',
-      navigationTarget: getProfileNavConfig('UpdatePersonalDataConfirmation'),
+      navigationTarget: getProfilePropConfig('UpdatePersonalDataConfirmation'),
     },
     {
       id: uuidv4(),
       title: 'ProfileInformationValidationUpdate',
-      navigationTarget: getProfileNavConfig('ProfileInformationValidationUpdate'),
+      navigationTarget: getProfilePropConfig('ProfileInformationValidationUpdate'),
     },
   ],
 }
@@ -119,7 +119,7 @@ const profileCheatcodeCategory: CheatcodeCategory = {
 export const cheatcodesNavigationProfileButtons: CheatcodeCategory[] = [profileCheatcodeCategory]
 
 export function CheatcodesNavigationProfile(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
   const {
     visible: expiredCreditModalVisible,
     showModal: showExpiredCreditModal,

--- a/src/cheatcodes/pages/features/share/CheatcodesNavigationShare.tsx
+++ b/src/cheatcodes/pages/features/share/CheatcodesNavigationShare.tsx
@@ -4,13 +4,13 @@ import { v4 as uuidv4 } from 'uuid'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToCheatcodesScreen } from 'cheatcodes/components/LinkToCheatcodesScreen'
 import { CheatcodeButton } from 'cheatcodes/types'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { useShareAppContext } from 'features/share/context/ShareAppWrapper'
 import { ShareAppModalType } from 'features/share/types'
 
 export function CheatcodesNavigationShare(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
   const { showShareAppModal } = useShareAppContext()
 
   const actionButtons: CheatcodeButton[] = [

--- a/src/cheatcodes/pages/features/subscription/CheatcodesNavigationSubscription.tsx
+++ b/src/cheatcodes/pages/features/subscription/CheatcodesNavigationSubscription.tsx
@@ -5,7 +5,7 @@ import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/Cheatcodes
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToCheatcodesScreen } from 'cheatcodes/components/LinkToCheatcodesScreen'
 import { CheatcodeCategory } from 'cheatcodes/types'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { OnboardingSubscriptionModal } from 'features/subscription/components/modals/OnboardingSubscriptionModal'
 import { SubscriptionSuccessModal } from 'features/subscription/components/modals/SubscriptionSuccessModal'
@@ -43,7 +43,7 @@ export const cheatcodesNavigationSubscriptionButtons: CheatcodeCategory[] = [
 ]
 
 export function CheatcodesNavigationSubscription(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
   const [visibleModal, setVisibleModal] = useState<VisibleModal>(null)
 
   const visibleSubscreens = subscriptionCheatcodeCategory.subscreens.filter(

--- a/src/cheatcodes/pages/features/trustedDevice/CheatcodesNavigationTrustedDevice.tsx
+++ b/src/cheatcodes/pages/features/trustedDevice/CheatcodesNavigationTrustedDevice.tsx
@@ -7,7 +7,7 @@ import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/Cheatcodes
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToCheatcodesScreen } from 'cheatcodes/components/LinkToCheatcodesScreen'
 import { CheatcodeCategory } from 'cheatcodes/types'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { ROUTE_PARAMS } from 'features/trustedDevice/fixtures/fixtures'
@@ -57,7 +57,7 @@ export const cheatcodesNavigationTrustedDeviceButtons: CheatcodeCategory[] = [
 ]
 
 export function CheatcodesNavigationTrustedDevice(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
   const [value, setValue] = useState('')
   const { navigate } = useNavigation<UseNavigationType>()
 

--- a/src/cheatcodes/pages/others/CheatcodesNavigationAccountManagement.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesNavigationAccountManagement.tsx
@@ -4,8 +4,8 @@ import { v4 as uuidv4 } from 'uuid'
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { CheatcodeCategory } from 'cheatcodes/types'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 
 const accountManagementCheatcodeCategory: CheatcodeCategory = {
@@ -47,42 +47,42 @@ const accountManagementCheatcodeCategory: CheatcodeCategory = {
     {
       id: uuidv4(),
       title: 'DeleteProfileReason',
-      navigationTarget: getProfileNavConfig('DeleteProfileReason'),
+      navigationTarget: getProfilePropConfig('DeleteProfileReason'),
     },
     {
       id: uuidv4(),
       title: 'DebugScreen',
-      navigationTarget: getProfileNavConfig('DebugScreen'),
+      navigationTarget: getProfilePropConfig('DebugScreen'),
     },
     {
       id: uuidv4(),
       title: 'ConfirmDeleteProfile',
-      navigationTarget: getProfileNavConfig('ConfirmDeleteProfile'),
+      navigationTarget: getProfilePropConfig('ConfirmDeleteProfile'),
     },
     {
       id: uuidv4(),
       title: 'DeactivateProfileSuccess',
-      navigationTarget: getProfileNavConfig('DeactivateProfileSuccess'),
+      navigationTarget: getProfilePropConfig('DeactivateProfileSuccess'),
     },
     {
       id: uuidv4(),
       title: 'DeleteProfileSuccess',
-      navigationTarget: getProfileNavConfig('DeleteProfileSuccess'),
+      navigationTarget: getProfilePropConfig('DeleteProfileSuccess'),
     },
     {
       id: uuidv4(),
       title: 'DeleteProfileConfirmation',
-      navigationTarget: getProfileNavConfig('DeleteProfileConfirmation'),
+      navigationTarget: getProfilePropConfig('DeleteProfileConfirmation'),
     },
     {
       id: uuidv4(),
       title: 'DeleteProfileAccountNotDeletable',
-      navigationTarget: getProfileNavConfig('DeleteProfileAccountNotDeletable'),
+      navigationTarget: getProfilePropConfig('DeleteProfileAccountNotDeletable'),
     },
     {
       id: uuidv4(),
       title: 'DeleteProfileAccountHacked',
-      navigationTarget: getProfileNavConfig('DeleteProfileAccountHacked'),
+      navigationTarget: getProfilePropConfig('DeleteProfileAccountHacked'),
     },
   ],
 }
@@ -92,7 +92,7 @@ export const cheatcodesNavigationAccountManagementButtons: CheatcodeCategory[] =
 ]
 
 export function CheatcodesNavigationAccountManagement(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
 
   return (
     <CheatcodesTemplateScreen title={accountManagementCheatcodeCategory.title} onGoBack={goBack}>

--- a/src/cheatcodes/pages/others/CheatcodesNavigationErrors.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesNavigationErrors.tsx
@@ -9,7 +9,7 @@ import { LinkToCheatcodesScreen } from 'cheatcodes/components/LinkToCheatcodesSc
 import { CheatcodeCategory } from 'cheatcodes/types'
 import { NoContentError } from 'features/home/pages/NoContentError'
 import { Maintenance } from 'features/maintenance/pages/Maintenance'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { useLogTypeFromRemoteConfig } from 'libs/hooks/useLogTypeFromRemoteConfig'
 import { AsyncError, LogTypeEnum, ScreenError } from 'libs/monitoring/errors'
@@ -47,7 +47,7 @@ const MaintenanceScreenForCheatcode = () => (
 )
 
 export const CheatcodesNavigationErrors: FunctionComponent = () => {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
   const [renderedError, setRenderedError] = useState(undefined)
   const [screenError, setScreenError] = useState<ScreenError | undefined>(undefined)
   const [asyncTestReqCount, setAsyncTestReqCount] = useState(0)

--- a/src/cheatcodes/pages/others/CheatcodesNavigationGenericPages.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesNavigationGenericPages.tsx
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { CheatcodeCategory } from 'cheatcodes/types'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 
 const genericPagesCheatcodeCategory: CheatcodeCategory = {
@@ -71,7 +71,7 @@ export const cheatcodesNavigationGenericPagesButtons: CheatcodeCategory[] = [
 ]
 
 export function CheatcodesNavigationGenericPages(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
 
   return (
     <CheatcodesTemplateScreen title={genericPagesCheatcodeCategory.title} onGoBack={goBack}>

--- a/src/cheatcodes/pages/others/CheatcodesNavigationNotScreensPages.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesNavigationNotScreensPages.tsx
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToCheatcodesScreen } from 'cheatcodes/components/LinkToCheatcodesScreen'
 import { CheatcodeButton } from 'cheatcodes/types'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { BrowserNotSupportedPage, supportedBrowsers } from 'web/SupportedBrowsersGate.web'
 
@@ -33,7 +33,7 @@ const getPageComponent = (page: Page, onBack: () => void): React.JSX.Element => 
 }
 
 export function CheatcodesNavigationNotScreensPages(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
   const [page, setPage] = useState<Page | null>(null)
 
   // If a page is selected, render it and provide a way to get back.

--- a/src/cheatcodes/pages/others/CheatcodesNavigationSignUp.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesNavigationSignUp.tsx
@@ -6,7 +6,7 @@ import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTempla
 import { LinkToCheatcodesScreen } from 'cheatcodes/components/LinkToCheatcodesScreen'
 import { useSomeOfferIdQuery } from 'cheatcodes/queries/useSomeOfferIdQuery'
 import { CheatcodeCategory } from 'cheatcodes/types'
-import { getCheatcodesStackConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesStackConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
 import { getSubscriptionPropConfig } from 'features/navigation/SubscriptionStackNavigator/getSubscriptionPropConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
@@ -74,7 +74,7 @@ const signUpCheatcodeCategory: CheatcodeCategory = {
 export const cheatcodesNavigationSignUpButtons: CheatcodeCategory[] = [signUpCheatcodeCategory]
 
 export function CheatcodesNavigationSignUp(): React.JSX.Element {
-  const { goBack } = useGoBack(...getCheatcodesStackConfig('CheatcodesMenu'))
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
   const offerId = useSomeOfferIdQuery()
   const [visibleModal, setVisibleModal] = useState<VisibleModal>(null)
 

--- a/src/cheatcodes/pages/others/CheatcodesScreenDebugInformations.web.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenDebugInformations.web.tsx
@@ -2,14 +2,14 @@ import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import React, { useCallback } from 'react'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { LoadingPage } from 'ui/pages/LoadingPage'
 
 export const CheatcodesScreenDebugInformations: React.FC = () => {
   const { navigate } = useNavigation<UseNavigationType>()
   useFocusEffect(
     useCallback(() => {
-      navigate(...homeNavConfig)
+      navigate(...homeNavigationConfig)
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
   )

--- a/src/cheatcodes/pages/others/CheatcodesScreenGenericErrorPage.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenGenericErrorPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
@@ -12,7 +12,7 @@ import { Typo, getSpacing } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 export const CheatcodesScreenGenericErrorPage = () => {
-  const { goBack } = useGoBack(...homeNavConfig)
+  const { goBack } = useGoBack(...homeNavigationConfig)
   const { top } = useCustomSafeInsets()
 
   return (

--- a/src/features/auth/pages/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.native.test.tsx
+++ b/src/features/auth/pages/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.native.test.tsx
@@ -6,7 +6,7 @@ import { navigate, replace, useRoute } from '__mocks__/@react-navigation/native'
 import { api } from 'api/api'
 import { UserProfileResponse, ValidateEmailResponse } from 'api/gen'
 import * as LoginAndRedirectAPI from 'features/auth/pages/signup/helpers/useLoginAndRedirect'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { nonBeneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics/provider'
 import * as datesLib from 'libs/dates'
@@ -102,7 +102,7 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
             timeout: SNACK_BAR_TIME_OUT,
           })
           expect(replace).toHaveBeenCalledTimes(1)
-          expect(replace).toHaveBeenCalledWith(...homeNavConfig)
+          expect(replace).toHaveBeenCalledWith(...homeNavigationConfig)
         },
         { timeout: 10_000 }
       )

--- a/src/features/auth/pages/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.tsx
+++ b/src/features/auth/pages/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.tsx
@@ -5,7 +5,7 @@ import { ValidateEmailResponse } from 'api/gen'
 import { useLoginAndRedirect } from 'features/auth/pages/signup/helpers/useLoginAndRedirect'
 import { useValidateEmailMutation } from 'features/auth/queries/useValidateEmailMutation'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useDeviceInfo } from 'features/trustedDevice/helpers/useDeviceInfo'
 import { analytics } from 'libs/analytics/provider'
 import { isTimestampExpired } from 'libs/dates'
@@ -71,7 +71,7 @@ export function AfterSignupEmailValidationBuffer() {
       message: 'Ce lien de validation n’est plus valide',
       timeout: SNACK_BAR_TIME_OUT,
     })
-    delayedReplace(...homeNavConfig)
+    delayedReplace(...homeNavigationConfig)
   }
 
   return <LoadingPage />

--- a/src/features/auth/pages/signup/SignupForm.tsx
+++ b/src/features/auth/pages/signup/SignupForm.tsx
@@ -13,7 +13,7 @@ import { DEFAULT_STEP_CONFIG, SSO_STEP_CONFIG } from 'features/auth/stepConfig'
 import { SignupData } from 'features/auth/types'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { useDeviceInfo } from 'features/trustedDevice/helpers/useDeviceInfo'
 import { analytics } from 'libs/analytics/provider'
@@ -58,7 +58,7 @@ export const SignupForm: FunctionComponent = () => {
       ? `Continuer vers l’étape ${nextStep.accessibilityTitle}`
       : undefined
 
-  const { goBack: goBackAndLeaveSignup } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack: goBackAndLeaveSignup } = useGoBack(...getTabHookConfig('Profile'))
 
   const goToPreviousStep = () => {
     if (isFirstStep) {

--- a/src/features/bookings/components/ArchiveBookingModal.tsx
+++ b/src/features/bookings/components/ArchiveBookingModal.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { extractApiErrorMessage } from 'api/apiHelpers'
 import { useArchiveBookingMutation } from 'features/bookings/queries'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonTertiaryPrimary } from 'ui/components/buttons/ButtonTertiaryPrimary'
@@ -21,7 +21,7 @@ export interface ArchiveBookingModalProps {
 }
 
 export const ArchiveBookingModal = (props: ArchiveBookingModalProps) => {
-  const { goBack } = useGoBack(...getTabNavConfig('Bookings'))
+  const { goBack } = useGoBack(...getTabHookConfig('Bookings'))
   const { showErrorSnackBar, showSuccessSnackBar } = useSnackBarContext()
 
   const { mutate, isLoading } = useArchiveBookingMutation({

--- a/src/features/bookings/components/BookingDetailsHeader.tsx
+++ b/src/features/bookings/components/BookingDetailsHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Animated } from 'react-native'
 
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { ContentHeader } from 'ui/components/headers/ContentHeader'
 
@@ -13,7 +13,7 @@ interface Props {
 export const BookingDetailsHeader: React.FC<Props> = (props) => {
   const { headerTransition, title } = props
 
-  const { goBack } = useGoBack(...getTabNavConfig('Bookings'))
+  const { goBack } = useGoBack(...getTabHookConfig('Bookings'))
 
   return (
     <ContentHeader headerTitle={title} headerTransition={headerTransition} onBackPress={goBack} />

--- a/src/features/bookings/components/CancelBookingModal.native.test.tsx
+++ b/src/features/bookings/components/CancelBookingModal.native.test.tsx
@@ -4,7 +4,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { BookingReponse } from 'api/gen'
 import { CancelBookingModal } from 'features/bookings/components/CancelBookingModal'
 import { bookingsSnap } from 'features/bookings/fixtures'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { beneficiaryUser, nonBeneficiaryUser as exBeneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
@@ -147,7 +147,7 @@ describe('<CancelBookingModal />', () => {
 
     await user.press(cancelButton)
 
-    expect(navigate).toHaveBeenCalledWith(...getTabNavConfig('Bookings'))
+    expect(navigate).toHaveBeenCalledWith(...getTabHookConfig('Bookings'))
     expect(mockShowErrorSnackBar).toHaveBeenCalledWith({
       message: response.message,
       timeout: 5000,

--- a/src/features/bookings/components/CancelBookingModal.tsx
+++ b/src/features/bookings/components/CancelBookingModal.tsx
@@ -8,7 +8,7 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useCancelBookingMutation } from 'features/bookings/queries'
 import { Booking } from 'features/bookings/types'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { analytics } from 'libs/analytics/provider'
 import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { convertCentsToEuros } from 'libs/parsers/pricesConversion'
@@ -43,7 +43,7 @@ export const CancelBookingModal: FunctionComponent<Props> = ({
   const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()
 
   function onSuccess() {
-    navigate(...getTabNavConfig('Bookings'))
+    navigate(...getTabHookConfig('Bookings'))
     showSuccessSnackBar({
       message:
         'La réservation a bien été annulée. Tu pourras la retrouver dans tes réservations terminées',
@@ -53,7 +53,7 @@ export const CancelBookingModal: FunctionComponent<Props> = ({
 
   function onError(error: unknown) {
     dismissModal()
-    navigate(...getTabNavConfig('Bookings'))
+    navigate(...getTabHookConfig('Bookings'))
     showErrorSnackBar({ message: extractApiErrorMessage(error), timeout: SNACK_BAR_TIME_OUT })
   }
 

--- a/src/features/culturalSurvey/components/CulturalSurveyPageHeader.tsx
+++ b/src/features/culturalSurvey/components/CulturalSurveyPageHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { CulturalSurveyProgressBar } from 'features/culturalSurvey/components/CulturalSurveyProgressBar'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ArrowPrevious as DefaultArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
@@ -52,7 +52,7 @@ interface BackButtonProps {
 }
 
 const BackIcon: React.FC<BackButtonProps> = (props) => {
-  const { goBack } = useGoBack(...homeNavConfig)
+  const { goBack } = useGoBack(...homeNavigationConfig)
   return (
     <StyledTouchableOpacity
       onPress={props.onGoBack ?? goBack}

--- a/src/features/culturalSurvey/helpers/useGetCulturalSurveyContent.ts
+++ b/src/features/culturalSurvey/helpers/useGetCulturalSurveyContent.ts
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { analytics } from 'libs/analytics/provider'
 import { ClockFilled } from 'ui/svg/icons/ClockFilled'
@@ -10,7 +10,7 @@ import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
 
 export const useGetCulturalSurveyContent = (enableCulturalSurveyMandatory: boolean) => {
   const { reset } = useNavigation<UseNavigationType>()
-  const { goBack } = useGoBack(...homeNavConfig)
+  const { goBack } = useGoBack(...homeNavigationConfig)
 
   const navigateSendAnalyticsAndShowShareAppModal = async () => {
     reset({ index: 0, routes: [{ name: navigateToHomeConfig.screen }] })

--- a/src/features/culturalSurvey/pages/CulturalSurveyQuestions.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyQuestions.tsx
@@ -20,7 +20,7 @@ import { useCulturalSurveyQuestionsQuery } from 'features/culturalSurvey/queries
 import { navigateToHome, navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { getSubscriptionHookConfig } from 'features/navigation/SubscriptionStackNavigator/getSubscriptionHookConfig'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { isCloseToBottom } from 'libs/analytics'
 import { analytics } from 'libs/analytics/provider'
@@ -55,7 +55,7 @@ export function CulturalSurveyQuestions() {
   }
 
   const currentQuestion = params?.question
-  const { goBack } = useGoBack(...homeNavConfig)
+  const { goBack } = useGoBack(...homeNavigationConfig)
   const { answers, dispatch, questionsToDisplay } = useCulturalSurveyContext()
   const [currentAnswers, setCurrentAnswers] = useState<CulturalSurveyAnswerEnum[]>([])
 

--- a/src/features/deeplinks/helpers/getScreenFromDeeplink.test.ts
+++ b/src/features/deeplinks/helpers/getScreenFromDeeplink.test.ts
@@ -1,7 +1,7 @@
 import { getScreenFromDeeplink } from 'features/deeplinks/helpers'
 import { getScreenPath } from 'features/navigation/RootNavigator/linking/getScreenPath'
-import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/getSearchStackConfig'
-import { getTabNavConfig, homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { getSearchHookConfig } from 'features/navigation/SearchStackNavigator/getSearchHookConfig'
+import { getTabHookConfig, homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { WEBAPP_V2_URL } from 'libs/environment/useWebAppUrl'
 
 jest.mock('libs/firebase/analytics/analytics')
@@ -17,7 +17,7 @@ describe('getScreenFromDeeplink()', () => {
 
   it('should return PageNotFound when prefix is not in known config', () => {
     const prefix = 'https://unknown.com'
-    const url = getFullUrl(getScreenPath(...homeNavConfig), prefix)
+    const url = getFullUrl(getScreenPath(...homeNavigationConfig), prefix)
     const { screen, params } = getScreenFromDeeplink(url)
 
     expect(screen).toEqual('PageNotFound')
@@ -25,7 +25,7 @@ describe('getScreenFromDeeplink()', () => {
   })
 
   it('should return Home', () => {
-    const url = getFullUrl(getScreenPath(...homeNavConfig))
+    const url = getFullUrl(getScreenPath(...homeNavigationConfig))
     const { screen, params } = getScreenFromDeeplink(url)
 
     expect(screen).toEqual('TabNavigator')
@@ -33,7 +33,7 @@ describe('getScreenFromDeeplink()', () => {
   })
 
   it('should also work with a different accepted prefix', () => {
-    const url = getFullUrl(getScreenPath(...homeNavConfig), '')
+    const url = getFullUrl(getScreenPath(...homeNavigationConfig), '')
     const screenFromDeeplink = getScreenFromDeeplink(url)
 
     expect(screenFromDeeplink.screen).toEqual('TabNavigator')
@@ -41,7 +41,7 @@ describe('getScreenFromDeeplink()', () => {
   })
 
   it('should return ProfileStackNavigator when url = /profil', () => {
-    const url = getFullUrl(getScreenPath(...getTabNavConfig('Profile')))
+    const url = getFullUrl(getScreenPath(...getTabHookConfig('Profile')))
     const { screen, params } = getScreenFromDeeplink(url)
 
     expect(screen).toEqual('TabNavigator')
@@ -49,7 +49,7 @@ describe('getScreenFromDeeplink()', () => {
   })
 
   it('should return SearchStackNavigator when url = /recherche/resultats', () => {
-    const url = getFullUrl(getScreenPath(...getSearchStackConfig('SearchResults')))
+    const url = getFullUrl(getScreenPath(...getSearchHookConfig('SearchResults')))
     const { screen, params } = getScreenFromDeeplink(url)
 
     expect(screen).toEqual('TabNavigator')
@@ -57,7 +57,7 @@ describe('getScreenFromDeeplink()', () => {
   })
 
   it('should return SearchStackNavigator when url = /recherche/accueil', () => {
-    const url = getFullUrl(getScreenPath(...getSearchStackConfig('SearchLanding')))
+    const url = getFullUrl(getScreenPath(...getSearchHookConfig('SearchLanding')))
     const { screen, params } = getScreenFromDeeplink(url)
 
     expect(screen).toEqual('TabNavigator')
@@ -73,7 +73,7 @@ describe('getScreenFromDeeplink()', () => {
   })
 
   it('should return SearchStackNavigator when url = /recherche/thematic', () => {
-    const url = getFullUrl(getScreenPath(...getSearchStackConfig('ThematicSearch')))
+    const url = getFullUrl(getScreenPath(...getSearchHookConfig('ThematicSearch')))
     const { screen, params } = getScreenFromDeeplink(url)
 
     expect(screen).toEqual('TabNavigator')

--- a/src/features/errors/pages/AsyncErrorBoundary.tsx
+++ b/src/features/errors/pages/AsyncErrorBoundary.tsx
@@ -3,7 +3,7 @@ import { FallbackProps } from 'react-error-boundary'
 import styled from 'styled-components/native'
 
 import { AsyncErrorBoundaryWithoutNavigation } from 'features/errors/pages/AsyncErrorBoundaryWithoutNavigation'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { ScreenError, AsyncError } from 'libs/monitoring/errors'
 import { styledButton } from 'ui/components/buttons/styledButton'
@@ -19,7 +19,7 @@ interface AsyncFallbackProps extends FallbackProps {
 }
 
 export const AsyncErrorBoundary = (props: AsyncFallbackProps) => {
-  const { goBack, canGoBack } = useGoBack(...homeNavConfig)
+  const { goBack, canGoBack } = useGoBack(...homeNavigationConfig)
   const { top } = useCustomSafeInsets()
 
   return (

--- a/src/features/favorites/pages/FavoritesSorts.tsx
+++ b/src/features/favorites/pages/FavoritesSorts.tsx
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { useFavoritesState } from 'features/favorites/context/FavoritesWrapper'
 import { FavoriteSortBy } from 'features/favorites/types'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { analytics } from 'libs/analytics/provider'
@@ -27,7 +27,7 @@ const SORT_OPTIONS: Record<FavoriteSortBy, string> = {
 const SORT_OPTIONS_LIST = Object.entries(SORT_OPTIONS) as Array<[FavoriteSortBy, string]>
 
 export const FavoritesSorts: React.FC = () => {
-  const { goBack } = useGoBack(...getTabNavConfig('Favorites'))
+  const { goBack } = useGoBack(...getTabHookConfig('Favorites'))
   const {
     geolocPosition,
     geolocPositionError,

--- a/src/features/home/components/modules/OffersModule.tsx
+++ b/src/features/home/components/modules/OffersModule.tsx
@@ -10,7 +10,7 @@ import {
   OffersModule as OffersModuleType,
   RecommendedOffersModule,
 } from 'features/home/types'
-import { getSearchNavConfig } from 'features/navigation/SearchStackNavigator/getSearchNavConfig'
+import { getSearchPropConfig } from 'features/navigation/SearchStackNavigator/getSearchPropConfig'
 import { OfferTileWrapper } from 'features/offer/components/OfferTile/OfferTileWrapper'
 import { useAdaptOffersPlaylistParameters } from 'libs/algolia/fetchAlgolia/fetchMultipleOffers/helpers/useAdaptOffersPlaylistParameters'
 import { analytics } from 'libs/analytics/provider'
@@ -75,7 +75,7 @@ export const OffersModule = (props: OffersModuleProps) => {
     locationParams,
     hitsPerPage: 20,
   }
-  const searchTabConfig = getSearchNavConfig('SearchResults', searchParams)
+  const searchTabConfig = getSearchPropConfig('SearchResults', searchParams)
 
   const moduleName = displayParameters.title ?? parameters?.title
 

--- a/src/features/home/pages/NoContentError.tsx
+++ b/src/features/home/pages/NoContentError.tsx
@@ -2,14 +2,14 @@ import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/getSearchStackConfig'
+import { getSearchHookConfig } from 'features/navigation/SearchStackNavigator/getSearchHookConfig'
 import { GenericErrorPage } from 'ui/pages/GenericErrorPage'
 import { BrokenConnection } from 'ui/svg/BrokenConnection'
 import { MagnifyingGlass } from 'ui/svg/icons/MagnifyingGlass'
 
 export const NoContentError = () => {
   const { navigate } = useNavigation<UseNavigationType>()
-  const navigateToSearchTab = () => navigate(...getSearchStackConfig('SearchLanding'))
+  const navigateToSearchTab = () => navigate(...getSearchHookConfig('SearchLanding'))
 
   const helmetTitle =
     'Page erreur\u00a0: Erreur pendant le chargement de nos recommandations | pass Culture'

--- a/src/features/home/pages/ThematicHome.tsx
+++ b/src/features/home/pages/ThematicHome.tsx
@@ -20,7 +20,7 @@ import { ThematicHomeHeader } from 'features/home/components/headers/ThematicHom
 import { GenericHome } from 'features/home/pages/GenericHome'
 import { ThematicHeader, ThematicHeaderType } from 'features/home/types'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { analytics } from 'libs/analytics/provider'
 import { useLocation } from 'libs/location/LocationWrapper'
@@ -163,7 +163,7 @@ export const ThematicHome: FunctionComponent = () => {
   }, [hasGeolocPosition, isFromDeeplink])
 
   const handleBackPress = () => {
-    params.from === 'chronicles' ? goBack() : navigate(...homeNavConfig)
+    params.from === 'chronicles' ? goBack() : navigate(...homeNavigationConfig)
   }
 
   return (

--- a/src/features/identityCheck/pages/DisableActivation.native.test.tsx
+++ b/src/features/identityCheck/pages/DisableActivation.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { DisableActivation } from 'features/identityCheck/pages/DisableActivation'
 import * as OpenUrlAPI from 'features/navigation/helpers/openUrl'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import {
   RemoteBannerRedirectionType,
   RemoteBannerType,
@@ -42,7 +42,7 @@ describe('<DisableActivation/>', () => {
     const goHomeButton = screen.getByText('Retourner à l’accueil')
     await userEvent.press(goHomeButton)
 
-    expect(navigate).toHaveBeenCalledWith(homeNavConfig[0], homeNavConfig[1])
+    expect(navigate).toHaveBeenCalledWith(homeNavigationConfig[0], homeNavigationConfig[1])
   })
 
   it('should open FAQ link when pressing "Plus d’infos dans notre FAQ"', async () => {

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
@@ -18,7 +18,7 @@ import { useSendPhoneValidationMutation } from 'features/identityCheck/queries/u
 import { IdentityCheckStep } from 'features/identityCheck/types'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getSubscriptionHookConfig } from 'features/navigation/SubscriptionStackNavigator/getSubscriptionHookConfig'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { analytics } from 'libs/analytics/provider'
 import { useSafeState } from 'libs/hooks'
@@ -42,7 +42,7 @@ export const SetPhoneNumber = () => {
   const [invalidPhoneNumberMessage, setInvalidPhoneNumberMessage] = useSafeState('')
   const [country, setCountry] = useState<Country>(INITIAL_COUNTRY)
   const { navigate } = useNavigation<UseNavigationType>()
-  const { goBack } = useGoBack(...homeNavConfig)
+  const { goBack } = useGoBack(...homeNavigationConfig)
   const isContinueButtonEnabled = isPhoneNumberValid(phoneNumber, country.id)
   const saveStep = useSaveStep()
 

--- a/src/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts.native.test.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts.native.test.tsx
@@ -4,7 +4,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { contactSupport } from 'features/auth/helpers/contactSupport'
 import { PhoneValidationTooManyAttempts } from 'features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { userEvent, render, waitFor, screen } from 'tests/utils'
 
 const openUrl = jest.spyOn(NavigationHelpers, 'openUrl')
@@ -38,6 +38,6 @@ describe('PhoneValidationTooManyAttempts', () => {
     render(<PhoneValidationTooManyAttempts />)
     await userEvent.press(screen.getByText('Retourner à l’accueil'))
 
-    expect(navigate).toHaveBeenCalledWith(homeNavConfig[0], homeNavConfig[1])
+    expect(navigate).toHaveBeenCalledWith(homeNavigationConfig[0], homeNavigationConfig[1])
   })
 })

--- a/src/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts.web.test.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts.web.test.tsx
@@ -4,7 +4,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { contactSupport } from 'features/auth/helpers/contactSupport'
 import { PhoneValidationTooManyAttempts } from 'features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { checkAccessibilityFor, fireEvent, render, screen, waitFor } from 'tests/utils/web'
 
 const openUrl = jest.spyOn(NavigationHelpers, 'openUrl')
@@ -35,7 +35,7 @@ describe('<PhoneValidationTooManyAttempts/>', () => {
 
       fireEvent.click(screen.getByText('Retourner à l’accueil'))
 
-      expect(navigate).toHaveBeenCalledWith(...homeNavConfig)
+      expect(navigate).toHaveBeenCalledWith(...homeNavigationConfig)
     })
   })
 

--- a/src/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { reset, useRoute } from '__mocks__/@react-navigation/native'
 import { SetProfileBookingError } from 'features/identityCheck/pages/profile/SetProfileBookingError'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
@@ -43,7 +43,7 @@ describe('<SetProfileBookingError/>', () => {
 
     expect(reset).toHaveBeenCalledWith({
       index: 0,
-      routes: [{ name: homeNavConfig[0] }],
+      routes: [{ name: homeNavigationConfig[0] }],
     })
   })
 

--- a/src/features/internal/components/DeeplinksGeneratorForm.tsx
+++ b/src/features/internal/components/DeeplinksGeneratorForm.tsx
@@ -20,9 +20,9 @@ import {
   ScreensUsedByMarketing,
 } from 'features/internal/config/deeplinksExportConfig'
 import { getScreenPath } from 'features/navigation/RootNavigator/linking/getScreenPath'
-import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/getSearchStackConfig'
+import { getSearchHookConfig } from 'features/navigation/SearchStackNavigator/getSearchHookConfig'
 import { isSearchStackScreen } from 'features/navigation/SearchStackNavigator/isSearchStackScreen'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { isTabNavigatorScreen } from 'features/navigation/TabBar/isTabNavigatorScreen'
 import { MAX_PRICE_IN_CENTS } from 'features/search/helpers/reducer.helpers'
 import { LocationFilter } from 'features/search/types'
@@ -300,15 +300,15 @@ export const DeeplinksGeneratorForm = ({ onCreate }: Props) => {
 
     let screenPath = getScreenPath(selectedScreen, appAndMarketingParams)
     if (isTabNavigatorScreen(selectedScreen)) {
-      const tabNavConfig = getTabNavConfig(
+      const tabNavigationConfig = getTabHookConfig(
         selectedScreen,
         appAndMarketingParams as Record<string, unknown>
       )
 
-      screenPath = getScreenPath(...tabNavConfig)
+      screenPath = getScreenPath(...tabNavigationConfig)
     }
     if (isSearchStackScreen(selectedScreen)) {
-      const searchStackConfig = getSearchStackConfig(selectedScreen, appAndMarketingParams)
+      const searchStackConfig = getSearchHookConfig(selectedScreen, appAndMarketingParams)
       screenPath = getScreenPath(...searchStackConfig)
     }
 

--- a/src/features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig.ts
+++ b/src/features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig.ts
@@ -3,7 +3,7 @@ import {
   CheatcodesStackRouteName,
 } from 'features/navigation/CheatcodesStackNavigator/CheatcodesStackTypes'
 
-export function getCheatcodesStackConfig<Screen extends CheatcodesStackRouteName>(
+export function getCheatcodesHookConfig<Screen extends CheatcodesStackRouteName>(
   screen: Screen,
   params?: CheatcodesStackParamList[Screen]
 ): [

--- a/src/features/navigation/OnboardingStackNavigator/getOnboardingHookConfig.ts
+++ b/src/features/navigation/OnboardingStackNavigator/getOnboardingHookConfig.ts
@@ -3,7 +3,7 @@ import {
   OnboardingStackRouteName,
 } from 'features/navigation/OnboardingStackNavigator/OnboardingStackTypes'
 
-export function getOnboardingStackConfig<Screen extends OnboardingStackRouteName>(
+export function getOnboardingHookConfig<Screen extends OnboardingStackRouteName>(
   screen: Screen,
   params?: OnboardingStackParamList[Screen]
 ): [

--- a/src/features/navigation/OnboardingStackNavigator/getOnboardingPropConfig.ts
+++ b/src/features/navigation/OnboardingStackNavigator/getOnboardingPropConfig.ts
@@ -3,7 +3,7 @@ import {
   OnboardingStackRouteName,
 } from 'features/navigation/OnboardingStackNavigator/OnboardingStackTypes'
 
-export function getOnboardingNavConfig<Screen extends OnboardingStackRouteName>(
+export function getOnboardingPropConfig<Screen extends OnboardingStackRouteName>(
   screen: Screen,
   params?: OnboardingStackParamList[Screen]
 ): {

--- a/src/features/navigation/ProfileStackNavigator/getProfileHookConfig.ts
+++ b/src/features/navigation/ProfileStackNavigator/getProfileHookConfig.ts
@@ -3,7 +3,7 @@ import {
   ProfileStackRouteName,
 } from 'features/navigation/ProfileStackNavigator/ProfileStackTypes'
 
-export function getProfileStackConfig<Screen extends ProfileStackRouteName>(
+export function getProfileHookConfig<Screen extends ProfileStackRouteName>(
   screen: Screen,
   params?: ProfileStackParamList[Screen]
 ): [

--- a/src/features/navigation/ProfileStackNavigator/getProfilePropConfig.ts
+++ b/src/features/navigation/ProfileStackNavigator/getProfilePropConfig.ts
@@ -3,7 +3,7 @@ import {
   ProfileStackRouteName,
 } from 'features/navigation/ProfileStackNavigator/ProfileStackTypes'
 
-export function getProfileNavConfig<Screen extends ProfileStackRouteName>(
+export function getProfilePropConfig<Screen extends ProfileStackRouteName>(
   screen: Screen,
   params?: ProfileStackParamList[Screen]
 ): {

--- a/src/features/navigation/RootNavigator/Header/AccessibleTabBar.web.test.tsx
+++ b/src/features/navigation/RootNavigator/Header/AccessibleTabBar.web.test.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { defaultDisabilitiesProperties } from 'features/accessibility/context/AccessibilityFiltersWrapper'
 import { useTabBarItemBadges } from 'features/navigation/helpers/useTabBarItemBadges'
 import * as navigationRefAPI from 'features/navigation/navigationRef'
-import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/getSearchStackConfig'
+import { getSearchHookConfig } from 'features/navigation/SearchStackNavigator/getSearchHookConfig'
 import {
   DEFAULT_TAB_ROUTES,
   useTabNavigationContext,
@@ -164,7 +164,7 @@ describe('AccessibleTabBar', () => {
     fireEvent.click(searchButton)
 
     expect(navigateFromRefSpy).toHaveBeenCalledWith(
-      ...getSearchStackConfig('SearchLanding', {
+      ...getSearchHookConfig('SearchLanding', {
         ...mockSearchState,
         query: '',
         locationFilter: mockedLocation,

--- a/src/features/navigation/RootNavigator/Header/AccessibleTabBar.web.tsx
+++ b/src/features/navigation/RootNavigator/Header/AccessibleTabBar.web.tsx
@@ -25,11 +25,15 @@ export const AccessibleTabBar = ({ id }: { id: string }) => {
       <TabBarContainer>
         <StyledUl>
           {tabRoutes.map((route) => {
-            const tabNavConfig = getTabNavigatorConfig(route, searchState)
+            const tabNavigationConfig = getTabNavigatorConfig(route, searchState)
             return (
               <LinkContainer key={route.name}>
                 <TabBarComponent
-                  navigateTo={{ screen: tabNavConfig[0], params: tabNavConfig[1], fromRef: true }}
+                  navigateTo={{
+                    screen: tabNavigationConfig[0],
+                    params: tabNavigationConfig[1],
+                    fromRef: true,
+                  }}
                   onPress={route.name === 'SearchStackNavigator' ? hideSuggestions : undefined}
                   tabName={route.name}
                   isSelected={route.isSelected}

--- a/src/features/navigation/RootNavigator/Header/Header.web.tsx
+++ b/src/features/navigation/RootNavigator/Header/Header.web.tsx
@@ -4,7 +4,7 @@ import styled, { useTheme } from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useTabBarItemBadges } from 'features/navigation/helpers/useTabBarItemBadges'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useMediaQuery } from 'libs/react-responsive/useMediaQuery'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { LogoPassCulture } from 'ui/svg/icons/LogoPassCulture'
@@ -31,8 +31,8 @@ export const Header = memo(function Header({ mainId }: { mainId: string }) {
         <LeftContainer>
           <LogoContainer
             navigateTo={{
-              screen: homeNavConfig[0],
-              params: homeNavConfig[1],
+              screen: homeNavigationConfig[0],
+              params: homeNavigationConfig[1],
               fromRef: true,
               withPush: true,
             }}>

--- a/src/features/navigation/RootNavigator/Header/Nav.native.test.tsx
+++ b/src/features/navigation/RootNavigator/Header/Nav.native.test.tsx
@@ -5,7 +5,7 @@ import { defaultDisabilitiesProperties } from 'features/accessibility/context/Ac
 import { useTabBarItemBadges } from 'features/navigation/helpers/useTabBarItemBadges'
 import * as navigationRefAPI from 'features/navigation/navigationRef'
 import { Nav } from 'features/navigation/RootNavigator/Header/Nav'
-import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/getSearchStackConfig'
+import { getSearchHookConfig } from 'features/navigation/SearchStackNavigator/getSearchHookConfig'
 import {
   DEFAULT_TAB_ROUTES,
   useTabNavigationContext,
@@ -127,7 +127,7 @@ describe('Nav', () => {
     await user.press(searchButton)
 
     expect(navigateFromRefSpy).toHaveBeenCalledWith(
-      ...getSearchStackConfig('SearchLanding', {
+      ...getSearchHookConfig('SearchLanding', {
         ...mockSearchState,
         query: '',
         locationFilter: mockedLocation,

--- a/src/features/navigation/RootNavigator/Header/Nav.tsx
+++ b/src/features/navigation/RootNavigator/Header/Nav.tsx
@@ -35,7 +35,7 @@ export const Nav: React.FC<Props> = ({ maxWidth, height, noShadow, routeBadgeMap
       noShadow={noShadow}>
       <Ul>
         {tabRoutes.map((route, index) => {
-          const tabNavConfig = getTabNavigatorConfig(route, searchState)
+          const tabNavigationConfig = getTabNavigatorConfig(route, searchState)
           return (
             <StyledLi key={`key-tab-nav-${route.name}`}>
               {index > 0 ? <Spacer.Row numberOfSpaces={1.5} /> : null}
@@ -48,8 +48,8 @@ export const Nav: React.FC<Props> = ({ maxWidth, height, noShadow, routeBadgeMap
                 }
                 badgeValue={routeBadgeMap?.[route.name]}
                 navigateTo={{
-                  screen: tabNavConfig[0],
-                  params: tabNavConfig[1],
+                  screen: tabNavigationConfig[0],
+                  params: tabNavigationConfig[1],
                   fromRef: true,
                 }}
               />

--- a/src/features/navigation/RootNavigator/Header/getTabNavigatorConfig.test.ts
+++ b/src/features/navigation/RootNavigator/Header/getTabNavigatorConfig.test.ts
@@ -1,29 +1,29 @@
 jest.mock('features/navigation/TabBar/helpers', () => ({
-  getTabNavConfig: jest.fn((name, config) => ({ name, config })),
+  getTabHookConfig: jest.fn((name, config) => ({ name, config })),
 }))
 
 import { defaultDisabilitiesProperties } from 'features/accessibility/context/AccessibilityFiltersWrapper'
 import { getTabNavigatorConfig } from 'features/navigation/RootNavigator/Header/getTabNavigatorConfig'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { TabStateRoute } from 'features/navigation/TabBar/TabStackNavigatorTypes'
 import { initialSearchState } from 'features/search/context/reducer'
 import { LocationMode } from 'libs/location/types'
 import { SuggestedPlace } from 'libs/place/types'
 
 describe('getTabNavigatorConfig', () => {
-  const mockGetTabNavConfig = getTabNavConfig as jest.Mock
+  const mockGetTabHookConfig = getTabHookConfig as jest.Mock
 
   beforeEach(() => {
-    mockGetTabNavConfig.mockClear()
+    mockGetTabHookConfig.mockClear()
   })
 
   describe('for non-SearchStackNavigator routes', () => {
     const homeRoute: TabStateRoute = { name: 'Home', key: 'home-initial', isSelected: true }
 
-    it('should call getTabNavConfig with received route', () => {
+    it('should call getTabNavigationConfig with received route', () => {
       getTabNavigatorConfig(homeRoute, initialSearchState)
 
-      expect(mockGetTabNavConfig).toHaveBeenCalledWith('Home')
+      expect(mockGetTabHookConfig).toHaveBeenCalledWith('Home')
     })
   })
 
@@ -55,7 +55,7 @@ describe('getTabNavigatorConfig', () => {
     it('should return config with empty params when route is not selected', () => {
       getTabNavigatorConfig(searchRouteNotSelected, initialSearchState)
 
-      expect(mockGetTabNavConfig).toHaveBeenCalledWith('SearchStackNavigator', {
+      expect(mockGetTabHookConfig).toHaveBeenCalledWith('SearchStackNavigator', {
         screen: 'SearchLanding',
         params: {},
       })
@@ -74,7 +74,7 @@ describe('getTabNavigatorConfig', () => {
         locationFilter: mockedLocation,
       })
 
-      expect(mockGetTabNavConfig).toHaveBeenCalledWith('SearchStackNavigator', {
+      expect(mockGetTabHookConfig).toHaveBeenCalledWith('SearchStackNavigator', {
         screen: 'SearchLanding',
         params: { ...mockedSearchState, query: '', locationFilter: mockedLocation },
       })

--- a/src/features/navigation/RootNavigator/Header/getTabNavigatorConfig.ts
+++ b/src/features/navigation/RootNavigator/Header/getTabNavigatorConfig.ts
@@ -1,12 +1,12 @@
 import { defaultDisabilitiesProperties } from 'features/accessibility/context/AccessibilityFiltersWrapper'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { TabStateRoute } from 'features/navigation/TabBar/TabStackNavigatorTypes'
 import { initialSearchState } from 'features/search/context/reducer'
 import { SearchState } from 'features/search/types'
 
 export const getTabNavigatorConfig = (route: TabStateRoute, searchState: SearchState) => {
   if (route.name !== 'SearchStackNavigator') {
-    return getTabNavConfig(route.name)
+    return getTabHookConfig(route.name)
   }
 
   const searchParams = route.isSelected
@@ -17,7 +17,7 @@ export const getTabNavigatorConfig = (route: TabStateRoute, searchState: SearchS
       }
     : {}
 
-  return getTabNavConfig(route.name, {
+  return getTabHookConfig(route.name, {
     screen: 'SearchLanding',
     params: searchParams,
   })

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -74,7 +74,7 @@ export type ThematicHomeParams = BaseThematicHome &
   (OtherThematicBlockHome | CategoryBlockThematicHome | HighlightThematicBlockThematicHome)
 
 export type AccessibilityRootStackParamList = {
-  Accessibility?: Record<string, unknown> // I had to put type Record<string, unknown> so that getProfileStackConfig in DeeplinksGeneratorForm can take appAndMarketingParams, otherwise I would have just put undefined.
+  Accessibility?: Record<string, unknown> // I had to put type Record<string, unknown> so that getProfileHookConfig in DeeplinksGeneratorForm can take appAndMarketingParams, otherwise I would have just put undefined.
   AccessibilityActionPlan?: undefined
   AccessibilityDeclarationMobile?: undefined
   AccessibilityDeclarationWeb?: undefined

--- a/src/features/navigation/RootNavigator/useInitialScreenConfig.tsx
+++ b/src/features/navigation/RootNavigator/useInitialScreenConfig.tsx
@@ -4,7 +4,7 @@ import { Platform } from 'react-native'
 import { UserProfileResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { performanceMonitoringStoreActions } from 'features/home/pages/helpers/usePerformanceMonitoringStore'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { analytics } from 'libs/analytics/provider'
 import { useSafeState } from 'libs/hooks'
 import { storage } from 'libs/storage'
@@ -51,17 +51,17 @@ async function getInitialScreen({
       }
     } catch {
       // If we cannot get user's information, we just go to the homepage
-      return homeNavConfig[0]
+      return homeNavigationConfig[0]
     }
   }
 
   try {
     const hasSeenTutorials = !!(await storage.readObject('has_seen_tutorials'))
     if (hasSeenTutorials || Platform.OS === 'web') {
-      return homeNavConfig[0]
+      return homeNavigationConfig[0]
     }
   } catch {
-    return homeNavConfig[0]
+    return homeNavigationConfig[0]
   }
 
   return 'OnboardingStackNavigator'

--- a/src/features/navigation/SearchStackNavigator/getSearchHookConfig.ts
+++ b/src/features/navigation/SearchStackNavigator/getSearchHookConfig.ts
@@ -1,6 +1,6 @@
 import { SearchStackRouteName, SearchStackParamList } from './SearchStackTypes'
 
-export function getSearchStackConfig<Screen extends SearchStackRouteName>(
+export function getSearchHookConfig<Screen extends SearchStackRouteName>(
   screen: Screen,
   params?: SearchStackParamList[Screen]
 ): [

--- a/src/features/navigation/SearchStackNavigator/getSearchPropConfig.ts
+++ b/src/features/navigation/SearchStackNavigator/getSearchPropConfig.ts
@@ -1,6 +1,6 @@
 import { SearchStackRouteName, SearchStackParamList } from './SearchStackTypes'
 
-export function getSearchNavConfig<Screen extends SearchStackRouteName>(
+export function getSearchPropConfig<Screen extends SearchStackRouteName>(
   screen: Screen,
   params?: SearchStackParamList[Screen]
 ): {

--- a/src/features/navigation/TabBar/TabBar.native.test.tsx
+++ b/src/features/navigation/TabBar/TabBar.native.test.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import { DisplayedDisabilitiesEnum } from 'features/accessibility/enums'
 import { useTabBarItemBadges } from 'features/navigation/helpers/useTabBarItemBadges'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import {
   DEFAULT_TAB_ROUTES,
   useTabNavigationContext,
@@ -268,7 +268,7 @@ describe('TabBar', () => {
     await user.press(searchButton)
 
     expect(navigation.navigate).toHaveBeenCalledWith(
-      ...getTabNavConfig('SearchStackNavigator', {
+      ...getTabHookConfig('SearchStackNavigator', {
         screen: 'SearchLanding',
         params: { ...initialSearchState, accessibilityFilter: mockAccessibilityState },
       })
@@ -285,7 +285,7 @@ describe('TabBar', () => {
     await user.press(searchButton)
 
     expect(navigation.navigate).toHaveBeenCalledWith(
-      ...getTabNavConfig('SearchStackNavigator', {
+      ...getTabHookConfig('SearchStackNavigator', {
         screen: 'SearchLanding',
         params: {
           ...initialSearchState,
@@ -307,7 +307,7 @@ describe('TabBar', () => {
     await user.press(searchButton)
 
     expect(navigation.navigate).toHaveBeenCalledWith(
-      ...getTabNavConfig('SearchStackNavigator', {
+      ...getTabHookConfig('SearchStackNavigator', {
         screen: 'SearchLanding',
         params: {
           ...initialSearchState,

--- a/src/features/navigation/TabBar/TabBar.tsx
+++ b/src/features/navigation/TabBar/TabBar.tsx
@@ -6,7 +6,7 @@ import {
   useAccessibilityFiltersContext,
 } from 'features/accessibility/context/AccessibilityFiltersWrapper'
 import { useTabBarItemBadges } from 'features/navigation/helpers/useTabBarItemBadges'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { TabBarContainer } from 'features/navigation/TabBar/TabBarContainer'
 import { useTabNavigationContext } from 'features/navigation/TabBar/TabNavigationStateContext'
 import { useTabBar } from 'features/navigation/TabBar/useTabBar'
@@ -72,11 +72,11 @@ export const TabBar: React.FC<Props> = ({ navigation, state }) => {
           }
           navigation.navigate('TabNavigator', navigateParams)
         }
-        const tabNavConfig = getTabNavConfig(route.name)
+        const tabNavigationConfig = getTabHookConfig(route.name)
 
         return (
           <TabBarComponent
-            navigateTo={{ screen: tabNavConfig[0], params: tabNavConfig[1] }}
+            navigateTo={{ screen: tabNavigationConfig[0], params: tabNavigationConfig[1] }}
             key={`key-tab-nav-${route.key}`}
             tabName={route.name}
             isSelected={route.isSelected}

--- a/src/features/navigation/TabBar/helpers.ts
+++ b/src/features/navigation/TabBar/helpers.ts
@@ -15,11 +15,11 @@ export function getShouldDisplayTab({
   }
 }
 
-export function getTabNavConfig<Screen extends TabRouteName>(
+export function getTabHookConfig<Screen extends TabRouteName>(
   screen: Screen,
   params?: TabParamList[Screen]
 ): ['TabNavigator', { screen: Screen; params: TabParamList[Screen] }] {
   return ['TabNavigator', { screen, params }]
 }
 
-export const homeNavConfig = getTabNavConfig('Home')
+export const homeNavigationConfig = getTabHookConfig('Home')

--- a/src/features/navigation/helpers/__mocks__/navigateToHome.ts
+++ b/src/features/navigation/helpers/__mocks__/navigateToHome.ts
@@ -1,8 +1,8 @@
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 
 export const navigateToHome = jest.fn()
 export const navigateToHomeConfig = {
-  screen: homeNavConfig[0],
-  params: homeNavConfig[1],
+  screen: homeNavigationConfig[0],
+  params: homeNavigationConfig[1],
   fromRef: true,
 }

--- a/src/features/navigation/helpers/navigateToHome.ts
+++ b/src/features/navigation/helpers/navigateToHome.ts
@@ -1,12 +1,12 @@
 import { navigateFromRef } from 'features/navigation/navigationRef'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 
 export function navigateToHome() {
-  navigateFromRef(...homeNavConfig)
+  navigateFromRef(...homeNavigationConfig)
 }
 
 export const navigateToHomeConfig = {
-  screen: homeNavConfig[0],
-  params: homeNavConfig[1],
+  screen: homeNavigationConfig[0],
+  params: homeNavigationConfig[1],
   fromRef: true,
 }

--- a/src/features/navigation/helpers/useNavigateToHomeWithReset.ts
+++ b/src/features/navigation/helpers/useNavigateToHomeWithReset.ts
@@ -1,12 +1,12 @@
 import { useNavigation } from '@react-navigation/native'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 
 export const useNavigateToHomeWithReset = () => {
   const { reset } = useNavigation<UseNavigationType>()
   const navigateToHomeWithReset = () => {
-    reset({ index: 0, routes: [{ name: homeNavConfig[0] }] })
+    reset({ index: 0, routes: [{ name: homeNavigationConfig[0] }] })
   }
   return { navigateToHomeWithReset }
 }

--- a/src/features/navigation/useGoBack.native.test.ts
+++ b/src/features/navigation/useGoBack.native.test.ts
@@ -1,4 +1,4 @@
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { renderHook } from 'tests/utils'
 
 import { useGoBack } from './useGoBack'
@@ -40,7 +40,7 @@ describe('useGoBack()', () => {
       const { result } = renderUseGoBack()
       result.current.goBack()
 
-      expect(mockNavigate).toHaveBeenCalledWith(...homeNavConfig)
+      expect(mockNavigate).toHaveBeenCalledWith(...homeNavigationConfig)
     })
 
     it("should use navigate if previous route doesn't exist", () => {
@@ -49,7 +49,7 @@ describe('useGoBack()', () => {
       const { result } = renderUseGoBack()
       result.current.goBack()
 
-      expect(mockNavigate).toHaveBeenCalledWith(...homeNavConfig)
+      expect(mockNavigate).toHaveBeenCalledWith(...homeNavigationConfig)
     })
 
     it('should call goBack if previous route exists and canGoBack = true', () => {
@@ -64,5 +64,5 @@ describe('useGoBack()', () => {
 })
 
 function renderUseGoBack() {
-  return renderHook(() => useGoBack(...homeNavConfig))
+  return renderHook(() => useGoBack(...homeNavigationConfig))
 }

--- a/src/features/navigation/useGoBack.web.test.ts
+++ b/src/features/navigation/useGoBack.web.test.ts
@@ -1,4 +1,4 @@
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { renderHook } from 'tests/utils/web'
 
 import { useGoBack } from './useGoBack'
@@ -59,7 +59,7 @@ describe('useGoBack()', () => {
       const { result } = renderUseGoBack()
       result.current.goBack()
 
-      expect(mockNavigate).toHaveBeenCalledWith(...homeNavConfig)
+      expect(mockNavigate).toHaveBeenCalledWith(...homeNavigationConfig)
     })
 
     it("should use history if previous route doesn't exist and canGoBack = true", async () => {
@@ -84,5 +84,5 @@ describe('useGoBack()', () => {
 })
 
 function renderUseGoBack() {
-  return renderHook(() => useGoBack(...homeNavConfig))
+  return renderHook(() => useGoBack(...homeNavigationConfig))
 }

--- a/src/features/offer/components/OfferHeader/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader/OfferHeader.tsx
@@ -3,7 +3,7 @@ import { Animated } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import { OfferResponseV2 } from 'api/gen'
-import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/getSearchStackConfig'
+import { getSearchHookConfig } from 'features/navigation/SearchStackNavigator/getSearchHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { getShareOffer } from 'features/share/helpers/getShareOffer'
 import { WebShareModal } from 'features/share/pages/WebShareModal'
@@ -37,7 +37,7 @@ export function OfferHeader({
     hideModal: hideShareOfferModal,
   } = useModal(false)
 
-  const { goBack } = useGoBack(...getSearchStackConfig('SearchLanding'))
+  const { goBack } = useGoBack(...getSearchHookConfig('SearchLanding'))
 
   const { share: shareOffer, shareContent } = getShareOffer({
     offer,

--- a/src/features/onboarding/components/AgeButton.stories.tsx
+++ b/src/features/onboarding/components/AgeButton.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta } from '@storybook/react'
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { getOnboardingNavConfig } from 'features/navigation/OnboardingStackNavigator/getOnboardingNavConfig'
+import { getOnboardingPropConfig } from 'features/navigation/OnboardingStackNavigator/getOnboardingPropConfig'
 import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
 import { All as InitialAll } from 'ui/svg/icons/venueAndCategories/All'
 import { Spacer, Typo } from 'ui/theme'
@@ -74,14 +74,14 @@ const variantConfig: Variants<typeof AgeButton> = [
     label: 'AgeButton default',
     props: {
       children: TextExample({}),
-      navigateTo: getOnboardingNavConfig('OnboardingAgeSelectionFork'),
+      navigateTo: getOnboardingPropConfig('OnboardingAgeSelectionFork'),
     },
   },
   {
     label: 'AgeButton dense',
     props: {
       children: TextExample({}),
-      navigateTo: getOnboardingNavConfig('OnboardingAgeSelectionFork'),
+      navigateTo: getOnboardingPropConfig('OnboardingAgeSelectionFork'),
       dense: true,
     },
   },
@@ -89,14 +89,14 @@ const variantConfig: Variants<typeof AgeButton> = [
     label: 'AgeButton with subtitle',
     props: {
       children: TextExample({ withSubtitle: true }),
-      navigateTo: getOnboardingNavConfig('OnboardingAgeSelectionFork'),
+      navigateTo: getOnboardingPropConfig('OnboardingAgeSelectionFork'),
     },
   },
   {
     label: 'AgeButton dense with subtitle',
     props: {
       children: TextExample({ withSubtitle: true }),
-      navigateTo: getOnboardingNavConfig('OnboardingAgeSelectionFork'),
+      navigateTo: getOnboardingPropConfig('OnboardingAgeSelectionFork'),
       dense: true,
     },
   },
@@ -104,7 +104,7 @@ const variantConfig: Variants<typeof AgeButton> = [
     label: 'AgeButton with icon',
     props: {
       children: TextExample({}),
-      navigateTo: getOnboardingNavConfig('OnboardingAgeSelectionFork'),
+      navigateTo: getOnboardingPropConfig('OnboardingAgeSelectionFork'),
       Icon: <All />,
     },
   },
@@ -112,7 +112,7 @@ const variantConfig: Variants<typeof AgeButton> = [
     label: 'AgeButton with subtitle and icon',
     props: {
       children: TextExample({ withSubtitle: true }),
-      navigateTo: getOnboardingNavConfig('OnboardingAgeSelectionFork'),
+      navigateTo: getOnboardingPropConfig('OnboardingAgeSelectionFork'),
       Icon: <All />,
     },
   },
@@ -120,7 +120,7 @@ const variantConfig: Variants<typeof AgeButton> = [
     label: 'AgeButton dense with subtitle and icon',
     props: {
       children: TextExample({ withSubtitle: true }),
-      navigateTo: getOnboardingNavConfig('OnboardingAgeSelectionFork'),
+      navigateTo: getOnboardingPropConfig('OnboardingAgeSelectionFork'),
       dense: true,
       Icon: <All />,
     },

--- a/src/features/onboarding/pages/onboarding/OnboardingAgeInformation.native.test.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingAgeInformation.native.test.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { navigate, reset } from '__mocks__/@react-navigation/native'
 import { OnboardingStackParamList } from 'features/navigation/OnboardingStackNavigator/OnboardingStackTypes'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import * as useGoBack from 'features/navigation/useGoBack'
 import { CreditStatus } from 'features/onboarding/enums'
 import { OnboardingAgeInformation } from 'features/onboarding/pages/onboarding/OnboardingAgeInformation'
@@ -41,7 +41,7 @@ describe('OnboardingAgeInformation', () => {
 
     expect(reset).toHaveBeenCalledWith({
       index: 0,
-      routes: [{ name: homeNavConfig[0] }],
+      routes: [{ name: homeNavigationConfig[0] }],
     })
     expect(eventMonitoring.captureException).toHaveBeenCalledWith('route.params.type is falsy')
   })
@@ -97,7 +97,7 @@ describe('OnboardingAgeInformation', () => {
 
       expect(reset).toHaveBeenCalledWith({
         index: 0,
-        routes: [{ name: homeNavConfig[0] }],
+        routes: [{ name: homeNavigationConfig[0] }],
       })
     }
   )

--- a/src/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { getOnboardingNavConfig } from 'features/navigation/OnboardingStackNavigator/getOnboardingNavConfig'
+import { getOnboardingPropConfig } from 'features/navigation/OnboardingStackNavigator/getOnboardingPropConfig'
 import { AgeButton } from 'features/onboarding/components/AgeButton'
 import { NonEligible } from 'features/onboarding/enums'
 import { EligibleAges } from 'features/onboarding/types'
@@ -32,28 +32,28 @@ export const OnboardingAgeSelectionFork: FunctionComponent = () => {
       startButtonTitle: 'J’ai ',
       age: '16 ans',
       endButtonTitle: ' ou moins',
-      navigateTo: getOnboardingNavConfig('OnboardingNotEligible'),
+      navigateTo: getOnboardingPropConfig('OnboardingNotEligible'),
       onBeforeNavigate: () => onAgeChoice(NonEligible.UNDER_17),
     },
     {
       startButtonTitle: 'J’ai ',
       age: '17 ans',
       endButtonTitle: '',
-      navigateTo: getOnboardingNavConfig('OnboardingAgeInformation', { age: 17 }),
+      navigateTo: getOnboardingPropConfig('OnboardingAgeInformation', { age: 17 }),
       onBeforeNavigate: () => onAgeChoice(17),
     },
     {
       startButtonTitle: 'J’ai ',
       age: '18 ans',
       endButtonTitle: '',
-      navigateTo: getOnboardingNavConfig('OnboardingAgeInformation', { age: 18 }),
+      navigateTo: getOnboardingPropConfig('OnboardingAgeInformation', { age: 18 }),
       onBeforeNavigate: () => onAgeChoice(18),
     },
     {
       startButtonTitle: 'J’ai ',
       age: '19 ans',
       endButtonTitle: ' ou plus',
-      navigateTo: getOnboardingNavConfig('OnboardingGeneralPublicWelcome'),
+      navigateTo: getOnboardingPropConfig('OnboardingGeneralPublicWelcome'),
       onBeforeNavigate: () => onAgeChoice(NonEligible.OVER_18),
     },
   ]

--- a/src/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { navigate, reset, push } from '__mocks__/@react-navigation/native'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { userEvent, render, screen } from 'tests/utils'
 
 import { OnboardingGeneralPublicWelcome } from './OnboardingGeneralPublicWelcome'
@@ -25,7 +25,7 @@ describe('OnboardingGeneralPublicWelcome', () => {
 
     expect(reset).toHaveBeenCalledWith({
       index: 0,
-      routes: [{ name: homeNavConfig[0] }],
+      routes: [{ name: homeNavigationConfig[0] }],
     })
   })
 

--- a/src/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { useNavigateToHomeWithReset } from 'features/navigation/helpers/useNavigateToHomeWithReset'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import QpiThanks from 'ui/animations/qpi_thanks.json'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 
@@ -25,7 +25,7 @@ export const OnboardingGeneralPublicWelcome = () => {
       buttonSecondary={{
         wording: 'Accéder au catalogue',
         navigateTo: {
-          screen: homeNavConfig[0],
+          screen: homeNavigationConfig[0],
           withPush: true,
         },
       }}

--- a/src/features/onboarding/pages/onboarding/OnboardingGeolocation.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingGeolocation.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from '@react-navigation/native'
 import React, { useCallback } from 'react'
 
-import { getOnboardingStackConfig } from 'features/navigation/OnboardingStackNavigator/getOnboardingStackConfig'
+import { getOnboardingHookConfig } from 'features/navigation/OnboardingStackNavigator/getOnboardingHookConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
 import { useLocation } from 'libs/location'
@@ -20,7 +20,7 @@ export const OnboardingGeolocation = () => {
   const { requestGeolocPermission } = useLocation()
 
   const navigateToNextScreen = useCallback(() => {
-    navigate(...getOnboardingStackConfig('OnboardingAgeSelectionFork'))
+    navigate(...getOnboardingHookConfig('OnboardingAgeSelectionFork'))
   }, [navigate])
 
   const onGeolocationButtonPress = useCallback(async () => {

--- a/src/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { navigate, reset } from '__mocks__/@react-navigation/native'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { OnboardingNotEligible } from 'features/onboarding/pages/onboarding/OnboardingNotEligible'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -39,7 +39,7 @@ describe('OnboardingNotEligible', () => {
 
     expect(reset).toHaveBeenCalledWith({
       index: 0,
-      routes: [{ name: homeNavConfig[0] }],
+      routes: [{ name: homeNavigationConfig[0] }],
     })
   })
 
@@ -51,7 +51,7 @@ describe('OnboardingNotEligible', () => {
 
     expect(reset).toHaveBeenCalledWith({
       index: 0,
-      routes: [{ name: homeNavConfig[0] }],
+      routes: [{ name: homeNavigationConfig[0] }],
     })
   })
 })

--- a/src/features/onboarding/pages/onboarding/OnboardingNotEligible.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingNotEligible.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { useNavigateToHomeWithReset } from 'features/navigation/helpers/useNavigateToHomeWithReset'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useAnimationToDisplay } from 'libs/styled/useAnimationToDisplay'
 import BirthdayCakeAnimation from 'ui/animations/onboarding_birthday_cake.json'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
@@ -32,7 +32,7 @@ export const OnboardingNotEligible = () => {
       buttonSecondary={{
         wording: 'Accéder au catalogue',
         navigateTo: {
-          screen: homeNavConfig[0],
+          screen: homeNavigationConfig[0],
           withReset: true,
         },
       }}

--- a/src/features/onboarding/pages/onboarding/OnboardingWelcome.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingWelcome.tsx
@@ -5,7 +5,7 @@ import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
 
 import { AuthenticationButton } from 'features/auth/components/AuthenticationButton/AuthenticationButton'
-import { getOnboardingNavConfig } from 'features/navigation/OnboardingStackNavigator/getOnboardingNavConfig'
+import { getOnboardingPropConfig } from 'features/navigation/OnboardingStackNavigator/getOnboardingPropConfig'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
 import { WELCOME_BACKGROUND_SOURCE } from 'features/onboarding/components/welcomeBackground'
 import { analytics } from 'libs/analytics/provider'
@@ -48,7 +48,7 @@ export const OnboardingWelcome: FunctionComponent = () => {
             wording="C’est parti&nbsp;!"
             icon={PlainArrowNext}
             iconAfterWording
-            navigateTo={getOnboardingNavConfig('OnboardingGeolocation')}
+            navigateTo={getOnboardingPropConfig('OnboardingGeolocation')}
             onBeforeNavigate={onStartPress}
           />
           <Spacer.Column numberOfSpaces={4} />

--- a/src/features/profile/components/CreditExplanation/CreditExplanation.tsx
+++ b/src/features/profile/components/CreditExplanation/CreditExplanation.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { ExpiredCreditModal } from 'features/profile/components/Modals/ExpiredCreditModal'
 import { analytics } from 'libs/analytics/provider'
 import { ButtonQuaternaryBlack } from 'ui/components/buttons/ButtonQuaternaryBlack'
@@ -48,7 +48,7 @@ export const CreditExplanation: FunctionComponent<Props> = ({ age, isDepositExpi
         as={StyledButtonQuaternaryBlack}
         icon={Question}
         wording="Comment ça marche&nbsp;?"
-        navigateTo={getProfileNavConfig('ProfileTutorialAgeInformationCredit')}
+        navigateTo={getProfilePropConfig('ProfileTutorialAgeInformationCredit')}
         onBeforeNavigate={onTutorialClick}
       />
     </React.Fragment>

--- a/src/features/profile/components/EditableFiled/EditableField.tsx
+++ b/src/features/profile/components/EditableFiled/EditableField.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { ProfileNavigateParams } from 'features/navigation/RootNavigator/types'
 import { EditButton } from 'features/profile/components/Buttons/EditButton/EditButton'
 import { Separator } from 'ui/components/Separator'
@@ -41,7 +41,7 @@ export function EditableField({
         )}
         {showButton ? (
           <EditButton
-            navigateTo={getProfileNavConfig(navigateTo, navigateParams)}
+            navigateTo={getProfilePropConfig(navigateTo, navigateParams)}
             onPress={onBeforeNavigate}
             wording={isCompleted ? 'Modifier' : 'Compléter'}
             accessibilityLabel={accessibilityLabel}

--- a/src/features/profile/helpers/getSiteMapLinks.ts
+++ b/src/features/profile/helpers/getSiteMapLinks.ts
@@ -1,5 +1,5 @@
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { CategoryButtonProps } from 'shared/categoryButton/CategoryButton'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 
@@ -11,7 +11,7 @@ type SubPage = {
 
 type SiteMap = SubPage & { subPages: SubPage[] }
 
-const toInternalNavigationProps = ([screen, params]: ReturnType<typeof getTabNavConfig>) => ({
+const toInternalNavigationProps = ([screen, params]: ReturnType<typeof getTabHookConfig>) => ({
   screen,
   params,
 })
@@ -21,13 +21,13 @@ export const getSiteMapLinks = (
 ): SiteMap[] => [
   {
     wording: 'Accueil',
-    navigateTo: toInternalNavigationProps(getTabNavConfig('Home')),
+    navigateTo: toInternalNavigationProps(getTabHookConfig('Home')),
     isLoggedIn: false,
     subPages: [],
   },
   {
     wording: 'Recherche',
-    navigateTo: toInternalNavigationProps(getTabNavConfig('SearchStackNavigator')),
+    navigateTo: toInternalNavigationProps(getTabHookConfig('SearchStackNavigator')),
     isLoggedIn: false,
     subPages: [
       { wording: 'Explore la carte', navigateTo: { screen: 'VenueMap' }, isLoggedIn: false },
@@ -40,19 +40,19 @@ export const getSiteMapLinks = (
   },
   {
     wording: 'Réservations',
-    navigateTo: toInternalNavigationProps(getTabNavConfig('Bookings')),
+    navigateTo: toInternalNavigationProps(getTabHookConfig('Bookings')),
     isLoggedIn: true,
     subPages: [],
   },
   {
     wording: 'Favoris',
-    navigateTo: toInternalNavigationProps(getTabNavConfig('Favorites')),
+    navigateTo: toInternalNavigationProps(getTabHookConfig('Favorites')),
     isLoggedIn: true,
     subPages: [],
   },
   {
     wording: 'Profil',
-    navigateTo: toInternalNavigationProps(getTabNavConfig('Profile')),
+    navigateTo: toInternalNavigationProps(getTabHookConfig('Profile')),
     isLoggedIn: false,
     subPages: [
       {
@@ -72,47 +72,47 @@ export const getSiteMapLinks = (
       },
       {
         wording: 'Notifications',
-        navigateTo: getProfileNavConfig('NotificationsSettings'),
+        navigateTo: getProfilePropConfig('NotificationsSettings'),
         isLoggedIn: false,
       },
       {
         wording: 'Comment ça marche\u00a0?',
-        navigateTo: getProfileNavConfig('ProfileTutorialAgeInformationCredit'),
+        navigateTo: getProfilePropConfig('ProfileTutorialAgeInformationCredit'),
         isLoggedIn: false,
       },
       {
         wording: 'Informations personnelles',
-        navigateTo: getProfileNavConfig('PersonalData'),
+        navigateTo: getProfilePropConfig('PersonalData'),
         isLoggedIn: true,
       },
       {
         wording: 'Préférence d’affichage',
-        navigateTo: getProfileNavConfig('DisplayPreference'),
+        navigateTo: getProfilePropConfig('DisplayPreference'),
         isLoggedIn: false,
       },
       {
         wording: 'Accessibilité',
-        navigateTo: getProfileNavConfig('Accessibility'),
+        navigateTo: getProfilePropConfig('Accessibility'),
         isLoggedIn: false,
       },
       {
         wording: 'Faire une suggestion',
-        navigateTo: getProfileNavConfig('FeedbackInApp'),
+        navigateTo: getProfilePropConfig('FeedbackInApp'),
         isLoggedIn: false,
       },
       {
         wording: 'Informations légales',
-        navigateTo: getProfileNavConfig('LegalNotices'),
+        navigateTo: getProfilePropConfig('LegalNotices'),
         isLoggedIn: false,
       },
       {
         wording: 'Confidentialité',
-        navigateTo: getProfileNavConfig('ConsentSettings'),
+        navigateTo: getProfilePropConfig('ConsentSettings'),
         isLoggedIn: false,
       },
       {
         wording: 'Débuggage',
-        navigateTo: getProfileNavConfig('DebugScreen'),
+        navigateTo: getProfilePropConfig('DebugScreen'),
         isLoggedIn: true,
       },
     ],

--- a/src/features/profile/helpers/useChangeEmailMutation.ts
+++ b/src/features/profile/helpers/useChangeEmailMutation.ts
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 import { useMutation } from '@tanstack/react-query'
 
 import { api } from 'api/api'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import {
   SNACK_BAR_TIME_OUT,
@@ -23,7 +23,7 @@ export const useChangeEmailMutation = () => {
             'E-mail envoyé sur ton adresse actuelle\u00a0! Tu as 24h pour valider ta demande. Si tu ne le trouves pas, pense à vérifier tes spams.',
           timeout: SNACK_BAR_TIME_OUT_LONG,
         })
-        replace(...getProfileStackConfig('TrackEmailChange'))
+        replace(...getProfileHookConfig('TrackEmailChange'))
       },
       onError: () => {
         showErrorSnackBar({

--- a/src/features/profile/pages/Accessibility/Accessibility.native.test.tsx
+++ b/src/features/profile/pages/Accessibility/Accessibility.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { push } from '__mocks__/@react-navigation/native'
 import { Accessibility } from 'features/profile/pages/Accessibility/Accessibility'
 import { render, userEvent, screen } from 'tests/utils'
 
@@ -35,7 +35,7 @@ describe('Accessibility', () => {
     const row = screen.getByText(title)
     await user.press(row)
 
-    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+    expect(push).toHaveBeenCalledWith('ProfileStackNavigator', {
       params: undefined,
       screen: route,
     })

--- a/src/features/profile/pages/Accessibility/Accessibility.tsx
+++ b/src/features/profile/pages/Accessibility/Accessibility.tsx
@@ -6,7 +6,7 @@ import {
   AccessibilityRootStackParamList,
   UseNavigationType,
 } from 'features/navigation/RootNavigator/types'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { AccessibleUnorderedList } from 'ui/components/accessibility/AccessibleUnorderedList'
 import { SectionRow } from 'ui/components/SectionRow'
@@ -52,7 +52,7 @@ const sectionConfig: {
 ]
 
 export function Accessibility() {
-  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack } = useGoBack(...getTabHookConfig('Profile'))
   const { push } = useNavigation<UseNavigationType>()
 
   return (

--- a/src/features/profile/pages/Accessibility/Accessibility.tsx
+++ b/src/features/profile/pages/Accessibility/Accessibility.tsx
@@ -1,8 +1,11 @@
+import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
-import { ProfileStackParamList } from 'features/navigation/ProfileStackNavigator/ProfileStackTypes'
+import {
+  AccessibilityRootStackParamList,
+  UseNavigationType,
+} from 'features/navigation/RootNavigator/types'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { AccessibleUnorderedList } from 'ui/components/accessibility/AccessibleUnorderedList'
@@ -18,7 +21,7 @@ const StyledSectionRow = styled(SectionRow)<{ noTopMargin?: boolean }>(({ noTopM
 
 const sectionConfig: {
   title: string
-  screen: keyof ProfileStackParamList
+  screen: keyof AccessibilityRootStackParamList
   noTopMargin?: boolean
 }[] = [
   {
@@ -48,22 +51,28 @@ const sectionConfig: {
   },
 ]
 
-const sections = sectionConfig.map(({ title, screen, noTopMargin }) => (
-  <StyledSectionRow
-    key={title}
-    title={title}
-    type="navigable"
-    navigateTo={getProfileNavConfig(screen)}
-    noTopMargin={noTopMargin}
-  />
-))
-
 export function Accessibility() {
   const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+  const { push } = useNavigation<UseNavigationType>()
 
   return (
     <SecondaryPageWithBlurHeader title="Accessibilité" enableMaxWidth={false} onGoBack={goBack}>
-      <AccessibleUnorderedList items={sections} Separator={<Separator.Horizontal />} />
+      <AccessibleUnorderedList
+        items={sectionConfig.map(({ title, screen, noTopMargin }) => (
+          <StyledSectionRow
+            key={title}
+            title={title}
+            type="navigable"
+            onPress={() =>
+              push('ProfileStackNavigator', {
+                screen: screen,
+              })
+            }
+            noTopMargin={noTopMargin}
+          />
+        ))}
+        Separator={<Separator.Horizontal />}
+      />
     </SecondaryPageWithBlurHeader>
   )
 }

--- a/src/features/profile/pages/Accessibility/AccessibilityActionPlan.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityActionPlan.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { AccessibilityActionPlanSection } from 'features/profile/components/AccessibilityActionPlanSection/AccessibilityActionPlanSection'
 import { ContactSupportButton } from 'features/profile/components/Buttons/ContactSupportButton/ContactSupportButton'
@@ -21,7 +21,7 @@ import { DOUBLE_LINE_BREAK, LINE_BREAK } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export function AccessibilityActionPlan() {
-  const { goBack } = useGoBack(...getProfileStackConfig('Accessibility'))
+  const { goBack } = useGoBack(...getProfileHookConfig('Accessibility'))
   return (
     <SecondaryPageWithBlurHeader
       onGoBack={goBack}

--- a/src/features/profile/pages/Accessibility/AccessibilityActionPlan.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityActionPlan.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
+import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { useGoBack } from 'features/navigation/useGoBack'
 import { AccessibilityActionPlanSection } from 'features/profile/components/AccessibilityActionPlanSection/AccessibilityActionPlanSection'
 import { ContactSupportButton } from 'features/profile/components/Buttons/ContactSupportButton/ContactSupportButton'
 import { accessibility2022 } from 'features/profile/pages/Accessibility/accessibility2022'
@@ -19,8 +21,12 @@ import { DOUBLE_LINE_BREAK, LINE_BREAK } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export function AccessibilityActionPlan() {
+  const { goBack } = useGoBack(...getProfileStackConfig('Accessibility'))
   return (
-    <SecondaryPageWithBlurHeader title="Schéma pluriannuel" enableMaxWidth={false}>
+    <SecondaryPageWithBlurHeader
+      onGoBack={goBack}
+      title="Schéma pluriannuel"
+      enableMaxWidth={false}>
       <Typo.BodyItalic>Schéma pluriannuel d’accessibilité 2022 - 2024</Typo.BodyItalic>
       <StyledBody marginTop={getSpacing(6)}>
         L’article 47 de la loi n° 2005-102 du 11 février 2005 pour l’égalité des droits et des

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobile.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobile.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { contactSupport } from 'features/auth/helpers/contactSupport'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { env } from 'libs/environment/env'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
@@ -26,7 +26,7 @@ const rightsDefenderUrl = { url: 'https://formulaire.defenseurdesdroits.fr/' }
 const rightsDelegateUrl = { url: 'https://www.defenseurdesdroits.fr/saisir/delegues' }
 
 export function AccessibilityDeclarationMobile() {
-  const { goBack } = useGoBack(...getProfileStackConfig('Accessibility'))
+  const { goBack } = useGoBack(...getProfileHookConfig('Accessibility'))
   return (
     <SecondaryPageWithBlurHeader
       onGoBack={goBack}

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobile.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobile.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { contactSupport } from 'features/auth/helpers/contactSupport'
+import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { useGoBack } from 'features/navigation/useGoBack'
 import { env } from 'libs/environment/env'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
 import { Separator } from 'ui/components/Separator'
@@ -24,8 +26,12 @@ const rightsDefenderUrl = { url: 'https://formulaire.defenseurdesdroits.fr/' }
 const rightsDelegateUrl = { url: 'https://www.defenseurdesdroits.fr/saisir/delegues' }
 
 export function AccessibilityDeclarationMobile() {
+  const { goBack } = useGoBack(...getProfileStackConfig('Accessibility'))
   return (
-    <SecondaryPageWithBlurHeader title="Déclaration d’accessibilité mobile" enableMaxWidth={false}>
+    <SecondaryPageWithBlurHeader
+      onGoBack={goBack}
+      title="Déclaration d’accessibilité mobile"
+      enableMaxWidth={false}>
       <ViewGap gap={6}>
         <Typo.BodyItalic>Cette déclaration a été établie le 30 janvier 2025.</Typo.BodyItalic>
         <Typo.Body>

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { contactSupport } from 'features/auth/helpers/contactSupport'
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { WEBAPP_V2_URL } from 'libs/environment/useWebAppUrl'
 import { BulletListItem } from 'ui/components/BulletListItem'
@@ -38,7 +38,7 @@ const rightsDefenderUrl = { url: 'https://formulaire.defenseurdesdroits.fr/' }
 const rightsDelegateUrl = { url: 'https://www.defenseurdesdroits.fr/saisir/delegues' }
 
 export function AccessibilityDeclarationWeb() {
-  const { goBack } = useGoBack(...getProfileStackConfig('Accessibility'))
+  const { goBack } = useGoBack(...getProfileHookConfig('Accessibility'))
   return (
     <SecondaryPageWithBlurHeader
       onGoBack={goBack}
@@ -57,7 +57,7 @@ export function AccessibilityDeclarationWeb() {
                 as={ButtonInsideText}
                 wording="Schéma pluriannuel d’accessibilité 2022 - 2025"
                 icon={PlainArrowNext}
-                navigateTo={getProfileNavConfig('AccessibilityActionPlan')}
+                navigateTo={getProfilePropConfig('AccessibilityActionPlan')}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -67,7 +67,7 @@ export function AccessibilityDeclarationWeb() {
                 as={ButtonInsideText}
                 wording="Actions réalisées depuis 2022"
                 icon={PlainArrowNext}
-                navigateTo={getProfileNavConfig('AccessibilityActionPlan')}
+                navigateTo={getProfilePropConfig('AccessibilityActionPlan')}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -77,7 +77,7 @@ export function AccessibilityDeclarationWeb() {
                 as={ButtonInsideText}
                 wording="Plan d’actions 2024"
                 icon={PlainArrowNext}
-                navigateTo={getProfileNavConfig('AccessibilityActionPlan')}
+                navigateTo={getProfilePropConfig('AccessibilityActionPlan')}
               />
             </Typo.BodyXs>
           </BulletListItem>

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components/native'
 
 import { contactSupport } from 'features/auth/helpers/contactSupport'
 import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { useGoBack } from 'features/navigation/useGoBack'
 import { WEBAPP_V2_URL } from 'libs/environment/useWebAppUrl'
 import { BulletListItem } from 'ui/components/BulletListItem'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
@@ -36,8 +38,12 @@ const rightsDefenderUrl = { url: 'https://formulaire.defenseurdesdroits.fr/' }
 const rightsDelegateUrl = { url: 'https://www.defenseurdesdroits.fr/saisir/delegues' }
 
 export function AccessibilityDeclarationWeb() {
+  const { goBack } = useGoBack(...getProfileStackConfig('Accessibility'))
   return (
-    <SecondaryPageWithBlurHeader title="Déclaration d’accessibilité web" enableMaxWidth={false}>
+    <SecondaryPageWithBlurHeader
+      onGoBack={goBack}
+      title="Déclaration d’accessibilité web"
+      enableMaxWidth={false}>
       <Typo.Body>
         Le pass Culture s’engage à rendre son site internet accessible conformément à l’article 47
         de la loi n° 2005-102 du 11 février 2005. À cette fin, il met en œuvre la stratégie et les

--- a/src/features/profile/pages/Accessibility/AccessibilityEngagement.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityEngagement.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
+import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { useGoBack } from 'features/navigation/useGoBack'
 import { ContactSupportButton } from 'features/profile/components/Buttons/ContactSupportButton/ContactSupportButton'
 import { env } from 'libs/environment/env'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
@@ -12,8 +14,12 @@ import { DOUBLE_LINE_BREAK, LINE_BREAK } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export function AccessibilityEngagement() {
+  const { goBack } = useGoBack(...getProfileStackConfig('Accessibility'))
   return (
-    <SecondaryPageWithBlurHeader title="Les engagements du pass Culture" enableMaxWidth={false}>
+    <SecondaryPageWithBlurHeader
+      onGoBack={goBack}
+      title="Les engagements du pass Culture"
+      enableMaxWidth={false}>
       <Typo.BodyItalic>Date de publication&nbsp;: 19 mai 2022</Typo.BodyItalic>
       <StyledBody>
         Au pass Culture, notre mission est de renforcer et de diversifier les pratiques culturelles

--- a/src/features/profile/pages/Accessibility/AccessibilityEngagement.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityEngagement.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { ContactSupportButton } from 'features/profile/components/Buttons/ContactSupportButton/ContactSupportButton'
 import { env } from 'libs/environment/env'
@@ -14,7 +14,7 @@ import { DOUBLE_LINE_BREAK, LINE_BREAK } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export function AccessibilityEngagement() {
-  const { goBack } = useGoBack(...getProfileStackConfig('Accessibility'))
+  const { goBack } = useGoBack(...getProfileHookConfig('Accessibility'))
   return (
     <SecondaryPageWithBlurHeader
       onGoBack={goBack}

--- a/src/features/profile/pages/Accessibility/RecommendedPaths.tsx
+++ b/src/features/profile/pages/Accessibility/RecommendedPaths.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { BulletListItem } from 'ui/components/BulletListItem'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
@@ -12,7 +12,7 @@ import { Spacer, Typo } from 'ui/theme'
 import { DOUBLE_LINE_BREAK, LINE_BREAK } from 'ui/theme/constants'
 
 export function RecommendedPaths() {
-  const { goBack } = useGoBack(...getProfileStackConfig('Accessibility'))
+  const { goBack } = useGoBack(...getProfileHookConfig('Accessibility'))
   return (
     <SecondaryPageWithBlurHeader
       title="Parcours recommandés web"

--- a/src/features/profile/pages/Accessibility/RecommendedPaths.tsx
+++ b/src/features/profile/pages/Accessibility/RecommendedPaths.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { useGoBack } from 'features/navigation/useGoBack'
 import { BulletListItem } from 'ui/components/BulletListItem'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
@@ -10,8 +12,12 @@ import { Spacer, Typo } from 'ui/theme'
 import { DOUBLE_LINE_BREAK, LINE_BREAK } from 'ui/theme/constants'
 
 export function RecommendedPaths() {
+  const { goBack } = useGoBack(...getProfileStackConfig('Accessibility'))
   return (
-    <SecondaryPageWithBlurHeader title="Parcours recommandés web" enableMaxWidth={false}>
+    <SecondaryPageWithBlurHeader
+      title="Parcours recommandés web"
+      enableMaxWidth={false}
+      onGoBack={goBack}>
       <Typo.Body>
         En complément de la mise en conformité du pass Culture au regard des critères du RGAA qui
         reste partielle, les équipes du pass Culture se sont attachées à travailler des parcours

--- a/src/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx
+++ b/src/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { initialSearchState } from 'features/search/context/reducer'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -48,7 +48,7 @@ describe('SiteMapScreen', () => {
     const homeButton = screen.getByText('Accueil')
     await user.press(homeButton)
 
-    expect(navigate).toHaveBeenCalledWith(...getTabNavConfig('Home'))
+    expect(navigate).toHaveBeenCalledWith(...getTabHookConfig('Home'))
   })
 
   it('should navigate to thematic search "Cinema" when press "Cinéma" button', async () => {

--- a/src/features/profile/pages/Accessibility/SiteMapScreen.tsx
+++ b/src/features/profile/pages/Accessibility/SiteMapScreen.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { getSiteMapLinks } from 'features/profile/helpers/getSiteMapLinks'
 import { useSortedSearchCategories } from 'features/search/helpers/useSortedSearchCategories/useSortedSearchCategories'
@@ -13,7 +13,7 @@ import { VerticalUl } from 'ui/components/Ul'
 import { SecondaryPageWithBlurHeader } from 'ui/pages/SecondaryPageWithBlurHeader'
 
 export function SiteMapScreen() {
-  const { goBack } = useGoBack(...getProfileStackConfig('Accessibility'))
+  const { goBack } = useGoBack(...getProfileHookConfig('Accessibility'))
   const { isLoggedIn } = useAuthContext()
   const sortedCategories = useSortedSearchCategories()
   const siteMapLinks = getSiteMapLinks(sortedCategories)

--- a/src/features/profile/pages/Accessibility/SiteMapScreen.tsx
+++ b/src/features/profile/pages/Accessibility/SiteMapScreen.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { getSiteMapLinks } from 'features/profile/helpers/getSiteMapLinks'
 import { useSortedSearchCategories } from 'features/search/helpers/useSortedSearchCategories/useSortedSearchCategories'
@@ -13,7 +13,7 @@ import { VerticalUl } from 'ui/components/Ul'
 import { SecondaryPageWithBlurHeader } from 'ui/pages/SecondaryPageWithBlurHeader'
 
 export function SiteMapScreen() {
-  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack } = useGoBack(...getProfileStackConfig('Accessibility'))
   const { isLoggedIn } = useAuthContext()
   const sortedCategories = useSortedSearchCategories()
   const siteMapLinks = getSiteMapLinks(sortedCategories)

--- a/src/features/profile/pages/ChangeAddress/useSubmitChangeAddress.ts
+++ b/src/features/profile/pages/ChangeAddress/useSubmitChangeAddress.ts
@@ -10,7 +10,7 @@ import { IdentityCheckError } from 'features/identityCheck/pages/profile/errors'
 import { addressActions, useAddress } from 'features/identityCheck/pages/profile/store/addressStore'
 import { useCity } from 'features/identityCheck/pages/profile/store/cityStore'
 import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
 import { eventMonitoring } from 'libs/monitoring/services'
@@ -105,9 +105,9 @@ export const useSubmitChangeAddress = () => {
   const { mutate: patchProfile } = usePatchProfileMutation({
     onSuccess: (_, variables) => {
       if (isMandatoryUpdatePersonalData) {
-        navigate(...getProfileStackConfig('ChangeStatus', { type }))
+        navigate(...getProfileHookConfig('ChangeStatus', { type }))
       } else {
-        navigate(...getProfileStackConfig('PersonalData'))
+        navigate(...getProfileHookConfig('PersonalData'))
         showSuccessSnackBar({
           message: 'Ton adresse de résidence a bien été modifiée\u00a0!',
           timeout: SNACK_BAR_TIME_OUT,

--- a/src/features/profile/pages/ChangeCity/useSubmitChangeCity.ts
+++ b/src/features/profile/pages/ChangeCity/useSubmitChangeCity.ts
@@ -6,7 +6,7 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { CityForm, cityResolver } from 'features/identityCheck/pages/profile/SetCity'
 import { cityActions, useCity } from 'features/identityCheck/pages/profile/store/cityStore'
 import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
 import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation'
@@ -45,9 +45,9 @@ export const useSubmitChangeCity = () => {
   const { mutate: patchProfile, isLoading } = usePatchProfileMutation({
     onSuccess: (_, variables) => {
       if (isFromProfileUpdateFlow) {
-        navigate(...getProfileStackConfig('ChangeAddress', { type }))
+        navigate(...getProfileHookConfig('ChangeAddress', { type }))
       } else {
-        navigate(...getProfileStackConfig('PersonalData'))
+        navigate(...getProfileHookConfig('PersonalData'))
         showSuccessSnackBar({
           message: 'Ta ville de résidence a bien été modifiée\u00a0!',
           timeout: SNACK_BAR_TIME_OUT,

--- a/src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
+++ b/src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react'
 import { Platform } from 'react-native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { DeleteProfileReasonNewEmailModal } from 'features/profile/components/Modals/DeleteProfileReasonNewEmailModal'
 import { useCheckHasCurrentEmailChange } from 'features/profile/helpers/useCheckHasCurrentEmailChange'
@@ -24,7 +24,7 @@ export function ChangeEmail() {
   const handleHideModal = () => {
     hideModal()
     if (Platform.OS === 'web')
-      return replace(...getProfileStackConfig('ChangeEmail', { showModal: false }))
+      return replace(...getProfileHookConfig('ChangeEmail', { showModal: false }))
   }
 
   const { hasCurrentEmailChange } = useCheckHasCurrentEmailChange()

--- a/src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.tsx
+++ b/src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
 import { LayoutExpiredLink } from 'ui/components/LayoutExpiredLink'
@@ -17,7 +17,7 @@ export function ChangeEmailExpiredLink() {
   const changeEmailExpiredLink = () => {
     resendEmailNumberOfHits++
     analytics.logSendActivationMailAgain(resendEmailNumberOfHits)
-    isLoggedIn ? navigate(...getProfileStackConfig('ChangeEmail')) : navigate('Login')
+    isLoggedIn ? navigate(...getProfileHookConfig('ChangeEmail')) : navigate('Login')
   }
 
   const upperBodyText =

--- a/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.tsx
+++ b/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form'
 import { Platform } from 'react-native'
 import styled from 'styled-components/native'
 
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { useChangeEmailSetPasswordMutation } from 'features/profile/helpers/useChangeEmailSetPasswordMutation'
 import { eventMonitoring } from 'libs/monitoring/services'
@@ -51,7 +51,7 @@ export const ChangeEmailSetPassword = () => {
         timeout: SNACK_BAR_TIME_OUT,
       })
       if (!params?.emailSelectionToken) return // emailSelectionToken should never be undefined if token is defined
-      replace(...getProfileStackConfig('NewEmailSelection', { token: params?.emailSelectionToken }))
+      replace(...getProfileHookConfig('NewEmailSelection', { token: params?.emailSelectionToken }))
     },
     onError: () =>
       showErrorSnackBar({

--- a/src/features/profile/pages/ChangePassword/ChangePassword.tsx
+++ b/src/features/profile/pages/ChangePassword/ChangePassword.tsx
@@ -10,7 +10,7 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useChangePasswordMutation } from 'features/auth/queries/useChangePasswordMutation'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { changePasswordSchema } from 'features/profile/pages/ChangePassword/schema/changePasswordSchema'
 import { analytics } from 'libs/analytics/provider'
 import { eventMonitoring } from 'libs/monitoring/services'
@@ -81,7 +81,7 @@ export function ChangePassword() {
               message: 'Ton mot de passe est modifié',
               timeout: SNACK_BAR_TIME_OUT,
             })
-            navigate(...getTabNavConfig('Profile'))
+            navigate(...getTabHookConfig('Profile'))
             analytics.logHasChangedPassword({ from: 'personaldata', reason: 'changePassword' })
             resolve()
           },

--- a/src/features/profile/pages/ChangeStatus/useSubmitChangeStatus.tsx
+++ b/src/features/profile/pages/ChangeStatus/useSubmitChangeStatus.tsx
@@ -8,7 +8,7 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { StatusForm } from 'features/identityCheck/pages/profile/StatusFlatList'
 import { useStatus } from 'features/identityCheck/pages/profile/store/statusStore'
 import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
 import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation'
@@ -34,9 +34,9 @@ export const useSubmitChangeStatus = () => {
   const { mutate: patchProfile, isLoading } = usePatchProfileMutation({
     onSuccess: (_, variables) => {
       if (isMandatoryUpdatePersonalData) {
-        navigate(...getProfileStackConfig('UpdatePersonalDataConfirmation'))
+        navigate(...getProfileHookConfig('UpdatePersonalDataConfirmation'))
       } else {
-        navigate(...getProfileStackConfig('PersonalData'))
+        navigate(...getProfileHookConfig('PersonalData'))
         showSuccessSnackBar({
           message: successSnackBarMessage,
           timeout: SNACK_BAR_TIME_OUT,

--- a/src/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx
+++ b/src/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { navigate, replace, reset, useRoute } from '__mocks__/@react-navigation/native'
 import { EmailChangeConfirmationResponse } from 'api/gen'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { ConfirmChangeEmail } from 'features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail'
 import { EmptyResponse } from 'libs/fetch'
 import { getRefreshToken } from 'libs/keychain/keychain'
@@ -75,7 +75,7 @@ describe('<ConfirmChangeEmail />', () => {
 
     await act(async () => userEvent.press(screen.getByText('Annuler')))
 
-    expect(navigate).toHaveBeenCalledWith(...homeNavConfig)
+    expect(navigate).toHaveBeenCalledWith(...homeNavigationConfig)
   })
 
   it('should navigate to new email selection on change email confirmation success', async () => {

--- a/src/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.tsx
+++ b/src/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.tsx
@@ -5,7 +5,7 @@ import { ApiError } from 'api/ApiError'
 import { AccountState } from 'api/gen'
 import { useLoginRoutine } from 'features/auth/helpers/useLoginRoutine'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { useConfirmChangeEmailMutationV2 } from 'features/profile/helpers/useConfirmChangeEmailMutationV2'
 import { isTimestampExpired } from 'libs/dates'
@@ -34,13 +34,13 @@ export function ConfirmChangeEmail() {
 
       if (resetPasswordToken) {
         replace(
-          ...getProfileStackConfig('ChangeEmailSetPassword', {
+          ...getProfileHookConfig('ChangeEmailSetPassword', {
             token: resetPasswordToken,
             emailSelectionToken: newEmailSelectionToken,
           })
         )
       } else {
-        replace(...getProfileStackConfig('NewEmailSelection', { token: newEmailSelectionToken }))
+        replace(...getProfileHookConfig('NewEmailSelection', { token: newEmailSelectionToken }))
       }
     },
     onError: (error) => {

--- a/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
+++ b/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
@@ -9,7 +9,7 @@ import { startTrackingAcceptedCookies } from 'features/cookies/helpers/startTrac
 import { useCookies } from 'features/cookies/helpers/useCookies'
 import { CookiesChoiceByCategory } from 'features/cookies/types'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
@@ -25,7 +25,7 @@ import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const ConsentSettings = () => {
   const { navigate } = useNavigation<UseNavigationType>()
-  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack } = useGoBack(...getTabHookConfig('Profile'))
 
   const { showSuccessSnackBar } = useSnackBarContext()
   const { setCookiesConsent } = useCookies()
@@ -51,7 +51,7 @@ export const ConsentSettings = () => {
       message: 'Ton choix a bien été enregistré.',
       timeout: SNACK_BAR_TIME_OUT,
     })
-    navigate(...getTabNavConfig('Profile'))
+    navigate(...getTabHookConfig('Profile'))
   }, [navigate, setCookiesConsent, settingsCookiesChoice, showSuccessSnackBar])
 
   return (

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.tsx
@@ -1,9 +1,9 @@
 import { useNavigation } from '@react-navigation/native'
 import React, { FC } from 'react'
 
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { InfoBanner } from 'ui/components/banners/InfoBanner'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
@@ -15,10 +15,10 @@ import { Typo } from 'ui/theme'
 export const DeleteProfileAccountHacked: FC = () => {
   const { navigate } = useNavigation<UseNavigationType>()
 
-  const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
+  const navigateToProfile = () => navigate(...getTabHookConfig('Profile'))
 
   const navigateToSuspendAccount = () => {
-    navigate(...getProfileStackConfig('SuspendAccountConfirmationWithoutAuthentication'))
+    navigate(...getProfileHookConfig('SuspendAccountConfirmationWithoutAuthentication'))
   }
 
   return (

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
@@ -2,9 +2,9 @@ import { useNavigation } from '@react-navigation/native'
 import React, { FC } from 'react'
 import styled from 'styled-components/native'
 
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { env } from 'libs/environment/env'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
@@ -19,8 +19,8 @@ import { SPACE } from 'ui/theme/constants'
 export const DeleteProfileAccountNotDeletable: FC = () => {
   const { navigate } = useNavigation<UseNavigationType>()
 
-  const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
-  const navigateToNotifications = () => navigate(...getProfileStackConfig('NotificationsSettings'))
+  const navigateToProfile = () => navigate(...getTabHookConfig('Profile'))
+  const navigateToNotifications = () => navigate(...getProfileHookConfig('NotificationsSettings'))
 
   return (
     <GenericInfoPage

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 
 import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { useAnonymizeAccountMutation } from 'features/profile/queries/useAnonymizeAccountMutation'
 import { env } from 'libs/environment/env'
@@ -23,7 +23,7 @@ export const DeleteProfileConfirmation = () => {
   const { anonymizeAccount } = useAnonymizeAccountMutation({
     onSuccess: async () => {
       await signOut()
-      navigate(...getProfileStackConfig('DeleteProfileSuccess'))
+      navigate(...getProfileHookConfig('DeleteProfileSuccess'))
     },
     onError: () => {
       showErrorSnackBar({
@@ -35,7 +35,7 @@ export const DeleteProfileConfirmation = () => {
   })
 
   const navigateToDeleteProfileReason = () =>
-    navigate(...getProfileStackConfig('DeleteProfileReason'))
+    navigate(...getProfileHookConfig('DeleteProfileReason'))
 
   return (
     <GenericInfoPage

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.tsx
@@ -4,7 +4,7 @@ import { Platform } from 'react-native'
 import styled from 'styled-components/native'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { Email } from 'ui/svg/icons/Email'
@@ -23,7 +23,7 @@ export const DeleteProfileContactSupport: FC = () => {
   const { requestSendMail } = getContactSupportForDeletionProfile({ emailProvider })
   const { navigate } = useNavigation<UseNavigationType>()
 
-  const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
+  const navigateToProfile = () => navigate(...getTabHookConfig('Profile'))
   return (
     <GenericInfoPage
       withGoBack

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.tsx
@@ -1,9 +1,9 @@
 import { useNavigation } from '@react-navigation/native'
 import React, { FC } from 'react'
 
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { Clear } from 'ui/svg/icons/Clear'
@@ -13,12 +13,12 @@ import { Typo } from 'ui/theme'
 export const DeleteProfileEmailHacked: FC = () => {
   const { navigate } = useNavigation<UseNavigationType>()
 
-  const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
+  const navigateToProfile = () => navigate(...getTabHookConfig('Profile'))
 
-  const navigateToChangeEmail = () => navigate(...getProfileStackConfig('ChangeEmail'))
+  const navigateToChangeEmail = () => navigate(...getProfileHookConfig('ChangeEmail'))
 
   const navigateToSuspendAccount = () => {
-    navigate(...getProfileStackConfig('SuspendAccountConfirmationWithoutAuthentication'))
+    navigate(...getProfileHookConfig('SuspendAccountConfirmationWithoutAuthentication'))
   }
 
   return (

--- a/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.tsx
+++ b/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.tsx
@@ -3,8 +3,8 @@ import { FlatList, Platform, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { useOnViewableItemsChanged } from 'features/subscription/helpers/useOnViewableItemsChanged'
 import { analytics } from 'libs/analytics/provider'
@@ -31,13 +31,13 @@ type ReasonButton = {
 const reasonButtons = (canDelete: boolean): ReasonButton[] => [
   {
     wording: 'J’aimerais créer un compte avec une adresse e-mail différente',
-    navigateTo: { ...getProfileNavConfig('ChangeEmail', { showModal: true }) },
+    navigateTo: { ...getProfilePropConfig('ChangeEmail', { showModal: true }) },
     analyticsReason: 'changeEmail',
   },
   {
     wording: 'Je n’utilise plus l’application',
     navigateTo: {
-      ...getProfileNavConfig(
+      ...getProfilePropConfig(
         canDelete ? 'DeleteProfileConfirmation' : 'DeleteProfileAccountNotDeletable'
       ),
     },
@@ -46,7 +46,7 @@ const reasonButtons = (canDelete: boolean): ReasonButton[] => [
   {
     wording: 'Je n’ai plus de crédit ou très peu de crédit restant',
     navigateTo: {
-      ...getProfileNavConfig(
+      ...getProfilePropConfig(
         canDelete ? 'DeleteProfileConfirmation' : 'DeleteProfileAccountNotDeletable'
       ),
     },
@@ -55,7 +55,7 @@ const reasonButtons = (canDelete: boolean): ReasonButton[] => [
   {
     wording: 'Je souhaite supprimer mes données personnelles',
     navigateTo: {
-      ...getProfileNavConfig(
+      ...getProfilePropConfig(
         canDelete ? 'DeleteProfileConfirmation' : 'DeleteProfileAccountNotDeletable'
       ),
     },
@@ -64,14 +64,14 @@ const reasonButtons = (canDelete: boolean): ReasonButton[] => [
   {
     wording: 'Je pense que quelqu’un d’autre a accès à mon compte',
     navigateTo: {
-      ...getProfileNavConfig('DeleteProfileAccountHacked'),
+      ...getProfilePropConfig('DeleteProfileAccountHacked'),
     },
     analyticsReason: 'hackedAccount',
   },
   {
     wording: 'Autre',
     navigateTo: {
-      ...getProfileNavConfig('DeleteProfileContactSupport'),
+      ...getProfilePropConfig('DeleteProfileContactSupport'),
     },
     analyticsReason: 'other',
   },
@@ -84,7 +84,7 @@ export function DeleteProfileReason() {
   const canDeleteProfile = !user?.isBeneficiary || userIsDefinedAndAbove21
   const reasons = reasonButtons(!!canDeleteProfile)
   const { onViewableItemsChanged } = useOnViewableItemsChanged(gradientRef, reasons)
-  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack } = useGoBack(...getTabHookConfig('Profile'))
 
   return (
     <SecondaryPageWithBlurHeader onGoBack={goBack} title="Suppression de compte">

--- a/src/features/profile/pages/DisplayPreference/DisplayPreference.tsx
+++ b/src/features/profile/pages/DisplayPreference/DisplayPreference.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Platform } from 'react-native'
 import styled from 'styled-components/native'
 
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { FilterSwitchWithLabel } from 'features/search/components/FilterSwitchWithLabel/FilterSwitchWithLabel'
 import { analytics } from 'libs/analytics/provider'
@@ -26,7 +26,7 @@ const DEBOUNCE_TOGGLE_DELAY_MS = 5000
 export const DisplayPreference = () => {
   const enableDarkMode = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ENABLE_DARK_MODE)
 
-  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack } = useGoBack(...getTabHookConfig('Profile'))
 
   const [isOrientationLocked, toggleIsOrientationLocked] = useOrientationLocked()
 

--- a/src/features/profile/pages/FeedbackInApp/FeedbackInApp.tsx
+++ b/src/features/profile/pages/FeedbackInApp/FeedbackInApp.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components/native'
 
 import { contactSupport } from 'features/auth/helpers/contactSupport'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import {
   FEEDBACK_IN_APP_VALUE_MAX_LENGTH,
@@ -31,7 +31,7 @@ type FormValue = {
 
 export const FeedbackInApp = () => {
   const { navigate } = useNavigation<UseNavigationType>()
-  const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
+  const navigateToProfile = () => navigate(...getTabHookConfig('Profile'))
   const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()
 
   const {
@@ -64,7 +64,7 @@ export const FeedbackInApp = () => {
     sendFeedback({ feedback })
   }
 
-  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack } = useGoBack(...getTabHookConfig('Profile'))
 
   return (
     <PageWithHeader

--- a/src/features/profile/pages/LegalNotices/LegalNotices.tsx
+++ b/src/features/profile/pages/LegalNotices/LegalNotices.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { contactSupport } from 'features/auth/helpers/contactSupport'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { env } from 'libs/environment/env'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
@@ -18,7 +18,7 @@ import { Typo } from 'ui/theme'
 import { LINE_BREAK, SECTION_ROW_ICON_SIZE, SPACE } from 'ui/theme/constants'
 
 export function LegalNotices() {
-  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack } = useGoBack(...getTabHookConfig('Profile'))
 
   return (
     <SecondaryPageWithBlurHeader title="Informations légales" onGoBack={goBack} scrollable>

--- a/src/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.tsx
+++ b/src/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { UserError } from 'ui/svg/UserError'
 
@@ -11,7 +11,7 @@ export const MandatoryUpdatePersonalData = () => (
     subtitle="Avant de continuer, assure-toi que tes informations personnelles sont toujours correctes. C’est rapide, promis."
     buttonPrimary={{
       wording: 'Commencer',
-      navigateTo: getProfileNavConfig('ProfileInformationValidationUpdate'),
+      navigateTo: getProfilePropConfig('ProfileInformationValidationUpdate'),
     }}
   />
 )

--- a/src/features/profile/pages/MandatoryUpdatePersonalData/ProfileInformationValidationUpdate.tsx
+++ b/src/features/profile/pages/MandatoryUpdatePersonalData/ProfileInformationValidationUpdate.tsx
@@ -5,9 +5,9 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { Summary } from 'features/identityCheck/components/Summary'
 import { getActivityLabel } from 'features/identityCheck/helpers/getActivityLabel'
 import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
@@ -20,14 +20,14 @@ export const ProfileInformationValidationUpdate = () => {
   const { user } = useAuthContext()
   const { navigate, reset } = useNavigation<UseNavigationType>()
   const { showErrorSnackBar } = useSnackBarContext()
-  const [navigatorName, screenConfig] = getProfileStackConfig('UpdatePersonalDataConfirmation')
+  const [navigatorName, screenConfig] = getProfileHookConfig('UpdatePersonalDataConfirmation')
 
   const { mutate: patchProfile, isLoading } = usePatchProfileMutation({
     onSuccess: () => {
       reset({
         index: 1,
         routes: [
-          { name: homeNavConfig[0], params: homeNavConfig[1] },
+          { name: homeNavigationConfig[0], params: homeNavigationConfig[1] },
           { name: navigatorName, params: screenConfig },
         ],
       })
@@ -47,7 +47,7 @@ export const ProfileInformationValidationUpdate = () => {
 
   const onChangeInformation = () =>
     navigate(
-      ...getProfileStackConfig('ChangeCity', {
+      ...getProfileHookConfig('ChangeCity', {
         type: PersonalDataTypes.MANDATORY_UPDATE_PERSONAL_DATA,
       })
     )

--- a/src/features/profile/pages/NewEmailSelection/NewEmailSelection.tsx
+++ b/src/features/profile/pages/NewEmailSelection/NewEmailSelection.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { useForm } from 'react-hook-form'
 import styled from 'styled-components/native'
 
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { useNewEmailSelectionMutation } from 'features/profile/helpers/useNewEmailSelectionMutation'
 import { newEmailSelectionSchema } from 'features/profile/pages/NewEmailSelection/schema/newEmailSelectionSchema'
@@ -52,7 +52,7 @@ export const NewEmailSelection = () => {
           'E-mail envoyé sur ta nouvelle adresse\u00a0! Tu as 24h pour valider ta demande. Si tu ne le trouves pas, pense à vérifier tes spams.',
         timeout: SNACK_BAR_TIME_OUT_LONG,
       })
-      replace(...getProfileStackConfig('TrackEmailChange'))
+      replace(...getProfileHookConfig('TrackEmailChange'))
     },
     onError: () =>
       showErrorSnackBar({

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -4,7 +4,7 @@ import { PermissionStatus } from 'react-native-permissions'
 import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { PushNotificationsModal } from 'features/notifications/pages/PushNotificationsModal'
 import { SectionWithSwitch } from 'features/profile/components/SectionWithSwitch/SectionWithSwitch'
@@ -134,7 +134,7 @@ export const NotificationsSettings = () => {
     }
   }
 
-  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack } = useGoBack(...getTabHookConfig('Profile'))
 
   return (
     <SecondaryPageWithBlurHeader

--- a/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.tsx
+++ b/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
@@ -21,7 +21,7 @@ export const UnsavedSettingsModal: FunctionComponent<Props> = ({
   dismissModal,
   onPressSaveChanges,
 }) => {
-  const { goBack: goBackAndLeaveNotificationsSettings } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack: goBackAndLeaveNotificationsSettings } = useGoBack(...getTabHookConfig('Profile'))
 
   return (
     <AppModal

--- a/src/features/profile/pages/PersonalData/PersonalData.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.tsx
@@ -3,9 +3,9 @@ import React, { useMemo } from 'react'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { getActivityLabel } from 'features/identityCheck/helpers/getActivityLabel'
 import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { ProfileNavigateParams } from 'features/navigation/RootNavigator/types'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { EditableField } from 'features/profile/components/EditableFiled/EditableField'
 import { useCheckHasCurrentEmailChange } from 'features/profile/helpers/useCheckHasCurrentEmailChange'
@@ -28,7 +28,7 @@ function onEmailChangeClick() {
 
 export function PersonalData() {
   const { user } = useAuthContext()
-  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack } = useGoBack(...getTabHookConfig('Profile'))
 
   const fullname = [user?.firstName, user?.lastName].filter(Boolean).join(' ').trim()
   const hasCity = user?.postalCode && user?.city
@@ -89,7 +89,7 @@ export function PersonalData() {
         <SectionRow
           title="Supprimer mon compte"
           type="navigable"
-          navigateTo={getProfileNavConfig('DeleteProfileReason')}
+          navigateTo={getProfilePropConfig('DeleteProfileReason')}
           onPress={analytics.logAccountDeletion}
           icon={Trash}
           iconSize={SECTION_ROW_ICON_SIZE}

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -7,7 +7,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
 import { useFavoritesState } from 'features/favorites/context/FavoritesWrapper'
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { ProfileHeader } from 'features/profile/components/Header/ProfileHeader/ProfileHeader'
 import { SectionWithSwitch } from 'features/profile/components/SectionWithSwitch/SectionWithSwitch'
 import { SocialNetwork } from 'features/profile/components/SocialNetwork/SocialNetwork'
@@ -175,7 +175,7 @@ const OnlineProfile: React.FC = () => {
                       <Row
                         title="Informations personnelles"
                         type="navigable"
-                        navigateTo={getProfileNavConfig('PersonalData')}
+                        navigateTo={getProfilePropConfig('PersonalData')}
                         icon={ProfileIcon}
                       />
                     </Li>
@@ -185,7 +185,7 @@ const OnlineProfile: React.FC = () => {
                       type="navigable"
                       title="Notifications"
                       icon={Bell}
-                      navigateTo={getProfileNavConfig('NotificationsSettings')}
+                      navigateTo={getProfilePropConfig('NotificationsSettings')}
                     />
                   </Li>
                   <LiWithMarginVertical>
@@ -217,7 +217,7 @@ const OnlineProfile: React.FC = () => {
                       <Row
                         title="Comment ça marche&nbsp;?"
                         type="navigable"
-                        navigateTo={getProfileNavConfig('ProfileTutorialAgeInformationCredit')}
+                        navigateTo={getProfilePropConfig('ProfileTutorialAgeInformationCredit')}
                         onPress={() =>
                           analytics.logConsultTutorial({ age: userAge, from: 'ProfileHelp' })
                         }
@@ -252,7 +252,7 @@ const OnlineProfile: React.FC = () => {
                       <Row
                         title="Préférences d’affichage"
                         type="navigable"
-                        navigateTo={getProfileNavConfig('DisplayPreference')}
+                        navigateTo={getProfilePropConfig('DisplayPreference')}
                         icon={ArtMaterial}
                       />
                     </Li>
@@ -261,7 +261,7 @@ const OnlineProfile: React.FC = () => {
                     <Row
                       title="Accessibilité"
                       type="navigable"
-                      navigateTo={getProfileNavConfig('Accessibility')}
+                      navigateTo={getProfilePropConfig('Accessibility')}
                       icon={HandicapMental}
                     />
                   </Li>
@@ -270,7 +270,7 @@ const OnlineProfile: React.FC = () => {
                       <Row
                         title="Faire une suggestion"
                         type="navigable"
-                        navigateTo={getProfileNavConfig('FeedbackInApp')}
+                        navigateTo={getProfilePropConfig('FeedbackInApp')}
                         icon={Bulb}
                       />
                     </Li>
@@ -279,7 +279,7 @@ const OnlineProfile: React.FC = () => {
                     <Row
                       title="Informations légales"
                       type="navigable"
-                      navigateTo={getProfileNavConfig('LegalNotices')}
+                      navigateTo={getProfilePropConfig('LegalNotices')}
                       icon={LegalNotices}
                     />
                   </Li>
@@ -287,7 +287,7 @@ const OnlineProfile: React.FC = () => {
                     <Row
                       title="Confidentialité"
                       type="navigable"
-                      navigateTo={getProfileNavConfig('ConsentSettings')}
+                      navigateTo={getProfilePropConfig('ConsentSettings')}
                       icon={Confidentiality}
                     />
                   </Li>
@@ -332,7 +332,7 @@ const OnlineProfile: React.FC = () => {
                     <InternalTouchableLink
                       as={ButtonQuaternaryBlack}
                       wording="Débuggage"
-                      navigateTo={getProfileNavConfig('DebugScreen')}
+                      navigateTo={getProfilePropConfig('DebugScreen')}
                       justifyContent="flex-start"
                       inline
                     />

--- a/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.tsx
+++ b/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/native'
 import { api } from 'api/api'
 import { ApiError } from 'api/ApiError'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
-import { getProfileStackConfig } from 'features/navigation/ProfileStackNavigator/getProfileStackConfig'
+import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { ProfileStackParamList } from 'features/navigation/ProfileStackNavigator/ProfileStackTypes'
 import { RootStackParamList } from 'features/navigation/RootNavigator/types'
 import { useEmailUpdateStatus } from 'features/profile/helpers/useEmailUpdateStatus'
@@ -46,7 +46,7 @@ export function SuspendAccountConfirmation({
     setIsLoading(true)
     try {
       await mutate()
-      navigation.navigate(...getProfileStackConfig('TrackEmailChange'))
+      navigation.navigate(...getProfileHookConfig('TrackEmailChange'))
     } catch (error) {
       if (error instanceof ApiError && error.statusCode === 401) {
         navigation.reset({ routes: [{ name: 'ChangeEmailExpiredLink' }] })

--- a/src/features/profile/pages/TrackEmailChange/TrackEmailChange.tsx
+++ b/src/features/profile/pages/TrackEmailChange/TrackEmailChange.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Platform, ScrollView } from 'react-native'
 import styled from 'styled-components/native'
 
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { TrackEmailChangeContent } from 'features/profile/pages/TrackEmailChange/TrackEmailChangeContent'
 import { BackButton } from 'ui/components/headers/BackButton'
@@ -13,7 +13,7 @@ const HEADER_HEIGHT = getSpacing(8)
 
 export function TrackEmailChange() {
   const { top } = useCustomSafeInsets()
-  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack } = useGoBack(...getTabHookConfig('Profile'))
 
   return (
     <StyledScrollViewContainer>

--- a/src/features/profile/pages/TrackEmailChange/TrackEmailChangeContent.native.test.tsx
+++ b/src/features/profile/pages/TrackEmailChange/TrackEmailChangeContent.native.test.tsx
@@ -3,7 +3,7 @@ import { openInbox } from 'react-native-email-link'
 
 import { navigate, replace, reset } from '__mocks__/@react-navigation/native'
 import { EmailHistoryEventTypeEnum, EmailUpdateStatusResponse } from 'api/gen'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { TrackEmailChangeContent } from 'features/profile/pages/TrackEmailChange/TrackEmailChangeContent'
 import { beneficiaryUser, nonBeneficiaryUser } from 'fixtures/user'
 import { mockServer } from 'tests/mswServer'
@@ -91,7 +91,7 @@ describe('TrackEmailChangeContent', () => {
     render(reactQueryProviderHOC(<TrackEmailChangeContent />))
 
     await waitFor(() => {
-      expect(replace).toHaveBeenCalledWith(...homeNavConfig)
+      expect(replace).toHaveBeenCalledWith(...homeNavigationConfig)
     })
   })
 

--- a/src/features/profile/pages/TrackEmailChange/TrackEmailChangeContent.tsx
+++ b/src/features/profile/pages/TrackEmailChange/TrackEmailChangeContent.tsx
@@ -5,9 +5,9 @@ import { openInbox } from 'react-native-email-link'
 import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { getEmailUpdateStep } from 'features/profile/helpers/getEmailUpdateStep'
 import { useEmailUpdateStatus } from 'features/profile/helpers/useEmailUpdateStatus'
 import { Step } from 'ui/components/Step/Step'
@@ -78,7 +78,7 @@ export const TrackEmailChangeContent = () => {
         disabled: DisabledConfidentialityIcon,
         retry: DisabledConfidentialityIcon,
       },
-      navigateTo: getProfileNavConfig('ChangeEmailSetPassword', {
+      navigateTo: getProfilePropConfig('ChangeEmailSetPassword', {
         token: requestStatus?.resetPasswordToken,
         emailSelectionToken: requestStatus?.token,
       }),
@@ -93,7 +93,7 @@ export const TrackEmailChangeContent = () => {
         disabled: DisabledPencilIcon,
         retry: DisabledPencilIcon,
       },
-      navigateTo: getProfileNavConfig('NewEmailSelection', { token: requestStatus?.token }),
+      navigateTo: getProfilePropConfig('NewEmailSelection', { token: requestStatus?.token }),
     },
     VALIDATION: {
       currentTitle: 'Valide ta nouvelle adresse',
@@ -110,7 +110,7 @@ export const TrackEmailChangeContent = () => {
   }
 
   if (!isRequestStatusLoading && !requestStatus?.status) {
-    replace(...homeNavConfig)
+    replace(...homeNavigationConfig)
     return null
   }
   if (!isRequestStatusLoading && requestStatus?.expired) {

--- a/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.tsx
+++ b/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { CreditTimelineV3 } from 'features/onboarding/components/CreditTimelineV3'
 import { CreditProgressBar } from 'features/profile/components/CreditInfo/CreditProgressBar'
@@ -26,7 +26,7 @@ import { LINE_BREAK } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const ProfileTutorialAgeInformationCredit = () => {
-  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack } = useGoBack(...getTabHookConfig('Profile'))
 
   const { onScroll, headerTransition } = useOpacityTransition()
   const headerHeight = useGetHeaderHeight()

--- a/src/features/profile/pages/ValidateEmailChange/ValidateEmailChange.native.test.tsx
+++ b/src/features/profile/pages/ValidateEmailChange/ValidateEmailChange.native.test.tsx
@@ -9,7 +9,7 @@ import { EmailHistoryEventTypeEnum, EmailUpdateStatusResponse } from 'api/gen'
 import * as Auth from 'features/auth/context/AuthContext'
 import { ProfileStackParamList } from 'features/navigation/ProfileStackNavigator/ProfileStackTypes'
 import { RootStackParamList, StepperOrigin } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import * as useEmailUpdateStatus from 'features/profile/helpers/useEmailUpdateStatus'
 import { ValidateEmailChange } from 'features/profile/pages/ValidateEmailChange/ValidateEmailChange'
 import { eventMonitoring } from 'libs/monitoring/services'
@@ -188,7 +188,7 @@ describe('ValidateEmailChange', () => {
 
     renderValidateEmailChange()
 
-    expect(navigation.replace).toHaveBeenCalledWith(...homeNavConfig)
+    expect(navigation.replace).toHaveBeenCalledWith(...homeNavigationConfig)
   })
 
   it('should log to sentry, redirect to home and show error message when token is falsy', async () => {
@@ -199,7 +199,7 @@ describe('ValidateEmailChange', () => {
     expect(eventMonitoring.captureException).toHaveBeenCalledWith(
       new Error('Expected a string, but received undefined')
     )
-    expect(navigation.replace).toHaveBeenCalledWith(...homeNavConfig)
+    expect(navigation.replace).toHaveBeenCalledWith(...homeNavigationConfig)
     expect(mockShowErrorSnackbar).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/features/profile/pages/ValidateEmailChange/ValidateEmailChange.tsx
+++ b/src/features/profile/pages/ValidateEmailChange/ValidateEmailChange.tsx
@@ -9,7 +9,7 @@ import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { ProfileStackParamList } from 'features/navigation/ProfileStackNavigator/ProfileStackTypes'
 import { RootStackParamList, StepperOrigin } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useEmailUpdateStatus } from 'features/profile/helpers/useEmailUpdateStatus'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { Separator } from 'ui/components/Separator'
@@ -69,7 +69,7 @@ export function ValidateEmailChange({ route: { params }, navigation }: ValidateE
         timeout: SNACK_BAR_TIME_OUT,
       })
       eventMonitoring.captureException(error)
-      navigation.replace(...homeNavConfig)
+      navigation.replace(...homeNavigationConfig)
     } finally {
       setIsLoading(false)
     }
@@ -78,7 +78,7 @@ export function ValidateEmailChange({ route: { params }, navigation }: ValidateE
   useEffect(() => {
     if (!isLoadingEmailUpdateStatus) {
       if (!emailUpdateStatus) {
-        navigation.replace(...homeNavConfig)
+        navigation.replace(...homeNavigationConfig)
       }
       if (emailUpdateStatus?.expired) {
         navigation.reset({ routes: [{ name: 'ChangeEmailExpiredLink' }] })

--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -15,7 +15,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { SearchGroupNameEnumv2 } from 'api/gen'
 import { defaultDisabilitiesProperties } from 'features/accessibility/context/AccessibilityFiltersWrapper'
 import { useSettingsContext } from 'features/auth/context/SettingsContext'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { HiddenSuggestionsButton } from 'features/search/components/Buttons/HiddenSuggestionsButton'
 import { SearchMainInput } from 'features/search/components/SearchMainInput/SearchMainInput'
@@ -58,7 +58,7 @@ export const SearchBox: React.FunctionComponent<Props> = ({
   const { isDesktopViewport } = useTheme()
   const { searchState, dispatch, isFocusOnSuggestions, hideSuggestions, showSuggestions } =
     useSearch()
-  const { goBack } = useGoBack(...homeNavConfig)
+  const { goBack } = useGoBack(...homeNavigationConfig)
   const { showErrorSnackBar } = useSnackBarContext()
   const [displayedQuery, setDisplayedQuery] = useState<string>(searchState.query)
   const inputRef = useRef<RNTextInput | null>(null)

--- a/src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.ts
+++ b/src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid'
 
 import { SearchGroupNameEnumv2 } from 'api/gen'
-import { getSearchNavConfig } from 'features/navigation/SearchStackNavigator/getSearchNavConfig'
+import { getSearchPropConfig } from 'features/navigation/SearchStackNavigator/getSearchPropConfig'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { isOnlyOnline } from 'features/search/helpers/categoriesHelpers/categoriesHelpers'
 import { useAvailableCategories } from 'features/search/helpers/useAvailableCategories/useAvailableCategories'
@@ -35,7 +35,7 @@ export const useSortedSearchCategories = (): ListCategoryButtonProps => {
   const hasAThematicSearch = useHasAThematicPageList()
   const { searchState, dispatch } = useSearch()
   const navigateTo = (facetFilter: SearchGroupNameEnumv2) => {
-    const searchTabConfig = getSearchNavConfig(
+    const searchTabConfig = getSearchPropConfig(
       hasAThematicSearch.includes(facetFilter) ? 'ThematicSearch' : 'SearchResults',
       {
         offerCategories: [facetFilter],

--- a/src/features/subscription/components/modals/SubscriptionSuccessModal.tsx
+++ b/src/features/subscription/components/modals/SubscriptionSuccessModal.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { mapSubscriptionThemeToDescription } from 'features/subscription/helpers/mapSubscriptionThemeToDescription'
 import { mapSubscriptionThemeToName } from 'features/subscription/helpers/mapSubscriptionThemeToName'
 import { SubscriptionTheme } from 'features/subscription/types'
@@ -39,7 +39,7 @@ export const SubscriptionSuccessModal: FunctionComponent<Props> = ({
           as={ButtonTertiaryBlack}
           wording="Voir mes préférences"
           icon={Parameters}
-          navigateTo={getProfileNavConfig('NotificationsSettings')}
+          navigateTo={getProfilePropConfig('NotificationsSettings')}
           onBeforeNavigate={dismissModal}
         />
       </StyledButtonContainer>

--- a/src/features/subscription/page/OnboardingSubscription.native.test.tsx
+++ b/src/features/subscription/page/OnboardingSubscription.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { replace } from '__mocks__/@react-navigation/native'
 import * as API from 'api/api'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import * as useGoBack from 'features/navigation/useGoBack'
 import { OnboardingSubscription } from 'features/subscription/page/OnboardingSubscription'
 import { SubscriptionTheme } from 'features/subscription/types'
@@ -130,7 +130,7 @@ describe('OnboardingSubscription', () => {
     await user.press(screen.getByLabelText('Activités créatives'))
     await user.press(screen.getByText('Suivre la sélection'))
 
-    expect(replace).toHaveBeenCalledWith(...homeNavConfig)
+    expect(replace).toHaveBeenCalledWith(...homeNavigationConfig)
   })
 
   it('should show success snackbar on subscription success', async () => {

--- a/src/features/subscription/page/OnboardingSubscription.tsx
+++ b/src/features/subscription/page/OnboardingSubscription.tsx
@@ -7,7 +7,7 @@ import styled, { useTheme } from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { getTabNavConfig, homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig, homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { usePushPermission } from 'features/profile/pages/NotificationSettings/usePushPermission'
 import { SubscriptionThematicButton } from 'features/subscription/components/buttons/SubscriptionThematicButton'
@@ -34,7 +34,7 @@ const VIEWABILITY_CONFIG = { itemVisiblePercentThreshold: 100 }
 
 export const OnboardingSubscription = () => {
   const { replace } = useNavigation<UseNavigationType>()
-  const { goBack } = useGoBack(...getTabNavConfig('Home'))
+  const { goBack } = useGoBack(...getTabHookConfig('Home'))
   const { user } = useAuthContext()
   const theme = useTheme()
   const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()
@@ -73,7 +73,7 @@ export const OnboardingSubscription = () => {
         message: 'Thèmes suivis\u00a0! Tu peux gérer tes alertes depuis ton profil.',
         timeout: SNACK_BAR_TIME_OUT,
       })
-      replace(...homeNavConfig)
+      replace(...homeNavigationConfig)
     },
     onError: () => {
       showErrorSnackBar({

--- a/src/features/venue/components/VenueCTA/VenueCTA.native.test.tsx
+++ b/src/features/venue/components/VenueCTA/VenueCTA.native.test.tsx
@@ -4,7 +4,7 @@ import { push } from '__mocks__/@react-navigation/native'
 import { SearchState } from 'features/search/types'
 import { VenueCTA } from 'features/venue/components/VenueCTA/VenueCTA'
 import { venueDataTest } from 'features/venue/fixtures/venueDataTest'
-import { SearchNavConfig } from 'features/venue/types'
+import { SearchNavigationConfig } from 'features/venue/types'
 import { analytics } from 'libs/analytics/provider'
 import { LocationMode } from 'libs/location/types'
 import { render, screen, userEvent, waitFor } from 'tests/utils'
@@ -35,7 +35,7 @@ const defaultParams: SearchState = {
   },
 } as SearchState
 
-const searchNavConfigMock: SearchNavConfig = {
+const searchNavigationConfigMock: SearchNavigationConfig = {
   screen: 'TabNavigator',
   params: {
     screen: 'SearchStackNavigator',
@@ -54,7 +54,9 @@ const user = userEvent.setup()
 
 describe('<VenueCTA />', () => {
   it('should navigate to the search page when pressed on', async () => {
-    render(<VenueCTA searchNavConfig={searchNavConfigMock} onBeforeNavigate={jest.fn()} />)
+    render(
+      <VenueCTA searchNavigationConfig={searchNavigationConfigMock} onBeforeNavigate={jest.fn()} />
+    )
 
     await user.press(await screen.findByText('Rechercher une offre'))
 
@@ -81,7 +83,7 @@ describe('<VenueCTA />', () => {
   it('should log event when pressed on', async () => {
     render(
       <VenueCTA
-        searchNavConfig={searchNavConfigMock}
+        searchNavigationConfig={searchNavigationConfigMock}
         onBeforeNavigate={() => analytics.logVenueSeeAllOffersClicked(venueDataTest.id)}
       />
     )

--- a/src/features/venue/components/VenueCTA/VenueCTA.tsx
+++ b/src/features/venue/components/VenueCTA/VenueCTA.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { SearchNavConfig } from 'features/venue/types'
+import { SearchNavigationConfig } from 'features/venue/types'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { StickyBottomWrapper } from 'ui/components/StickyBottomWrapper/StickyBottomWrapper'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
@@ -11,16 +11,19 @@ import { Spacer } from 'ui/theme'
 export const VENUE_CTA_HEIGHT_IN_SPACES = 6 + 10 + 6
 
 interface Props {
-  searchNavConfig: SearchNavConfig
+  searchNavigationConfig: SearchNavigationConfig
   onBeforeNavigate: () => void
 }
 
-export const VenueCTA: FunctionComponent<Props> = ({ searchNavConfig, onBeforeNavigate }) => {
+export const VenueCTA: FunctionComponent<Props> = ({
+  searchNavigationConfig,
+  onBeforeNavigate,
+}) => {
   return (
     <StickyBottomWrapper>
       <CallToActionContainer>
         <InternalTouchableLink
-          navigateTo={searchNavConfig}
+          navigateTo={searchNavigationConfig}
           onBeforeNavigate={onBeforeNavigate}
           as={ButtonPrimary}
           wording="Rechercher une offre"

--- a/src/features/venue/components/VenueContent/VenueContent.tsx
+++ b/src/features/venue/components/VenueContent/VenueContent.tsx
@@ -71,7 +71,7 @@ export const VenueContent: React.FunctionComponent<Props> = ({
   const headerHeight = useGetHeaderHeight()
   const isLargeScreen = isDesktopViewport || isTabletViewport
   const { isButtonVisible, wording } = useOfferCTA()
-  const searchNavConfig = useNavigateToSearchWithVenueOffers(venue)
+  const searchNavigationConfig = useNavigateToSearchWithVenueOffers(venue)
 
   const renderVenueCTA = useCallback(() => {
     if (showAccessScreeningButton && wording.length) {
@@ -79,7 +79,7 @@ export const VenueContent: React.FunctionComponent<Props> = ({
     }
     return isCTADisplayed ? (
       <VenueCTA
-        searchNavConfig={searchNavConfig}
+        searchNavigationConfig={searchNavigationConfig}
         onBeforeNavigate={() => analytics.logVenueSeeAllOffersClicked(venue.id)}
       />
     ) : null
@@ -89,7 +89,7 @@ export const VenueContent: React.FunctionComponent<Props> = ({
     showAccessScreeningButton,
     venue.id,
     wording.length,
-    searchNavConfig,
+    searchNavigationConfig,
   ])
 
   return (

--- a/src/features/venue/components/VenueHeader/VenueHeader.tsx
+++ b/src/features/venue/components/VenueHeader/VenueHeader.tsx
@@ -3,7 +3,7 @@ import { Animated } from 'react-native'
 import { useTheme } from 'styled-components/native'
 
 import { VenueResponse } from 'api/gen'
-import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/getSearchStackConfig'
+import { getSearchHookConfig } from 'features/navigation/SearchStackNavigator/getSearchHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { getShareVenue } from 'features/share/helpers/getShareVenue'
 import { WebShareModal } from 'features/share/pages/WebShareModal'
@@ -23,7 +23,7 @@ interface Props {
  */
 export const VenueHeader: React.FC<Props> = ({ headerTransition, venue }) => {
   const theme = useTheme()
-  const { goBack } = useGoBack(...getSearchStackConfig('SearchLanding'))
+  const { goBack } = useGoBack(...getSearchHookConfig('SearchLanding'))
 
   const { share: shareVenue, shareContent } = getShareVenue({ venue, utmMedium: 'header' })
   const {

--- a/src/features/venue/components/VenueOffers/VenueOffersList.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffersList.tsx
@@ -56,7 +56,7 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
   const { user } = useAuthContext()
   const artistsPlaylistEnabled = useFeatureFlag(RemoteStoreFeatureFlags.WIP_VENUE_ARTISTS_PLAYLIST)
   const { params: routeParams } = useRoute<UseRouteType<'Offer'>>()
-  const searchNavConfig = useNavigateToSearchWithVenueOffers(venue)
+  const searchNavigationConfig = useNavigateToSearchWithVenueOffers(venue)
 
   const { hits = [], nbHits = 0 } = venueOffers ?? {}
   const { artists = [] } = venueArtists ?? {}
@@ -69,7 +69,7 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
     <SeeMore
       width={width}
       height={height}
-      navigateTo={showSeeMore ? searchNavConfig : undefined}
+      navigateTo={showSeeMore ? searchNavigationConfig : undefined}
       onPress={() => analytics.logVenueSeeMoreClicked(venue.id)}
     />
   )
@@ -127,7 +127,7 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
         itemWidth={LENGTH_M * RATIO_HOME_IMAGE}
         onPressSeeMore={onPressSeeMore}
         renderItem={renderItem}
-        titleSeeMoreLink={showSeeMore ? searchNavConfig : undefined}
+        titleSeeMoreLink={showSeeMore ? searchNavigationConfig : undefined}
         renderFooter={renderFooter}
         keyExtractor={keyExtractor}
         FlatListComponent={FlatList}

--- a/src/features/venue/helpers/useNavigateToSearchWithVenueOffers.ts
+++ b/src/features/venue/helpers/useNavigateToSearchWithVenueOffers.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 
 import { VenueResponse } from 'api/gen'
-import { getSearchNavConfig } from 'features/navigation/SearchStackNavigator/getSearchNavConfig'
+import { getSearchPropConfig } from 'features/navigation/SearchStackNavigator/getSearchPropConfig'
 import { SearchStackParamList } from 'features/navigation/SearchStackNavigator/SearchStackTypes'
 import { useVenueSearchParameters } from 'features/venue/helpers/useVenueSearchParameters'
 
@@ -9,7 +9,7 @@ export const useNavigateToSearchWithVenueOffers = (venue: VenueResponse) => {
   const venueSearchParams: SearchStackParamList['SearchResults'] = useVenueSearchParameters(venue)
   return useMemo(
     () => ({
-      ...getSearchNavConfig('SearchResults', {
+      ...getSearchPropConfig('SearchResults', {
         ...venueSearchParams,
       }),
       withPush: true,

--- a/src/features/venue/types.ts
+++ b/src/features/venue/types.ts
@@ -77,7 +77,7 @@ export type Artist = {
 
 export type VenueOffersArtists = { artists: Artist[] }
 
-export type SearchNavConfig = {
+export type SearchNavigationConfig = {
   screen: RootNavigateParams[0]
   params?: RootNavigateParams[1]
   withPush?: boolean

--- a/src/features/venueMap/pages/VenueMap/VenueMapBase.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMapBase.tsx
@@ -1,14 +1,14 @@
 import React, { FunctionComponent, PropsWithChildren } from 'react'
 import styled from 'styled-components/native'
 
-import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/getSearchStackConfig'
+import { getSearchHookConfig } from 'features/navigation/SearchStackNavigator/getSearchHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { FilterCategoriesBannerContainer } from 'features/venueMap/components/FilterBannerContainer/FilterCategoriesBannerContainer'
 import { venuesFilterActions } from 'features/venueMap/store/venuesFilterStore'
 import { PageHeaderWithoutPlaceholder } from 'ui/components/headers/PageHeaderWithoutPlaceholder'
 
 export const VenueMapBase: FunctionComponent<PropsWithChildren> = ({ children }) => {
-  const { goBack } = useGoBack(...getSearchStackConfig('SearchLanding'))
+  const { goBack } = useGoBack(...getSearchHookConfig('SearchLanding'))
   const { setVenuesFilters } = venuesFilterActions
 
   const handleGoBack = () => {

--- a/src/shared/AccessibilityFooter/AccessibilityFooter.tsx
+++ b/src/shared/AccessibilityFooter/AccessibilityFooter.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Platform } from 'react-native'
 import styled from 'styled-components/native'
 
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { env } from 'libs/environment/env'
 import { ButtonQuaternaryGrey } from 'ui/components/buttons/ButtonQuaternaryGrey'
 import { Separator } from 'ui/components/Separator'
@@ -26,13 +26,13 @@ export const AccessibilityFooter = () => {
             <ColoredPassCultureLogo />
           </LogoContainer>
           <LinksContainer gap={4}>
-            <InternalTouchableLink navigateTo={getProfileNavConfig('Accessibility')}>
+            <InternalTouchableLink navigateTo={getProfilePropConfig('Accessibility')}>
               <StyledBodyAccentXs>Accessibilité&nbsp;: partiellement conforme</StyledBodyAccentXs>
             </InternalTouchableLink>
-            <InternalTouchableLink navigateTo={getProfileNavConfig('SiteMapScreen')}>
+            <InternalTouchableLink navigateTo={getProfilePropConfig('SiteMapScreen')}>
               <StyledBodyAccentXs>Plan du site</StyledBodyAccentXs>
             </InternalTouchableLink>
-            <InternalTouchableLink navigateTo={getProfileNavConfig('LegalNotices')}>
+            <InternalTouchableLink navigateTo={getProfilePropConfig('LegalNotices')}>
               <StyledBodyAccentXs>Informations légales</StyledBodyAccentXs>
             </InternalTouchableLink>
             <ExternalTouchableLink

--- a/src/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.tsx
+++ b/src/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, useCallback } from 'react'
 import styled from 'styled-components/native'
 
 import { Referrals, UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabHookConfig } from 'features/navigation/TabBar/helpers'
 import { AddToFavoritesButton } from 'features/offer/components/AddToFavoritesButton/AddToFavoritesButton'
 import { analytics } from 'libs/analytics/provider'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
@@ -36,7 +36,7 @@ export const ErrorApplicationModal: FunctionComponent<Props> = ({
   const navigateToProfile = () => {
     analytics.logGoToProfil({ from: 'ErrorApplicationModal', offerId })
     hideModal()
-    navigate(...getTabNavConfig('Profile'))
+    navigate(...getTabHookConfig('Profile'))
   }
 
   return (

--- a/src/ui/components/NoResultsView.tsx
+++ b/src/ui/components/NoResultsView.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
-import { getSearchNavConfig } from 'features/navigation/SearchStackNavigator/getSearchNavConfig'
+import { getSearchPropConfig } from 'features/navigation/SearchStackNavigator/getSearchPropConfig'
 import { useLogBeforeNavToSearchResults } from 'features/search/helpers/useLogBeforeNavToSearchResults/useLogBeforeNavToSearchResults'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
@@ -45,7 +45,7 @@ export const NoResultsView = ({
           <ButtonContainer>
             <InternalTouchableLink
               as={ButtonPrimary}
-              navigateTo={getSearchNavConfig('SearchLanding')}
+              navigateTo={getSearchPropConfig('SearchLanding')}
               wording="Découvrir le catalogue"
               onBeforeNavigate={onPressExploreOffers}
               buttonHeight="tall"

--- a/src/ui/components/SectionRow.native.test.tsx
+++ b/src/ui/components/SectionRow.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { render, screen } from 'tests/utils'
 
 import { SectionRow } from './SectionRow'
@@ -13,7 +13,7 @@ describe('<SectionRow/>', () => {
       <SectionRow
         type="navigable"
         title="navigable"
-        navigateTo={getProfileNavConfig('Accessibility')}
+        navigateTo={getProfilePropConfig('Accessibility')}
       />
     )
 

--- a/src/ui/components/SeeMore.native.test.tsx
+++ b/src/ui/components/SeeMore.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { getProfileNavConfig } from 'features/navigation/ProfileStackNavigator/getProfileNavConfig'
+import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { SeeMore } from './SeeMore'
@@ -26,7 +26,7 @@ describe('<SeeMore />', () => {
   })
 
   it('is a link when navigateTo is given', () => {
-    render(<SeeMore {...props} navigateTo={getProfileNavConfig('Accessibility')} />)
+    render(<SeeMore {...props} navigateTo={getProfilePropConfig('Accessibility')} />)
 
     expect(screen.getByRole('link')).toBeOnTheScreen()
   })

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButton.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButton.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Platform, useWindowDimensions } from 'react-native'
 import styled from 'styled-components/native'
 
-import { getSearchNavConfig } from 'features/navigation/SearchStackNavigator/getSearchNavConfig'
+import { getSearchPropConfig } from 'features/navigation/SearchStackNavigator/getSearchPropConfig'
 import { NativeCategoryEnum, SearchState } from 'features/search/types'
 import { useHandleFocus } from 'libs/hooks/useHandleFocus'
 import { useHandleHover } from 'libs/hooks/useHandleHover'
@@ -47,7 +47,7 @@ export const SubcategoryButton = ({
       {...hoverProps}
       onMouseDown={(e: Event) => e.preventDefault()} // Prevent focus on click
       onBeforeNavigate={onBeforeNavigate}
-      navigateTo={getSearchNavConfig('SearchResults', searchParams)}
+      navigateTo={getSearchPropConfig('SearchResults', searchParams)}
       testID={`SubcategoryButton ${label}`}
       accessibilityLabel={label}
       windowWidth={windowWidth}

--- a/src/ui/components/headers/BackButton.tsx
+++ b/src/ui/components/headers/BackButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { ColorsType } from 'theme/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
@@ -16,7 +16,7 @@ interface HeaderIconProps {
 }
 
 export const BackButton: React.FC<HeaderIconProps> = ({ onGoBack, color }) => {
-  const { goBack } = useGoBack(...homeNavConfig)
+  const { goBack } = useGoBack(...homeNavigationConfig)
   return (
     <StyledTouchable onPress={onGoBack || goBack} accessibilityLabel="Revenir en arrière">
       <ArrowPrevious testID="icon-back" color={color} />

--- a/src/ui/components/headers/EmptyHeader.tsx
+++ b/src/ui/components/headers/EmptyHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { BackButton } from 'ui/components/headers/BackButton'
 import { getSpacing, Spacer } from 'ui/theme'
@@ -16,7 +16,7 @@ interface Props {
 export const EmptyHeader = ({ onGoBack }: Props) => {
   const { designSystem } = useTheme()
   const { top } = useCustomSafeInsets()
-  const { goBack } = useGoBack(...homeNavConfig)
+  const { goBack } = useGoBack(...homeNavigationConfig)
   return (
     <React.Fragment>
       <TopSpacer top={top} />

--- a/src/ui/components/touchableLink/ExternalTouchableLink.native.test.tsx
+++ b/src/ui/components/touchableLink/ExternalTouchableLink.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { navigateFromRef } from 'features/navigation/navigationRef'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { mockedFullAddress } from 'libs/address/fixtures/mockedFormatFullAddress'
 import { WEBAPP_V2_URL } from 'libs/environment/useWebAppUrl'
 import { getGoogleMapsItineraryUrl } from 'libs/itinerary/openGoogleMapsItinerary'
@@ -102,7 +102,7 @@ describe('<ExternalTouchableLink />', () => {
       user.press(screen.getByText(linkText))
 
       await waitFor(() => {
-        expect(navigateFromRef).toHaveBeenCalledWith(...homeNavConfig)
+        expect(navigateFromRef).toHaveBeenCalledWith(...homeNavigationConfig)
       })
     })
   })

--- a/src/ui/components/touchableLink/ExternalTouchableLink.web.test.tsx
+++ b/src/ui/components/touchableLink/ExternalTouchableLink.web.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { navigateFromRef } from 'features/navigation/navigationRef'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { mockedFullAddress } from 'libs/address/fixtures/mockedFormatFullAddress'
 import { WEBAPP_V2_URL } from 'libs/environment/useWebAppUrl'
 import { getGoogleMapsItineraryUrl } from 'libs/itinerary/openGoogleMapsItinerary'
@@ -99,7 +99,7 @@ describe('<ExternalTouchableLink />', () => {
       fireEvent.click(screen.getByText(linkText))
 
       await waitFor(() => {
-        expect(navigateFromRef).toHaveBeenCalledWith(...homeNavConfig)
+        expect(navigateFromRef).toHaveBeenCalledWith(...homeNavigationConfig)
       })
     })
   })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36999

What was changed: The list of links on the main Accessibility.tsx screen was refactored. Instead of using a navigation helper, it now uses push.

Why this was done: The previous implementation used navigation.navigate(), which caused a bug: after navigating to a sub-page (e.g., "Les engagements") and then returning, the link to that page would become unresponsive.

Using push ensures the navigation action is always executed, fixing the bug and making the UI behave predictably for the user.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
