### PR TITLE
(PC-36901) feat(eslint): add rule to prevent theme from theme

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -17,3 +17,6 @@ scripts/parse-perf-results.js
 
 # If your build storybook locally
 storybook-static
+
+# If your build the web app locally
+dist

--- a/.eslintignore
+++ b/.eslintignore
@@ -14,3 +14,6 @@ src/api/gen
 # Occurred while linting /home/runner/work/pass-culture-app-native/pass-culture-app-native/scripts/parse-perf-results.js:42
 # Rule: "local-rules/apostrophe-in-text"
 scripts/parse-perf-results.js
+
+# If your build storybook locally
+storybook-static

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'error',
     'local-rules/independent-mocks': 'error',
     'local-rules/no-direct-consult-offer-log': 'error',
+    'local-rules/no-theme-from-theme': 'warn',
     'local-rules/no-empty-arrow-function': 'off',
     'local-rules/no-fireEvent': 'error',
     'local-rules/no-hardcoded-id-in-svg': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,7 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'error',
     'local-rules/independent-mocks': 'error',
     'local-rules/no-direct-consult-offer-log': 'error',
-    'local-rules/no-theme-from-theme': 'warn',
+    'local-rules/no-theme-from-theme': 'error',
     'local-rules/no-empty-arrow-function': 'off',
     'local-rules/no-fireEvent': 'error',
     'local-rules/no-hardcoded-id-in-svg': 'error',
