### PR TITLE
(PC-37272) feat(DS): update design system lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@hookform/resolvers": "^2.9.11",
     "@hot-updater/react-native": "0.19.9",
     "@openspacelabs/react-native-zoomable-view": "^2.1.5",
-    "@pass-culture/design-system": "0.1.4",
+    "@pass-culture/design-system": "0.2.0",
     "@ptomasroos/react-native-multi-slider": "^2.2.2",
     "@react-native-async-storage/async-storage": "^1.17.11",
     "@react-native-clipboard/clipboard": "^1.16.2",

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
@@ -3,11 +3,11 @@ import { LayoutChangeEvent, Platform } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import { ChronicleCardData } from 'features/chronicle/type'
+import { getLineHeightPx } from 'libs/parsers/getLineHeightPx'
 import { InfoHeader } from 'ui/components/InfoHeader/InfoHeader'
 import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo, getShadow, getSpacing } from 'ui/theme'
-import { REM_TO_PX } from 'ui/theme/constants'
 
 const CHRONICLE_THUMBNAIL_SIZE = getSpacing(14)
 
@@ -39,10 +39,9 @@ export const ChronicleCard: FunctionComponent<Props> = ({
   const [shouldDisplayButton, setShouldDisplayButton] = useState(false)
 
   // height depending on the platform
-  const DEFAULT_HEIGHT_WEB =
-    parseFloat(designSystem.typography.bodyAccentS.lineHeight) * MAX_LINES * REM_TO_PX
-  const DEFAULT_HEIGHT_MOBILE =
-    parseFloat(designSystem.typography.bodyAccentS.lineHeight) * MAX_LINES
+  const lineHeight = designSystem.typography.bodyAccentS.lineHeight
+  const DEFAULT_HEIGHT_WEB = getLineHeightPx(lineHeight, true) * MAX_LINES
+  const DEFAULT_HEIGHT_MOBILE = getLineHeightPx(lineHeight, false) * MAX_LINES
   const defaultHeight = Platform.OS === 'web' ? DEFAULT_HEIGHT_WEB : DEFAULT_HEIGHT_MOBILE
 
   const handleOnLayout = (event: LayoutChangeEvent) => {

--- a/src/libs/parsers/getLineHeightPx.native.test.ts
+++ b/src/libs/parsers/getLineHeightPx.native.test.ts
@@ -1,0 +1,40 @@
+import { getLineHeightPx } from 'libs/parsers/getLineHeightPx'
+import { REM_TO_PX } from 'ui/theme/constants'
+
+describe('getLineHeightPx', () => {
+  it('should convert a rem string to px when shouldConvertRemToPx is true', () => {
+    const result = getLineHeightPx('1.5rem', true)
+
+    expect(result).toEqual(1.5 * REM_TO_PX)
+  })
+
+  it('should parse a rem string without multiplying if shouldConvertRemToPx is false', () => {
+    const result = getLineHeightPx('1.5rem', false)
+
+    expect(result).toEqual(1.5)
+  })
+
+  it('should parse a rem string without multiplying if shouldConvertRemToPx is undefined', () => {
+    const result = getLineHeightPx('2rem', undefined)
+
+    expect(result).toEqual(2)
+  })
+
+  it('should return the number directly if lineHeight is a number and shouldConvertRemToPx is true', () => {
+    const result = getLineHeightPx(20, true)
+
+    expect(result).toEqual(20)
+  })
+
+  it('should return the number directly if lineHeight is a number and shouldConvertRemToPx is false', () => {
+    const result = getLineHeightPx(25.6, false)
+
+    expect(result).toEqual(25.6)
+  })
+
+  it('should return the number directly if lineHeight is a number and shouldConvertRemToPx is undefined', () => {
+    const result = getLineHeightPx(18, undefined)
+
+    expect(result).toEqual(18)
+  })
+})

--- a/src/libs/parsers/getLineHeightPx.ts
+++ b/src/libs/parsers/getLineHeightPx.ts
@@ -1,0 +1,11 @@
+import { REM_TO_PX } from 'ui/theme/constants'
+
+export function getLineHeightPx(
+  lineHeight: string | number,
+  shouldConvertRemToPx: boolean | undefined
+): number {
+  if (shouldConvertRemToPx && typeof lineHeight === 'string') {
+    return parseFloat(lineHeight) * REM_TO_PX
+  }
+  return typeof lineHeight === 'number' ? lineHeight : parseFloat(lineHeight)
+}

--- a/src/ui/components/BulletListItem.tsx
+++ b/src/ui/components/BulletListItem.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
+import { getLineHeightPx } from 'libs/parsers/getLineHeightPx'
 import { Li } from 'ui/components/Li'
 import { VerticalUl } from 'ui/components/Ul'
 import { Dot } from 'ui/svg/icons/Dot'
 import { getSpacing, Typo } from 'ui/theme'
-import { REM_TO_PX } from 'ui/theme/constants'
 
 // Use with Ul or VerticalUl to be accessible in web
 export const BulletListItem: React.FC<{
@@ -71,9 +71,7 @@ const NestedBullet = styled(Dot).attrs(({ theme }) => ({
 }))``
 
 const BulletContainer = styled.View(({ theme }) => ({
-  height: theme.isDesktopViewport
-    ? parseFloat(theme.designSystem.typography.body.lineHeight) * REM_TO_PX
-    : parseFloat(theme.designSystem.typography.body.lineHeight),
+  height: getLineHeightPx(theme.designSystem.typography.body.lineHeight, theme.isDesktopViewport),
   justifyContent: 'center',
 }))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7541,10 +7541,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pass-culture/design-system@npm:0.1.4":
-  version: 0.1.4
-  resolution: "@pass-culture/design-system@npm:0.1.4"
-  checksum: 3fbfd5ddd7c7780a349ae1d1219cab356f85f95c207e27088dfb45ac65d4415fc735309de8c59559c74a410eeecc36a021b05d4e8d198493607a264155aa68c7
+"@pass-culture/design-system@npm:0.2.0":
+  version: 0.2.0
+  resolution: "@pass-culture/design-system@npm:0.2.0"
+  checksum: 167716d77d2771ec7a6c50c07fe2a3ea0dfe7299c5fa107ca14f9357f956f73fb95c7d0b132b5f37397e48b8f5e2d8b79db90a2839d58d3ad4221acefb528d0f
   languageName: node
   linkType: hard
 
@@ -10997,7 +10997,7 @@ __metadata:
     "@hot-updater/react-native": 0.19.9
     "@lhci/cli": ^0.14.0
     "@openspacelabs/react-native-zoomable-view": ^2.1.5
-    "@pass-culture/design-system": 0.1.4
+    "@pass-culture/design-system": 0.2.0
     "@ptomasroos/react-native-multi-slider": ^2.2.2
     "@react-native-async-storage/async-storage": ^1.17.11
     "@react-native-clipboard/clipboard": ^1.16.2


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37272

La fonction est nécessaire car en mobile désormais on renvoie en number mais par contre en web on maintiens ce qu'on faisait avant et on renvoie le token en rem sous forme de string

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

<img width="258" height="466" alt="Capture d’écran 2025-07-31 à 16 26 17" src="https://github.com/user-attachments/assets/75facd67-ed24-4a8d-b17e-e00e04994cc0" />


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
