### PR TITLE
(PC-37006) feat(perfs): add slack notif and labeled run for performance test

### DIFF
--- a/.github/workflows/dev_on_pull_request_run_e2e.yml
+++ b/.github/workflows/dev_on_pull_request_run_e2e.yml
@@ -11,7 +11,12 @@ permissions:
 
 jobs:
   notify_test_launch:
-    if: ${{ startsWith(github.event.label.name, 'e2e') }}
+    if: |
+      ${{
+        github.event.label.name == 'e2e' ||
+        github.event.label.name == 'e2e iOS' ||
+        github.event.label.name == 'e2e Android'
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: Comment PR

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -19,7 +19,6 @@ jobs:
     name: 'Run Flashlight Android Performance Test'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    # Ne s'exécuter que si le label est 'perf' ou 'perfs' (pour les PRs)
     if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'e2e perfs')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -1,8 +1,10 @@
-name: '[on_schedule] Flashlight Android Staging Performance test'
+name: 'Flashlight Android Performance Test'
 
 on:
   schedule:
     - cron: '0 22 * * 0' # At 10PM every Sunday
+  pull_request:
+    types: [labeled]
 
 permissions:
   contents: write
@@ -17,6 +19,8 @@ jobs:
     name: 'Run Flashlight Android Performance Test'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    # Ne s'exécuter que si le label est 'perf' ou 'perfs' (pour les PRs)
+    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'e2e perfs')
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -85,4 +89,54 @@ jobs:
         run: echo '${{ steps.secrets.outputs.ANDROID_KEYSTORE }}' | base64 --decode > android/keystores/staging.keystore
 
       - name: Run the full test script
-        run: ./scripts/run_flashlight_on_android.sh
+        id: run_test
+        run: |
+          set +e
+          ./scripts/run_flashlight_on_android.sh 2>&1 | tee test_output.log
+          TEST_EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+
+          OVERALL_SCORE=$(grep -oP 'Overall Score\s+\x1b\[1;32m\K[0-9.]+' test_output.log | tail -1 || echo 'N/A')
+          AVG_FPS=$(grep -oP 'Average FPS\s+\K[0-9]+' test_output.log | tail -1 || echo 'N/A')
+          AVG_RAM=$(grep -oP 'Average RAM Usage\s+\K[0-9]+' test_output.log | tail -1 || echo 'N/A')
+          AVG_CPU=$(grep -oP 'Average Total CPU\s+\K[0-9]+' test_output.log | tail -1 || echo 'N/A')
+
+          BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
+          BRANCH_NAME=${BRANCH_NAME#refs/heads/}
+
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "overall_score=$OVERALL_SCORE" >> $GITHUB_OUTPUT
+          echo "avg_fps=$AVG_FPS" >> $GITHUB_OUTPUT
+          echo "avg_ram=$AVG_RAM" >> $GITHUB_OUTPUT
+          echo "avg_cpu=$AVG_CPU" >> $GITHUB_OUTPUT
+
+          echo "short_sha=${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+
+          if [ $TEST_EXIT_CODE -ne 0 ]; then
+            exit $TEST_EXIT_CODE
+          fi
+
+      - name: Send Slack notification
+        if: always()
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: 'C05MH81G9LY'  # channel #equipe-e2e-jeunes
+          payload: |
+            {
+              "attachments": [
+                {
+                  "mrkdwn_in": ["text"],
+                  "color": "${{ fromJSON('["#36a64f", "#A30002"]')[job.status == 'failure'] }}",
+                  "author_name": "${{github.actor}}",
+                  "author_link": "https://github.com/${{github.actor}}",
+                  "author_icon": "https://github.com/${{github.actor}}.png",
+                  "title": "PERFORMANCE TEST ANDROID",
+                  "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
+                  "text": "Le test de performance sur la branche `${{ steps.run_test.outputs.branch_name || github.ref_name }}` a ${{ fromJSON('["réussi :rocket:", "échoué :boom:"]')[job.status == 'failure'] }}\n\n*Métriques :*\n*- Score:* ${{ steps.run_test.outputs.overall_score || 'N/A' }}\n*- FPS moyen:* ${{ steps.run_test.outputs.avg_fps || 'N/A' }}\n*- RAM moyenne:* ${{ steps.run_test.outputs.avg_ram || 'N/A' }} MB\n*- CPU moyen:* ${{ steps.run_test.outputs.avg_cpu || 'N/A' }}%"
+                }
+              ],
+              "unfurl_links": false,
+              "unfurl_media": false
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37006

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshot

<img width="476" height="223" alt="Capture d’écran 2025-07-24 à 12 49 17" src="https://github.com/user-attachments/assets/152dbd70-7039-4ee7-adae-c379529e6332" />


## ADR

- Les métriques extraites (**score global**, **FPS moyen**, **RAM moyenne**, **CPU moyen**) sont affichées dans une notification Slack, envoyée à la fin de chaque run.
- Le format de la notification Slack a été aligné sur celui des notifications E2E web :
Présentation claire, titres, auteur, couleurs, émojis, et liens directs vers le workflow.

## Amélioration futures

- Un comparatif automatique avec la mesure précédente (affichage de l’évolution des métriques) pourra être ajouté dans une prochaine PR, via l’utilisation d’artefacts GitHub pour stocker l’historique court terme.
