### PR TITLE
(PC-36872) feat(VideoSection): link back to front for offer video

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -2944,6 +2944,11 @@ export interface OfferResponse {
    * @type {string}
    * @memberof OfferResponse
    */
+  videoUrl?: string | null
+  /**
+   * @type {string}
+   * @memberof OfferResponse
+   */
   withdrawalDetails?: string | null
 }
 /**
@@ -3096,6 +3101,11 @@ export interface OfferResponseV2 {
    * @memberof OfferResponseV2
    */
   venue: OfferVenueResponse
+  /**
+   * @type {string}
+   * @memberof OfferResponseV2
+   */
+  videoUrl?: string | null
   /**
    * @type {string}
    * @memberof OfferResponseV2

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -17,6 +17,7 @@ import { OfferReactionSection } from 'features/offer/components/OfferReactionSec
 import { OfferSummaryInfoList } from 'features/offer/components/OfferSummaryInfoList/OfferSummaryInfoList'
 import { OfferTitle } from 'features/offer/components/OfferTitle/OfferTitle'
 import { OfferVenueButton } from 'features/offer/components/OfferVenueButton/OfferVenueButton'
+import { extractYoutubeVideoId } from 'features/offer/helpers/extractYoutubeVideoId/extractYoutubeVideoId'
 import { getOfferMetadata } from 'features/offer/helpers/getOfferMetadata/getOfferMetadata'
 import { getOfferPrices } from 'features/offer/helpers/getOfferPrice/getOfferPrice'
 import { getOfferTags } from 'features/offer/helpers/getOfferTags/getOfferTags'
@@ -51,7 +52,6 @@ type Props = {
   chroniclesCount?: number | null
   distance?: string | null
   headlineOffersCount?: number
-  videoData?: { videoId: string; thumbnailUri: string }
   chronicles?: ChronicleCardData[]
 }
 
@@ -63,13 +63,13 @@ export const OfferBody: FunctionComponent<Props> = ({
   chroniclesCount,
   distance,
   headlineOffersCount,
-  videoData,
   chronicleVariantInfo,
   chronicles,
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
 
   const hasArtistPage = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ARTIST_PAGE)
+  const isVideoSectionEnabled = useFeatureFlag(RemoteStoreFeatureFlags.WIP_OFFER_VIDEO_SECTION)
 
   const { user } = useAuthContext()
   const currency = useGetCurrencyToDisplay()
@@ -189,10 +189,10 @@ export const OfferBody: FunctionComponent<Props> = ({
         </MarginContainer>
       ) : null}
 
-      {videoData ? (
+      {offer.videoUrl && isVideoSectionEnabled ? (
         <VideoSection
-          videoId={videoData.videoId}
-          videoThumbnail={<VideoThumbnailImage url={videoData.thumbnailUri} resizeMode="cover" />}
+          videoId={extractYoutubeVideoId(offer.videoUrl)}
+          videoThumbnail={<VideoThumbnailImage url={offer.videoUrl} resizeMode="cover" />}
           title="Vidéo"
           offerId={offer.id}
         />

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -26,7 +26,6 @@ import { PlaylistType } from 'features/offer/enums'
 import { chronicleVariantInfoFixture } from 'features/offer/fixtures/chronicleVariantInfo'
 import { mockSubcategory } from 'features/offer/fixtures/mockSubcategory'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
-import { videoDataFixture } from 'features/offer/fixtures/videoDataFixture'
 import * as useSimilarOffersAPI from 'features/offer/queries/useSimilarOffersQuery'
 import { beneficiaryUser } from 'fixtures/user'
 import {
@@ -842,7 +841,7 @@ describe('<OfferContent />', () => {
 
   describe('See video button', () => {
     it('should not display see video button when video data not defined', async () => {
-      renderOfferContent({})
+      renderOfferContent({ offer: { ...offerResponseSnap, videoUrl: undefined } })
 
       await screen.findByText('Réserver l’offre')
 
@@ -851,14 +850,14 @@ describe('<OfferContent />', () => {
 
     it('should display see video button when video data defined', async () => {
       setFeatureFlags([RemoteStoreFeatureFlags.WIP_OFFER_VIDEO_SECTION])
-      renderOfferContent({ videoData: videoDataFixture })
+      renderOfferContent({})
 
       expect(await screen.findByText('Voir la vidéo')).toBeOnTheScreen()
     })
 
     it('should navigate to OfferVideoPreview screen when pressing see video button', async () => {
       setFeatureFlags([RemoteStoreFeatureFlags.WIP_OFFER_VIDEO_SECTION])
-      renderOfferContent({ videoData: videoDataFixture })
+      renderOfferContent({})
 
       await screen.findByText('Réserver l’offre')
 
@@ -880,7 +879,6 @@ function renderOfferContent({
   subcategory = mockSubcategory,
   isDesktopViewport,
   chronicles,
-  videoData,
 }: RenderOfferContentType) {
   const subtitle = 'Membre du Book Club'
   const chroniclesData =
@@ -895,7 +893,6 @@ function renderOfferContent({
           subcategory={subcategory}
           chronicles={chroniclesData}
           chronicleVariantInfo={chronicleVariantInfoFixture}
-          videoData={videoData}
         />
       </NavigationContainer>
     ),

--- a/src/features/offer/components/OfferContent/OfferContent.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.tsx
@@ -18,7 +18,6 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   subcategory,
   chronicles,
   chronicleVariantInfo,
-  videoData,
   defaultReaction,
   headlineOffersCount,
   onReactionButtonPress,
@@ -43,14 +42,13 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
         searchGroupList={searchGroupList}
         contentContainerStyle={CONTENT_CONTAINER_STYLE}
         onOfferPreviewPress={handlePreviewPress}
-        onSeeVideoPress={videoData ? handleVideoPress : undefined}
+        onSeeVideoPress={offer.videoUrl ? handleVideoPress : undefined}
         BodyWrapper={BodyWrapper}
         chronicles={chronicles}
         chronicleVariantInfo={chronicleVariantInfo}
         headlineOffersCount={headlineOffersCount}
         subcategory={subcategory}
         defaultReaction={defaultReaction}
-        videoData={videoData}
         onReactionButtonPress={onReactionButtonPress}
         onLayout={onLayout}>
         {comingSoonFooterHeight ? (

--- a/src/features/offer/components/OfferContent/OfferContent.web.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.tsx
@@ -21,7 +21,6 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   chronicles,
   chronicleVariantInfo,
   defaultReaction,
-  videoData,
   onReactionButtonPress,
   headlineOffersCount,
 }) => {
@@ -74,9 +73,8 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
           chronicles={chronicles}
           chronicleVariantInfo={chronicleVariantInfo}
           onOfferPreviewPress={handlePreviewPress}
-          onSeeVideoPress={videoData ? handleVideoPress : undefined}
+          onSeeVideoPress={offer.videoUrl ? handleVideoPress : undefined}
           BodyWrapper={BodyWrapper}
-          videoData={videoData}
           defaultReaction={defaultReaction}
           onReactionButtonPress={onReactionButtonPress}
           headlineOffersCount={headlineOffersCount}

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -64,7 +64,6 @@ type OfferContentBaseProps = OfferContentProps &
     onOfferPreviewPress: (index?: number) => void
     onSeeVideoPress?: () => void
     chronicles?: ChronicleCardData[]
-    videoData?: { videoId: string; thumbnailUri: string }
     likesCount?: number
     headlineOffersCount?: number
     defaultReaction?: ReactionTypeEnum | null
@@ -90,7 +89,6 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
   onReactionButtonPress,
   BodyWrapper = React.Fragment,
   onLayout,
-  videoData,
   children,
 }) => {
   const theme = useTheme()
@@ -282,7 +280,6 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
               chronicles={chronicles}
               distance={distance}
               headlineOffersCount={headlineOffersCount}
-              videoData={videoData}
               chronicleVariantInfo={chronicleVariantInfo}>
               {theme.isDesktopViewport ? offerCtaButton : null}
             </OfferBody>

--- a/src/features/offer/fixtures/offerResponse.ts
+++ b/src/features/offer/fixtures/offerResponse.ts
@@ -131,4 +131,5 @@ export const offerResponseSnap = toMutable({
   },
   isExternalBookingsDisabled: false,
   artists: [],
+  videoUrl: 'https://www.youtube.com/watch?v=hWdLhB2okqA',
 } as const satisfies ReadonlyDeep<OfferResponseV2>)

--- a/src/features/offer/fixtures/videoDataFixture.ts
+++ b/src/features/offer/fixtures/videoDataFixture.ts
@@ -1,5 +1,0 @@
-export const videoDataFixture = {
-  videoId: 'hCqdTGWspes',
-  thumbnailUri:
-    'https://rukminim2.flixcart.com/image/750/900/kgcl7680-0/poster/0/o/c/medium-sa-503-cartoon-sticker-poster-peppa-pig-wall-poster-original-imafwhuqjgjjtucs.jpeg?q=90&crop=false',
-}

--- a/src/features/offer/helpers/extractYoutubeVideoId/extractYoutubeVideoId.native.test.ts
+++ b/src/features/offer/helpers/extractYoutubeVideoId/extractYoutubeVideoId.native.test.ts
@@ -1,0 +1,33 @@
+import { extractYoutubeVideoId } from 'features/offer/helpers/extractYoutubeVideoId/extractYoutubeVideoId'
+
+describe('extractYoutubeVideoId', () => {
+  it('should extract video ID from standard YouTube URL', () => {
+    const url = 'https://www.youtube.com/watch?v=hWdLhB2okqA'
+
+    expect(extractYoutubeVideoId(url)).toBe('hWdLhB2okqA')
+  })
+
+  it('should extract video ID when there are extra query params', () => {
+    const url = 'https://www.youtube.com/watch?v=hWdLhB2okqA&t=30s'
+
+    expect(extractYoutubeVideoId(url)).toBe('hWdLhB2okqA')
+  })
+
+  it('should return undefined if "v" parameter is missing', () => {
+    const url = 'https://www.youtube.com/watch?time=30'
+
+    expect(extractYoutubeVideoId(url)).toBeUndefined()
+  })
+
+  it('should return undefined if URL is not a YouTube watch URL', () => {
+    const url = 'https://www.google.com'
+
+    expect(extractYoutubeVideoId(url)).toBeUndefined()
+  })
+
+  it('should handle malformed URLs without throwing', () => {
+    const url = 'not a real url'
+
+    expect(extractYoutubeVideoId(url)).toBeUndefined()
+  })
+})

--- a/src/features/offer/helpers/extractYoutubeVideoId/extractYoutubeVideoId.ts
+++ b/src/features/offer/helpers/extractYoutubeVideoId/extractYoutubeVideoId.ts
@@ -1,0 +1,4 @@
+export function extractYoutubeVideoId(url: string): string | undefined {
+  const match = url.match(/[?&]v=([^&]+)/)
+  return match?.[1]
+}

--- a/src/features/offer/helpers/extractYoutubeVideoId/extractYoutubeVideoId.ts
+++ b/src/features/offer/helpers/extractYoutubeVideoId/extractYoutubeVideoId.ts
@@ -1,4 +1,5 @@
 export function extractYoutubeVideoId(url: string): string | undefined {
-  const match = url.match(/[?&]v=([^&]+)/)
+  const regex = /[?&]v=([^&]+)/
+  const match = regex.exec(url)
   return match?.[1]
 }

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -7,7 +7,6 @@ import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { chroniclePreviewToChronicalCardData } from 'features/offer/adapters/chroniclePreviewToChronicleCardData'
 import { OfferContent } from 'features/offer/components/OfferContent/OfferContent'
 import { OfferContentPlaceholder } from 'features/offer/components/OfferContentPlaceholder/OfferContentPlaceholder'
-import { videoDataFixture } from 'features/offer/fixtures/videoDataFixture'
 import { chronicleVariant } from 'features/offer/helpers/chronicleVariant/chronicleVariant'
 import { useFetchHeadlineOffersCountQuery } from 'features/offer/queries/useFetchHeadlineOffersCountQuery'
 import { ReactionChoiceModal } from 'features/reactions/components/ReactionChoiceModal/ReactionChoiceModal'
@@ -34,7 +33,6 @@ export function Offer() {
     RemoteStoreFeatureFlags.WIP_OFFER_CHRONICLE_SECTION
   )
   const isReactionEnabled = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
-  const isVideoSectionEnabled = useFeatureFlag(RemoteStoreFeatureFlags.WIP_OFFER_VIDEO_SECTION)
 
   const { isLoggedIn } = useAuthContext()
   const { data: offer, isInitialLoading: isLoading } = useOfferQuery({
@@ -53,8 +51,6 @@ export function Offer() {
     enabled: isLoggedIn && isReactionEnabled && !!offer?.id,
   })
   const { mutate: saveReaction } = useReactionMutation()
-
-  const videoData = isVideoSectionEnabled ? videoDataFixture : undefined
 
   const handleSaveReaction = useCallback(
     ({ offerId, reactionType }: { offerId: number; reactionType: ReactionTypeEnum }) => {
@@ -103,7 +99,6 @@ export function Offer() {
         searchGroupList={subcategories.searchGroups}
         subcategory={subcategoriesMapping[offer.subcategoryId]}
         defaultReaction={booking?.userReaction}
-        videoData={videoData}
         onReactionButtonPress={booking?.canReact ? showModal : undefined}
       />
     </Page>

--- a/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.tsx
+++ b/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.tsx
@@ -7,7 +7,7 @@ import { RATIO169 } from 'features/home/components/helpers/getVideoPlayerDimensi
 import { YoutubePlayer } from 'features/home/components/modules/video/YoutubePlayer/YoutubePlayer'
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { useGoBack } from 'features/navigation/useGoBack'
-import { videoDataFixture } from 'features/offer/fixtures/videoDataFixture'
+import { extractYoutubeVideoId } from 'features/offer/helpers/extractYoutubeVideoId/extractYoutubeVideoId'
 import { FastImage } from 'libs/resizing-image-on-demand/FastImage'
 import { useOfferQuery } from 'queries/offer/useOfferQuery'
 import { ContentHeader } from 'ui/components/headers/ContentHeader'
@@ -36,13 +36,15 @@ export const OfferVideoPreview: FunctionComponent = () => {
         onBackPress={goBack}
       />
 
-      <YoutubePlayer
-        videoId={videoDataFixture.videoId}
-        height={videoHeight}
-        width={viewportWidth < MAX_WIDTH ? undefined : MAX_WIDTH}
-        initialPlayerParams={{ autoplay: true }}
-        thumbnail={<VideoThumbnailImage url={videoDataFixture.thumbnailUri} resizeMode="cover" />}
-      />
+      {offer?.videoUrl ? (
+        <YoutubePlayer
+          videoId={extractYoutubeVideoId(offer.videoUrl)}
+          height={videoHeight}
+          width={viewportWidth < MAX_WIDTH ? undefined : MAX_WIDTH}
+          initialPlayerParams={{ autoplay: true }}
+          thumbnail={<VideoThumbnailImage url={offer?.videoUrl} resizeMode="cover" />}
+        />
+      ) : null}
     </Container>
   )
 }

--- a/src/features/offer/types.ts
+++ b/src/features/offer/types.ts
@@ -75,7 +75,6 @@ export type OfferContentProps = {
   chronicleVariantInfo: ChronicleVariantInfo
   subcategory: Subcategory
   chronicles?: ChronicleCardData[]
-  videoData?: { videoId: string; thumbnailUri: string }
   headlineOffersCount?: number
   defaultReaction?: ReactionTypeEnum | null
   onReactionButtonPress?: () => void


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36872

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots


https://github.com/user-attachments/assets/fec17e24-ae5a-4c98-9099-7da0bd93d955


https://github.com/user-attachments/assets/c4ca3d4e-6a8d-4124-9e78-8e494bb45a80



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
