### PR TITLE
(PC-37196) chore(lib): remove devsettings

### DIFF
--- a/doc/development/how-to/state-management.md
+++ b/doc/development/how-to/state-management.md
@@ -82,17 +82,9 @@ The name `count-bears-store` is used to identify the store in the AsyncStore/Loc
 
 #### Native
 
-In order to use the devtools in a React Native app, we import `react-native-devsettings` in your `App.tsx` when in development mode:
+After RN 0.76, you can simply press `j` in metro to access dev tools.
 
-```tsx
-if (process.env.NODE_ENV === 'development') {
-  import('react-native-devsettings')
-}
-```
-
-Then, you can open React Native Debugger, shake your device and press `(*) Debug JS Remotely`.
-
-Once React Native Debugger is connected, you'll see your state in the Redux DevTools section.
+[Remote JS debugging was deprecated in 0.73](https://reactnative.dev/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#remote-javascript-debugging)
 
 #### Web
 

--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "react-native-date-picker": "^5.0.13",
     "react-native-detector": "^0.2.3",
     "react-native-device-info": "^11.1.0",
-    "react-native-devsettings": "^1.0.5",
     "react-native-email-link": "^1.10.0",
     "react-native-fast-image": "^8.6.3",
     "react-native-geolocation-service": "5.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,9 +9,6 @@ import 'react-native-get-random-values' // required for `uuid` module to work
 
 // if __DEV__ import if you want to debug
 // import './why-did-you-render'
-if (process.env.NODE_ENV === 'development') {
-  import('react-native-devsettings')
-}
 
 import { AccessibilityFiltersWrapper } from 'features/accessibility/context/AccessibilityFiltersWrapper'
 import { AuthWrapper } from 'features/auth/context/AuthWrapper'

--- a/yarn.lock
+++ b/yarn.lock
@@ -11167,7 +11167,6 @@ __metadata:
     react-native-date-picker: ^5.0.13
     react-native-detector: ^0.2.3
     react-native-device-info: ^11.1.0
-    react-native-devsettings: ^1.0.5
     react-native-email-link: ^1.10.0
     react-native-fast-image: ^8.6.3
     react-native-geolocation-service: 5.3.1
@@ -24939,13 +24938,6 @@ __metadata:
   peerDependencies:
     react-native: "*"
   checksum: 272cab82573933a1f3a9bc394b82a387ccbdf9fbef131fc1f04b8ff78b36f581931b5c643f5aa278f28577cbc320ef2ac588cafdb73292e9b0cf4427d54c44ce
-  languageName: node
-  linkType: hard
-
-"react-native-devsettings@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "react-native-devsettings@npm:1.0.5"
-  checksum: a59be2a07a94d16e8cd6443636ef44ebad15a8ddf6dcb742b737949c9029a9ff295894198e81a5ffd89f5714708be4b02b54b544566656e466e87982ffc89166
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37196

NOT NEEDED AFTER RN 0.76

Source:
https://github.com/gusgard/react-native-devsettings?tab=readme-ov-file#react-native-devsettings

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
