### PR TITLE
(PC-35733) fix(onboarding): display amount in the correct currency in the subtitle

### DIFF
--- a/src/features/home/api/useActivationBanner.ts
+++ b/src/features/home/api/useActivationBanner.ts
@@ -1,41 +1,21 @@
-import { CurrencyEnum } from 'api/gen'
-import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useBannerQuery } from 'features/home/queries/useBannerQuery'
-import { useGetStepperInfoQuery } from 'features/identityCheck/queries/useGetStepperInfoQuery'
-import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
-import { RemoteStoreFeatureFlags as featureFlags } from 'libs/firebase/firestore/types'
 import { GeolocPermissionState, useLocation } from 'libs/location'
-import { LocationMode } from 'libs/location/types'
-import { useGetDepositAmountsByAge } from 'shared/user/useGetDepositAmountsByAge'
+import { useOverrideCreditActivationAmount } from 'shared/user/useOverrideCreditActivationAmount'
 
 export function useActivationBanner() {
-  const enablePacificFrancCurrency = useFeatureFlag(featureFlags.ENABLE_PACIFIC_FRANC_CURRENCY)
-  const { user } = useAuthContext()
-  const { selectedLocationMode, permissionState } = useLocation()
-  const { data: subscription } = useGetStepperInfoQuery()
-
-  const amount = useGetDepositAmountsByAge(user?.birthDate)
-
-  const nextSubscriptionStepEnable = !!subscription?.nextSubscriptionStep
-  const isEligibleForBeneficiaryUpgrade = !!user?.isEligibleForBeneficiaryUpgrade
-  const isActivationProcessEnable = nextSubscriptionStepEnable || isEligibleForBeneficiaryUpgrade
-
-  const isUserLocated = selectedLocationMode !== LocationMode.EVERYWHERE
-  const isUserRegisteredInPacificFrancRegion = user?.currency === CurrencyEnum.XPF
-  const isUserInRelevantLocation = isUserLocated || isUserRegisteredInPacificFrancRegion
+  const { shouldBeOverriden, amount: overriddenAmount } = useOverrideCreditActivationAmount()
+  const { permissionState } = useLocation()
 
   const isGeolocated = permissionState === GeolocPermissionState.GRANTED
   const { data } = useBannerQuery(isGeolocated)
 
-  if (enablePacificFrancCurrency) {
-    if (isActivationProcessEnable || isUserInRelevantLocation) {
-      return {
-        banner: {
-          title: amount ? `Débloque tes ${amount}` : 'Débloque ton crédit',
-          text: data?.banner?.text,
-          name: data?.banner?.name,
-        },
-      }
+  if (shouldBeOverriden) {
+    return {
+      banner: {
+        title: overriddenAmount ? `Débloque tes ${overriddenAmount}` : `Débloque ton crédit`,
+        text: data?.banner?.text,
+        name: data?.banner?.name,
+      },
     }
   }
   return { banner: { ...data?.banner } }

--- a/src/features/identityCheck/pages/helpers/useStepperInfo.native.test.tsx
+++ b/src/features/identityCheck/pages/helpers/useStepperInfo.native.test.tsx
@@ -14,6 +14,7 @@ import { IdentityCheckStep } from 'features/identityCheck/types'
 import { beneficiaryUser } from 'fixtures/user'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { useOverrideCreditActivationAmount } from 'shared/user/useOverrideCreditActivationAmount'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
 
 const mockIdentityCheckState = mockState
@@ -54,10 +55,29 @@ jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({
   })),
 }))
 
