### PR TITLE
(PC-36913) feat(offer): add offer subcategory for offer video qualtrics link

### DIFF
--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -195,6 +195,7 @@ export const OfferBody: FunctionComponent<Props> = ({
           videoThumbnail={<VideoThumbnailImage url={videoData.thumbnailUri} resizeMode="cover" />}
           title="Vidéo"
           offerId={offer.id}
+          offerSubcategory={offer.subcategoryId}
         />
       ) : null}
 

--- a/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.native.test.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.native.test.tsx
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import React from 'react'
 
-import { ReactionTypeEnum } from 'api/gen'
+import { ReactionTypeEnum, SubcategoryIdEnum } from 'api/gen'
 import { FeedBackVideo } from 'features/offer/components/OfferContent/VideoSection/FeedBackVideo'
 import { render, screen, userEvent, waitFor } from 'tests/utils'
 
@@ -15,6 +15,7 @@ const asyncStorageSetItemSpy = jest.spyOn(AsyncStorage, 'setItem')
 
 describe('<FeedBackVideo />', () => {
   const offerId = 123
+  const offerSubcategory = SubcategoryIdEnum.SEANCE_CINE
   const storageKey = `feedback_reaction_${offerId}`
 
   beforeEach(() => {
@@ -24,7 +25,7 @@ describe('<FeedBackVideo />', () => {
   it('should display feedback question when no reaction is stored', async () => {
     asyncStorageSpyOn.mockResolvedValueOnce(null)
 
-    render(<FeedBackVideo offerId={offerId} />)
+    render(<FeedBackVideo offerId={offerId} offerSubcategory={offerSubcategory} />)
 
     expect(await screen.findByText('Trouves-tu le contenu de cette vidéo utile ?')).toBeTruthy()
   })
@@ -32,7 +33,7 @@ describe('<FeedBackVideo />', () => {
   it('should not show thank you message when reaction is restored without recent interaction', async () => {
     asyncStorageSpyOn.mockResolvedValueOnce(ReactionTypeEnum.LIKE)
 
-    render(<FeedBackVideo offerId={offerId} />)
+    render(<FeedBackVideo offerId={offerId} offerSubcategory={offerSubcategory} />)
 
     await waitFor(() => {
       expect(AsyncStorage.getItem).toHaveBeenCalledWith(storageKey)
@@ -46,7 +47,7 @@ describe('<FeedBackVideo />', () => {
   it('should show thank you message immediately after user selects a reaction', async () => {
     asyncStorageSpyOn.mockResolvedValueOnce(null)
 
-    render(<FeedBackVideo offerId={offerId} />)
+    render(<FeedBackVideo offerId={offerId} offerSubcategory={offerSubcategory} />)
 
     const thumbUp = await screen.findByTestId('thumbUp')
     await user.press(thumbUp)
@@ -57,7 +58,7 @@ describe('<FeedBackVideo />', () => {
   it('should store the LIKE reaction when user clicks on Oui', async () => {
     asyncStorageSpyOn.mockResolvedValueOnce(null)
 
-    render(<FeedBackVideo offerId={offerId} />)
+    render(<FeedBackVideo offerId={offerId} offerSubcategory={offerSubcategory} />)
 
     const yesButton = await screen.findByText('Oui')
     await user.press(yesButton)
@@ -71,7 +72,7 @@ describe('<FeedBackVideo />', () => {
   it('should store the DISLIKE reaction when user clicks on Non', async () => {
     asyncStorageSpyOn.mockResolvedValueOnce(null)
 
-    render(<FeedBackVideo offerId={offerId} />)
+    render(<FeedBackVideo offerId={offerId} offerSubcategory={offerSubcategory} />)
 
     const noButton = await screen.findByText('Non')
     await user.press(noButton)

--- a/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { AppState, AppStateStatus } from 'react-native'
 import styled from 'styled-components/native'
 
-import { ReactionTypeEnum } from 'api/gen'
+import { ReactionTypeEnum, SubcategoryIdEnum } from 'api/gen'
 import { MAX_WIDTH_VIDEO } from 'features/offer/constant'
 import { ReactionChoiceValidation } from 'features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
@@ -17,9 +17,10 @@ const getStorageKey = (offerId: number) => `feedback_reaction_${offerId}`
 
 type Props = {
   offerId: number
+  offerSubcategory: SubcategoryIdEnum
 }
 
-export function FeedBackVideo({ offerId }: Props) {
+export function FeedBackVideo({ offerId, offerSubcategory }: Props) {
   const [reaction, setReaction] = useState<ReactionTypeEnum | null>(null)
   const [hasJustReacted, setHasJustReacted] = useState(false)
 
@@ -73,8 +74,8 @@ export function FeedBackVideo({ offerId }: Props) {
 
   const url =
     reaction === ReactionTypeEnum.LIKE
-      ? 'https://passculture.qualtrics.com/jfe/form/SV_238Dd248lT6UuJE'
-      : 'https://passculture.qualtrics.com/jfe/form/SV_3lb1IPodkGiMzWe'
+      ? `https://passculture.qualtrics.com/jfe/form/SV_238Dd248lT6UuJE?subcategory=${offerSubcategory}`
+      : `https://passculture.qualtrics.com/jfe/form/SV_3lb1IPodkGiMzWe?subcategory=${offerSubcategory}`
 
   if (reaction && hasJustReacted) {
     return (

--- a/src/features/offer/components/OfferContent/VideoSection/VideoSection.native.test.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/VideoSection.native.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { SubcategoryIdEnum } from 'api/gen'
 import { VideoSection } from 'features/offer/components/OfferContent/VideoSection/VideoSection'
 import { render, screen } from 'tests/utils'
 
@@ -7,6 +8,7 @@ jest.mock('libs/firebase/analytics/analytics')
 
 const defaultProps = {
   offerId: 123,
+  offerSubcategory: SubcategoryIdEnum.SEANCE_CINE,
   videoId: 'abc123',
   title: 'Peppa Pig',
   subtitle: 'le cochon rose',

--- a/src/features/offer/components/OfferContent/VideoSection/VideoSection.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/VideoSection.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, useCallback } from 'react'
 import { StyleProp, ViewStyle, useWindowDimensions } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
+import { SubcategoryIdEnum } from 'api/gen'
 import { RATIO169 } from 'features/home/components/helpers/getVideoPlayerDimensions'
 import { YoutubePlayer } from 'features/home/components/modules/video/YoutubePlayer/YoutubePlayer'
 import { FeedBackVideo } from 'features/offer/components/OfferContent/VideoSection/FeedBackVideo'
@@ -14,6 +15,7 @@ import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 type VideoSectionProps = {
   title: string
   offerId: number
+  offerSubcategory: SubcategoryIdEnum
   videoId?: string
   subtitle?: string
   videoThumbnail?: ReactElement
@@ -31,6 +33,7 @@ export const VideoSection = ({
   maxWidth = MAX_WIDTH_VIDEO,
   playerRatio = RATIO169,
   offerId,
+  offerSubcategory,
 }: VideoSectionProps) => {
   const { isDesktopViewport } = useTheme()
   const { width: viewportWidth } = useWindowDimensions()
@@ -48,10 +51,20 @@ export const VideoSection = ({
           width={viewportWidth < maxWidth ? undefined : maxWidth}
           initialPlayerParams={{ autoplay: true }}
         />
-        <FeedBackVideo offerId={offerId} />
+        <FeedBackVideo offerId={offerId} offerSubcategory={offerSubcategory} />
       </React.Fragment>
     )
-  }, [maxWidth, offerId, subtitle, title, videoHeight, videoId, videoThumbnail, viewportWidth])
+  }, [
+    maxWidth,
+    offerId,
+    offerSubcategory,
+    subtitle,
+    title,
+    videoHeight,
+    videoId,
+    videoThumbnail,
+    viewportWidth,
+  ])
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36913

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
