### PR TITLE
(PC-37215) fix(thematicHome): fix thematic home gradient

### DIFF
--- a/src/ui/svg/HomeGradient.tsx
+++ b/src/ui/svg/HomeGradient.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
-import { Circle, ClipPath, Defs, FeFlood, FeGaussianBlur, Filter, G, Rect } from 'react-native-svg'
-import styled from 'styled-components/native'
+import { Circle, ClipPath, Defs, FeGaussianBlur, Filter, G, Rect } from 'react-native-svg'
+import styled, { useTheme } from 'styled-components/native'
 
 import { ColorsType } from 'theme/types'
 import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
@@ -23,6 +23,7 @@ const HomeGradientSvg: React.FunctionComponent<HomeGradientProps> = ({
   const { id: clipPathId, fill: clipPath } = svgIdentifier()
   const { id: filterId1, fill: filterPath1 } = svgIdentifier()
   const { id: filterId2, fill: filterPath2 } = svgIdentifier()
+  const { colors: themeColors } = useTheme()
 
   return (
     <AccessibleSvg
@@ -35,10 +36,15 @@ const HomeGradientSvg: React.FunctionComponent<HomeGradientProps> = ({
       fill="none">
       <G clip-path={clipPath}>
         <G opacity="0.9" filter={filterPath1}>
-          <Circle cx="345.5" cy="-17.5" r="193.5" fill={colors[0]} />
+          <Circle
+            cx="345.5"
+            cy="-17.5"
+            r="193.5"
+            fill={colors ? colors[0] : themeColors.lilacLight}
+          />
         </G>
         <G opacity="0.9" filter={filterPath2}>
-          <Circle cx="53" cy="-56" r="164" fill={colors[1]} />
+          <Circle cx="53" cy="-56" r="164" fill={colors ? colors[1] : themeColors.goldLight100} />
         </G>
       </G>
       <Defs>
@@ -50,7 +56,6 @@ const HomeGradientSvg: React.FunctionComponent<HomeGradientProps> = ({
           height="687"
           filterUnits="userSpaceOnUse"
           color-interpolation-filters="sRGB">
-          <FeFlood flood-opacity="0" result="BackgroundImageFix" />
           <FeGaussianBlur stdDeviation="50" result="effect1_foregroundBlur_3901_37" />
         </Filter>
         <Filter
@@ -61,7 +66,6 @@ const HomeGradientSvg: React.FunctionComponent<HomeGradientProps> = ({
           height="628"
           filterUnits="userSpaceOnUse"
           color-interpolation-filters="sRGB">
-          <FeFlood flood-opacity="0" result="BackgroundImageFix" />
           <FeGaussianBlur stdDeviation="50" result="effect1_foregroundBlur_3901_37" />
         </Filter>
         <ClipPath id={clipPathId}>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37215

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1179" height="2556" alt="simulator_screenshot_4A2E5392-5315-4B59-8AE8-ECD036426115" src="https://github.com/user-attachments/assets/7c29f04a-9770-46b5-ac9c-288819efd864" />|<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-28 at 16 40 57" src="https://github.com/user-attachments/assets/884828d2-69fa-4eeb-995c-11fe6b56373a" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