@@ -387,7 +387,10 @@ module.exports = {
     // Stories overrides
     {
       files: ['**/*.stories.tsx'],
-      rules: { 'local-rules/no-currency-symbols': 'off' },
+      rules: {
+        'local-rules/no-currency-symbols': 'off',
+        'local-rules/no-theme-from-theme': 'off',
+      },
     },
     // Tests overrides
     {
@@ -395,6 +398,7 @@ module.exports = {
       env: { jest: true },
       extends: 'plugin:@bam.tech/tests',
       rules: {
+        'local-rules/no-theme-from-theme': 'off',
         '@typescript-eslint/no-empty-function': 'off',
         'local-rules/nbsp-in-text': 'off',
         'local-rules/no-currency-symbols': 'off',

--- a/eslint-custom-rules/apostrophe-in-text.js
+++ b/eslint-custom-rules/apostrophe-in-text.js
@@ -11,8 +11,8 @@ function buildTree(...args) {
 
 function isTemplateLiteralParentStyledComponents(node) {
   return (
-    node.parent.parent.type === 'TaggedTemplateExpression' &&
-    node.parent.parent.tag.object.name === 'styled'
+    node.parent?.parent?.type === 'TaggedTemplateExpression' &&
+    node.parent?.parent?.tag?.object?.name === 'styled'
   )
 }
 
@@ -33,8 +33,13 @@ module.exports = {
   },
   create(context) {
     const handler = (node, autofix = true) => {
-      // Returns problematic word in the string literal
-      const word = node.raw.match(/([A-zÀ-ú]+'[A-zÀ-ú]+)/)[0]
+      const match = node.raw.match(/([A-zÀ-ú]+'[A-zÀ-ú]+)/)
+
+      if (!match) {
+        return
+      }
+
+      const word = match[0]
 
       context.report({
         node,
@@ -45,7 +50,7 @@ module.exports = {
         },
         data: {
           before: word,
-          after: word.replace(/'/, '‘'),
+          after: word.replace(/'/, '’'),
         },
       })
     }
@@ -66,14 +71,20 @@ module.exports = {
         // Do not handle `styled-components` template literals.
         if (isTemplateLiteralParentStyledComponents(node)) return
 
-        const word = node.value.raw.match(/([A-zÀ-ú]+'[A-zÀ-ú]+)/)[0]
+        const match = node.value.raw.match(/([A-zÀ-ú]+'[A-zÀ-ú]+)/)
+
+        if (!match) {
+          return
+        }
+
+        const word = match[0]
 
         context.report({
           node,
           messageId: 'useApostrophe',
           data: {
-            before: node.value.raw,
-            after: node.value.raw.replace(/'/, '’'),
+            before: word,
+            after: word.replace(/'/, '’'),
           },
         })
       },

--- a/eslint-custom-rules/no-theme-from-theme.js
+++ b/eslint-custom-rules/no-theme-from-theme.js
@@ -1,0 +1,32 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow direct import of `theme` and suggest using `useTheme` hook',
+    },
+    messages: {
+      noDirectThemeImport:
+        "Do not import `{ theme }` directly from 'theme'. Instead, use the `useTheme` hook from 'styled-components/native'.",
+    },
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== 'theme') {
+          return
+        }
+
+        const themeSpecifier = node.specifiers.find(
+          (specifier) => specifier.type === 'ImportSpecifier' && specifier.imported.name === 'theme'
+        )
+
+        if (themeSpecifier) {
+          context.report({
+            node: themeSpecifier,
+            messageId: 'noDirectThemeImport',
+          })
+        }
+      },
+    }
+  },
+}

--- a/eslint-custom-rules/no-theme-from-theme.test.js
+++ b/eslint-custom-rules/no-theme-from-theme.test.js
@@ -1,0 +1,22 @@
+import { RuleTester } from 'eslint'
+import { config } from './config'
+
+import rule from './no-theme-from-theme'
+
+const ruleTester = new RuleTester()
+
+const tests = {
+  valid: [
+    { code: "import styled, { useTheme } from 'styled-components/native'" },
+    { code: "import { other } from 'theme'" },
+  ],
+  invalid: [
+    { code: "import { AppThemeType, theme } from 'theme'", errors: 1 },
+    { code: "import { theme } from 'theme'", errors: 1 },
+  ],
+}
+
+tests.valid.forEach((t) => Object.assign(t, config))
+tests.invalid.forEach((t) => Object.assign(t, config))
+
+ruleTester.run('no-theme-from-theme', rule, tests)

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -17,6 +17,7 @@ const queriesMustBeInQueriesFolder = require('./eslint-custom-rules/queries-must
 const noFireEvent = require('./eslint-custom-rules/no-fireEvent')
 const noSpacer = require('./eslint-custom-rules/no-spacer')
 const noThemeColors = require('./eslint-custom-rules/no-theme-colors')
+const noThemeFromTheme = require('./eslint-custom-rules/no-theme-from-theme')
 const noTsExpectError = require('./eslint-custom-rules/no-ts-expect-error')
 const noUselessHook = require('./eslint-custom-rules/no-useless-hook')
 const mockPathExists = require('./eslint-custom-rules/mock-path-exists')
@@ -41,6 +42,7 @@ module.exports = {
   'no-fireEvent': noFireEvent,
   'no-spacer': noSpacer,
   'no-theme-colors': noThemeColors,
+  'no-theme-from-theme': noThemeFromTheme,
   'no-ts-expect-error': noTsExpectError,
   'no-useless-hook': noUselessHook,
   'mock-path-exists': mockPathExists,

--- a/src/cheatcodes/components/CodePushButton.tsx
+++ b/src/cheatcodes/components/CodePushButton.tsx
@@ -2,6 +2,7 @@ import React, { Component, ReactElement } from 'react'
 import { StyleSheet, Text } from 'react-native'
 import CodePush from 'react-native-code-push' // @codepush
 
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 

--- a/src/features/home/components/helpers/getVideoPlayerDimensions.ts
+++ b/src/features/home/components/helpers/getVideoPlayerDimensions.ts
@@ -1,5 +1,6 @@
 import { PixelRatio } from 'react-native'
 
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 
 export const RATIO169 = 9 / 16

--- a/src/features/identityCheck/components/IconStepCurrent.tsx
+++ b/src/features/identityCheck/components/IconStepCurrent.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react'
 
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 

--- a/src/features/identityCheck/components/IconStepDisabled.tsx
+++ b/src/features/identityCheck/components/IconStepDisabled.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react'
 
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 

--- a/src/features/identityCheck/components/IconStepDone.tsx
+++ b/src/features/identityCheck/components/IconStepDone.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react'
 
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 

--- a/src/features/identityCheck/pages/profile/StatusFlatList.tsx
+++ b/src/features/identityCheck/pages/profile/StatusFlatList.tsx
@@ -10,6 +10,7 @@ import { useActivityTypes } from 'features/identityCheck/queries/useActivityType
 import { useOnViewableItemsChanged } from 'features/subscription/helpers/useOnViewableItemsChanged'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { AnimatedViewRefType, createAnimatableComponent } from 'libs/react-native-animatable'
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { Li } from 'ui/components/Li'

--- a/src/features/offer/components/InteractionTag/InteractionTag.tsx
+++ b/src/features/offer/components/InteractionTag/InteractionTag.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react'
 
 import { SubcategoryIdEnum } from 'api/gen'
 import { isBookClubSubcategory } from 'features/chronicle/helpers/isBookClubSubcategory'
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { Tag } from 'ui/components/Tag/Tag'
 import { TagVariant } from 'ui/components/Tag/types'

--- a/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.tsx
+++ b/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.tsx
@@ -10,6 +10,7 @@ import { useOnViewableItemsChanged } from 'features/subscription/helpers/useOnVi
 import { analytics } from 'libs/analytics/provider'
 import { AnimatedViewRefType } from 'libs/react-native-animatable'
 import { getAge } from 'shared/user/getAge'
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { HeroButtonList } from 'ui/components/buttons/HeroButtonList'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'

--- a/src/features/search/helpers/getGridTileRatio.ts
+++ b/src/features/search/helpers/getGridTileRatio.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { getSpacing } from 'ui/theme'
 

--- a/src/features/venueMap/components/VenueMapTypeFilter/VenueMapTypeFilter.tsx
+++ b/src/features/venueMap/components/VenueMapTypeFilter/VenueMapTypeFilter.tsx
@@ -10,6 +10,7 @@ import { FILTERS_VENUE_TYPE_MAPPING } from 'features/venueMap/constant'
 import { VenueMapFiltersModal } from 'features/venueMap/pages/modals/VenueMapFiltersModal/VenueMapFiltersModal'
 import { venuesFilterActions } from 'features/venueMap/store/venuesFilterStore'
 import { MAP_VENUE_TYPE_TO_LABEL, VenueTypeCode } from 'libs/parsers/venueType'
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { Checkbox } from 'ui/components/inputs/Checkbox/Checkbox'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'

--- a/src/features/venueMap/constant.ts
+++ b/src/features/venueMap/constant.ts
@@ -1,6 +1,7 @@
 import { VenueTypeCodeKey } from 'api/gen'
 import { ClusterImageColorName } from 'features/venueMap/components/VenueMapView/types'
 import { FilterGroupData } from 'features/venueMap/types'
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { Show } from 'ui/svg/icons/Show'
 import { Sort } from 'ui/svg/icons/Sort'

--- a/src/libs/styled/ThemeWrapper.tsx
+++ b/src/libs/styled/ThemeWrapper.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { ThemeProvider } from 'libs/styled'
 import { useColorScheme } from 'libs/styled/useColorScheme'
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 
 export const ThemeWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/src/tests/computedTheme.tsx
+++ b/src/tests/computedTheme.tsx
@@ -1,4 +1,5 @@
 import { ColorScheme } from 'libs/styled/useColorScheme'
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { AppThemeType, theme } from 'theme'
 
 export const computedTheme: Readonly<AppThemeType> = {

--- a/src/ui/components/Avatar/Avatar.tsx
+++ b/src/ui/components/Avatar/Avatar.tsx
@@ -2,6 +2,7 @@ import React, { PropsWithChildren } from 'react'
 import { Platform } from 'react-native'
 import styled from 'styled-components/native'
 
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { getShadow, getSpacing } from 'ui/theme'
 import { AVATAR_SMALL } from 'ui/theme/constants'

--- a/src/ui/components/ModuleBanner/GenericBanner.tsx
+++ b/src/ui/components/ModuleBanner/GenericBanner.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, ReactElement } from 'react'
 import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { ArrowNext } from 'ui/svg/icons/ArrowNext'
 import { AccessibleIcon } from 'ui/svg/icons/types'

--- a/src/ui/components/inputs/BaseTextInput.tsx
+++ b/src/ui/components/inputs/BaseTextInput.tsx
@@ -3,6 +3,7 @@ import React, { forwardRef, useEffect, useRef } from 'react'
 import { Platform, TextInput as RNTextInput } from 'react-native'
 import styled from 'styled-components/native'
 
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { getSpacing } from 'ui/theme'
 

--- a/src/ui/components/inputs/types.ts
+++ b/src/ui/components/inputs/types.ts
@@ -1,6 +1,7 @@
 import { ComponentProps, FunctionComponent, RefAttributes } from 'react'
 import { TextInput as RNTextInput, ViewStyle } from 'react-native'
 
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { ColorsType } from 'theme/types'
 import { AccessibleIcon } from 'ui/svg/icons/types'

--- a/src/ui/theme/customFocusOutline/customFocusOutline.web.ts
+++ b/src/ui/theme/customFocusOutline/customFocusOutline.web.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import { isSafari, browserVersion } from 'react-device-detect'
 
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { Argument } from 'ui/theme/customFocusOutline/type'
 

--- a/src/ui/theme/typography.tsx
+++ b/src/ui/theme/typography.tsx
@@ -1,6 +1,7 @@
 import { Text as RNText } from 'react-native'
 import styled from 'styled-components/native'
 
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { TextColorKey } from 'theme/types'
 import { getHeadingAttrs, HeadingLevel } from 'ui/theme/typographyAttrs/getHeadingAttrs'

--- a/src/ui/theme/videoModuleColorsMapping.ts
+++ b/src/ui/theme/videoModuleColorsMapping.ts
@@ -1,4 +1,5 @@
 import { Color } from 'features/home/types'
+// eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { BackgroundColorKey } from 'theme/types'
 // eslint-disable-next-line no-restricted-imports


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36901

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
