### PR TITLE
(PC-36840) feat(Offer): handle timestamp format and desktop cta

### DIFF
--- a/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
@@ -17,8 +17,8 @@ import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, render, screen, userEvent } from 'tests/utils'
 const offerFixture = offersFixture[0]
 
-const today = '2025-01-14T16:05:46+02:00'
-const tomorrow = '2025-01-15T16:05:46+02:00'
+const today = 1736861146 //'2025-01-14T16:05:46+02:00'
+const tomorrow = 1736947546 //'2025-01-15T16:05:46+02:00'
 
 jest.mock('libs/jwt/jwt')
 jest.mock('features/home/api/useHighlightOffer')

--- a/src/features/home/components/modules/marketing/MarketingBlockExclusivity.native.test.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockExclusivity.native.test.tsx
@@ -10,9 +10,9 @@ import { render, screen, userEvent } from 'tests/utils'
 
 import { MarketingBlockExclusivity } from './MarketingBlockExclusivity'
 
-const today = '2025-01-14T16:05:46+02:00'
-const tomorrow = '2025-01-15T16:05:46+02:00'
-const yesterday = '2025-01-13T16:05:46+02:00'
+const today = 1736853946 //'2025-01-14T16:05:46+02:00'
+const tomorrow = 1736940346 //'2025-01-15T16:05:46+02:00'
+const yesterday = 1736767546 //'2025-01-13T16:05:46+02:00'
 
 const props = {
   moduleId: '1',

--- a/src/features/home/components/modules/marketing/MarketingBlockExclusivity.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockExclusivity.tsx
@@ -34,7 +34,7 @@ const UnmemoizedMarketingBlockExclusivity = ({
   const bookingAllowedDatetime = offer.offer.bookingAllowedDatetime
   const comingSoon = bookingAllowedDatetime
     ? formatBookingAllowedDatetime({
-        bookingAllowedDatetime: new Date(bookingAllowedDatetime),
+        bookingAllowedDatetime: new Date(bookingAllowedDatetime * 1000),
         shouldDisplayBookingAllowedDatetime,
       })
     : undefined

--- a/src/features/offer/components/OfferContent/ComingSoonCTAs/FavoritesCTA.tsx
+++ b/src/features/offer/components/OfferContent/ComingSoonCTAs/FavoritesCTA.tsx
@@ -1,0 +1,78 @@
+import React, { FC } from 'react'
+import { View } from 'react-native'
+import styled from 'styled-components/native'
+
+import { FavoriteAuthModal } from 'features/offer/components/FavoriteAuthModal/FavoriteAuthModal'
+import { FavoriteProps } from 'features/offer/types'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { ButtonSecondary } from 'ui/components/buttons/ButtonSecondary'
+import { ModalSettings } from 'ui/components/modals/useModal'
+import { Favorite } from 'ui/svg/icons/Favorite'
+import { FavoriteFilled } from 'ui/svg/icons/FavoriteFilled'
+import { Typo, getSpacing } from 'ui/theme'
+
+type Props = {
+  offerId: number
+  onPressFavoriteCTA: () => void
+  favoriteAuthModal: ModalSettings
+  caption?: string
+} & Partial<FavoriteProps>
+
+export const FavoritesCTA: FC<Props> = ({
+  offerId,
+  isAddFavoriteLoading,
+  isRemoveFavoriteLoading,
+  favorite,
+  onPressFavoriteCTA,
+  favoriteAuthModal,
+  caption,
+}) => {
+  return (
+    <Container>
+      {caption ? <Caption>{caption}</Caption> : null}
+      {favorite ? (
+        <ButtonContainer>
+          <ButtonSecondary
+            wording="Retirer des favoris"
+            onPress={onPressFavoriteCTA}
+            icon={FavoriteFilled}
+            isLoading={isRemoveFavoriteLoading}
+          />
+        </ButtonContainer>
+      ) : (
+        <ButtonContainer>
+          <ButtonPrimary
+            wording="Mettre en favori"
+            onPress={onPressFavoriteCTA}
+            icon={Favorite}
+            isLoading={isAddFavoriteLoading}
+          />
+          <FavoriteAuthModal
+            visible={favoriteAuthModal.visible}
+            offerId={offerId}
+            dismissModal={favoriteAuthModal.hideModal}
+          />
+        </ButtonContainer>
+      )}
+    </Container>
+  )
+}
+
+const Container = styled(View)(({ theme }) => ({
+  ...(theme.isDesktopViewport
+    ? {
+        flexDirection: 'row-reverse',
+        justifyContent: 'start',
+        alignItems: 'center',
+      }
+    : {}),
+  gap: getSpacing(2),
+}))
+const ButtonContainer = styled.View(({ theme }) => ({
+  alignItems: 'center',
+  ...(theme.isDesktopViewport ? { width: '50%' } : undefined),
+}))
+
+const Caption = styled(Typo.BodyAccentXs)({
+  textAlign: 'center',
+})

--- a/src/features/offer/components/OfferContent/ComingSoonCTAs/RemindersCTA.tsx
+++ b/src/features/offer/components/OfferContent/ComingSoonCTAs/RemindersCTA.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react'
+
+import { NotificationAuthModal } from 'features/offer/components/NotificationAuthModal/NotificationAuthModal'
+import { StickyFooterContentProps } from 'features/offer/components/OfferContent/StickyFooterContent/StickyFooterContentBase'
+import { StickyFooterNotificationsProps } from 'features/offer/components/OfferFooter/types'
+import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
+import { Bell } from 'ui/svg/icons/Bell'
+import { BellFilled } from 'ui/svg/icons/BellFilled'
+
+type Props = StickyFooterContentProps & StickyFooterNotificationsProps
+
+export const RemindersCTA: FC<Props> = (props) => (
+  <React.Fragment>
+    <ButtonTertiaryBlack
+      wording={props.hasReminder ? 'Désactiver le rappel' : 'Ajouter un rappel'}
+      onPress={props.onPressReminderCTA}
+      icon={props.hasReminder ? BellFilled : Bell}
+    />
+    <NotificationAuthModal
+      visible={props.reminderAuthModal.visible}
+      offerId={props.offerId}
+      dismissModal={props.reminderAuthModal.hideModal}
+    />
+  </React.Fragment>
+)

--- a/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
@@ -79,7 +79,7 @@ describe('<OfferContent />', () => {
   })
 
   it('should display sticky booking button on mobile', async () => {
-    const { unmount } = renderOfferContent({ isDesktopViewport: false })
+    const { unmount } = renderOfferContent({ isDesktopViewport: false, isMobileViewport: true })
     await screen.findByText('Réserver l’offre')
 
     expect(screen.getByTestId('sticky-booking-button')).toBeInTheDocument()
@@ -98,7 +98,7 @@ describe('<OfferContent />', () => {
   })
 
   it('should display mobile body on mobile', async () => {
-    const { unmount } = renderOfferContent({ isDesktopViewport: false })
+    const { unmount } = renderOfferContent({ isDesktopViewport: false, isMobileViewport: true })
 
     await screen.findByText('Réserver l’offre')
 
@@ -160,12 +160,14 @@ describe('<OfferContent />', () => {
 
 type RenderOfferContentType = Partial<ComponentProps<typeof OfferContent>> & {
   isDesktopViewport?: boolean
+  isMobileViewport?: boolean
 }
 
 const renderOfferContent = ({
   offer = offerResponseSnap,
   subcategory = mockSubcategory,
   isDesktopViewport = false,
+  isMobileViewport = false,
 }: RenderOfferContentType) => {
   return render(
     reactQueryProviderHOC(
@@ -177,7 +179,7 @@ const renderOfferContent = ({
       />
     ),
     {
-      theme: { isDesktopViewport },
+      theme: { isDesktopViewport, isMobileViewport },
     }
   )
 }

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -27,7 +27,7 @@ import { OfferBody } from 'features/offer/components/OfferBody/OfferBody'
 import { ChronicleSection } from 'features/offer/components/OfferContent/ChronicleSection/ChronicleSection'
 import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
 import { OfferCTAButton } from 'features/offer/components/OfferCTAButton/OfferCTAButton'
-import { OfferFooter } from 'features/offer/components/OfferFooter/OfferFooter'
+import { OfferContentCTAs } from 'features/offer/components/OfferFooter/OfferContentCTAs'
 import { OfferHeader } from 'features/offer/components/OfferHeader/OfferHeader'
 import { OfferReactionHeaderButton } from 'features/offer/components/OfferHeader/OfferReactionHeaderButton'
 import { OfferImageContainer } from 'features/offer/components/OfferImageContainer/OfferImageContainer'
@@ -283,7 +283,11 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
               headlineOffersCount={headlineOffersCount}
               chronicleVariantInfo={chronicleVariantInfo}
               userId={userId}>
-              {theme.isDesktopViewport ? offerCtaButton : null}
+              {theme.isDesktopViewport ? (
+                <OfferContentCTAs offer={offer} {...favoriteButtonProps}>
+                  {offerCtaButton}
+                </OfferContentCTAs>
+              ) : null}
             </OfferBody>
           </BodyWrapper>
 
@@ -320,11 +324,13 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
           />
           {children}
         </ScrollViewContainer>
-        <FooterContainer>
-          <OfferFooter offer={offer} onLayout={onLayout} {...favoriteButtonProps}>
-            {offerCtaButton}
-          </OfferFooter>
-        </FooterContainer>
+        {theme.isMobileViewport ? (
+          <FooterContainer>
+            <OfferContentCTAs offer={offer} onLayout={onLayout} {...favoriteButtonProps}>
+              {offerCtaButton}
+            </OfferContentCTAs>
+          </FooterContainer>
+        ) : null}
       </AnchorProvider>
     </Container>
   )

--- a/src/features/offer/components/OfferContent/StickyFooterContent/StickyFooterContent.tsx
+++ b/src/features/offer/components/OfferContent/StickyFooterContent/StickyFooterContent.tsx
@@ -1,30 +1,18 @@
 import React, { FC } from 'react'
 
-import { NotificationAuthModal } from 'features/offer/components/NotificationAuthModal/NotificationAuthModal'
+import { RemindersCTA } from 'features/offer/components/OfferContent/ComingSoonCTAs/RemindersCTA'
 import {
   StickyFooterContentBase,
   StickyFooterContentProps,
 } from 'features/offer/components/OfferContent/StickyFooterContent/StickyFooterContentBase'
 import { StickyFooterNotificationsProps } from 'features/offer/components/OfferFooter/types'
-import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
-import { Bell } from 'ui/svg/icons/Bell'
-import { BellFilled } from 'ui/svg/icons/BellFilled'
 
 type Props = StickyFooterContentProps & StickyFooterNotificationsProps
 
 export const StickyFooterContent: FC<Props> = (props) => {
   return (
     <StickyFooterContentBase {...props}>
-      <ButtonTertiaryBlack
-        wording={props.hasReminder ? 'Désactiver le rappel' : 'Ajouter un rappel'}
-        onPress={props.onPressReminderCTA}
-        icon={props.hasReminder ? BellFilled : Bell}
-      />
-      <NotificationAuthModal
-        visible={props.reminderAuthModal.visible}
-        offerId={props.offerId}
-        dismissModal={props.reminderAuthModal.hideModal}
-      />
+      <RemindersCTA {...props} />
     </StickyFooterContentBase>
   )
 }

--- a/src/features/offer/components/OfferContent/StickyFooterContent/StickyFooterContentBase.tsx
+++ b/src/features/offer/components/OfferContent/StickyFooterContent/StickyFooterContentBase.tsx
@@ -2,15 +2,11 @@ import React, { FC, PropsWithChildren } from 'react'
 import { LayoutChangeEvent } from 'react-native'
 import styled from 'styled-components/native'
 
-import { FavoriteAuthModal } from 'features/offer/components/FavoriteAuthModal/FavoriteAuthModal'
+import { FavoritesCTA } from 'features/offer/components/OfferContent/ComingSoonCTAs/FavoritesCTA'
 import { FavoriteProps } from 'features/offer/types'
-import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
-import { ButtonSecondary } from 'ui/components/buttons/ButtonSecondary'
 import { ModalSettings } from 'ui/components/modals/useModal'
 import { StickyBottomWrapper } from 'ui/components/StickyBottomWrapper/StickyBottomWrapper'
-import { Favorite } from 'ui/svg/icons/Favorite'
-import { FavoriteFilled } from 'ui/svg/icons/FavoriteFilled'
-import { getShadow, getSpacing, Typo } from 'ui/theme'
+import { getShadow, getSpacing } from 'ui/theme'
 
 export type StickyFooterContentProps = {
   offerId: number
@@ -22,50 +18,17 @@ export type StickyFooterContentProps = {
 type StickyFooterContentBaseProps = StickyFooterContentProps & PropsWithChildren
 
 export const StickyFooterContentBase: FC<StickyFooterContentBaseProps> = ({
-  offerId,
-  isAddFavoriteLoading,
-  isRemoveFavoriteLoading,
-  favorite,
-  onPressFavoriteCTA,
-  favoriteAuthModal,
   onLayout,
   children,
+  ...props
 }) => {
   return (
     <StickyFooterWrapper onLayout={onLayout}>
-      <Caption>Cette offre sera bientôt disponible</Caption>
-      {favorite ? (
-        <ButtonContainer>
-          <ButtonSecondary
-            wording="Retirer des favoris"
-            onPress={onPressFavoriteCTA}
-            icon={FavoriteFilled}
-            isLoading={isRemoveFavoriteLoading}
-          />
-        </ButtonContainer>
-      ) : (
-        <ButtonContainer>
-          <ButtonPrimary
-            wording="Mettre en favori"
-            onPress={onPressFavoriteCTA}
-            icon={Favorite}
-            isLoading={isAddFavoriteLoading}
-          />
-          <FavoriteAuthModal
-            visible={favoriteAuthModal.visible}
-            offerId={offerId}
-            dismissModal={favoriteAuthModal.hideModal}
-          />
-        </ButtonContainer>
-      )}
+      <FavoritesCTA {...props} caption="Cette offre sera bientôt disponible" />
       {children}
     </StickyFooterWrapper>
   )
 }
-
-const ButtonContainer = styled.View({
-  alignItems: 'center',
-})
 
 const StickyFooterWrapper = styled(StickyBottomWrapper)(({ theme }) => ({
   backgroundColor: theme.designSystem.color.background.default,
@@ -76,11 +39,7 @@ const StickyFooterWrapper = styled(StickyBottomWrapper)(({ theme }) => ({
   ...getShadow({
     shadowOffset: { width: 0, height: getSpacing(1) },
     shadowRadius: getSpacing(5),
-    shadowColor: theme.colors.black,
+    shadowColor: theme.designSystem.color.background.lockedInverted,
     shadowOpacity: 0.25,
   }),
 }))
-
-const Caption = styled(Typo.BodyAccentXs)({
-  textAlign: 'center',
-})

--- a/src/features/offer/components/OfferFooter/OfferContentCTAs.native.test.tsx
+++ b/src/features/offer/components/OfferFooter/OfferContentCTAs.native.test.tsx
@@ -9,7 +9,7 @@ import { favoriteOfferResponseSnap } from 'features/favorites/fixtures/favoriteO
 import { favoriteResponseSnap } from 'features/favorites/fixtures/favoriteResponseSnap'
 import * as useOfferCTAContextModule from 'features/offer/components/OfferContent/OfferCTAProvider'
 import { OfferCTAProvider } from 'features/offer/components/OfferContent/OfferCTAProvider'
-import { OfferFooter, OfferFooterProps } from 'features/offer/components/OfferFooter/OfferFooter'
+import { OfferContentCTAs, Props } from 'features/offer/components/OfferFooter/OfferContentCTAs'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { reminder, remindersResponse } from 'features/offer/fixtures/remindersResponse'
 import { beneficiaryUser } from 'fixtures/user'
@@ -51,7 +51,7 @@ const mockUseOfferCTAReturnValue = {
 jest.useFakeTimers()
 const user = userEvent.setup()
 
-describe('OfferFooter', () => {
+describe('OfferContentCTAs', () => {
   beforeAll(() => {
     useRemoteConfigSpy.mockReturnValue(remoteConfigResponseFixture)
     useOfferCTASpy.mockReturnValue(mockUseOfferCTAReturnValue)
@@ -75,7 +75,7 @@ describe('OfferFooter', () => {
     })
 
     it('should display cineContentCTA when remote config is on', async () => {
-      renderOfferFooter({})
+      renderOfferContentCTAs({})
 
       expect(await screen.findByText('Cine content CTA')).toBeOnTheScreen()
     })
@@ -102,20 +102,20 @@ describe('OfferFooter', () => {
     })
 
     it('should display coming soon banner', async () => {
-      renderOfferFooter({ offer: offerWithPublicationDate })
+      renderOfferContentCTAs({ offer: offerWithPublicationDate })
 
       expect(await screen.findByText('Cette offre sera bientôt disponible')).toBeOnTheScreen()
     })
 
     it('should display addToFavorites button when offer has not been added to favorites', async () => {
-      renderOfferFooter({ offer: offerWithPublicationDate, favorite: null })
+      renderOfferContentCTAs({ offer: offerWithPublicationDate, favorite: null })
       await screen.findByText('Cette offre sera bientôt disponible')
 
       expect(await screen.findByText('Mettre en favori')).toBeOnTheScreen()
     })
 
     it('should display removeFromFavorites button when offer has been added to favorites', async () => {
-      renderOfferFooter({
+      renderOfferContentCTAs({
         offer: offerWithPublicationDate,
         favorite: { id: favoriteOfferResponseSnap.id, offer: favoriteOfferResponseSnap },
       })
@@ -126,7 +126,7 @@ describe('OfferFooter', () => {
     })
 
     it('should display addReminder button', async () => {
-      renderOfferFooter({ offer: offerWithPublicationDate })
+      renderOfferContentCTAs({ offer: offerWithPublicationDate })
 
       await screen.findByText('Cette offre sera bientôt disponible')
 
@@ -136,7 +136,7 @@ describe('OfferFooter', () => {
     it('should display disableReminder button', async () => {
       mockAuthContextWithUser(beneficiaryUser, { persist: true })
 
-      renderOfferFooter({
+      renderOfferContentCTAs({
         offer: {
           ...offerWithPublicationDate,
 
@@ -152,7 +152,7 @@ describe('OfferFooter', () => {
     it('should display signinModal when user presses favorite button but is not logged in', async () => {
       mockAuthContextWithoutUser({ persist: true })
 
-      renderOfferFooter({ offer: offerWithPublicationDate })
+      renderOfferContentCTAs({ offer: offerWithPublicationDate })
 
       await screen.findByText('Cette offre sera bientôt disponible')
 
@@ -164,7 +164,7 @@ describe('OfferFooter', () => {
     it('should add offer to favorites when user is logged in and presses addTofavorite button', async () => {
       mockAuthContextWithUser(beneficiaryUser, { persist: true })
 
-      const { addFavorite } = renderOfferFooter({ offer: offerWithPublicationDate })
+      const { addFavorite } = renderOfferContentCTAs({ offer: offerWithPublicationDate })
 
       await screen.findByText('Cette offre sera bientôt disponible')
 
@@ -176,7 +176,7 @@ describe('OfferFooter', () => {
     it('should remove offer from favorites when user is logged in and presses removeFromfavorite button', async () => {
       mockAuthContextWithUser(beneficiaryUser, { persist: true })
 
-      const { removeFavorite, favorite } = renderOfferFooter({
+      const { removeFavorite, favorite } = renderOfferContentCTAs({
         offer: offerWithPublicationDate,
         favorite: { id: favoriteResponseSnap.id, offer: favoriteResponseSnap.offer },
       })
@@ -189,7 +189,7 @@ describe('OfferFooter', () => {
     })
 
     it('should display loader when addToFavorite button is loading', async () => {
-      renderOfferFooter({ offer: offerWithPublicationDate, isAddFavoriteLoading: true })
+      renderOfferContentCTAs({ offer: offerWithPublicationDate, isAddFavoriteLoading: true })
 
       await screen.findByText('Cette offre sera bientôt disponible')
 
@@ -203,7 +203,7 @@ describe('OfferFooter', () => {
 
       addReminderMutationSpy.mockRejectedValueOnce({ status: 400 })
 
-      renderOfferFooter({
+      renderOfferContentCTAs({
         offer: offerWithPublicationDate,
       })
 
@@ -221,7 +221,7 @@ describe('OfferFooter', () => {
       mockAuthContextWithoutUser({ persist: true })
 
       mockServer.getApi<GetRemindersResponse>('/v1/me/reminders', {})
-      renderOfferFooter({ offer: offerWithPublicationDate })
+      renderOfferContentCTAs({ offer: offerWithPublicationDate })
 
       await screen.findByText('Cette offre sera bientôt disponible')
 
@@ -238,7 +238,7 @@ describe('OfferFooter', () => {
         responseOptions: { statusCode: 201, data: {} },
       })
 
-      renderOfferFooter({
+      renderOfferContentCTAs({
         offer: offerWithPublicationDate,
       })
 
@@ -256,7 +256,7 @@ describe('OfferFooter', () => {
         responseOptions: { statusCode: 201, data: {} },
       })
 
-      renderOfferFooter({
+      renderOfferContentCTAs({
         offer: { ...offerWithPublicationDate, id: reminder.offer.id },
       })
 
@@ -282,7 +282,7 @@ describe('OfferFooter', () => {
     })
 
     it('should display CTA received as props', async () => {
-      renderOfferFooter({
+      renderOfferContentCTAs({
         offer: offerWithPublicationDate,
         children: <Button title="Réserver l’offre" />,
       })
@@ -293,7 +293,7 @@ describe('OfferFooter', () => {
 
   describe('Content when offer is not a movie screening, does not have a bookingAllowedDatetime in the future and viewport is desktop', () => {
     it('should return null', async () => {
-      renderOfferFooter({
+      renderOfferContentCTAs({
         children: <Button title="Réserver l’offre" />,
         isDesktopViewport: true,
       })
@@ -305,11 +305,11 @@ describe('OfferFooter', () => {
   })
 })
 
-type RenderOfferFooterType = Partial<OfferFooterProps> & {
+type RenderOfferFooterType = Partial<Props> & {
   isDesktopViewport?: boolean
 }
 
-const renderOfferFooter = ({
+const renderOfferContentCTAs = ({
   offer = offerResponseSnap,
   children,
   addFavorite = jest.fn(),
@@ -322,7 +322,7 @@ const renderOfferFooter = ({
   render(
     reactQueryProviderHOC(
       <OfferCTAProvider>
-        <OfferFooter
+        <OfferContentCTAs
           offer={offer}
           addFavorite={addFavorite}
           isAddFavoriteLoading={isAddFavoriteLoading}
@@ -330,7 +330,7 @@ const renderOfferFooter = ({
           isRemoveFavoriteLoading={isRemoveFavoriteLoading}
           favorite={favorite}>
           {children}
-        </OfferFooter>
+        </OfferContentCTAs>
       </OfferCTAProvider>
     ),
     {

--- a/src/features/offer/components/OfferFooter/OfferContentCTAs.tsx
+++ b/src/features/offer/components/OfferFooter/OfferContentCTAs.tsx
@@ -5,6 +5,7 @@ import { useTheme } from 'styled-components/native'
 import { OfferResponseV2 } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { CineContentCTA } from 'features/offer/components/OfferCine/CineContentCTA'
+import { FavoritesCTA } from 'features/offer/components/OfferContent/ComingSoonCTAs/FavoritesCTA'
 import { useOfferCTA } from 'features/offer/components/OfferContent/OfferCTAProvider'
 import { StickyFooterContent } from 'features/offer/components/OfferContent/StickyFooterContent/StickyFooterContent'
 import { getIsAComingSoonOffer } from 'features/offer/helpers/getIsAComingSoonOffer'
@@ -17,13 +18,13 @@ import { useRemoteConfigQuery } from 'libs/firebase/remoteConfig/queries/useRemo
 import { useModal } from 'ui/components/modals/useModal'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 
-export type OfferFooterProps = PropsWithChildren<{
+export type Props = PropsWithChildren<{
   offer: OfferResponseV2
   onLayout?: (params: LayoutChangeEvent) => void
 }> &
   FavoriteProps
 
-export const OfferFooter: FC<OfferFooterProps> = ({
+export const OfferContentCTAs: FC<Props> = ({
   offer,
   addFavorite,
   isAddFavoriteLoading,
@@ -37,7 +38,7 @@ export const OfferFooter: FC<OfferFooterProps> = ({
 
   const { isLoggedIn } = useAuthContext()
 
-  const { isDesktopViewport } = useTheme()
+  const { isDesktopViewport, isMobileViewport } = useTheme()
   const { isButtonVisible } = useOfferCTA()
   const {
     data: { showAccessScreeningButton },
@@ -80,26 +81,42 @@ export const OfferFooter: FC<OfferFooterProps> = ({
 
   const isAComingSoonOffer = getIsAComingSoonOffer(offer.bookingAllowedDatetime)
 
-  if (showAccessScreeningButton && isButtonVisible) {
-    return <CineContentCTA />
-  }
-
-  if (isAComingSoonOffer && !isDesktopViewport) {
+  if (isDesktopViewport && isAComingSoonOffer) {
     return (
-      <StickyFooterContent
+      <FavoritesCTA
         offerId={offer.id}
         favorite={favorite}
         onPressFavoriteCTA={onPressFavoriteCTA}
         isAddFavoriteLoading={isAddFavoriteLoading}
         isRemoveFavoriteLoading={isRemoveFavoriteLoading}
-        hasReminder={hasReminder}
-        onPressReminderCTA={onPressReminderCTA}
         favoriteAuthModal={favoriteAuthModal}
-        reminderAuthModal={reminderAuthModal}
-        onLayout={onLayout}
+        caption="Cette offre sera bientôt disponible"
       />
     )
   }
 
-  return <React.Fragment>{isDesktopViewport ? null : children}</React.Fragment>
+  if (isMobileViewport) {
+    if (showAccessScreeningButton && isButtonVisible) {
+      return <CineContentCTA />
+    }
+
+    if (isAComingSoonOffer) {
+      return (
+        <StickyFooterContent
+          offerId={offer.id}
+          favorite={favorite}
+          onPressFavoriteCTA={onPressFavoriteCTA}
+          isAddFavoriteLoading={isAddFavoriteLoading}
+          isRemoveFavoriteLoading={isRemoveFavoriteLoading}
+          hasReminder={hasReminder}
+          onPressReminderCTA={onPressReminderCTA}
+          favoriteAuthModal={favoriteAuthModal}
+          reminderAuthModal={reminderAuthModal}
+          onLayout={onLayout}
+        />
+      )
+    }
+  }
+
+  return <React.Fragment>{children}</React.Fragment>
 }

--- a/src/features/offer/helpers/getIsAComingSoonOffer.test.ts
+++ b/src/features/offer/helpers/getIsAComingSoonOffer.test.ts
@@ -25,4 +25,14 @@ describe('getIsAComingSoonOffer', () => {
     expect(getIsAComingSoonOffer(null)).toBe(false)
     expect(getIsAComingSoonOffer(undefined)).toBe(false)
   })
+
+  it('should handle timestamp (in seconds) correctly', () => {
+    const futureTimestampSeconds = Math.floor(new Date('2025-07-28T12:30:00Z').getTime() / 1000)
+
+    expect(getIsAComingSoonOffer(futureTimestampSeconds)).toBe(true)
+
+    const pastTimestampSeconds = Math.floor(new Date('2025-07-28T11:30:00Z').getTime() / 1000)
+
+    expect(getIsAComingSoonOffer(pastTimestampSeconds)).toBe(false)
+  })
 })

--- a/src/features/offer/helpers/getIsAComingSoonOffer.ts
+++ b/src/features/offer/helpers/getIsAComingSoonOffer.ts
@@ -1,4 +1,14 @@
 import { isAfter } from 'date-fns'
 
-export const getIsAComingSoonOffer = (bookingAllowedDatetime: string | null | undefined): boolean =>
-  !!bookingAllowedDatetime && isAfter(new Date(bookingAllowedDatetime), new Date())
+export const getIsAComingSoonOffer = (
+  bookingAllowedDatetime: string | number | null | undefined
+): boolean => {
+  if (!bookingAllowedDatetime) return false
+
+  const date =
+    typeof bookingAllowedDatetime === 'number'
+      ? new Date(bookingAllowedDatetime * 1000)
+      : new Date(bookingAllowedDatetime)
+
+  return isAfter(date, new Date())
+}

--- a/src/libs/algolia/types.ts
+++ b/src/libs/algolia/types.ts
@@ -34,7 +34,7 @@ export type HitOffer = {
   bookFormat?: string | null
   artist?: string
   ean?: string
-  bookingAllowedDatetime?: string | null
+  bookingAllowedDatetime?: number | null
   likes?: number
   chroniclesCount?: number
   headlineCount?: number

--- a/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
@@ -319,9 +319,10 @@ describe('HorizontalOfferTile component', () => {
     })
 
     describe('coming soon offer', () => {
+      const bookingAllowedDatetime = 1753886400 // '2025-07-30T14:00:00+02:00'
       const mockComingSoonOffer = {
         ...mockOffer,
-        offer: { ...mockOffer.offer, bookingAllowedDatetime: '2025-07-30T14:00:00+02:00' },
+        offer: { ...mockOffer.offer, bookingAllowedDatetime },
       }
 
       beforeEach(jest.fn())


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36840

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [X] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [X] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               | <video src="https://github.com/user-attachments/assets/1de8d309-e62e-4579-a699-79c79f8eacc2" /> |
| Desktop - Chrome |               | <video src="https://github.com/user-attachments/assets/e2f1ab84-f9de-45a8-9152-ff658a747d7f" /> |



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4


## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
