### PR TITLE
(PC-36833) feat(offer): trigger ValidateReaction log when pressing feedback video buttons

### DIFF
--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -53,6 +53,7 @@ type Props = {
   distance?: string | null
   headlineOffersCount?: number
   chronicles?: ChronicleCardData[]
+  userId?: number
 }
 
 export const OfferBody: FunctionComponent<Props> = ({
@@ -65,6 +66,7 @@ export const OfferBody: FunctionComponent<Props> = ({
   headlineOffersCount,
   chronicleVariantInfo,
   chronicles,
+  userId,
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
 
@@ -196,6 +198,7 @@ export const OfferBody: FunctionComponent<Props> = ({
           title="Vidéo"
           offerId={offer.id}
           offerSubcategory={offer.subcategoryId}
+          userId={userId}
         />
       ) : null}
 

--- a/src/features/offer/components/OfferContent/OfferContent.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.tsx
@@ -22,6 +22,7 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   defaultReaction,
   headlineOffersCount,
   onReactionButtonPress,
+  userId,
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
 
@@ -52,7 +53,8 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
         subcategory={subcategory}
         defaultReaction={defaultReaction}
         onReactionButtonPress={onReactionButtonPress}
-        onLayout={onLayout}>
+        onLayout={onLayout}
+        userId={userId}>
         {comingSoonFooterHeight ? (
           <ComingSoonFooterOffset
             testID="coming-soon-footer-offset"

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -89,6 +89,7 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
   onReactionButtonPress,
   BodyWrapper = React.Fragment,
   onLayout,
+  userId,
   children,
 }) => {
   const theme = useTheme()
@@ -280,7 +281,8 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
               chronicles={chronicles}
               distance={distance}
               headlineOffersCount={headlineOffersCount}
-              chronicleVariantInfo={chronicleVariantInfo}>
+              chronicleVariantInfo={chronicleVariantInfo}
+              userId={userId}>
               {theme.isDesktopViewport ? offerCtaButton : null}
             </OfferBody>
           </BodyWrapper>

--- a/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.native.test.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.native.test.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 
 import { ReactionTypeEnum, SubcategoryIdEnum } from 'api/gen'
 import { FeedBackVideo } from 'features/offer/components/OfferContent/VideoSection/FeedBackVideo'
+import { ReactionFromEnum } from 'features/reactions/enum'
+import { analytics } from 'libs/analytics/provider'
 import { render, screen, userEvent, waitFor } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
@@ -81,5 +83,20 @@ describe('<FeedBackVideo />', () => {
       'feedback_reaction_123',
       ReactionTypeEnum.DISLIKE
     )
+  })
+
+  it('should trigger ValidateReaction log when user clicks on a reaction', async () => {
+    asyncStorageSpyOn.mockResolvedValueOnce(null)
+
+    render(<FeedBackVideo offerId={offerId} offerSubcategory={offerSubcategory} />)
+
+    const yesButton = await screen.findByText('Oui')
+    await user.press(yesButton)
+
+    expect(analytics.logValidateReaction).toHaveBeenCalledWith({
+      offerId,
+      reactionType: ReactionTypeEnum.LIKE,
+      from: ReactionFromEnum.OFFER_VIDEO_SURVEY,
+    })
   })
 })

--- a/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.tsx
@@ -7,6 +7,8 @@ import styled from 'styled-components/native'
 import { ReactionTypeEnum, SubcategoryIdEnum } from 'api/gen'
 import { MAX_WIDTH_VIDEO } from 'features/offer/constant'
 import { ReactionChoiceValidation } from 'features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation'
+import { ReactionFromEnum } from 'features/reactions/enum'
+import { analytics } from 'libs/analytics/provider'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -18,9 +20,10 @@ const getStorageKey = (offerId: number) => `feedback_reaction_${offerId}`
 type Props = {
   offerId: number
   offerSubcategory: SubcategoryIdEnum
+  userId?: number
 }
 
-export function FeedBackVideo({ offerId, offerSubcategory }: Props) {
+export function FeedBackVideo({ offerId, offerSubcategory, userId }: Props) {
   const [reaction, setReaction] = useState<ReactionTypeEnum | null>(null)
   const [hasJustReacted, setHasJustReacted] = useState(false)
 
@@ -44,11 +47,18 @@ export function FeedBackVideo({ offerId, offerSubcategory }: Props) {
     async (type: ReactionTypeEnum) => {
       if (type !== ReactionTypeEnum.LIKE && type !== ReactionTypeEnum.DISLIKE) return
 
+      analytics.logValidateReaction({
+        offerId,
+        reactionType: type,
+        from: ReactionFromEnum.OFFER_VIDEO_SURVEY,
+        userId,
+      })
+
       setReaction(type)
       setHasJustReacted(true)
       await AsyncStorage.setItem(getStorageKey(offerId), type)
     },
-    [offerId]
+    [offerId, userId]
   )
 
   // When navigating away from the screen, hide the questionnaire invitation.

--- a/src/features/offer/components/OfferContent/VideoSection/VideoSection.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/VideoSection.tsx
@@ -22,6 +22,7 @@ type VideoSectionProps = {
   style?: StyleProp<ViewStyle>
   maxWidth?: number
   playerRatio?: number
+  userId?: number
 }
 
 export const VideoSection = ({
@@ -34,6 +35,7 @@ export const VideoSection = ({
   playerRatio = RATIO169,
   offerId,
   offerSubcategory,
+  userId,
 }: VideoSectionProps) => {
   const { isDesktopViewport } = useTheme()
   const { width: viewportWidth } = useWindowDimensions()
@@ -51,7 +53,7 @@ export const VideoSection = ({
           width={viewportWidth < maxWidth ? undefined : maxWidth}
           initialPlayerParams={{ autoplay: true }}
         />
-        <FeedBackVideo offerId={offerId} offerSubcategory={offerSubcategory} />
+        <FeedBackVideo offerId={offerId} offerSubcategory={offerSubcategory} userId={userId} />
       </React.Fragment>
     )
   }, [
@@ -60,6 +62,7 @@ export const VideoSection = ({
     offerSubcategory,
     subtitle,
     title,
+    userId,
     videoHeight,
     videoId,
     videoThumbnail,

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -34,7 +34,7 @@ export function Offer() {
   )
   const isReactionEnabled = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
 
-  const { isLoggedIn } = useAuthContext()
+  const { isLoggedIn, user } = useAuthContext()
   const { data: offer, isInitialLoading: isLoading } = useOfferQuery({
     offerId,
     select: (data) => ({
@@ -100,6 +100,7 @@ export function Offer() {
         subcategory={subcategoriesMapping[offer.subcategoryId]}
         defaultReaction={booking?.userReaction}
         onReactionButtonPress={booking?.canReact ? showModal : undefined}
+        userId={user?.id}
       />
     </Page>
   )

--- a/src/features/offer/types.ts
+++ b/src/features/offer/types.ts
@@ -78,6 +78,7 @@ export type OfferContentProps = {
   headlineOffersCount?: number
   defaultReaction?: ReactionTypeEnum | null
   onReactionButtonPress?: () => void
+  userId?: number
 }
 
 export type OfferImageContainerDimensions = {

--- a/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.native.test.tsx
+++ b/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.native.test.tsx
@@ -241,6 +241,7 @@ describe('ReactionChoiceModal', () => {
         offerId: mockOffer.id,
         reactionType: ReactionTypeEnum.LIKE,
         userId: 1234,
+        from: ReactionFromEnum.ENDED_BOOKING,
       })
     })
   })

--- a/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.tsx
+++ b/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.tsx
@@ -80,10 +80,12 @@ export const ReactionChoiceModal: FunctionComponent<Props> = ({
       offerId: offer.id,
       reactionType: reactionStatus,
     })
+
     analytics.logValidateReaction({
       offerId: offer.id,
       reactionType: reactionStatus,
       userId: profile?.id,
+      from,
     })
   }
 

--- a/src/features/reactions/enum.ts
+++ b/src/features/reactions/enum.ts
@@ -1,6 +1,7 @@
 export enum ReactionFromEnum {
   HOME = 'home',
   ENDED_BOOKING = 'ended_booking',
+  OFFER_VIDEO_SURVEY = 'offer_video_survey',
 }
 
 export enum ReactionChoiceModalBodyEnum {

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -24,6 +24,7 @@ import { SearchStackRouteName } from 'features/navigation/SearchStackNavigator/S
 import { PlaylistType } from 'features/offer/enums'
 import { NonEligible } from 'features/onboarding/enums'
 import { EligibleAges } from 'features/onboarding/types'
+import { ReactionFromEnum } from 'features/reactions/enum'
 import {
   RemoteBannerOrigin,
   RemoteBannerType,
@@ -652,6 +653,7 @@ export const logEventAnalytics = {
   logValidateReaction: (params: {
     offerId: number
     reactionType: ReactionTypeEnum
+    from: ReactionFromEnum
     userId?: number
   }) => analytics.logEvent({ firebase: AnalyticsEvent.VALIDATE_REACTION }, params),
   logVenueContact: (params: { type: keyof VenueContactModel; venueId: number }) =>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36833

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
