### PR TITLE
(PC-37125) docs(perf): add about local & ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,45 @@ See doc about deployment process [here](./doc/ci-cd/deployment.md) for the mobil
 
 ## Performances
 
+You can find most of the code related to performance measurement in `src/performance`.
+
+### Mobile performances
+
+#### Local development
+
+For local development, you can monitor the performances by pressing `d` in your metro console. The developer menu should popup on your emulator. Press the "performance monitor" button. You can track the JS thread, UI thread and RAM usage on features you are developing.
+
+#### Deployed versions (Android only)
+
+Thanks to maestro and flashlight, we are able to have a measure for each version of the app in the CI.
+
+[Here are examples of runs](https://github.com/pass-culture/pass-culture-app-native/actions/workflows/dev_on_schedule_flashlight_android.yml).
+
+Additionally, you can add a tag `e2e perfs` to your PR to get the flashlight performance score of your feature.
+
+Here is an example of a flashlight performance report:
+
+```
+===== Aggregated Performance Summary =====
+  - Overall Score            82.00 / 100
+  - Successful Iterations    10 / 10
+
+===== Averaged Metrics (across all successful runs) =====
+  - Average FPS              39
+  - Average RAM Usage        250 MB
+  - Average Total CPU        51 %
+
+===== Average CPU Usage Per Thread =====
+  - UI Thread                4.45 %
+  - mqt_js                   0.00 %
+  - RenderThread             30.27 %
+```
+
+#### Production measurements
+
 Starting in the version v344, to measure performances, we have decided to measure the time to interactive of the home (see [adr](./doc/decision-records/DR007%20-%20mesure-performances.md))
+
+At the moment, it would seem that the measure is more reliable on iOS (between 10 and 20 seconds) than on Android (where we are getting ttis of more than 40 seconds). Because of the way we measure the tti (we trigger an event when the Home finishes loading) if any screen interposes itself between the start of the app and the Home, the time the user spends on that screen will be counted in the tti, thus producing erroneous measures. We are still investigating possible issues.
 
 You can find this measure on firebase performance monitor for the different environments:
 
@@ -167,3 +205,21 @@ You can find this measure on firebase performance monitor for the different envi
 - [staging Android](https://console.firebase.google.com/project/pc-native-staging/performance/app/android:app.passculture.staging/trends?hl=fr)
 - [production iOS](https://console.firebase.google.com/project/pc-native-production/performance/app/ios:app.passculture/troubleshooting/trace/DURATION_TRACE/home_time_to_interactive_container/counter/home_time_to_interactive_in_ms?hl=fr&time=24h)
 - [production Android](https://console.firebase.google.com/project/pc-native-production/performance/app/android:app.passculture.webapp/troubleshooting/trace/DURATION_TRACE/home_time_to_interactive_container/counter/home_time_to_interactive_in_ms?hl=fr&time=24h)
+
+### Web performances
+
+We currently use lighthouse to measure performances on the web app. There is a job that runs lighthouse in the CI once a week, you can see the runs [here](https://github.com/pass-culture/pass-culture-app-native/actions/workflows/dev_on_schedule_lighthouse.yml).
+
+By running the performance test once a week, we have a measure for each version of the app. Here is an example of a report:
+
+```
+--- Lighthouse Performance Summary ---
+🟢 Performance Score: 48 / 100
+ FCP: 0.8 s
+ LCP: 16.6 s
+ TBT: 590 ms
+ CLS: 0.108
+------------------------------------
+
+You can also run lighthouse locally from your browser's dev tools (make sure to run them in incognito mode to avoid extensions degrading performances).
+```


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37125

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
