### PR TITLE
(PC-37221) feat(Favorite): remove booking button on coming soon offers

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -1858,6 +1858,11 @@ export interface FavoriteMediationResponse {
  */
 export interface FavoriteOfferResponse {
   /**
+   * @type {string}
+   * @memberof FavoriteOfferResponse
+   */
+  bookingAllowedDatetime?: string | null
+  /**
    * @type {Coordinates}
    * @memberof FavoriteOfferResponse
    */

--- a/src/features/favorites/components/Favorite.native.test.tsx
+++ b/src/features/favorites/components/Favorite.native.test.tsx
@@ -25,6 +25,7 @@ import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 
 import { Favorite } from './Favorite'
+import mockdate from 'mockdate'
 
 const mockShowErrorSnackBar = jest.fn()
 jest.mock('ui/components/snackBar/SnackBarContext', () => ({
@@ -173,6 +174,37 @@ describe('<Favorite /> component', () => {
       type: 'Offer',
       from: 'favorites',
       offerId: favorite.offer.id,
+    })
+  })
+
+  describe('coming soon offer', () => {
+    const TODAY = '2025-07-29T15:15:00Z'
+    const TODAY_PLUS_ONE_MINUTE = '2025-07-29T15:16:00Z'
+    beforeAll(() => mockdate.set(new Date(TODAY)))
+    it('should not show booking button on an offer not yet bookable', async () => {
+      renderFavorite({
+        favorite: {
+          ...favorite,
+          offer: { ...favorite.offer, bookingAllowedDatetime: TODAY_PLUS_ONE_MINUTE },
+        },
+      })
+
+      await screen.findByText(favorite.offer.name)
+
+      expect(screen.queryByText('Réserver')).not.toBeOnTheScreen()
+    })
+
+    it('should show booking button on a bookable offer', async () => {
+      renderFavorite({
+        favorite: {
+          ...favorite,
+          offer: { ...favorite.offer, bookingAllowedDatetime: TODAY },
+        },
+      })
+
+      await screen.findByText(favorite.offer.name)
+
+      expect(await screen.findByText('Réserver')).toBeOnTheScreen()
     })
   })
 })

--- a/src/features/favorites/components/Favorite.tsx
+++ b/src/features/favorites/components/Favorite.tsx
@@ -33,6 +33,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { useLayout } from 'ui/hooks/useLayout'
 import { ExternalSite } from 'ui/svg/icons/ExternalSite'
 import { getSpacing, Typo } from 'ui/theme'
+import { getIsAComingSoonOffer } from 'features/offer/helpers/getIsAComingSoonOffer'
 
 interface Props {
   favorite: FavoriteResponse
@@ -44,12 +45,12 @@ const SPACER_BETWEEN_IMAGE_AND_CONTENT = 4
 
 export const Favorite: React.FC<Props> = (props) => {
   const { offer } = props.favorite
+  const isAComingSoonOffer = getIsAComingSoonOffer(offer.bookingAllowedDatetime)
   const { onLayout, height } = useLayout()
   const animatedOpacity = useRef(new Animated.Value(1)).current
   const animatedCollapse = useRef(new Animated.Value(1)).current
   const prePopulateOffer = usePrePopulateOffer()
   const { userLocation, selectedPlace, selectedLocationMode } = useLocation()
-
   const distanceToOffer = getDistance(
     {
       lat: offer.coordinates?.latitude,
@@ -228,7 +229,7 @@ export const Favorite: React.FC<Props> = (props) => {
               disabled={isLoading}
             />
           </ButtonContainer>
-          <ButtonContainer>{BookingButton}</ButtonContainer>
+          {isAComingSoonOffer ? null : <ButtonContainer>{BookingButton}</ButtonContainer>}
         </FavoriteButtonsContainer>
         <LineSeparator />
       </Animated.View>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37221

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome | <img width="522" height="290" alt="Capture d’écran 2025-08-04 à 12 57 06" src="https://github.com/user-attachments/assets/2c2bac0d-9fc3-4bfb-934a-5c80428082e3" /> |  <img width="515" height="262" alt="Capture d’écran 2025-08-04 à 12 57 42" src="https://github.com/user-attachments/assets/8f40bdd0-2066-49b5-8077-82f8152c4c20" />  |


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
