### PR TITLE
(PC-37069) feat(FeedBackVideo): remove button or quiz when we leave the screen

### DIFF
--- a/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.native.test.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.native.test.tsx
@@ -29,7 +29,7 @@ describe('<FeedBackVideo />', () => {
     expect(await screen.findByText('Trouves-tu le contenu de cette vidéo utile ?')).toBeTruthy()
   })
 
-  it('should NOT display thank you message if reaction was stored but user did not just react', async () => {
+  it('should not show thank you message when reaction is restored without recent interaction', async () => {
     asyncStorageSpyOn.mockResolvedValueOnce(ReactionTypeEnum.LIKE)
 
     render(<FeedBackVideo offerId={offerId} />)
@@ -43,7 +43,7 @@ describe('<FeedBackVideo />', () => {
     ).toBeNull()
   })
 
-  it('should display thank you message right after user reacts', async () => {
+  it('should show thank you message immediately after user selects a reaction', async () => {
     asyncStorageSpyOn.mockResolvedValueOnce(null)
 
     render(<FeedBackVideo offerId={offerId} />)

--- a/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.native.test.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import { ReactionTypeEnum } from 'api/gen'
 import { FeedBackVideo } from 'features/offer/components/OfferContent/VideoSection/FeedBackVideo'
-import { render, screen, userEvent } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
 
@@ -11,6 +11,7 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 const asyncStorageSpyOn = jest.spyOn(AsyncStorage, 'getItem')
+const asyncStorageSetItemSpy = jest.spyOn(AsyncStorage, 'setItem')
 
 describe('<FeedBackVideo />', () => {
   const offerId = 123
@@ -28,19 +29,21 @@ describe('<FeedBackVideo />', () => {
     expect(await screen.findByText('Trouves-tu le contenu de cette vidéo utile ?')).toBeTruthy()
   })
 
-  it('should display thank you message when LIKE reaction is stored', async () => {
+  it('should NOT display thank you message if reaction was stored but user did not just react', async () => {
     asyncStorageSpyOn.mockResolvedValueOnce(ReactionTypeEnum.LIKE)
 
     render(<FeedBackVideo offerId={offerId} />)
 
-    expect(AsyncStorage.getItem).toHaveBeenCalledWith(storageKey)
+    await waitFor(() => {
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(storageKey)
+    })
 
     expect(
-      await screen.findByText('Merci pour ta réponse ! As-tu 2 minutes pour nous dire pourquoi ?')
-    ).toBeTruthy()
+      screen.queryByText('Merci pour ta réponse ! As-tu 2 minutes pour nous dire pourquoi ?')
+    ).toBeNull()
   })
 
-  it('should store the reaction when user clicks a button', async () => {
+  it('should display thank you message right after user reacts', async () => {
     asyncStorageSpyOn.mockResolvedValueOnce(null)
 
     render(<FeedBackVideo offerId={offerId} />)
@@ -49,5 +52,33 @@ describe('<FeedBackVideo />', () => {
     await user.press(thumbUp)
 
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(storageKey, ReactionTypeEnum.LIKE)
+  })
+
+  it('should store the LIKE reaction when user clicks on Oui', async () => {
+    asyncStorageSpyOn.mockResolvedValueOnce(null)
+
+    render(<FeedBackVideo offerId={offerId} />)
+
+    const yesButton = await screen.findByText('Oui')
+    await user.press(yesButton)
+
+    expect(asyncStorageSetItemSpy).toHaveBeenCalledWith(
+      'feedback_reaction_123',
+      ReactionTypeEnum.LIKE
+    )
+  })
+
+  it('should store the DISLIKE reaction when user clicks on Non', async () => {
+    asyncStorageSpyOn.mockResolvedValueOnce(null)
+
+    render(<FeedBackVideo offerId={offerId} />)
+
+    const noButton = await screen.findByText('Non')
+    await user.press(noButton)
+
+    expect(asyncStorageSetItemSpy).toHaveBeenCalledWith(
+      'feedback_reaction_123',
+      ReactionTypeEnum.DISLIKE
+    )
   })
 })

--- a/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.tsx
@@ -66,6 +66,8 @@ export function FeedBackVideo({ offerId }: Props) {
       <ReactionChoiceValidation
         reactionStatus={null}
         handleOnPressReactionButton={handleReaction}
+        likeLabel="Oui"
+        dislikeLabel="Non"
       />
     </Container>
   )

--- a/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.tsx
@@ -1,5 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useFocusEffect } from '@react-navigation/native'
 import React, { useCallback, useEffect, useState } from 'react'
+import { AppState, AppStateStatus } from 'react-native'
 import styled from 'styled-components/native'
 
 import { ReactionTypeEnum } from 'api/gen'
@@ -19,31 +21,62 @@ type Props = {
 
 export function FeedBackVideo({ offerId }: Props) {
   const [reaction, setReaction] = useState<ReactionTypeEnum | null>(null)
+  const [hasJustReacted, setHasJustReacted] = useState(false)
 
+  // Use stored reaction to prevent reshowing the buttons and
+  // If app is killed and relaunched, reaction is still stored but "thank you" message is not shown.
   useEffect(() => {
     const fetchReaction = async () => {
       const saved = await AsyncStorage.getItem(getStorageKey(offerId))
+
       if (saved === ReactionTypeEnum.LIKE || saved === ReactionTypeEnum.DISLIKE) {
         setReaction(saved)
+      } else {
+        setReaction(null)
       }
     }
     fetchReaction()
   }, [offerId])
 
+  // When user reacts, store the reaction and show the questionnaire invitation immediately.
   const handleReaction = useCallback(
     async (type: ReactionTypeEnum) => {
+      if (type !== ReactionTypeEnum.LIKE && type !== ReactionTypeEnum.DISLIKE) return
+
       setReaction(type)
+      setHasJustReacted(true)
       await AsyncStorage.setItem(getStorageKey(offerId), type)
     },
     [offerId]
   )
+
+  // When navigating away from the screen, hide the questionnaire invitation.
+  useFocusEffect(
+    useCallback(() => {
+      return () => {
+        setHasJustReacted(false)
+      }
+    }, [])
+  )
+
+  // When app goes to background, hide the questionnaire invitation.
+  useEffect(() => {
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
+      if (nextAppState !== 'active') {
+        setHasJustReacted(false)
+      }
+    }
+
+    const subscription = AppState.addEventListener('change', handleAppStateChange)
+    return () => subscription.remove()
+  }, [])
 
   const url =
     reaction === ReactionTypeEnum.LIKE
       ? 'https://passculture.qualtrics.com/jfe/form/SV_238Dd248lT6UuJE'
       : 'https://passculture.qualtrics.com/jfe/form/SV_3lb1IPodkGiMzWe'
 
-  if (reaction) {
+  if (reaction && hasJustReacted) {
     return (
       <Container gap={2}>
         <Typo.BodyAccent>
@@ -60,17 +93,21 @@ export function FeedBackVideo({ offerId }: Props) {
     )
   }
 
-  return (
-    <Container gap={3}>
-      <Typo.BodyAccent>Trouves-tu le contenu de cette vidéo utile&nbsp;?</Typo.BodyAccent>
-      <ReactionChoiceValidation
-        reactionStatus={null}
-        handleOnPressReactionButton={handleReaction}
-        likeLabel="Oui"
-        dislikeLabel="Non"
-      />
-    </Container>
-  )
+  if (!reaction) {
+    return (
+      <Container gap={3}>
+        <Typo.BodyAccent>Trouves-tu le contenu de cette vidéo utile&nbsp;?</Typo.BodyAccent>
+        <ReactionChoiceValidation
+          reactionStatus={null}
+          handleOnPressReactionButton={handleReaction}
+          likeLabel="Oui"
+          dislikeLabel="Non"
+        />
+      </Container>
+    )
+  }
+
+  return null
 }
 
 const Container = styled(ViewGap)({

--- a/src/features/reactions/components/ReactionChoiceModalBodyWithValidation/ReactionChoiceModalBodyWithValidation.tsx
+++ b/src/features/reactions/components/ReactionChoiceModalBodyWithValidation/ReactionChoiceModalBodyWithValidation.tsx
@@ -53,6 +53,8 @@ export const ReactionChoiceModalBodyWithValidation: FunctionComponent<Props> = (
       <StyledReactionChoiceValidation
         reactionStatus={reactionStatus}
         handleOnPressReactionButton={handleOnPressReactionButton}
+        likeLabel="J’aime"
+        dislikeLabel="Je n’aime pas"
       />
     </Container>
   )

--- a/src/features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation.native.test.tsx
+++ b/src/features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation.native.test.tsx
@@ -13,6 +13,8 @@ describe('ReactionChoiceValidation', () => {
       <ReactionChoiceValidation
         reactionStatus={ReactionTypeEnum.LIKE}
         handleOnPressReactionButton={jest.fn()}
+        likeLabel="J’aime"
+        dislikeLabel="Je n’aime pas"
       />
     )
 
@@ -25,6 +27,8 @@ describe('ReactionChoiceValidation', () => {
       <ReactionChoiceValidation
         reactionStatus={ReactionTypeEnum.LIKE}
         handleOnPressReactionButton={jest.fn()}
+        likeLabel="J’aime"
+        dislikeLabel="Je n’aime pas"
       />
     )
 
@@ -38,6 +42,8 @@ describe('ReactionChoiceValidation', () => {
       <ReactionChoiceValidation
         reactionStatus={ReactionTypeEnum.DISLIKE}
         handleOnPressReactionButton={mockHandleOnPress}
+        likeLabel="J’aime"
+        dislikeLabel="Je n’aime pas"
       />
     )
 

--- a/src/features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation.tsx
+++ b/src/features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation.tsx
@@ -10,11 +10,15 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 type Props = {
   handleOnPressReactionButton: (reactionType: ReactionTypeEnum) => void
   reactionStatus?: ReactionTypeEnum | null
+  likeLabel: string
+  dislikeLabel: string
 }
 
 export const ReactionChoiceValidation: FunctionComponent<Props> = ({
   reactionStatus,
   handleOnPressReactionButton,
+  likeLabel,
+  dislikeLabel,
   ...props
 }) => {
   const iconFactory = useIconFactory()
@@ -49,18 +53,19 @@ export const ReactionChoiceValidation: FunctionComponent<Props> = ({
     }),
     [getStyledIcon]
   )
+
   return (
     <ButtonsContainer gap={4} {...props}>
       <ReactionToggleButton
         active={reactionStatus === ReactionTypeEnum.LIKE}
-        label="J’aime"
+        label={likeLabel}
         Icon={ThumbUpIcon.default}
         FilledIcon={ThumbUpIcon.pressed}
         onPress={() => handleOnPressReactionButton(ReactionTypeEnum.LIKE)}
       />
       <ReactionToggleButton
         active={reactionStatus === ReactionTypeEnum.DISLIKE}
-        label="Je n’aime pas"
+        label={dislikeLabel}
         Icon={ThumbDownIcon.default}
         FilledIcon={ThumbDownIcon.pressed}
         onPress={() => handleOnPressReactionButton(ReactionTypeEnum.DISLIKE)}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37069

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots


https://github.com/user-attachments/assets/f53b5e63-4e88-44e3-afe6-418af1aec0da

https://github.com/user-attachments/assets/6443a2d3-adbc-4152-b1be-bbed4f5a779b




[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
