### PR TITLE
(PC-36551) feat(BookingDetails): dark mode booking and remove error banner when no ticket

### DIFF
--- a/src/features/bookings/components/BookingDetailsContent.native.test.tsx
+++ b/src/features/bookings/components/BookingDetailsContent.native.test.tsx
@@ -2,7 +2,7 @@ import mockdate from 'mockdate'
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import type { BookingResponse } from 'api/gen'
+import { BookingResponse, TicketDisplayEnum } from 'api/gen'
 import { BookingDetailsContent } from 'features/bookings/components/BookingDetailsContent'
 import { bookingsSnapV2 } from 'features/bookings/fixtures'
 import { BookingProperties } from 'features/bookings/types'
@@ -189,6 +189,40 @@ describe('<BookingDetailsContent />', () => {
     renderBookingDetailsContent({ properties: { ...mockProperties, isEvent: false }, booking })
 
     expect(screen.getByTestId('ticket-full')).toBeOnTheScreen()
+  })
+
+  it('should display not display error banner when booking is no ticket', async () => {
+    renderBookingDetailsContent({
+      properties: { ...mockProperties, isEvent: false },
+      booking: {
+        ...bookingsSnapV2.ongoingBookings[0],
+        ticket: {
+          ...bookingsSnapV2.ongoingBookings[0].ticket,
+          display: TicketDisplayEnum.no_ticket,
+        },
+      },
+    })
+
+    expect(
+      screen.queryByText('Tu n’as pas le droit de céder ou de revendre ton billet.')
+    ).not.toBeOnTheScreen()
+  })
+
+  it('should display display error banner when booking has a ticket', async () => {
+    renderBookingDetailsContent({
+      properties: { ...mockProperties, isEvent: false },
+      booking: {
+        ...bookingsSnapV2.ongoingBookings[0],
+        ticket: {
+          ...bookingsSnapV2.ongoingBookings[0].ticket,
+          display: TicketDisplayEnum.ticket,
+        },
+      },
+    })
+
+    expect(
+      screen.getByText('Tu n’as pas le droit de céder ou de revendre ton billet.')
+    ).toBeOnTheScreen()
   })
 })
 

--- a/src/features/bookings/components/BookingDetailsContent.tsx
+++ b/src/features/bookings/components/BookingDetailsContent.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Platform, ScrollView, useWindowDimensions } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
-import { BookingResponse, UserProfileResponse } from 'api/gen'
+import { BookingResponse, TicketDisplayEnum, UserProfileResponse } from 'api/gen'
 import { ArchiveBookingModal } from 'features/bookings/components/ArchiveBookingModal'
 import { BookingDetailsCancelButton } from 'features/bookings/components/BookingDetailsCancelButton'
 import { BookingDetailsContentDesktop } from 'features/bookings/components/BookingDetailsContentDesktop'