+jest.mock('shared/user/useOverrideCreditActivationAmount')
+const mockOverrideCreditActivationAmount = jest.mocked(useOverrideCreditActivationAmount)
+mockOverrideCreditActivationAmount.mockReturnValue({
+  shouldBeOverriden: false,
+  amount: '150 €',
+})
+
 describe('useStepperInfo', () => {
   beforeEach(() => {
     setFeatureFlags()
     setSettings({ enablePhoneValidation: true })
+  })
+
+  it('should convert subtitle amount from € to CPF', () => {
+    mockOverrideCreditActivationAmount.mockReturnValueOnce({
+      shouldBeOverriden: true,
+      amount: '17 900 F',
+    })
+    const { subtitle } = useStepperInfo()
+
+    expect(subtitle).toEqual(
+      'Pour débloquer tes 17 900 F tu dois suivre les étapes suivantes\u00a0:'
+    )
   })
 
   it('should return title and subtitle', () => {

--- a/src/features/identityCheck/pages/helpers/useStepperInfo.tsx
+++ b/src/features/identityCheck/pages/helpers/useStepperInfo.tsx
@@ -15,6 +15,7 @@ import { usePhoneValidationRemainingAttemptsQuery } from 'features/identityCheck
 import { StepExtendedDetails, IdentityCheckStep, StepConfig } from 'features/identityCheck/types'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { useOverrideCreditActivationAmount } from 'shared/user/useOverrideCreditActivationAmount'
 import { StepButtonState } from 'ui/components/StepButton/types'
 import { IdCard } from 'ui/svg/icons/IdCard'
 import { LegalNotices } from 'ui/svg/icons/LegalNotices'
@@ -44,6 +45,8 @@ export const useStepperInfo = (): StepperInfo => {
   const { remainingAttempts } = usePhoneValidationRemainingAttemptsQuery()
   const { data } = useGetStepperInfoQuery()
   const { data: settings } = useSettingsContext()
+  const { shouldBeOverriden: shouldCreditAmountBeOverriden, amount: overriddenCreditAmount } =
+    useOverrideCreditActivationAmount()
 
   if (!data) {
     return {
@@ -158,10 +161,17 @@ export const useStepperInfo = (): StepperInfo => {
 
   const stepsDetails = stepDetailsList.filter((step): step is StepExtendedDetails => step != null)
 
+  let overridenSubtitle = subtitle
+  if (shouldCreditAmountBeOverriden) {
+    overridenSubtitle = overriddenCreditAmount
+      ? `Pour débloquer tes ${overriddenCreditAmount} tu dois suivre les étapes suivantes\u00a0:`
+      : 'Pour débloquer ton crédit tu dois suivre les étapes suivantes\u00a0:'
+  }
+
   return {
     stepsDetails,
     title,
-    subtitle,
+    subtitle: overridenSubtitle,
     errorMessage: subscriptionMessage?.messageSummary,
   }
 }

--- a/src/shared/user/useOverrideCreditActivationAmount.ts
+++ b/src/shared/user/useOverrideCreditActivationAmount.ts
@@ -1,0 +1,32 @@
+import { CurrencyEnum } from 'api/gen'
+import { useAuthContext } from 'features/auth/context/AuthContext'
+import { useGetStepperInfoQuery } from 'features/identityCheck/queries/useGetStepperInfoQuery'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags as featureFlags } from 'libs/firebase/firestore/types'
+import { useLocation } from 'libs/location'
+import { LocationMode } from 'libs/location/types'
+import { useGetDepositAmountsByAge } from 'shared/user/useGetDepositAmountsByAge'
+
+export function useOverrideCreditActivationAmount() {
+  const enablePacificFrancCurrency = useFeatureFlag(featureFlags.ENABLE_PACIFIC_FRANC_CURRENCY)
+  const { user } = useAuthContext()
+  const { selectedLocationMode } = useLocation()
+  const { data: subscription } = useGetStepperInfoQuery()
+
+  const amount = useGetDepositAmountsByAge(user?.birthDate)
+
+  const nextSubscriptionStepEnable = !!subscription?.nextSubscriptionStep
+  const isEligibleForBeneficiaryUpgrade = !!user?.isEligibleForBeneficiaryUpgrade
+  const isActivationProcessEnable = nextSubscriptionStepEnable || isEligibleForBeneficiaryUpgrade
+
+  const isUserLocated = selectedLocationMode !== LocationMode.EVERYWHERE
+  const isUserRegisteredInPacificFrancRegion = user?.currency === CurrencyEnum.XPF
+  const isUserInRelevantLocation = isUserLocated || isUserRegisteredInPacificFrancRegion
+
+  if (enablePacificFrancCurrency) {
+    if (isActivationProcessEnable || isUserInRelevantLocation) {
+      return { shouldBeOverriden: true, amount }
+    }
+  }
+  return { shouldBeOverriden: false, amount }
+}


### PR DESCRIPTION

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35733

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

<img width="404" height="379" alt="Capture d’écran 2025-07-31 à 18 00 02" src="https://github.com/user-attachments/assets/561aebae-a997-4a62-a1ca-9ce91736b645" />

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
