### PR TITLE
(PC-37244) feat(eslint): add warning rule to avoid getSpacing use

### DIFF
--- a/eslint-custom-rules/no-get-spacing.js
+++ b/eslint-custom-rules/no-get-spacing.js
@@ -1,0 +1,25 @@
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Forbids the use of getSpacing and recommends using theme.designSystem.size.*',
+      recommended: true,
+    },
+    messages: {
+      noGetSpacing: 'Use theme.designSystem.size.* instead of getSpacing',
+    },
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === 'Identifier' && node.callee.name === 'getSpacing') {
+          context.report({
+            node,
+            messageId: 'noGetSpacing',
+          })
+        }
+      },
+    }
+  },
+}

--- a/eslint-custom-rules/no-get-spacing.test.js
+++ b/eslint-custom-rules/no-get-spacing.test.js
@@ -1,0 +1,36 @@
+const { RuleTester } = require('eslint')
+const rule = require('./no-get-spacing')
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+})
+
+ruleTester.run('no-get-spacing', rule, {
+  valid: [
+    { code: `const spacing = theme.designSystem.size.spacing.l;` },
+    { code: `const spacing = someOtherFunction(8);` },
+    { code: `function getSpacing() { return 10 }` },
+    { code: `const spacing = obj.getSpacing();` },
+  ],
+  invalid: [
+    {
+      code: `const padding = getSpacing(2);`,
+      errors: [{ messageId: 'noGetSpacing' }],
+    },
+    {
+      code: `
+        const SelectedDay = styled(View)(({ theme }) => ({
+          borderRadius: getSpacing(3),
+          width: getSpacing(6),
+        }));
+      `,
+      errors: [{ messageId: 'noGetSpacing' }, { messageId: 'noGetSpacing' }],
+    },
+  ],
+})

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -15,6 +15,7 @@ const noQueriesOutsideQueryFiles = require('./eslint-custom-rules/no-queries-out
 const queriesOnlyInUseQueryFunctions = require('./eslint-custom-rules/queries-only-in-use-query-functions.js')
 const queriesMustBeInQueriesFolder = require('./eslint-custom-rules/queries-must-be-in-queries-folder.js')
 const noFireEvent = require('./eslint-custom-rules/no-fireEvent')
+const noGetSpacing = require('./eslint-custom-rules/no-get-spacing')
 const noSpacer = require('./eslint-custom-rules/no-spacer')
 const noThemeColors = require('./eslint-custom-rules/no-theme-colors')
 const noThemeFromTheme = require('./eslint-custom-rules/no-theme-from-theme')
@@ -40,6 +41,7 @@ module.exports = {
   'queries-only-in-use-query-functions': queriesOnlyInUseQueryFunctions,
   'queries-must-be-in-queries-folder': queriesMustBeInQueriesFolder,
   'no-fireEvent': noFireEvent,
+  'no-get-spacing': noGetSpacing,
   'no-spacer': noSpacer,
   'no-theme-colors': noThemeColors,
   'no-theme-from-theme': noThemeFromTheme,

--- a/eslint-soft-rules.js
+++ b/eslint-soft-rules.js
@@ -6,6 +6,7 @@ const softRules = {
     'react/no-unstable-nested-components': 'warn', // TODO(PC-25291): enable when its issues are fixed
     'local-rules/no-spacer': 'warn',
     'local-rules/no-ts-expect-error': 'warn',
+    'local-rules/no-get-spacing': 'warn',
     'local-rules/no-theme-colors': 'warn',
   },
   archi: {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