@@ -78,8 +78,8 @@ export const BookingDetailsContent = ({
     analytics.logClickEmailOrganizer()
   }
 
+  const isNoTicket = booking.ticket.display === TicketDisplayEnum.no_ticket
   const errorBannerMessage = `Tu n’as pas le droit de céder ou de revendre ${properties.isDuo ? 'tes billets' : 'ton billet'}.`
-
   return booking.ticket ? (
     <MainContainer>
       <ScrollView
@@ -110,7 +110,7 @@ export const BookingDetailsContent = ({
             }
             rightBlock={
               <React.Fragment>
-                <ErrorBanner message={errorBannerMessage} />
+                {isNoTicket ? null : <ErrorBanner message={errorBannerMessage} />}
                 {booking.stock.offer.bookingContact || booking.ticket.withdrawal.details ? (
                   <BookingPrecisions
                     bookingContactEmail={booking.stock.offer.bookingContact}
@@ -142,7 +142,7 @@ export const BookingDetailsContent = ({
             }
             onEmailPress={onEmailPress}
             booking={booking}
-            errorBannerMessage={errorBannerMessage}
+            errorBannerMessage={isNoTicket ? null : errorBannerMessage}
             cancelBooking={cancelBooking}
             showArchiveModal={showArchiveModal}
           />

--- a/src/features/bookings/components/BookingDetailsContentMobile.tsx
+++ b/src/features/bookings/components/BookingDetailsContentMobile.tsx
@@ -20,7 +20,7 @@ export const BookingDetailsContentMobile = ({
   topBlock: React.JSX.Element
   booking: BookingResponse
   onEmailPress: () => void
-  errorBannerMessage: string
+  errorBannerMessage: string | null
   cancelBooking: () => void
   showArchiveModal: () => void
 }) => {
@@ -29,9 +29,11 @@ export const BookingDetailsContentMobile = ({
       <SectionContainer>
         <TicketCutoutContainer>{topBlock}</TicketCutoutContainer>
 
-        <Container>
-          <ErrorBanner message={errorBannerMessage} />
-        </Container>
+        {errorBannerMessage ? (
+          <ErrorBannerContainer>
+            <ErrorBanner message={errorBannerMessage} />
+          </ErrorBannerContainer>
+        ) : null}
       </SectionContainer>
 
       {booking.stock.offer.bookingContact || booking.ticket?.withdrawal.details ? (
@@ -87,10 +89,11 @@ const Container = styled.View({
 const TicketCutoutContainer = styled.View({
   width: '100%',
   maxWidth: MAX_CONTENT_WIDTH,
-  marginBottom: getSpacing(8),
   alignSelf: 'center',
 })
 
 const BookingDetailsCancelButtonContainer = styled(Container)({
   marginBottom: getSpacing(10),
 })
+
+const ErrorBannerContainer = styled(Container)({ marginTop: getSpacing(8) })

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
@@ -741,7 +741,7 @@ describe('BookingDetails', () => {
       ).toBeOnTheScreen()
     })
 
-    it('should render error message with plural when booking is duo', async () => {
+    it('should not render error message when booking is no ticket', async () => {
       renderBookingDetailsV2({
         ...ongoingBookingV2,
         quantity: 2,
@@ -750,6 +750,25 @@ describe('BookingDetails', () => {
           display: TicketDisplayEnum.no_ticket,
           withdrawal: {
             type: WithdrawalTypeEnum.no_ticket,
+          },
+        },
+      })
+      await screen.findAllByText(ongoingBookingV2.stock.offer.name)
+
+      expect(
+        screen.queryByText('Tu n’as pas le droit de céder ou de revendre tes billets.')
+      ).not.toBeOnTheScreen()
+    })
+
+    it('should render error message with plural when booking is duo', async () => {
+      renderBookingDetailsV2({
+        ...ongoingBookingV2,
+        quantity: 2,
+        ticket: {
+          ...ongoingBookingV2.ticket,
+          display: TicketDisplayEnum.email_sent,
+          withdrawal: {
+            type: WithdrawalTypeEnum.by_email,
           },
         },
       })
@@ -773,9 +792,9 @@ describe('BookingDetails', () => {
         },
         ticket: {
           ...ongoingBookingV2.ticket,
-          display: TicketDisplayEnum.no_ticket,
+          display: TicketDisplayEnum.email_sent,
           withdrawal: {
-            type: WithdrawalTypeEnum.no_ticket,
+            type: WithdrawalTypeEnum.by_email,
           },
         },
       })

--- a/src/ui/svg/CutoutHorizontal.tsx
+++ b/src/ui/svg/CutoutHorizontal.tsx
@@ -29,8 +29,11 @@ export const CutoutHorizontal: React.FC<Props> = ({
       style={{ transform: [{ rotate }] }}>
       <Defs>
         <Mask id={maskId}>
-          <Rect x="0" y="0" width="20" height="40" fill={backgroundColor} />
-          <Path d="M0 39.5C5.17172 39.5 10.1316 37.4455 13.7886 33.7886C17.4455 30.1316 19.5 25.1717 19.5 20C19.5 14.8283 17.4455 9.86838 13.7886 6.21142C10.1316 2.55446 5.17172 0.5 0 0.5" />
+          <Rect x="0" y="0" width="20" height="40" fill="white" />
+          <Path
+            d="M0 39.5C5.17172 39.5 10.1316 37.4455 13.7886 33.7886C17.4455 30.1316 19.5 25.1717 19.5 20C19.5 14.8283 17.4455 9.86838 13.7886 6.21142C10.1316 2.55446 5.17172 0.5 0 0.5"
+            fill="black"
+          />
         </Mask>
       </Defs>
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36551

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
