### PR TITLE
(PC-37158) fix(permission): BatchPush.refreshToken

### DIFF
--- a/__mocks__/@batch.com/react-native-plugin.ts
+++ b/__mocks__/@batch.com/react-native-plugin.ts
@@ -22,6 +22,7 @@ export const BatchUser = {
 
 export const BatchPush = {
   requestNotificationAuthorization: jest.fn(),
+  refreshToken: jest.fn(),
 }
 
 export const BatchMessaging = {

--- a/src/App.native.test.tsx
+++ b/src/App.native.test.tsx
@@ -3,7 +3,7 @@ import { LogBox, Platform, StatusBar } from 'react-native'
 
 import { campaignTracker } from 'libs/campaign'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
-import { BatchMessaging } from 'libs/react-native-batch'
+import { BatchMessaging, BatchPush } from 'libs/react-native-batch'
 import { configureGoogleSignin } from 'libs/react-native-google-sso/configureGoogleSignin'
 import { render, waitFor } from 'tests/utils'
 
@@ -39,6 +39,12 @@ describe('<App /> with mocked RootNavigator', () => {
     renderApp()
 
     expect(BatchMessaging.setFontOverride).toHaveBeenCalledTimes(1)
+  })
+
+  it('should request push notifications permission', () => {
+    renderApp()
+
+    expect(BatchPush.refreshToken).toHaveBeenCalledTimes(1)
   })
 
   it('should not init AppsFlyer on launch', () => {

--- a/src/App.native.test.tsx
+++ b/src/App.native.test.tsx
@@ -41,7 +41,7 @@ describe('<App /> with mocked RootNavigator', () => {
     expect(BatchMessaging.setFontOverride).toHaveBeenCalledTimes(1)
   })
 
-  it('should request push notifications permission', () => {
+  it('should refresh batch token at app start', () => {
     renderApp()
 
     expect(BatchPush.refreshToken).toHaveBeenCalledTimes(1)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ import { LocationWrapper } from 'libs/location'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { NetInfoWrapper } from 'libs/network/NetInfoWrapper'
 import { OfflineModeContainer } from 'libs/network/OfflineModeContainer'
-import { BatchMessaging } from 'libs/react-native-batch'
+import { BatchMessaging, BatchPush } from 'libs/react-native-batch'
 import { configureGoogleSignin } from 'libs/react-native-google-sso/configureGoogleSignin'
 import { SafeAreaProvider } from 'libs/react-native-save-area-provider'
 import { ReactQueryClientProvider } from 'libs/react-query/ReactQueryClientProvider'
@@ -70,6 +70,7 @@ const App: FunctionComponent = function () {
 
   useEffect(() => {
     initAlgoliaAnalytics()
+    BatchPush.refreshToken() //  Synchronizes the user's iOS token with Batch. Should be called at each app launch. No effect on Android.
     BatchMessaging.setFontOverride('Montserrat-Regular', 'Montserrat-Bold', 'Montserrat-Italic')
     configureGoogleSignin({
       webClientId: env.GOOGLE_CLIENT_ID,


### PR DESCRIPTION
Now that requestNotificationAuthorization is no longer at start, we should refresh the token manually

- Using the above method, the push token will automatically be fetched by the SDK.
- Alternatively, you can call requestNotificationAuthorization later
- But, you should always refresh your token on each application start
- This will make sure that even if your user's token changes, you still get notifications

Source:
https://doc.batch.com/developer/sdk/react-native/sdk-integration/expo-integration#enable-push-notifications

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37158

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
