### PR TITLE
(PC-37172) feat(GridList): add tracker on gridListToggle

### DIFF
--- a/src/features/search/components/SearchListHeader/SearchListHeader.tsx
+++ b/src/features/search/components/SearchListHeader/SearchListHeader.tsx
@@ -84,10 +84,16 @@ export const SearchListHeader: React.FC<SearchListHeaderProps> = ({
     nbHits > 0 &&
     !shouldDisplayAvailableUserDataMessage
 
+  const handleToggleChange = (layout: GridListLayout) => {
+    const fromLayout = layout === GridListLayout.GRID ? GridListLayout.LIST : GridListLayout.GRID
+    analytics.logHasClickedGridListToggle({ fromLayout })
+    setGridListLayout?.(layout)
+  }
+
   const getLayoutButtonProps = (layout: GridListLayout) => ({
     layout,
     isSelected: selectedGridListLayout === layout,
-    onPress: () => setGridListLayout?.(layout),
+    onPress: () => handleToggleChange(layout),
   })
 
   return (

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -947,6 +947,21 @@ describe('SearchResultsContent component', () => {
         expect(screen.getAllByTestId('OfferTile')).toBeTruthy()
       })
 
+      it('should trigger logHasClickedGridListToggle whith previous layout when pressing gridListToggle', async () => {
+        renderSearchResultContent()
+
+        await initSearchResultsFlashlist()
+
+        const grilleIcon = await screen.findByTestId('Grille-icon')
+        await user.press(grilleIcon)
+
+        await initSearchResultsFlashlist()
+
+        expect(analytics.logHasClickedGridListToggle).toHaveBeenCalledWith({
+          fromLayout: 'Liste',
+        })
+      })
+
       it('should display list word on toggle when list mode', async () => {
         renderSearchResultContent()
 

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -95,6 +95,7 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logHasChosenPrice: jest.fn(),
   logHasChosenTime: jest.fn(),
   logHasClickedDuoStep: jest.fn(),
+  logHasClickedGridListToggle: jest.fn(),
   logHasClickedMissingCode: jest.fn(),
   logHasClickedRemoteActivationBanner: jest.fn(),
   logHasClickedRemoteGenericBanner: jest.fn(),

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -30,7 +30,7 @@ import {
   RemoteBannerType,
   RemoteBannerOrigin,
 } from 'features/remoteBanners/utils/remoteBannerSchema'
-import { SearchState } from 'features/search/types'
+import { GridListLayout, SearchState } from 'features/search/types'
 import { ShareAppModalType } from 'features/share/types'
 import { SubscriptionAnalyticsParams } from 'features/subscription/types'
 import { AmplitudeEvent } from 'libs/amplitude/events'
@@ -365,6 +365,8 @@ export const logEventAnalytics = {
   logHasChosenPrice: () => analytics.logEvent({ firebase: AnalyticsEvent.HAS_CHOSEN_PRICE }),
   logHasChosenTime: () => analytics.logEvent({ firebase: AnalyticsEvent.HAS_CHOSEN_TIME }),
   logHasClickedDuoStep: () => analytics.logEvent({ firebase: AnalyticsEvent.HAS_CLICKED_DUO_STEP }),
+  logHasClickedGridListToggle: ({ fromLayout }: { fromLayout: GridListLayout }) =>
+    analytics.logEvent({ firebase: AnalyticsEvent.HAS_CLICKED_GRID_LIST_TOGGLE }, { fromLayout }),
   logHasClickedMissingCode: () =>
     analytics.logEvent({ firebase: AnalyticsEvent.HAS_CLICKED_MISSING_CODE }),
   logHasClickedRemoteActivationBanner: (from: RemoteBannerOrigin, options: RemoteBannerType) =>

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -92,6 +92,7 @@ export enum AnalyticsEvent {
   HAS_CHOSEN_TIME = 'HasChosenTime',
   HAS_CLICKED_DUO_STEP = 'HasClickedDuoStep',
   HAS_CLICKED_MISSING_CODE = 'HasClickedMissingCode',
+  HAS_CLICKED_GRID_LIST_TOGGLE = 'HasClickedGridListToggle',
   HAS_CLICKED_REMOTE_ACTIVATION_BANNER = 'HasClickedRemoteActivationBanner',
   HAS_CLICKED_REMOTE_GENERIC_BANNER = 'HasClickedRemoteGenericBanner',
   HAS_CLICKED_TUTORIAL_FAQ = 'HasClickedTutorialFAQ',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37172

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] I am aware of all the best practices and respected them.

## Screenshots
<img width="533" height="364" alt="Screenshot 2025-07-23 at 16 10 12" src="https://github.com/user-attachments/assets/795ebb96-2959-407a-9162-366a641887e4" />

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
