### PR TITLE
(PC-37026) chore(api): update contract for activation scope

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -1687,27 +1687,6 @@ export enum EmailHistoryEventTypeEnum {
 }
 /**
  * @export
- * @interface EmailUpdateStatus
- */
-export interface EmailUpdateStatus {
-  /**
-   * @type {boolean}
-   * @memberof EmailUpdateStatus
-   */
-  expired: boolean
-  /**
-   * @type {string}
-   * @memberof EmailUpdateStatus
-   */
-  newEmail: string
-  /**
-   * @type {EmailHistoryEventTypeEnum}
-   * @memberof EmailUpdateStatus
-   */
-  status: EmailHistoryEventTypeEnum
-}
-/**
- * @export
  * @interface EmailUpdateStatusResponse
  */
 export interface EmailUpdateStatusResponse {
@@ -2446,37 +2425,6 @@ export interface NewEmailSelectionRequest {
    * @memberof NewEmailSelectionRequest
    */
   token: string
-}
-/**
- * @export
- * @interface NextSubscriptionStepResponse
- */
-export interface NextSubscriptionStepResponse {
-  /**
-   * @type {Array<IdentityCheckMethod>}
-   * @memberof NextSubscriptionStepResponse
-   */
-  allowedIdentityCheckMethods: Array<IdentityCheckMethod>
-  /**
-   * @type {boolean}
-   * @memberof NextSubscriptionStepResponse
-   */
-  hasIdentityCheckPending: boolean
-  /**
-   * @type {MaintenancePageType}
-   * @memberof NextSubscriptionStepResponse
-   */
-  maintenancePageType?: MaintenancePageType | null
-  /**
-   * @type {SubscriptionStep}
-   * @memberof NextSubscriptionStepResponse
-   */
-  nextSubscriptionStep?: SubscriptionStep | null
-  /**
-   * @type {SubscriptionMessage}
-   * @memberof NextSubscriptionStepResponse
-   */
-  subscriptionMessage?: SubscriptionMessage | null
 }
 /**
  * @export
@@ -4470,42 +4418,6 @@ export enum SubscriptionStepTitle {
 }
 /**
  * @export
- * @interface SubscriptionStepperResponse
- */
-export interface SubscriptionStepperResponse {
-  /**
-   * @type {Array<IdentityCheckMethod>}
-   * @memberof SubscriptionStepperResponse
-   */
-  allowedIdentityCheckMethods: Array<IdentityCheckMethod>
-  /**
-   * @type {string}
-   * @memberof SubscriptionStepperResponse
-   */
-  errorMessage?: string | null
-  /**
-   * @type {MaintenancePageType}
-   * @memberof SubscriptionStepperResponse
-   */
-  maintenancePageType?: MaintenancePageType | null
-  /**
-   * @type {Array<SubscriptionStepDetailsResponse>}
-   * @memberof SubscriptionStepperResponse
-   */
-  subscriptionStepsToDisplay: Array<SubscriptionStepDetailsResponse>
-  /**
-   * @type {string}
-   * @memberof SubscriptionStepperResponse
-   */
-  subtitle?: string | null
-  /**
-   * @type {string}
-   * @memberof SubscriptionStepperResponse
-   */
-  title: string
-}
-/**
- * @export
  * @interface SubscriptionStepperResponseV2
  */
 export interface SubscriptionStepperResponseV2 {
@@ -4654,22 +4566,6 @@ export interface UpdateEmailTokenExpiration {
    * @memberof UpdateEmailTokenExpiration
    */
   expiration?: string | null
-}
-/**
- * @export
- * @interface UserProfileEmailUpdate
- */
-export interface UserProfileEmailUpdate {
-  /**
-   * @type {string}
-   * @memberof UserProfileEmailUpdate
-   */
-  email: string
-  /**
-   * @type {string}
-   * @memberof UserProfileEmailUpdate
-   */
-  password: string
 }
 /**
  * @export
@@ -5781,25 +5677,6 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
       }
     },
     /**
-     * @summary get_email_update_status <GET>
-     * @deprecated
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getNativeV1ProfileEmailUpdateStatus(options: any = {}): Promise<FetchArgs> {
-      let pathname = `/native/v1/profile/email_update/status`
-      let secureOptions = Object.assign(options, { credentials: 'omit' })
-      // authentication JWTAuth required
-      secureOptions = Object.assign(secureOptions, { credentials: 'include' })
-      const localVarRequestOptions = Object.assign({ method: 'GET' }, secureOptions)
-      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
-      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
-      return {
-        url: pathname,
-        options: localVarRequestOptions,
-      }
-    },
-    /**
      * @summary get_email_update_token_expiration_date <GET>
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -5944,50 +5821,12 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
       }
     },
     /**
-     * @summary next_subscription_step <GET>
-     * @deprecated
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getNativeV1SubscriptionNextStep(options: any = {}): Promise<FetchArgs> {
-      let pathname = `/native/v1/subscription/next_step`
-      let secureOptions = Object.assign(options, { credentials: 'omit' })
-      // authentication JWTAuth required
-      secureOptions = Object.assign(secureOptions, { credentials: 'include' })
-      const localVarRequestOptions = Object.assign({ method: 'GET' }, secureOptions)
-      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
-      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
-      return {
-        url: pathname,
-        options: localVarRequestOptions,
-      }
-    },
-    /**
      * @summary get_profile <GET>
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getNativeV1SubscriptionProfile(options: any = {}): Promise<FetchArgs> {
       let pathname = `/native/v1/subscription/profile`
-      let secureOptions = Object.assign(options, { credentials: 'omit' })
-      // authentication JWTAuth required
-      secureOptions = Object.assign(secureOptions, { credentials: 'include' })
-      const localVarRequestOptions = Object.assign({ method: 'GET' }, secureOptions)
-      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
-      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
-      return {
-        url: pathname,
-        options: localVarRequestOptions,
-      }
-    },
-    /**
-     * @summary get_subscription_stepper_deprecated <GET>
-     * @deprecated
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getNativeV1SubscriptionStepper(options: any = {}): Promise<FetchArgs> {
-      let pathname = `/native/v1/subscription/stepper`
       let secureOptions = Object.assign(options, { credentials: 'omit' })
       // authentication JWTAuth required
       secureOptions = Object.assign(secureOptions, { credentials: 'include' })
@@ -6619,63 +6458,8 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
       const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
       localVarHeaderParameter['Content-Type'] = 'application/json'
       localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
-      const needsSerialization =
-        <any>'ChangeBeneficiaryEmailBody' !== 'string' ||
-        localVarRequestOptions.headers['Content-Type'] === 'application/json'
-      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body || {}) : body || ''
-      return {
-        url: pathname,
-        options: localVarRequestOptions,
-      }
-    },
-    /**
-     * @summary confirm_email_update <POST>
-     * @param {ChangeBeneficiaryEmailBody} [body]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async postNativeV1ProfileEmailUpdateConfirm(
-      body?: ChangeBeneficiaryEmailBody,
-      options: any = {}
-    ): Promise<FetchArgs> {
-      let pathname = `/native/v1/profile/email_update/confirm`
-      let secureOptions = Object.assign(options, { credentials: 'omit' })
-      const localVarRequestOptions = Object.assign({ method: 'POST' }, secureOptions)
-      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
-      localVarHeaderParameter['Content-Type'] = 'application/json'
-      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
-      const needsSerialization =
-        <any>'ChangeBeneficiaryEmailBody' !== 'string' ||
-        localVarRequestOptions.headers['Content-Type'] === 'application/json'
-      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body || {}) : body || ''
-      return {
-        url: pathname,
-        options: localVarRequestOptions,
-      }
-    },
-    /**
-     * @summary update_user_email <POST>
-     * @deprecated
-     * @param {UserProfileEmailUpdate} [body]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async postNativeV1ProfileUpdateEmail(
-      body?: UserProfileEmailUpdate,
-      options: any = {}
-    ): Promise<FetchArgs> {
-      let pathname = `/native/v1/profile/update_email`
-      let secureOptions = Object.assign(options, { credentials: 'omit' })
-      // authentication JWTAuth required
-      secureOptions = Object.assign(secureOptions, { credentials: 'include' })
-      const localVarRequestOptions = Object.assign({ method: 'POST' }, secureOptions)
-      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
-      localVarHeaderParameter['Content-Type'] = 'application/json'
-      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
-      const needsSerialization =
-        <any>'UserProfileEmailUpdate' !== 'string' ||
-        localVarRequestOptions.headers['Content-Type'] === 'application/json'
-      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body || {}) : body || ''
+      const needsSerialization = (<any>"ChangeBeneficiaryEmailBody" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json'
+      localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "")
       return {
         url: pathname,
         options: localVarRequestOptions,
@@ -7443,37 +7227,9 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    async getNativeV1PhoneValidationRemainingAttempts(
-      options?: any
-    ): Promise<PhoneValidationRemainingAttemptsRequest> {
-      const localVarFetchArgs =
-        await DefaultApiFetchParamCreator(
-          configuration
-        ).getNativeV1PhoneValidationRemainingAttempts(options)
-      const response = await safeFetch(
-        configuration?.basePath + localVarFetchArgs.url,
-        localVarFetchArgs.options,
-        api
-      )
-      return handleGeneratedApiResponse(response)
-    },
-    /**
-     *
-     * @summary get_email_update_status <GET>
-     * @deprecated
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getNativeV1ProfileEmailUpdateStatus(options?: any): Promise<EmailUpdateStatus> {
-      const localVarFetchArgs =
-        await DefaultApiFetchParamCreator(configuration).getNativeV1ProfileEmailUpdateStatus(
-          options
-        )
-      const response = await safeFetch(
-        configuration?.basePath + localVarFetchArgs.url,
-        localVarFetchArgs.options,
-        api
-      )
+    async getNativeV1PhoneValidationRemainingAttempts(options?: any): Promise<PhoneValidationRemainingAttemptsRequest> {
+      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1PhoneValidationRemainingAttempts(options)
+      const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
       return handleGeneratedApiResponse(response)
     },
     /**
@@ -7544,32 +7300,8 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
      * @throws {RequiredError}
      */
     async getNativeV1SubscriptionActivityTypes(options?: any): Promise<ActivityTypesResponse> {
-      const localVarFetchArgs =
-        await DefaultApiFetchParamCreator(configuration).getNativeV1SubscriptionActivityTypes(
-          options
-        )
-      const response = await safeFetch(
-        configuration?.basePath + localVarFetchArgs.url,
-        localVarFetchArgs.options,
-        api
-      )
-      return handleGeneratedApiResponse(response)
-    },
-    /**
-     *
-     * @summary next_subscription_step <GET>
-     * @deprecated
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getNativeV1SubscriptionNextStep(options?: any): Promise<NextSubscriptionStepResponse> {
-      const localVarFetchArgs =
-        await DefaultApiFetchParamCreator(configuration).getNativeV1SubscriptionNextStep(options)
-      const response = await safeFetch(
-        configuration?.basePath + localVarFetchArgs.url,
-        localVarFetchArgs.options,
-        api
-      )
+      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1SubscriptionActivityTypes(options)
+      const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
       return handleGeneratedApiResponse(response)
     },
     /**
@@ -7579,30 +7311,8 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
      * @throws {RequiredError}
      */
     async getNativeV1SubscriptionProfile(options?: any): Promise<EmptyResponse> {
-      const localVarFetchArgs =
-        await DefaultApiFetchParamCreator(configuration).getNativeV1SubscriptionProfile(options)
-      const response = await safeFetch(
-        configuration?.basePath + localVarFetchArgs.url,
-        localVarFetchArgs.options,
-        api
-      )
-      return handleGeneratedApiResponse(response)
-    },
-    /**
-     *
-     * @summary get_subscription_stepper_deprecated <GET>
-     * @deprecated
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getNativeV1SubscriptionStepper(options?: any): Promise<SubscriptionStepperResponse> {
-      const localVarFetchArgs =
-        await DefaultApiFetchParamCreator(configuration).getNativeV1SubscriptionStepper(options)
-      const response = await safeFetch(
-        configuration?.basePath + localVarFetchArgs.url,
-        localVarFetchArgs.options,
-        api
-      )
+      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1SubscriptionProfile(options)
+      const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
       return handleGeneratedApiResponse(response)
     },
     /**
@@ -7960,61 +7670,9 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    async postNativeV1ProfileEmailUpdateCancel(
-      body?: ChangeBeneficiaryEmailBody,
-      options?: any
-    ): Promise<EmptyResponse> {
-      const localVarFetchArgs = await DefaultApiFetchParamCreator(
-        configuration
-      ).postNativeV1ProfileEmailUpdateCancel(body, options)
-      const response = await safeFetch(
-        configuration?.basePath + localVarFetchArgs.url,
-        localVarFetchArgs.options,
-        api
-      )
-      return handleGeneratedApiResponse(response)
-    },
-    /**
-     *
-     * @summary confirm_email_update <POST>
-     * @param {ChangeBeneficiaryEmailBody} [body]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async postNativeV1ProfileEmailUpdateConfirm(
-      body?: ChangeBeneficiaryEmailBody,
-      options?: any
-    ): Promise<EmptyResponse> {
-      const localVarFetchArgs = await DefaultApiFetchParamCreator(
-        configuration
-      ).postNativeV1ProfileEmailUpdateConfirm(body, options)
-      const response = await safeFetch(
-        configuration?.basePath + localVarFetchArgs.url,
-        localVarFetchArgs.options,
-        api
-      )
-      return handleGeneratedApiResponse(response)
-    },
-    /**
-     *
-     * @summary update_user_email <POST>
-     * @deprecated
-     * @param {UserProfileEmailUpdate} [body]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async postNativeV1ProfileUpdateEmail(
-      body?: UserProfileEmailUpdate,
-      options?: any
-    ): Promise<EmptyResponse> {
-      const localVarFetchArgs = await DefaultApiFetchParamCreator(
-        configuration
-      ).postNativeV1ProfileUpdateEmail(body, options)
-      const response = await safeFetch(
-        configuration?.basePath + localVarFetchArgs.url,
-        localVarFetchArgs.options,
-        api
-      )
+    async postNativeV1ProfileEmailUpdateCancel(body?: ChangeBeneficiaryEmailBody, options?: any): Promise<EmptyResponse> {
+      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1ProfileEmailUpdateCancel(body, options)
+      const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
       return handleGeneratedApiResponse(response)
     },
     /**
@@ -8543,18 +8201,6 @@ export class DefaultApi extends BaseAPI {
     return DefaultApiFp(this, configuration).getNativeV1PhoneValidationRemainingAttempts(options)
   }
   /**
-   *
-   * @summary get_email_update_status <GET>
-   * @deprecated
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof DefaultApi
-   */
-  public async getNativeV1ProfileEmailUpdateStatus(options?: any) {
-    const configuration = this.getConfiguration()
-    return DefaultApiFp(this, configuration).getNativeV1ProfileEmailUpdateStatus(options)
-  }
-  /**
     * 
     * @summary get_email_update_token_expiration_date <GET>
     * @param {*} [options] Override http request option.
@@ -8627,18 +8273,6 @@ export class DefaultApi extends BaseAPI {
     return DefaultApiFp(this, configuration).getNativeV1SubscriptionActivityTypes(options)
   }
   /**
-   *
-   * @summary next_subscription_step <GET>
-   * @deprecated
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof DefaultApi
-   */
-  public async getNativeV1SubscriptionNextStep(options?: any) {
-    const configuration = this.getConfiguration()
-    return DefaultApiFp(this, configuration).getNativeV1SubscriptionNextStep(options)
-  }
-  /**
     * 
     * @summary get_profile <GET>
     * @param {*} [options] Override http request option.
@@ -8648,18 +8282,6 @@ export class DefaultApi extends BaseAPI {
   public async getNativeV1SubscriptionProfile(options?: any) {
     const configuration = this.getConfiguration()
     return DefaultApiFp(this, configuration).getNativeV1SubscriptionProfile(options)
-  }
-  /**
-   *
-   * @summary get_subscription_stepper_deprecated <GET>
-   * @deprecated
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof DefaultApi
-   */
-  public async getNativeV1SubscriptionStepper(options?: any) {
-    const configuration = this.getConfiguration()
-    return DefaultApiFp(this, configuration).getNativeV1SubscriptionStepper(options)
   }
   /**
     * 
@@ -8996,34 +8618,6 @@ export class DefaultApi extends BaseAPI {
   public async postNativeV1ProfileEmailUpdateCancel(body?: ChangeBeneficiaryEmailBody, options?: any) {
     const configuration = this.getConfiguration()
     return DefaultApiFp(this, configuration).postNativeV1ProfileEmailUpdateCancel(body, options)
-  }
-  /**
-   *
-   * @summary confirm_email_update <POST>
-   * @param {ChangeBeneficiaryEmailBody} [body]
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof DefaultApi
-   */
-  public async postNativeV1ProfileEmailUpdateConfirm(
-    body?: ChangeBeneficiaryEmailBody,
-    options?: any
-  ) {
-    const configuration = this.getConfiguration()
-    return DefaultApiFp(this, configuration).postNativeV1ProfileEmailUpdateConfirm(body, options)
-  }
-  /**
-   *
-   * @summary update_user_email <POST>
-   * @deprecated
-   * @param {UserProfileEmailUpdate} [body]
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof DefaultApi
-   */
-  public async postNativeV1ProfileUpdateEmail(body?: UserProfileEmailUpdate, options?: any) {
-    const configuration = this.getConfiguration()
-    return DefaultApiFp(this, configuration).postNativeV1ProfileUpdateEmail(body, options)
   }
   /**
     * 

--- a/src/features/identityCheck/pages/Stepper.web.test.tsx
+++ b/src/features/identityCheck/pages/Stepper.web.test.tsx
@@ -1,7 +1,7 @@
 import mockdate from 'mockdate'
 import React from 'react'
 
-import { NextSubscriptionStepResponse } from 'api/gen'
+import { SubscriptionStepperResponseV2 } from 'api/gen'
 import { stepsDetailsFixture } from 'features/identityCheck/pages/helpers/stepDetails.fixture'
 import { useRehydrateProfile } from 'features/identityCheck/pages/helpers/useRehydrateProfile'
 import { useStepperInfo } from 'features/identityCheck/pages/helpers/useStepperInfo'
@@ -16,7 +16,7 @@ jest.mock('libs/firebase/analytics/analytics')
 
 mockdate.set(new Date('2020-12-01T00:00:00.000Z'))
 
-const subscriptionStep: NextSubscriptionStepResponse = {
+const subscriptionStep: Partial<SubscriptionStepperResponseV2> = {
   allowedIdentityCheckMethods: [],
   hasIdentityCheckPending: false,
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37026

Inventory of type changes in our scope:
- `EmailUpdateStatus` type removed (containing `expired`, `newEmail`, `status`)
- `NextSubscriptionStepResponse` type removed (containing `nextSubscriptionStep`, `maintenancePageType`...)
- `SubscriptionStepperResponse` type removed (containing `errorMessage`, `subscriptionStepsToDisplay`...)
- `UserProfileEmailUpdate` type removed (containing `email` and `password`)

Inventory of changes of "Fetch Arguments Creator" Methods:
- `getNativeV1ProfileEmailUpdateStatus` for the route `/native/v1/profile/email_update/status` removed. It was marked as `deprecated` 17 months ago.
- `getNativeV1SubscriptionNextStep` for the route `/native/v1/subscription/next_step` removed. It was marked as `deprecated` 15 months ago.
- `postNativeV1ProfileEmailUpdateConfirm` for the route `/native/v1/profile/email_update/confirm` removed.
- `postNativeV1ProfileUpdateEmail` for the route `/native/v1/profile/update_email` removed. This was using the type `UserProfileEmailUpdate` listed above. I should check the type used in the function `UserProfileEmailUpdate`.

Inventory of changes of "Fetch Implementation" Methods:
- Removed `getNativeV1ProfileEmailUpdateStatus`
- Removed `getNativeV1SubscriptionNextStep`
- Removed `getNativeV1SubscriptionStepper`
- Removed `postNativeV1ProfileEmailUpdateConfirm`
- Removed `postNativeV1ProfileUpdateEmail`

Inventory of changes of "Public API" Methods:
- Removed `getNativeV1SubscriptionNextStep`,  
- Removed `getNativeV1SubscriptionStepper`,
- Removed `postNativeV1ProfileEmailUpdateConfirm`, 
- Removed `postNativeV1ProfileUpdateEmail`.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
