### PR TITLE
(PC-36891) feat(Stepper): added 'Confirme tes infos' when user already has completed profile

### DIFF
--- a/src/features/identityCheck/pages/helpers/useStepperInfo.native.test.tsx
+++ b/src/features/identityCheck/pages/helpers/useStepperInfo.native.test.tsx
@@ -85,6 +85,16 @@ describe('useStepperInfo', () => {
     expect(stepsDetails).toHaveLength(4)
   })
 
+  describe('profile step', () => {
+    it('should show subtitle if user has already filled their profile', () => {
+      mockAuthContextWithUser({ ...beneficiaryUser, needsToFillCulturalSurvey: true })
+      const { stepsDetails } = useStepperInfo()
+      const confirmationStep = stepsDetails.find((step) => step.name === IdentityCheckStep.PROFILE)
+
+      expect(confirmationStep?.subtitle).toEqual('Sous-titre Profil')
+    })
+  })
+
   describe('identification step', () => {
     it('should default return "SelectIDOrigin"', () => {
       const { stepsDetails } = useStepperInfo()

--- a/src/features/identityCheck/pages/helpers/useStepperInfo.tsx
+++ b/src/features/identityCheck/pages/helpers/useStepperInfo.tsx
@@ -95,6 +95,7 @@ export const useStepperInfo = (): StepperInfo => {
       firstScreenType: hasUserCompletedInfo
         ? ProfileTypes.RECAP_EXISTING_DATA
         : ProfileTypes.IDENTITY_CHECK,
+      subtitle: hasUserCompletedInfo ? 'Confirme tes informations' : undefined,
     },
     [IdentityCheckStep.IDENTIFICATION]: {
       name: IdentityCheckStep.IDENTIFICATION,
@@ -145,7 +146,7 @@ export const useStepperInfo = (): StepperInfo => {
         const stepDetails: StepExtendedDetails = {
           name: currentStepConfig.name,
           title: step.title,
-          subtitle: step.subtitle ?? undefined,
+          subtitle: step.subtitle ?? currentStepConfig.subtitle,
           icon: currentStepConfig.icon,
           stepState: mapCompletionState(step.completionState),
           firstScreen: currentStepConfig.firstScreen,

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -35,19 +35,20 @@ const exception = 'Failed to fetch data from API: https://api-adresse.data.gouv.
 
 export const SetAddress = () => {
   const { params } = useRoute<UseRouteType<'SetAddress'>>()
-  const type = params?.type
-  const isIdentityCheck = type === ProfileTypes.IDENTITY_CHECK
-  const pageInfos = isIdentityCheck
-    ? {
-        headerTitle: 'Profil',
-        title: 'Quelle est ton adresse\u00a0?',
-        navigateParamsType: ProfileTypes.IDENTITY_CHECK,
-      }
-    : {
-        headerTitle: 'Informations personnelles',
-        title: 'Saisis ton adresse postale',
-        navigateParamsType: ProfileTypes.BOOKING_FREE_OFFER_15_16,
-      }
+  const type = params?.type ?? ProfileTypes.IDENTITY_CHECK // Fallback to most common scenario
+
+  const identityCheckAndRecapExistingDataConfig = {
+    headerTitle: 'Profil',
+    title: 'Quelle est ton adresse\u00a0?',
+  }
+  const pageConfigByType = {
+    [ProfileTypes.IDENTITY_CHECK]: identityCheckAndRecapExistingDataConfig,
+    [ProfileTypes.BOOKING_FREE_OFFER_15_16]: {
+      headerTitle: 'Informations personnelles',
+      title: 'Saisis ton adresse postale',
+    },
+    [ProfileTypes.RECAP_EXISTING_DATA]: identityCheckAndRecapExistingDataConfig,
+  }
 
   const { data: settings } = useSettingsContext()
   const storedAddress = useAddress()
@@ -112,18 +113,18 @@ export const SetAddress = () => {
   const submitAddress = async () => {
     if (!enabled) return
     setStoreAddress(selectedAddress ?? query)
-    navigate('SetStatus', { type: pageInfos.navigateParamsType })
+    navigate('SetStatus', { type })
   }
 
   useEnterKeyAction(enabled ? submitAddress : undefined)
 
   return (
     <PageWithHeader
-      title={pageInfos.headerTitle}
+      title={pageConfigByType[type].headerTitle}
       scrollChildren={
         <React.Fragment>
           <Form.MaxWidth>
-            <Typo.Title3 {...getHeadingAttrs(2)}>{pageInfos.title}</Typo.Title3>
+            <Typo.Title3 {...getHeadingAttrs(2)}>{pageConfigByType[type].title}</Typo.Title3>
             <Container>
               <SearchInput
                 autoFocus

--- a/src/features/identityCheck/pages/profile/SetCity.tsx
+++ b/src/features/identityCheck/pages/profile/SetCity.tsx
@@ -31,17 +31,18 @@ export const cityResolver = object().shape({
 
 export const SetCity = () => {
   const { params } = useRoute<UseRouteType<'SetCity'>>()
-  const type = params?.type
-  const isIdentityCheck = type === ProfileTypes.IDENTITY_CHECK
-  const pageInfos = isIdentityCheck
-    ? {
-        headerTitle: 'Profil',
-        navigateParamsType: ProfileTypes.IDENTITY_CHECK,
-      }
-    : {
-        headerTitle: 'Informations personnelles',
-        navigateParamsType: ProfileTypes.BOOKING_FREE_OFFER_15_16,
-      }
+  const type = params?.type ?? ProfileTypes.IDENTITY_CHECK // Fallback to most common scenario
+
+  const identityCheckAndRecapExistingDataConfig = {
+    headerTitle: 'Profil',
+  }
+  const pageConfigByType = {
+    [ProfileTypes.IDENTITY_CHECK]: identityCheckAndRecapExistingDataConfig,
+    [ProfileTypes.BOOKING_FREE_OFFER_15_16]: {
+      headerTitle: 'Informations personnelles',
+    },
+    [ProfileTypes.RECAP_EXISTING_DATA]: identityCheckAndRecapExistingDataConfig,
+  }
 
   const { navigate } = useNavigation<StackNavigationProp<SubscriptionStackParamList>>()
   const storedCity = useCity()
@@ -58,12 +59,12 @@ export const SetCity = () => {
 
   const onSubmit = ({ city }: CityForm) => {
     setStoreCity(city)
-    navigate('SetAddress', { type: pageInfos.navigateParamsType })
+    navigate('SetAddress', { type })
   }
 
   return (
     <PageWithHeader
-      title={pageInfos.headerTitle}
+      title={pageConfigByType[type].headerTitle}
       scrollChildren={
         <ViewGap gap={5}>
           <Typo.Title3 {...getHeadingAttrs(2)}>Renseigne ta ville de résidence</Typo.Title3>

--- a/src/features/identityCheck/pages/profile/SetName.tsx
+++ b/src/features/identityCheck/pages/profile/SetName.tsx
@@ -28,23 +28,26 @@ type FormValues = {
 
 export const SetName = () => {
   const { params } = useRoute<UseRouteType<'SetName'>>()
-  const type = params?.type
-  const isIdentityCheck = type === ProfileTypes.IDENTITY_CHECK
-  const pageInfos = isIdentityCheck
-    ? {
-        headerTitle: 'Profil',
-        title: 'Comment t’appelles-tu\u00a0?',
-        bannerMessage:
-          'Saisis ton nom et ton prénom tels qu’ils sont affichés sur ta pièce d’identité. Nous les vérifions et ils ne pourront plus être modifiés par la suite.',
-        navigateParamsType: ProfileTypes.IDENTITY_CHECK,
-      }
-    : {
-        headerTitle: 'Informations personnelles',
-        title: 'Renseigne ton prénom et ton nom',
-        bannerMessage:
-          'Pour réserver une offre gratuite, on a besoin de ton prénom, nom, ton lieu de résidence et adresse, ainsi que ton statut. Ces informations seront vérifiées par le partenaire culturel.',
-        navigateParamsType: ProfileTypes.BOOKING_FREE_OFFER_15_16,
-      }
+  const type = params?.type ?? ProfileTypes.IDENTITY_CHECK // Fallback to most common scenario
+
+  const identityCheckAndRecapExistingDataConfig = {
+    headerTitle: 'Profil',
+    title: 'Comment t’appelles-tu\u00a0?',
+    bannerMessage:
+      'Saisis ton nom et ton prénom tels qu’ils sont affichés sur ta pièce d’identité. Nous les vérifions et ils ne pourront plus être modifiés par la suite.',
+    navigateParamsType: ProfileTypes.IDENTITY_CHECK,
+  }
+
+  const pageConfigByType = {
+    [ProfileTypes.IDENTITY_CHECK]: identityCheckAndRecapExistingDataConfig,
+    [ProfileTypes.BOOKING_FREE_OFFER_15_16]: {
+      headerTitle: 'Informations personnelles',
+      title: 'Renseigne ton prénom et ton nom',
+      bannerMessage:
+        'Pour réserver une offre gratuite, on a besoin de ton prénom, nom, ton lieu de résidence et adresse, ainsi que ton statut. Ces informations seront vérifiées par le partenaire culturel.',
+    },
+    [ProfileTypes.RECAP_EXISTING_DATA]: identityCheckAndRecapExistingDataConfig,
+  }
 
   const storedName = useName()
   const { setName: setStoredName } = nameActions
@@ -68,19 +71,19 @@ export const SetName = () => {
   async function submitName({ firstName, lastName }: FormValues) {
     if (disabled) return
     setStoredName({ firstName, lastName })
-    navigate('SetCity', { type: pageInfos.navigateParamsType })
+    navigate('SetCity', { type })
   }
 
   useEnterKeyAction(disabled ? undefined : () => handleSubmit(submitName))
 
   return (
     <PageWithHeader
-      title={pageInfos.headerTitle}
+      title={pageConfigByType[type].headerTitle}
       scrollChildren={
         <Form.MaxWidth>
-          <Typo.Title3 {...getHeadingAttrs(2)}>{pageInfos.title}</Typo.Title3>
+          <Typo.Title3 {...getHeadingAttrs(2)}>{pageConfigByType[type].title}</Typo.Title3>
           <Spacer.Column numberOfSpaces={5} />
-          <InfoBanner icon={IdCard} message={pageInfos.bannerMessage} />
+          <InfoBanner icon={IdCard} message={pageConfigByType[type].bannerMessage} />
           <Spacer.Column numberOfSpaces={4} />
           <Controller
             control={control}

--- a/src/features/identityCheck/pages/profile/SetStatus.tsx
+++ b/src/features/identityCheck/pages/profile/SetStatus.tsx
@@ -46,10 +46,16 @@ export const SetStatus = () => {
     RemoteStoreFeatureFlags.ENABLE_BOOKING_FREE_OFFER_15_16
   )
 
-  const type = params?.type
-  const isIdentityCheck = type === ProfileTypes.IDENTITY_CHECK
+  const type = params?.type ?? ProfileTypes.IDENTITY_CHECK // Fallback to most common scenario
+
   const isBookingFreeOffer = type === ProfileTypes.BOOKING_FREE_OFFER_15_16
-  const title = isIdentityCheck ? 'Profil' : 'Informations personnelles'
+
+  const identityCheckAndRecapExistingDataConfig = 'Profil'
+  const pageConfigByType = {
+    [ProfileTypes.IDENTITY_CHECK]: identityCheckAndRecapExistingDataConfig,
+    [ProfileTypes.BOOKING_FREE_OFFER_15_16]: 'Informations personnelles',
+    [ProfileTypes.RECAP_EXISTING_DATA]: identityCheckAndRecapExistingDataConfig,
+  }
 
   const saveStep = useSaveStep()
   const storedName = useName()
@@ -125,7 +131,7 @@ export const SetStatus = () => {
 
   return (
     <React.Fragment>
-      <PageHeaderWithoutPlaceholder title={title} />
+      <PageHeaderWithoutPlaceholder title={pageConfigByType[type]} />
       <StatusFlatList
         handleSubmit={handleSubmit}
         isLoading={isLoading}

--- a/src/features/identityCheck/types.ts
+++ b/src/features/identityCheck/types.ts
@@ -34,6 +34,7 @@ export type StepConfig = Pick<StepDetails, 'icon'> & {
   name: IdentityCheckStep
   firstScreen: SubscriptionScreen
   firstScreenType: ProfileType
+  subtitle?: string
 }
 
 export type StepExtendedDetails = StepConfig & StepDetails


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36891

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
