### PR TITLE
(PC-35433) refactor(remoteConfig): return all react-query object

### DIFF
--- a/src/cheatcodes/pages/others/CheatcodesScreenRemoteConfig.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenRemoteConfig.tsx
@@ -21,7 +21,7 @@ const ConfigItem = ({ label, value }: { label: string; value: GenericRemoteConfi
 )
 
 export const CheatcodesScreenRemoteConfig = () => {
-  const remoteConfig = useRemoteConfigQuery()
+  const { data: remoteConfig } = useRemoteConfigQuery()
 
   const sortedRemoteConfigEntries = Object.entries(remoteConfig).sort(([keyA], [keyB]) =>
     keyA.localeCompare(keyB)

--- a/src/features/auth/components/SSOButton/SSOButton.native.test.tsx
+++ b/src/features/auth/components/SSOButton/SSOButton.native.test.tsx
@@ -10,6 +10,7 @@ import { beneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { eventMonitoring } from 'libs/monitoring/services'
@@ -124,10 +125,13 @@ describe('<SSOButton />', () => {
   })
 
   describe('When shouldLogInfo remote config is false', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        shouldLogInfo: false,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          shouldLogInfo: false,
+        },
       })
     })
 
@@ -144,13 +148,16 @@ describe('<SSOButton />', () => {
   describe('When shouldLogInfo remote config is true', () => {
     beforeAll(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        shouldLogInfo: true,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          shouldLogInfo: true,
+        },
       })
     })
 
     afterAll(() => {
-      useRemoteConfigSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+      useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
     })
 
     it('should log to Sentry on SSO login error', async () => {

--- a/src/features/auth/context/AuthContext.native.test.tsx
+++ b/src/features/auth/context/AuthContext.native.test.tsx
@@ -8,8 +8,8 @@ import { CURRENT_DATE } from 'features/auth/fixtures/fixtures'
 import * as NavigationRef from 'features/navigation/navigationRef'
 import { beneficiaryUser, nonBeneficiaryUser } from 'fixtures/user'
 // eslint-disable-next-line no-restricted-imports
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
-import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { decodedTokenWithRemainingLifetime, tokenRemainingLifetimeInMs } from 'libs/jwt/fixtures'
 import { clearRefreshToken, getRefreshToken, saveRefreshToken } from 'libs/keychain/keychain'
 import { eventMonitoring } from 'libs/monitoring/services'
@@ -38,7 +38,9 @@ jest.useFakeTimers()
 
 jest.mock('libs/firebase/analytics/analytics')
 
-jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue(DEFAULT_REMOTE_CONFIG)
+jest
+  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
+  .mockReturnValue(remoteConfigResponseFixture)
 
 describe('AuthContext', () => {
   beforeEach(async () => {

--- a/src/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx
+++ b/src/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx
@@ -9,8 +9,8 @@ import { ShareAppWrapper } from 'features/share/context/ShareAppWrapper'
 import { ShareAppModalType } from 'features/share/types'
 import { beneficiaryUser } from 'fixtures/user'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
-import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { render, screen, userEvent } from 'tests/utils'
 
@@ -18,7 +18,9 @@ import { AccountCreated } from './AccountCreated'
 
 jest.mock('libs/firebase/analytics/analytics')
 
-jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue(DEFAULT_REMOTE_CONFIG)
+jest
+  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
+  .mockReturnValue(remoteConfigResponseFixture)
 
 jest.mock('queries/profile/useResetRecreditAmountToShowMutation')
 jest.mock('features/navigation/helpers/navigateToHome')

--- a/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx
+++ b/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { api } from 'api/api'
 import { EmailValidationRemainingResendsResponse } from 'api/gen'
 import { analytics } from 'libs/analytics/provider'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { eventMonitoring } from 'libs/monitoring/services'
@@ -19,7 +20,7 @@ const resendEmailValidationSpy = jest.spyOn(api, 'postNativeV1ResendEmailValidat
 
 const useRemoteConfigSpy = jest
   .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
-  .mockReturnValue(DEFAULT_REMOTE_CONFIG)
+  .mockReturnValue(remoteConfigResponseFixture)
 
 jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   return function createAnimatedComponent(Component: unknown) {
@@ -159,8 +160,11 @@ describe('<EmailResendModal />', () => {
   describe('When shouldLogInfo remote config is false', () => {
     beforeAll(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        shouldLogInfo: false,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          shouldLogInfo: false,
+        },
       })
     })
 
@@ -179,13 +183,16 @@ describe('<EmailResendModal />', () => {
   describe('When shouldLogInfo remote config is true', () => {
     beforeAll(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        shouldLogInfo: true,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          shouldLogInfo: true,
+        },
       })
     })
 
     afterAll(() => {
-      useRemoteConfigSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+      useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
     })
 
     it('should log to Sentry on error', async () => {

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.web.test.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.web.test.tsx
@@ -15,6 +15,8 @@ import { Booking } from 'features/bookings/types'
 import { withAsyncErrorBoundary } from 'features/errors/hocs/withAsyncErrorBoundary'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
+import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import * as useNetInfoContextDefault from 'libs/network/NetInfoWrapper'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
 import { mockServer } from 'tests/mswServer'
@@ -34,6 +36,9 @@ jest.mock('libs/network/NetInfoWrapper')
 const mockUseNetInfoContext = jest.spyOn(useNetInfoContextDefault, 'useNetInfoContext') as jest.Mock
 
 jest.mock('libs/firebase/analytics/analytics')
+jest
+  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
+  .mockReturnValue(remoteConfigResponseFixture)
 
 describe('BookingDetails', () => {
   mockUseNetInfoContext.mockReturnValue({ isConnected: true })

--- a/src/features/cookies/helpers/useCookies.native.test.ts
+++ b/src/features/cookies/helpers/useCookies.native.test.ts
@@ -8,13 +8,14 @@ import { useCookies } from 'features/cookies/helpers/useCookies'
 import { CookiesConsent } from 'features/cookies/types'
 import { FAKE_USER_ID } from 'fixtures/fakeUserId'
 import { beneficiaryUser } from 'fixtures/user'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { eventMonitoring } from 'libs/monitoring/services'
 import * as PackageJson from 'libs/packageJson'
 import { getDeviceId } from 'libs/react-native-device-info/getDeviceId'
 import { storage } from 'libs/storage'
-import { mockAuthContextWithoutUser, mockAuthContextWithUser } from 'tests/AuthContextUtils'
+import { mockAuthContextWithUser, mockAuthContextWithoutUser } from 'tests/AuthContextUtils'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, renderHook, waitFor } from 'tests/utils'
 
@@ -462,8 +463,11 @@ describe.skip('useCookies', () => {
       describe('When shouldLogInfo remote config is false', () => {
         beforeAll(() => {
           useRemoteConfigSpy.mockReturnValue({
-            ...DEFAULT_REMOTE_CONFIG,
-            shouldLogInfo: false,
+            ...remoteConfigResponseFixture,
+            data: {
+              ...DEFAULT_REMOTE_CONFIG,
+              shouldLogInfo: false,
+            },
           })
         })
 
@@ -486,13 +490,13 @@ describe.skip('useCookies', () => {
       describe('When shouldLogInfo remote config is true', () => {
         beforeAll(() => {
           useRemoteConfigSpy.mockReturnValue({
-            ...DEFAULT_REMOTE_CONFIG,
-            shouldLogInfo: true,
+            ...remoteConfigResponseFixture,
+            data: { ...DEFAULT_REMOTE_CONFIG, shouldLogInfo: true },
           })
         })
 
         afterAll(() => {
-          useRemoteConfigSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+          useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
         })
 
         it('should notify sentry', async () => {

--- a/src/features/errors/pages/AsyncErrorBoundary.native.test.tsx
+++ b/src/features/errors/pages/AsyncErrorBoundary.native.test.tsx
@@ -6,6 +6,7 @@ import { AsyncErrorBoundary } from 'features/errors/pages/AsyncErrorBoundary'
 import { useMaintenance } from 'features/maintenance/helpers/useMaintenance/useMaintenance'
 import { MaintenanceErrorPage } from 'features/maintenance/pages/MaintenanceErrorPage'
 import * as useGoBack from 'features/navigation/useGoBack'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { AsyncError, LogTypeEnum, MonitoringError, ScreenError } from 'libs/monitoring/errors'
@@ -23,7 +24,7 @@ jest.spyOn(useGoBack, 'useGoBack').mockReturnValue({
 
 const useRemoteConfigSpy = jest
   .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
-  .mockReturnValue(DEFAULT_REMOTE_CONFIG)
+  .mockReturnValue(remoteConfigResponseFixture)
 
 jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   return function createAnimatedComponent(Component: unknown) {
@@ -107,13 +108,16 @@ describe('AsyncErrorBoundary component', () => {
   describe('When shouldLogInfo remote config is true', () => {
     beforeAll(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        shouldLogInfo: true,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          shouldLogInfo: true,
+        },
       })
     })
 
     afterAll(() => {
-      useRemoteConfigSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+      useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
     })
 
     it('should capture info when error is ApiError and error code is 401', () => {
@@ -132,8 +136,11 @@ describe('AsyncErrorBoundary component', () => {
   describe('When shouldLogInfo remote config is false', () => {
     beforeAll(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        shouldLogInfo: false,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          shouldLogInfo: false,
+        },
       })
     })
 

--- a/src/features/errors/pages/AsyncErrorBoundary.web.test.tsx
+++ b/src/features/errors/pages/AsyncErrorBoundary.web.test.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 
 import { AsyncErrorBoundary } from 'features/errors/pages/AsyncErrorBoundary'
 import * as useGoBack from 'features/navigation/useGoBack'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
-import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { AsyncError, LogTypeEnum } from 'libs/monitoring/errors'
 import { checkAccessibilityFor, fireEvent, render, screen } from 'tests/utils/web'
 
@@ -17,7 +17,9 @@ jest.spyOn(useGoBack, 'useGoBack').mockReturnValue({
   canGoBack: jest.fn(() => true),
 })
 
-jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue(DEFAULT_REMOTE_CONFIG)
+jest
+  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
+  .mockReturnValue(remoteConfigResponseFixture)
 jest.mock('ui/theme/customFocusOutline/customFocusOutline')
 
 describe('AsyncErrorBoundary component', () => {

--- a/src/features/home/helpers/selectHomepageEntry.native.test.ts
+++ b/src/features/home/helpers/selectHomepageEntry.native.test.ts
@@ -8,14 +8,15 @@ import { useSelectHomepageEntry } from 'features/home/helpers/selectHomepageEntr
 import { Homepage, HomepageTag } from 'features/home/types'
 import { UserOnboardingRole } from 'features/onboarding/enums'
 import * as OnboardingRoleAPI from 'features/onboarding/helpers/useUserRoleFromOnboarding'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { CustomRemoteConfig } from 'libs/firebase/remoteConfig/remoteConfig.types'
 import { useBookingsQuery, useUserHasBookingsQuery } from 'queries/bookings'
 import { Credit, getAvailableCredit } from 'shared/user/useAvailableCredit'
 import {
-  mockAuthContextWithoutUser,
   mockAuthContextWithUser,
+  mockAuthContextWithoutUser,
   mockUseAuthContext,
 } from 'tests/AuthContextUtils'
 import { renderHook, waitFor } from 'tests/utils'
@@ -122,7 +123,10 @@ const defaultRemoteConfig: CustomRemoteConfig = {
 
 describe('useSelectHomepageEntry', () => {
   it('should not return anything when no homepageEntries retrieved from contentful', () => {
-    useRemoteConfigSpy.mockReturnValueOnce(defaultRemoteConfig)
+    useRemoteConfigSpy.mockReturnValueOnce({
+      ...remoteConfigResponseFixture,
+      data: defaultRemoteConfig,
+    })
     const { result } = renderHook(() => useSelectHomepageEntry())
     const Homepage = result.current([])
 
@@ -130,7 +134,10 @@ describe('useSelectHomepageEntry', () => {
   })
 
   it('should return home entry corresponding to id provided', () => {
-    useRemoteConfigSpy.mockReturnValueOnce(defaultRemoteConfig)
+    useRemoteConfigSpy.mockReturnValueOnce({
+      ...remoteConfigResponseFixture,
+      data: defaultRemoteConfig,
+    })
     const { result } = renderHook(() => useSelectHomepageEntry(homeEntryId))
     const Homepage = result.current(shuffle(homepageEntries))
 
@@ -152,7 +159,10 @@ describe('useSelectHomepageEntry', () => {
         onboardingRole: UserOnboardingRole
         expectedHomepage: Homepage
       }) => {
-        useRemoteConfigSpy.mockReturnValueOnce(defaultRemoteConfig)
+        useRemoteConfigSpy.mockReturnValueOnce({
+          ...remoteConfigResponseFixture,
+          data: defaultRemoteConfig,
+        })
         mockAuthContextWithoutUser()
         mockUseUserRoleFromOnboarding.mockReturnValueOnce(onboardingRole)
         mockedUseUserHasBookings.mockReturnValueOnce(false)
@@ -167,7 +177,10 @@ describe('useSelectHomepageEntry', () => {
     )
 
     it('should return general home entry when user is logged in but undefined', () => {
-      useRemoteConfigSpy.mockReturnValueOnce(defaultRemoteConfig)
+      useRemoteConfigSpy.mockReturnValueOnce({
+        ...remoteConfigResponseFixture,
+        data: defaultRemoteConfig,
+      })
       mockUseAuthContext.mockReturnValueOnce({
         isLoggedIn: true,
         user: undefined,
@@ -206,7 +219,10 @@ describe('useSelectHomepageEntry', () => {
         credit: Credit
         expectedHomepage: Homepage
       }) => {
-        useRemoteConfigSpy.mockReturnValueOnce(defaultRemoteConfig)
+        useRemoteConfigSpy.mockReturnValueOnce({
+          ...remoteConfigResponseFixture,
+          data: defaultRemoteConfig,
+        })
         mockAuthContextWithUser(user)
 
         mockUseUserRoleFromOnboarding.mockReturnValueOnce(onboardingRole)
@@ -228,12 +244,15 @@ describe('useSelectHomepageEntry', () => {
   describe('default home entry when no remote config available', () => {
     beforeEach(() => {
       useRemoteConfigSpy.mockReturnValueOnce({
-        ...defaultRemoteConfig,
-        test_param: 'A',
-        homeEntryIdGeneral: '',
-        homeEntryIdWithoutBooking: '',
-        homeEntryIdBeneficiary: '',
-        homeEntryIdFreeBeneficiary: '',
+        ...remoteConfigResponseFixture,
+        data: {
+          ...defaultRemoteConfig,
+          test_param: 'A',
+          homeEntryIdGeneral: '',
+          homeEntryIdWithoutBooking: '',
+          homeEntryIdBeneficiary: '',
+          homeEntryIdFreeBeneficiary: '',
+        },
       })
     })
 

--- a/src/features/home/helpers/selectHomepageEntry.ts
+++ b/src/features/home/helpers/selectHomepageEntry.ts
@@ -35,10 +35,12 @@ export const useSelectHomepageEntry = (
   const userHasBookings = useUserHasBookingsQuery()
   const onboardingRole = useUserRoleFromOnboarding()
   const {
-    homeEntryIdGeneral,
-    homeEntryIdBeneficiary,
-    homeEntryIdFreeBeneficiary,
-    homeEntryIdWithoutBooking,
+    data: {
+      homeEntryIdGeneral,
+      homeEntryIdBeneficiary,
+      homeEntryIdFreeBeneficiary,
+      homeEntryIdWithoutBooking,
+    },
   } = useRemoteConfigQuery()
 
   return useCallback(

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx
@@ -8,16 +8,18 @@ import { ShareAppModalType } from 'features/share/types'
 import { beneficiaryUser, underageBeneficiaryUser } from 'fixtures/user'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
-import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { BatchProfile } from 'libs/react-native-batch'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { userEvent, render, screen, act, waitFor } from 'tests/utils'
+import { act, render, screen, userEvent, waitFor } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
 
-jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue(DEFAULT_REMOTE_CONFIG)
+jest
+  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
+  .mockReturnValue(remoteConfigResponseFixture)
 
 jest.mock('features/auth/context/AuthContext')
 

--- a/src/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx
@@ -4,6 +4,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { IdentificationFork } from 'features/identityCheck/pages/identification/IdentificationFork'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { analytics } from 'libs/analytics/provider'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { render, screen, userEvent, waitFor } from 'tests/utils'
@@ -12,7 +13,10 @@ const openUrl = jest.spyOn(NavigationHelpers, 'openUrl')
 
 const useRemoteConfigSpy = jest
   .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
-  .mockReturnValue({ ...DEFAULT_REMOTE_CONFIG, shouldDisplayReassuranceMention: true })
+  .mockReturnValue({
+    ...remoteConfigResponseFixture,
+    data: { ...DEFAULT_REMOTE_CONFIG, shouldDisplayReassuranceMention: true },
+  })
 
 jest.mock('libs/firebase/analytics/analytics')
 
@@ -88,8 +92,11 @@ describe('<IdentificationFork />', () => {
 
   it('should not display reassuring mention when firebase parameters is false', () => {
     useRemoteConfigSpy.mockReturnValueOnce({
-      ...DEFAULT_REMOTE_CONFIG,
-      shouldDisplayReassuranceMention: false,
+      ...remoteConfigResponseFixture,
+      data: {
+        ...DEFAULT_REMOTE_CONFIG,
+        shouldDisplayReassuranceMention: false,
+      },
     })
 
     render(<IdentificationFork />)

--- a/src/features/identityCheck/pages/identification/IdentificationFork.tsx
+++ b/src/features/identityCheck/pages/identification/IdentificationFork.tsx
@@ -28,7 +28,9 @@ export const IdentificationFork: FunctionComponent = () => {
 }
 
 const IdentificationForkEduconnectContent: FunctionComponent = () => {
-  const { shouldDisplayReassuranceMention } = useRemoteConfigQuery()
+  const {
+    data: { shouldDisplayReassuranceMention },
+  } = useRemoteConfigQuery()
   return (
     <Container>
       <JustifiedLeftTitle title="S’identifier en 2 min avec&nbsp;:" />

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -36,6 +36,7 @@ import {
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { Position } from 'libs/location'
@@ -146,19 +147,22 @@ const useScrollToAnchorSpy = jest.spyOn(AnchorContextModule, 'useScrollToAnchor'
 const useRemoteConfigSpy = jest
   .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
   .mockReturnValue({
-    ...DEFAULT_REMOTE_CONFIG,
-    sameAuthorPlaylist: 'withPlaylistAsFirst',
-    reactionFakeDoorCategories: {
-      categories: [
-        NativeCategoryIdEnumv2.SEANCES_DE_CINEMA,
-        NativeCategoryIdEnumv2.CD,
-        NativeCategoryIdEnumv2.MUSIQUE_EN_LIGNE,
-        NativeCategoryIdEnumv2.VINYLES,
-        NativeCategoryIdEnumv2.LIVRES_AUDIO_PHYSIQUES,
-        NativeCategoryIdEnumv2.LIVRES_NUMERIQUE_ET_AUDIO,
-        NativeCategoryIdEnumv2.LIVRES_PAPIER,
-        NativeCategoryIdEnumv2.DVD_BLU_RAY,
-      ],
+    ...remoteConfigResponseFixture,
+    data: {
+      ...DEFAULT_REMOTE_CONFIG,
+      sameAuthorPlaylist: 'withPlaylistAsFirst',
+      reactionFakeDoorCategories: {
+        categories: [
+          NativeCategoryIdEnumv2.SEANCES_DE_CINEMA,
+          NativeCategoryIdEnumv2.CD,
+          NativeCategoryIdEnumv2.MUSIQUE_EN_LIGNE,
+          NativeCategoryIdEnumv2.VINYLES,
+          NativeCategoryIdEnumv2.LIVRES_AUDIO_PHYSIQUES,
+          NativeCategoryIdEnumv2.LIVRES_NUMERIQUE_ET_AUDIO,
+          NativeCategoryIdEnumv2.LIVRES_PAPIER,
+          NativeCategoryIdEnumv2.DVD_BLU_RAY,
+        ],
+      },
     },
   })
 
@@ -656,8 +660,11 @@ describe('<OfferContent />', () => {
     describe('with remote config activated', () => {
       beforeAll(() => {
         useRemoteConfigSpy.mockReturnValue({
-          ...DEFAULT_REMOTE_CONFIG,
-          showAccessScreeningButton: true,
+          ...remoteConfigResponseFixture,
+          data: {
+            ...DEFAULT_REMOTE_CONFIG,
+            showAccessScreeningButton: true,
+          },
         })
       })
 
@@ -709,8 +716,11 @@ describe('<OfferContent />', () => {
     describe('with remote config deactivated', () => {
       beforeAll(() => {
         useRemoteConfigSpy.mockReturnValue({
-          ...DEFAULT_REMOTE_CONFIG,
-          showAccessScreeningButton: false,
+          ...remoteConfigResponseFixture,
+          data: {
+            ...DEFAULT_REMOTE_CONFIG,
+            showAccessScreeningButton: false,
+          },
         })
       })
 

--- a/src/features/offer/components/OfferFooter/OfferFooter.native.test.tsx
+++ b/src/features/offer/components/OfferFooter/OfferFooter.native.test.tsx
@@ -7,15 +7,16 @@ import { api } from 'api/api'
 import { GetRemindersResponse } from 'api/gen'
 import { favoriteOfferResponseSnap } from 'features/favorites/fixtures/favoriteOfferResponseSnap'
 import { favoriteResponseSnap } from 'features/favorites/fixtures/favoriteResponseSnap'
-import { OfferCTAProvider } from 'features/offer/components/OfferContent/OfferCTAProvider'
 import * as useOfferCTAContextModule from 'features/offer/components/OfferContent/OfferCTAProvider'
+import { OfferCTAProvider } from 'features/offer/components/OfferContent/OfferCTAProvider'
 import { OfferFooter, OfferFooterProps } from 'features/offer/components/OfferFooter/OfferFooter'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { reminder, remindersResponse } from 'features/offer/fixtures/remindersResponse'
 import { beneficiaryUser } from 'fixtures/user'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
-import { mockAuthContextWithoutUser, mockAuthContextWithUser } from 'tests/AuthContextUtils'
+import { mockAuthContextWithUser, mockAuthContextWithoutUser } from 'tests/AuthContextUtils'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, render, screen, userEvent } from 'tests/utils'
@@ -52,7 +53,7 @@ const user = userEvent.setup()
 
 describe('OfferFooter', () => {
   beforeAll(() => {
-    useRemoteConfigSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+    useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
     useOfferCTASpy.mockReturnValue(mockUseOfferCTAReturnValue)
   })
 
@@ -61,8 +62,11 @@ describe('OfferFooter', () => {
   describe('Content when offer is a movie screening', () => {
     beforeEach(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        showAccessScreeningButton: true,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          showAccessScreeningButton: true,
+        },
       })
       useOfferCTASpy.mockReturnValue({
         ...mockUseOfferCTAReturnValue,
@@ -89,8 +93,11 @@ describe('OfferFooter', () => {
     beforeEach(() => {
       mockDate.set(CURRENT_DATE)
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        showAccessScreeningButton: false,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          showAccessScreeningButton: false,
+        },
       })
     })
 

--- a/src/features/offer/components/OfferFooter/OfferFooter.tsx
+++ b/src/features/offer/components/OfferFooter/OfferFooter.tsx
@@ -39,7 +39,9 @@ export const OfferFooter: FC<OfferFooterProps> = ({
 
   const { isDesktopViewport } = useTheme()
   const { isButtonVisible } = useOfferCTA()
-  const { showAccessScreeningButton } = useRemoteConfigQuery()
+  const {
+    data: { showAccessScreeningButton },
+  } = useRemoteConfigQuery()
 
   const { data: reminder } = useGetRemindersQuery((data) => selectReminderByOfferId(data, offer.id))
   const hasReminder = !!reminder

--- a/src/features/profile/components/EmptyCredit/EmptyCredit.native.test.tsx
+++ b/src/features/profile/components/EmptyCredit/EmptyCredit.native.test.tsx
@@ -5,13 +5,15 @@ import { EligibilityType } from 'api/gen'
 import { EmptyCredit } from 'features/profile/components/EmptyCredit/EmptyCredit'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { render, screen, userEvent } from 'tests/utils'
 
-jest
-  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
-  .mockReturnValue({ ...DEFAULT_REMOTE_CONFIG, homeEntryIdFreeOffers: 'homeEntryIdFreeOffers' })
+jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue({
+  ...remoteConfigResponseFixture,
+  data: { ...DEFAULT_REMOTE_CONFIG, homeEntryIdFreeOffers: 'homeEntryIdFreeOffers' },
+})
 
 const user = userEvent.setup()
 jest.useFakeTimers()

--- a/src/features/profile/components/EmptyCredit/EmptyCredit.tsx
+++ b/src/features/profile/components/EmptyCredit/EmptyCredit.tsx
@@ -17,7 +17,9 @@ export const EmptyCredit = ({
   age: number
   eligibility?: EligibilityType | null
 }) => {
-  const { homeEntryIdFreeOffers } = useRemoteConfigQuery()
+  const {
+    data: { homeEntryIdFreeOffers },
+  } = useRemoteConfigQuery()
   const { sixteenYearsOldDeposit, seventeenYearsOldDeposit, eighteenYearsOldDeposit } =
     useDepositAmountsByAge()
 

--- a/src/features/profile/components/Header/CreditHeader/CreditHeader.native.test.tsx
+++ b/src/features/profile/components/Header/CreditHeader/CreditHeader.native.test.tsx
@@ -15,15 +15,17 @@ import * as ProfileUtils from 'features/profile/helpers/useIsUserUnderageBenefic
 import { formatToSlashedFrenchDate, setDateOneDayEarlier } from 'libs/dates'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('queries/profile/useResetRecreditAmountToShowMutation')
 
-jest
-  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
-  .mockReturnValue({ ...DEFAULT_REMOTE_CONFIG, homeEntryIdFreeOffers: 'homeEntryIdFreeOffers' })
+jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue({
+  ...remoteConfigResponseFixture,
+  data: { ...DEFAULT_REMOTE_CONFIG, homeEntryIdFreeOffers: 'homeEntryIdFreeOffers' },
+})
 
 const mockUseIsUserUnderageBeneficiary = jest
   .spyOn(ProfileUtils, 'useIsUserUnderageBeneficiary')

--- a/src/features/profile/components/Header/CreditHeader/CreditHeader.tsx
+++ b/src/features/profile/components/Header/CreditHeader/CreditHeader.tsx
@@ -38,7 +38,9 @@ export function CreditHeader({
   eligibility,
 }: CreditHeaderProps) {
   const { designSystem } = useTheme()
-  const { homeEntryIdFreeOffers } = useRemoteConfigQuery()
+  const {
+    data: { homeEntryIdFreeOffers },
+  } = useRemoteConfigQuery()
   const depositAmount = useDepositAmountsByAge()
 
   const sixteenYearsOldIncomingDeposit = {

--- a/src/features/profile/components/Header/ProfileHeader/ProfileHeader.web.test.tsx
+++ b/src/features/profile/components/Header/ProfileHeader/ProfileHeader.web.test.tsx
@@ -5,13 +5,15 @@ import { CurrencyEnum, UserProfileResponse, YoungStatusType } from 'api/gen'
 import { ProfileHeader } from 'features/profile/components/Header/ProfileHeader/ProfileHeader'
 import { domains_credit_v3 } from 'features/profile/fixtures/domainsCredit'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
-import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { render, screen } from 'tests/utils/web'
 
 jest.mock('libs/firebase/analytics/analytics')
 
-jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue(DEFAULT_REMOTE_CONFIG)
+jest
+  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
+  .mockReturnValue(remoteConfigResponseFixture)
 
 const user: UserProfileResponse = {
   bookedOffers: {},

--- a/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.web.test.tsx
+++ b/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.web.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
 import { ChangeEmailSetPassword } from 'features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
-import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, checkAccessibilityFor, render } from 'tests/utils/web'
 
@@ -15,7 +15,9 @@ jest.mock('uuid', () => {
   }
 })
 
-jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue(DEFAULT_REMOTE_CONFIG)
+jest
+  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
+  .mockReturnValue(remoteConfigResponseFixture)
 
 describe('<ChangeEmailSetPassword />', () => {
   describe('Accessibility', () => {

--- a/src/features/profile/pages/Profile.native.test.tsx
+++ b/src/features/profile/pages/Profile.native.test.tsx
@@ -16,14 +16,15 @@ import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import {
-  GeoCoordinates,
   GEOLOCATION_USER_ERROR_MESSAGE,
-  GeolocationError,
+  GeoCoordinates,
   GeolocPermissionState,
   GeolocPositionError,
+  GeolocationError,
 } from 'libs/location'
 import * as useNetInfoContextDefault from 'libs/network/NetInfoWrapper'
 import { mockServer } from 'tests/mswServer'
@@ -113,8 +114,11 @@ describe('Profile component', () => {
 
   beforeAll(() => {
     useRemoteConfigSpy.mockReturnValue({
-      ...DEFAULT_REMOTE_CONFIG,
-      displayInAppFeedback: true,
+      ...remoteConfigResponseFixture,
+      data: {
+        ...DEFAULT_REMOTE_CONFIG,
+        displayInAppFeedback: true,
+      },
     })
   })
 

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -75,7 +75,9 @@ const OnlineProfile: React.FC = () => {
   const scrollViewRef = useRef<ScrollView | null>(null)
   const locationActivationErrorId = uuidv4()
   const userAge = getAge(user?.birthDate)
-  const { displayInAppFeedback } = useRemoteConfigQuery()
+  const {
+    data: { displayInAppFeedback },
+  } = useRemoteConfigQuery()
   const {
     geolocPositionError,
     permissionState,

--- a/src/features/profile/pages/Profile.web.test.tsx
+++ b/src/features/profile/pages/Profile.web.test.tsx
@@ -1,15 +1,17 @@
 import React from 'react'
 
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
-import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { checkAccessibilityFor, render, screen } from 'tests/utils/web'
 import * as useVersion from 'ui/hooks/useVersion.web'
 
 import { Profile } from './Profile'
 
-jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue(DEFAULT_REMOTE_CONFIG)
+jest
+  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
+  .mockReturnValue(remoteConfigResponseFixture)
 
 jest.mock('features/favorites/context/FavoritesWrapper')
 

--- a/src/features/search/api/useSearchResults/useSearchResults.ts
+++ b/src/features/search/api/useSearchResults/useSearchResults.ts
@@ -45,7 +45,9 @@ export const useSearchInfiniteQuery = (searchState: SearchState) => {
   const transformHits = useTransformOfferHits()
   const { setCurrentQueryID } = useSearchAnalyticsState()
   const previousPageObjectIds = useRef<string[]>([])
-  const { aroundPrecision } = useRemoteConfigQuery()
+  const {
+    data: { aroundPrecision },
+  } = useRemoteConfigQuery()
 
   const { data, ...infiniteQuery } = useInfiniteQuery<SearchOfferResponse>(
     [

--- a/src/features/search/components/SearchHeader/SearchHeader.web.test.tsx
+++ b/src/features/search/components/SearchHeader/SearchHeader.web.test.tsx
@@ -5,8 +5,8 @@ import { v4 as uuidv4 } from 'uuid'
 import { initialSearchState } from 'features/search/context/reducer'
 import { ISearchContext } from 'features/search/context/SearchWrapper'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
-import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { act, render, screen, waitFor } from 'tests/utils/web'
 
 import { SearchHeader } from './SearchHeader'
@@ -40,7 +40,9 @@ jest.mock('features/search/context/SearchWrapper', () => ({
 
 jest.mock('libs/firebase/analytics/analytics')
 
-jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue(DEFAULT_REMOTE_CONFIG)
+jest
+  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
+  .mockReturnValue(remoteConfigResponseFixture)
 
 describe('SearchHeader component', () => {
   beforeEach(() => {

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -22,6 +22,7 @@ import { AlgoliaOffer, AlgoliaVenue, FacetData } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { GeolocPermissionState, Position } from 'libs/location'
@@ -224,9 +225,7 @@ const initSearchResultsFlashlist = async () => {
 describe('SearchResultsContent component', () => {
   beforeEach(() => {
     setFeatureFlags()
-    useRemoteConfigSpy.mockReturnValue({
-      ...DEFAULT_REMOTE_CONFIG,
-    })
+    useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
   })
 
   const user = userEvent.setup()
@@ -946,8 +945,11 @@ describe('SearchResultsContent component', () => {
       describe('gridListLayout remote config is grid', () => {
         it('should display results as grid', async () => {
           useRemoteConfigSpy.mockReturnValueOnce({
-            ...DEFAULT_REMOTE_CONFIG,
-            gridListLayoutRemoteConfig: 'Grille',
+            ...remoteConfigResponseFixture,
+            data: {
+              ...DEFAULT_REMOTE_CONFIG,
+              gridListLayoutRemoteConfig: 'Grille',
+            },
           })
 
           renderSearchResultContent()

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -128,7 +128,9 @@ export const SearchResultsContent: React.FC<SearchResultsContentProps> = ({
   )
   const enableGridList = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ENABLE_GRID_LIST)
   const shouldDisplayGridList = enableGridList && !isWeb
-  const { gridListLayoutRemoteConfig } = useRemoteConfigQuery()
+  const {
+    data: { gridListLayoutRemoteConfig },
+  } = useRemoteConfigQuery()
   const initialGridListLayout =
     gridListLayoutRemoteConfig === 'Grille' ? GridListLayout.GRID : GridListLayout.LIST
   const [gridListLayout, setGridListLayout] = useState(initialGridListLayout)

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.web.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.web.test.tsx
@@ -10,6 +10,8 @@ import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
 import { AlgoliaOffer, AlgoliaVenue, FacetData } from 'libs/algolia/types'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
+import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { GeoCoordinates, Position } from 'libs/location'
 import { useVenuesInRegionQuery } from 'queries/venueMap/useVenuesInRegionQuery'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -82,6 +84,10 @@ const mockUseCenterOnLocation = useCenterOnLocation as jest.Mock
 jest.mock('queries/venue/useVenueOffersQuery')
 jest.mock('features/venueMap/helpers/zoomOutIfMapEmpty')
 jest.mock('ui/theme/customFocusOutline/customFocusOutline')
+
+jest
+  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
+  .mockReturnValue(remoteConfigResponseFixture)
 
 describe('SearchResultsContent component', () => {
   beforeEach(() => {

--- a/src/features/search/helpers/useSearchHistory/useSearchHistory.native.test.ts
+++ b/src/features/search/helpers/useSearchHistory/useSearchHistory.native.test.ts
@@ -6,6 +6,7 @@ import { HISTORY_KEY, MAX_HISTORY_RESULTS } from 'features/search/constants'
 import { mockedSearchHistory } from 'features/search/fixtures/mockedSearchHistory'
 import { useSearchHistory } from 'features/search/helpers/useSearchHistory/useSearchHistory'
 import { CreateHistoryItem, HistoryItem } from 'features/search/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { eventMonitoring } from 'libs/monitoring/services'
@@ -33,7 +34,7 @@ const useRemoteConfigSpy = jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuer
 
 describe('useSearchHistory', () => {
   beforeAll(() => {
-    useRemoteConfigSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+    useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
   })
 
   beforeEach(async () => {
@@ -125,13 +126,16 @@ describe('useSearchHistory', () => {
   describe('When shouldLogInfo remote config is true', () => {
     beforeAll(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        shouldLogInfo: true,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          shouldLogInfo: true,
+        },
       })
     })
 
     afterAll(() => {
-      useRemoteConfigSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+      useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
     })
 
     it('should capture a message in Sentry when adding to history fails', async () => {
@@ -165,8 +169,11 @@ describe('useSearchHistory', () => {
   describe('When shouldLogInfo remote config is false', () => {
     beforeAll(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        shouldLogInfo: false,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          shouldLogInfo: false,
+        },
       })
     })
 

--- a/src/features/share/api/useShareAppModalViewmodel.native.test.ts
+++ b/src/features/share/api/useShareAppModalViewmodel.native.test.ts
@@ -1,6 +1,7 @@
 import * as shareApp from 'features/share/helpers/shareApp'
 import { ShareAppModalType } from 'features/share/types'
 import { analytics } from 'libs/analytics/__mocks__/provider'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { CustomRemoteConfig } from 'libs/firebase/remoteConfig/remoteConfig.types'
@@ -39,8 +40,11 @@ const givenRemoteConfigShareAppModalVersion = (
   version: CustomRemoteConfig['shareAppModalVersion']
 ) => {
   useRemoteConfigSpy.mockReturnValue({
-    ...DEFAULT_REMOTE_CONFIG,
-    shareAppModalVersion: version,
+    ...remoteConfigResponseFixture,
+    data: {
+      ...DEFAULT_REMOTE_CONFIG,
+      shareAppModalVersion: version,
+    },
   })
 }
 

--- a/src/features/share/api/useShareAppModalViewmodel.ts
+++ b/src/features/share/api/useShareAppModalViewmodel.ts
@@ -18,7 +18,9 @@ export const useShareAppModalViewmodel = ({
   showModal,
   setType,
 }: ShareAppModalSelectorViewmodelParams) => {
-  const { shareAppModalVersion: version } = useRemoteConfigQuery()
+  const {
+    data: { shareAppModalVersion: version },
+  } = useRemoteConfigQuery()
 
   const close = useCallback(() => {
     analytics.logDismissShareApp(type)

--- a/src/features/subscription/helpers/useMapSubscriptionHomeIdsToThematic.native.test.ts
+++ b/src/features/subscription/helpers/useMapSubscriptionHomeIdsToThematic.native.test.ts
@@ -1,17 +1,21 @@
 import { useMapSubscriptionHomeIdsToThematic } from 'features/subscription/helpers/useMapSubscriptionHomeIdsToThematic'
 import { SubscriptionTheme } from 'features/subscription/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 
 jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue({
-  ...DEFAULT_REMOTE_CONFIG,
-  subscriptionHomeEntryIds: {
-    [SubscriptionTheme.CINEMA]: 'cinemaId',
-    [SubscriptionTheme.MUSIQUE]: 'musiqueId',
-    [SubscriptionTheme.LECTURE]: 'lectureId',
-    [SubscriptionTheme.SPECTACLES]: 'spectaclesId',
-    [SubscriptionTheme.VISITES]: 'visiteId',
-    [SubscriptionTheme.ACTIVITES]: 'activitesId',
+  ...remoteConfigResponseFixture,
+  data: {
+    ...DEFAULT_REMOTE_CONFIG,
+    subscriptionHomeEntryIds: {
+      [SubscriptionTheme.CINEMA]: 'cinemaId',
+      [SubscriptionTheme.MUSIQUE]: 'musiqueId',
+      [SubscriptionTheme.LECTURE]: 'lectureId',
+      [SubscriptionTheme.SPECTACLES]: 'spectaclesId',
+      [SubscriptionTheme.VISITES]: 'visiteId',
+      [SubscriptionTheme.ACTIVITES]: 'activitesId',
+    },
   },
 })
 

--- a/src/features/subscription/helpers/useMapSubscriptionHomeIdsToThematic.ts
+++ b/src/features/subscription/helpers/useMapSubscriptionHomeIdsToThematic.ts
@@ -2,7 +2,9 @@ import { SubscriptionTheme } from 'features/subscription/types'
 import { useRemoteConfigQuery } from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 
 export const useMapSubscriptionHomeIdsToThematic = (homeId: string): SubscriptionTheme | null => {
-  const { subscriptionHomeEntryIds } = useRemoteConfigQuery()
+  const {
+    data: { subscriptionHomeEntryIds },
+  } = useRemoteConfigQuery()
   const ThematicList = Object.keys(subscriptionHomeEntryIds) as SubscriptionTheme[]
   return (
     ThematicList.find((key: SubscriptionTheme) => subscriptionHomeEntryIds[key] === homeId) ?? null

--- a/src/features/trustedDevice/pages/SuspensionChoice.native.test.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.native.test.tsx
@@ -5,6 +5,7 @@ import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import * as useGoBack from 'features/navigation/useGoBack'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { FetchError, MonitoringError } from 'libs/monitoring/errors'
@@ -79,8 +80,11 @@ describe('<SuspensionChoice/>', () => {
   describe('When shouldLogInfo remote config is false', () => {
     beforeAll(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        shouldLogInfo: false,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          shouldLogInfo: false,
+        },
       })
     })
 
@@ -99,13 +103,16 @@ describe('<SuspensionChoice/>', () => {
   describe('When shouldLogInfo remote config is true', () => {
     beforeAll(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        shouldLogInfo: true,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          shouldLogInfo: true,
+        },
       })
     })
 
     afterAll(() => {
-      useRemoteConfigSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+      useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
     })
 
     it('should capture an info in Sentry on suspension error', async () => {

--- a/src/features/trustedDevice/pages/SuspensionChoice.web.test.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.web.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
-import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
@@ -9,7 +9,9 @@ import { SuspensionChoice } from './SuspensionChoice'
 
 jest.mock('libs/firebase/analytics/analytics')
 
-jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue(DEFAULT_REMOTE_CONFIG)
+jest
+  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
+  .mockReturnValue(remoteConfigResponseFixture)
 
 describe('<SuspensionChoice/>', () => {
   describe('Accessibility', () => {

--- a/src/features/venue/components/VenueContent/VenueContent.tsx
+++ b/src/features/venue/components/VenueContent/VenueContent.tsx
@@ -37,7 +37,9 @@ export const VenueContent: React.FunctionComponent<Props> = ({
   const triggerBatch = useFunctionOnce(trackEventHasSeenVenueForSurvey)
   const scrollViewRef = useRef<ScrollView>(null)
   const scrollYRef = useRef<number>(0)
-  const { showAccessScreeningButton } = useRemoteConfigQuery()
+  const {
+    data: { showAccessScreeningButton },
+  } = useRemoteConfigQuery()
 
   useEffect(() => {
     const timeoutId = setTimeout(() => {

--- a/src/features/venue/pages/Venue/Venue.native.test.tsx
+++ b/src/features/venue/pages/Venue/Venue.native.test.tsx
@@ -24,6 +24,7 @@ import { Venue } from 'features/venue/pages/Venue/Venue'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { Network } from 'libs/share/types'
@@ -231,8 +232,11 @@ describe('<Venue />', () => {
   describe('movie screening access button', () => {
     beforeAll(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        showAccessScreeningButton: true,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          showAccessScreeningButton: true,
+        },
       })
 
       mockUseVenueOffers.mockReturnValue({
@@ -296,8 +300,11 @@ describe('<Venue />', () => {
     describe('remote config flag is deactivated', () => {
       beforeAll(() => {
         useRemoteConfigSpy.mockReturnValue({
-          ...DEFAULT_REMOTE_CONFIG,
-          showAccessScreeningButton: false,
+          ...remoteConfigResponseFixture,
+          data: {
+            ...DEFAULT_REMOTE_CONFIG,
+            showAccessScreeningButton: false,
+          },
         })
       })
 

--- a/src/features/venue/pages/Venue/Venue.tsx
+++ b/src/features/venue/pages/Venue/Venue.tsx
@@ -64,7 +64,9 @@ export const Venue: FunctionComponent = () => {
     transformHits,
     venue,
   })
-  const { artistPageSubcategories } = useRemoteConfigQuery()
+  const {
+    data: { artistPageSubcategories },
+  } = useRemoteConfigQuery()
   const { data: venueArtists } = getVenueOffersArtists(
     artistPageSubcategories.subcategories,
     venueOffers?.hits

--- a/src/libs/firebase/firestore/featureFlags/useFeatureFlag.native.test.ts
+++ b/src/libs/firebase/firestore/featureFlags/useFeatureFlag.native.test.ts
@@ -4,6 +4,7 @@ import {
   RemoteStoreDocuments,
   RemoteStoreFeatureFlags,
 } from 'libs/firebase/firestore/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import firestore from 'libs/firebase/shims/firestore'
@@ -24,7 +25,7 @@ const mockGet = jest.fn()
 const featureFlag = RemoteStoreFeatureFlags.WIP_DISABLE_STORE_REVIEW
 const useRemoteConfigSpy = jest
   .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
-  .mockReturnValue(DEFAULT_REMOTE_CONFIG)
+  .mockReturnValue(remoteConfigResponseFixture)
 
 //TODO(PC-35000): unskip this test
 describe.skip('useFeatureFlag', () => {
@@ -184,8 +185,11 @@ describe.skip('useFeatureFlag', () => {
     describe('When shouldLogInfo remote config is false', () => {
       beforeAll(() => {
         useRemoteConfigSpy.mockReturnValue({
-          ...DEFAULT_REMOTE_CONFIG,
-          shouldLogInfo: false,
+          ...remoteConfigResponseFixture,
+          data: {
+            ...DEFAULT_REMOTE_CONFIG,
+            shouldLogInfo: false,
+          },
         })
       })
 
@@ -207,13 +211,16 @@ describe.skip('useFeatureFlag', () => {
     describe('When shouldLogInfo remote config is true', () => {
       beforeAll(() => {
         useRemoteConfigSpy.mockReturnValue({
-          ...DEFAULT_REMOTE_CONFIG,
-          shouldLogInfo: true,
+          ...remoteConfigResponseFixture,
+          data: {
+            ...DEFAULT_REMOTE_CONFIG,
+            shouldLogInfo: true,
+          },
         })
       })
 
       afterAll(() => {
-        useRemoteConfigSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+        useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
       })
 
       it('should log to sentry when minimalBuildNumber is greater than maximalBuildNumber', async () => {

--- a/src/libs/firebase/firestore/featureFlags/useFeatureFlagOptions.native.test.ts
+++ b/src/libs/firebase/firestore/featureFlags/useFeatureFlagOptions.native.test.ts
@@ -4,6 +4,7 @@ import {
   RemoteStoreDocuments,
   RemoteStoreFeatureFlags,
 } from 'libs/firebase/firestore/types'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import firestore from 'libs/firebase/shims/firestore'
@@ -24,7 +25,7 @@ const mockGet = jest.fn()
 const featureFlag = RemoteStoreFeatureFlags.WIP_DISABLE_STORE_REVIEW
 const useRemoteConfigSpy = jest
   .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
-  .mockReturnValue(DEFAULT_REMOTE_CONFIG)
+  .mockReturnValue(remoteConfigResponseFixture)
 
 //TODO(PC-35000): unskip this test
 describe.skip('useFeatureFlagOptions', () => {
@@ -184,8 +185,11 @@ describe.skip('useFeatureFlagOptions', () => {
     describe('When shouldLogInfo remote config is false', () => {
       beforeAll(() => {
         useRemoteConfigSpy.mockReturnValue({
-          ...DEFAULT_REMOTE_CONFIG,
-          shouldLogInfo: false,
+          ...remoteConfigResponseFixture,
+          data: {
+            ...DEFAULT_REMOTE_CONFIG,
+            shouldLogInfo: false,
+          },
         })
       })
 
@@ -207,13 +211,16 @@ describe.skip('useFeatureFlagOptions', () => {
     describe('When shouldLogInfo remote config is true', () => {
       beforeAll(() => {
         useRemoteConfigSpy.mockReturnValue({
-          ...DEFAULT_REMOTE_CONFIG,
-          shouldLogInfo: true,
+          ...remoteConfigResponseFixture,
+          data: {
+            ...DEFAULT_REMOTE_CONFIG,
+            shouldLogInfo: true,
+          },
         })
       })
 
       afterAll(() => {
-        useRemoteConfigSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+        useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
       })
 
       it('should log to sentry when minimalBuildNumber is greater than maximalBuildNumber', async () => {

--- a/src/libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture.ts
+++ b/src/libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture.ts
@@ -1,0 +1,32 @@
+import { UseQueryResult } from '@tanstack/react-query'
+
+import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
+import { CustomRemoteConfig } from 'libs/firebase/remoteConfig/remoteConfig.types'
+
+export const remoteConfigResponseFixture = {
+  data: DEFAULT_REMOTE_CONFIG,
+  error: null,
+  isError: false,
+  isLoading: false,
+  isLoadingError: false,
+  isRefetchError: false,
+  isSuccess: true,
+  status: 'success',
+  dataUpdatedAt: Date.now(),
+  errorUpdatedAt: 0,
+  failureCount: 0,
+  isFetched: true,
+  isFetchedAfterMount: true,
+  isFetching: false,
+  isPaused: false,
+  isPlaceholderData: false,
+  isPreviousData: false,
+  isStale: false,
+  refetch: jest.fn(),
+  remove: jest.fn(),
+  fetchStatus: 'idle',
+  failureReason: '',
+  errorUpdateCount: 0,
+  isInitialLoading: false,
+  isRefetching: false,
+} satisfies UseQueryResult<CustomRemoteConfig, unknown>

--- a/src/libs/firebase/remoteConfig/queries/useRemoteConfigQuery.native.test.ts
+++ b/src/libs/firebase/remoteConfig/queries/useRemoteConfigQuery.native.test.ts
@@ -24,7 +24,7 @@ describe('useRemoteConfigQuery', () => {
       wrapper: ({ children }) => reactQueryProviderHOC(children),
     })
 
-    await waitFor(() => expect(result.current).toEqual(DEFAULT_REMOTE_CONFIG))
+    await waitFor(() => expect(result.current.data).toEqual(DEFAULT_REMOTE_CONFIG))
   })
 
   it('should capture Sentry exception when there is an error', async () => {

--- a/src/libs/firebase/remoteConfig/queries/useRemoteConfigQuery.ts
+++ b/src/libs/firebase/remoteConfig/queries/useRemoteConfigQuery.ts
@@ -23,14 +23,13 @@ const fetchRemoteConfig = async (): Promise<CustomRemoteConfig> => {
 }
 
 export function useRemoteConfigQuery() {
-  const { data = DEFAULT_REMOTE_CONFIG } = useQuery<CustomRemoteConfig>(
-    [QueryKeys.REMOTE_CONFIG],
-    fetchRemoteConfig,
-    {
-      placeholderData: DEFAULT_REMOTE_CONFIG,
-      staleTime: 1000 * 60 * 5,
-      useErrorBoundary: false,
-    }
-  )
-  return data
+  const query = useQuery<CustomRemoteConfig>([QueryKeys.REMOTE_CONFIG], fetchRemoteConfig, {
+    placeholderData: DEFAULT_REMOTE_CONFIG,
+    staleTime: 1000 * 60 * 5,
+    useErrorBoundary: false,
+  })
+  return {
+    ...query,
+    data: query.data ?? DEFAULT_REMOTE_CONFIG,
+  }
 }

--- a/src/libs/hooks/useLogTypeFromRemoteConfig.native.test.ts
+++ b/src/libs/hooks/useLogTypeFromRemoteConfig.native.test.ts
@@ -1,3 +1,4 @@
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { useLogTypeFromRemoteConfig } from 'libs/hooks/useLogTypeFromRemoteConfig'
@@ -10,13 +11,16 @@ describe('useLogTypeFromRemoteConfig', () => {
   describe('When shouldLogInfo remote config is false', () => {
     beforeAll(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        shouldLogInfo: false,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          shouldLogInfo: false,
+        },
       })
     })
 
     afterAll(() => {
-      useRemoteConfigSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+      useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
     })
 
     it('should return ignored as log type', () => {
@@ -29,13 +33,16 @@ describe('useLogTypeFromRemoteConfig', () => {
   describe('When shouldLogInfo remote config is true', () => {
     beforeAll(() => {
       useRemoteConfigSpy.mockReturnValue({
-        ...DEFAULT_REMOTE_CONFIG,
-        shouldLogInfo: true,
+        ...remoteConfigResponseFixture,
+        data: {
+          ...DEFAULT_REMOTE_CONFIG,
+          shouldLogInfo: true,
+        },
       })
     })
 
     afterAll(() => {
-      useRemoteConfigSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+      useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
     })
 
     it('should return info as log type', () => {

--- a/src/libs/hooks/useLogTypeFromRemoteConfig.ts
+++ b/src/libs/hooks/useLogTypeFromRemoteConfig.ts
@@ -2,7 +2,9 @@ import { useRemoteConfigQuery } from 'libs/firebase/remoteConfig/queries/useRemo
 import { LogTypeEnum } from 'libs/monitoring/errors'
 
 export const useLogTypeFromRemoteConfig = () => {
-  const { shouldLogInfo } = useRemoteConfigQuery()
+  const {
+    data: { shouldLogInfo },
+  } = useRemoteConfigQuery()
 
   return { logType: shouldLogInfo ? LogTypeEnum.INFO : LogTypeEnum.IGNORED }
 }

--- a/src/queries/offer/useArtistResultsQuery.native.test.ts
+++ b/src/queries/offer/useArtistResultsQuery.native.test.ts
@@ -1,5 +1,6 @@
 import { SubcategoryIdEnum } from 'api/gen'
 import { mockedAlgoliaOffersWithSameArtistResponse } from 'libs/algolia/fixtures/algoliaFixtures'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQueryAPI from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { Position } from 'libs/location/types'
@@ -34,8 +35,11 @@ jest.useFakeTimers()
 describe('useArtistResultsQuery', () => {
   beforeAll(() => {
     useRemoteConfigSpy.mockReturnValue({
-      ...DEFAULT_REMOTE_CONFIG,
-      artistPageSubcategories: { subcategories: [SubcategoryIdEnum.LIVRE_PAPIER] },
+      ...remoteConfigResponseFixture,
+      data: {
+        ...DEFAULT_REMOTE_CONFIG,
+        artistPageSubcategories: { subcategories: [SubcategoryIdEnum.LIVRE_PAPIER] },
+      },
     })
   })
 

--- a/src/queries/offer/useArtistResultsQuery.ts
+++ b/src/queries/offer/useArtistResultsQuery.ts
@@ -20,7 +20,9 @@ type UseArtistResultsProps = {
 export const useArtistResultsQuery = ({ artistId, subcategoryId }: UseArtistResultsProps) => {
   const transformHits = useTransformOfferHits()
   const { userLocation } = useLocation()
-  const { artistPageSubcategories } = useRemoteConfigQuery()
+  const {
+    data: { artistPageSubcategories },
+  } = useRemoteConfigQuery()
 
   const { data } = useQuery({
     queryKey: [QueryKeys.ARTIST_PLAYLIST, artistId],

--- a/src/ui/hooks/useGetFooterHeight/useGetFooterHeight.test.tsx
+++ b/src/ui/hooks/useGetFooterHeight/useGetFooterHeight.test.tsx
@@ -1,15 +1,17 @@
 import React from 'react'
 
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
-import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import { ThemeProvider } from 'libs/styled'
 import { ColorScheme } from 'libs/styled/useColorScheme'
 import { computedTheme } from 'tests/computedTheme'
 import { renderHook } from 'tests/utils'
 import { useGetFooterHeight } from 'ui/hooks/useGetFooterHeight/useGetFooterHeight'
 
-jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery').mockReturnValue(DEFAULT_REMOTE_CONFIG)
+jest
+  .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
+  .mockReturnValue(remoteConfigResponseFixture)
 
 describe('useGetFooterHeight', () => {
   beforeEach(() => {


### PR DESCRIPTION
Avant cette PR le hook useRemoteConfigQuery renvoyait uniquement la partie data de l'objet react-query. L'objectif de ce ticket est d'envoyer l'intégralité de l'objet react-query.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35433

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.


## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
