### PR TITLE
(PC-36894) chore(batch): upgrade to 10

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -67,7 +67,6 @@ target 'PassCulture' do
   pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '11.13.0'
   pod 'FirebaseCore', :modular_headers => true
   pod 'GoogleUtilities', :modular_headers => true
-  pod 'Batch', '~> 2.0.0'
   pod 'BatchFirebaseDispatcher'
 
   post_install do |installer|

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2679,10 +2679,10 @@ SPEC CHECKSUMS:
   Base64: cecfb41a004124895a7bcee567a89bae5a89d49b
   Batch: fe0c88b2182a8d0f6ca3b0ed725694206b2e3e44
   BatchFirebaseDispatcher: 1711b32884f4b6b3513553beab4c766056794ae1
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
+  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
   CodePush: d892f13c5012e9e2cb36640f4929654b7be21fe5
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 23d8c5470c648a635893dc0956c6dbaead54b656
   Firebase: 3435bc66b4d494c2f22c79fd3aae4c1db6662327
@@ -2705,8 +2705,8 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 1c6135e8a094cc6368949f5faeeca7ee8948b8aa
   FirebaseSessions: eaa8ec037e7793769defe4201c20bd4d976f9677
   FirebaseSharedSwift: aca73668bc95e8efccb618e0167eab05d19d3a75
-  fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
+  glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   GoogleAppMeasurement: 0dfca1a4b534d123de3945e28f77869d10d0d600
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1995,6 +1995,8 @@ PODS:
     - Firebase/RemoteConfig (= 11.13.0)
     - React-Core
     - RNFBApp
+  - RNFlashList (1.6.4):
+    - React-Core
   - RNGestureHandler (2.26.0):
     - DoubleConversion
     - glog
@@ -2391,6 +2393,7 @@ DEPENDENCIES:
   - "RNFBFirestore (from `../node_modules/@react-native-firebase/firestore`)"
   - "RNFBPerf (from `../node_modules/@react-native-firebase/perf`)"
   - "RNFBRemoteConfig (from `../node_modules/@react-native-firebase/remote-config`)"
+  - "RNFlashList (from `../node_modules/@shopify/flash-list`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - "RNGoogleSignin (from `../node_modules/@react-native-google-signin/google-signin`)"
   - RNKeychain (from `../node_modules/react-native-keychain`)
@@ -2645,6 +2648,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-firebase/perf"
   RNFBRemoteConfig:
     :path: "../node_modules/@react-native-firebase/remote-config"
+  RNFlashList:
+    :path: "../node_modules/@shopify/flash-list"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNGoogleSignin:
@@ -2797,7 +2802,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 9b3704075c2fe8fd7c739779655fb88700a1ca30
   ReactCodegen: 4ade497e5e62c9969da87fa6c845a7c301fe550a
   ReactCommon: 7f91538e91d390ebffd7238c8e47e3db8ee0f6a8
-  RNBatchPush: 05ea7f247d971abea8a6464641b41b0f14c6e229
+  RNBatchPush: 8986444edff758f9924a128af7a89f5893a39572
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
   RNCClipboard: de1561c12ba8a15f143347993a382c6474c0d2d6
   RNDeviceInfo: b899ce37a403a4dea52b7cb85e16e49c04a5b88e
@@ -2808,6 +2813,7 @@ SPEC CHECKSUMS:
   RNFBFirestore: fa1739cc4dc22aff2cc384808a963e809802d956
   RNFBPerf: c32ec64522c2e4d81d1562747809314e9050b75f
   RNFBRemoteConfig: 1bd86986a8372a52c95c00d83d73c44a3d61f31d
+  RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b
   RNGestureHandler: 6bd728f386096ebb26670b4dd6a604a67b14f65d
   RNGoogleSignin: a6a612cce56a45ab701c5c5c6e36f5390522d100
   RNKeychain: 4f63aada75ebafd26f4bc2c670199461eab85d94
@@ -2825,6 +2831,6 @@ SPEC CHECKSUMS:
   SSZipArchive: 62d4947b08730e4cda640473b0066d209ff033c9
   Yoga: 1a10502f162e8fc40ff0907c82d01cfe555d00c2
 
-PODFILE CHECKSUM: 661a611925b4047df8157b602f04b6fd49fef2e6
+PODFILE CHECKSUM: 1867a18ae22d869eedc7a57c64c4f848b9d75a83
 
 COCOAPODS: 1.14.3

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - AppsFlyerFramework/Main (= 6.16.2)
   - AppsFlyerFramework/Main (6.16.2)
   - Base64 (1.1.2)
-  - Batch (2.0.2)
+  - Batch (2.1.1)
   - BatchFirebaseDispatcher (3.2.0):
     - Batch (>= 1.19)
     - Firebase/Analytics
@@ -1920,8 +1920,28 @@ PODS:
     - React-perflogger (= 0.77.3)
     - React-utils (= 0.77.3)
   - RNBatchPush (1.0.0):
-    - Batch (~> 2.0.0)
+    - Batch (~> 2.1.0)
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNCAsyncStorage (1.17.11):
     - React-Core
   - RNCClipboard (1.16.2):
@@ -2269,7 +2289,6 @@ PODS:
   - Yoga (0.0.0)
 
 DEPENDENCIES:
-  - Batch (~> 2.0.0)
   - BatchFirebaseDispatcher
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
@@ -2658,12 +2677,12 @@ SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppsFlyerFramework: fe5303bffcdfd941d5f570c2d21eaaea982e7bdc
   Base64: cecfb41a004124895a7bcee567a89bae5a89d49b
-  Batch: 5910c05091914c3ca415ca8793e5ce6fcc36cfee
+  Batch: fe0c88b2182a8d0f6ca3b0ed725694206b2e3e44
   BatchFirebaseDispatcher: 1711b32884f4b6b3513553beab4c766056794ae1
-  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
+  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
   CodePush: d892f13c5012e9e2cb36640f4929654b7be21fe5
-  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
+  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 23d8c5470c648a635893dc0956c6dbaead54b656
   Firebase: 3435bc66b4d494c2f22c79fd3aae4c1db6662327
@@ -2686,8 +2705,8 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 1c6135e8a094cc6368949f5faeeca7ee8948b8aa
   FirebaseSessions: eaa8ec037e7793769defe4201c20bd4d976f9677
   FirebaseSharedSwift: aca73668bc95e8efccb618e0167eab05d19d3a75
-  fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
+  fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
+  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   GoogleAppMeasurement: 0dfca1a4b534d123de3945e28f77869d10d0d600
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
@@ -2778,7 +2797,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 9b3704075c2fe8fd7c739779655fb88700a1ca30
   ReactCodegen: 4ade497e5e62c9969da87fa6c845a7c301fe550a
   ReactCommon: 7f91538e91d390ebffd7238c8e47e3db8ee0f6a8
-  RNBatchPush: a6b97b7f58ddd26b1de82a0ab843bc6c947ffce4
+  RNBatchPush: 05ea7f247d971abea8a6464641b41b0f14c6e229
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
   RNCClipboard: de1561c12ba8a15f143347993a382c6474c0d2d6
   RNDeviceInfo: b899ce37a403a4dea52b7cb85e16e49c04a5b88e

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1995,8 +1995,6 @@ PODS:
     - Firebase/RemoteConfig (= 11.13.0)
     - React-Core
     - RNFBApp
-  - RNFlashList (1.6.4):
-    - React-Core
   - RNGestureHandler (2.26.0):
     - DoubleConversion
     - glog
@@ -2393,7 +2391,6 @@ DEPENDENCIES:
   - "RNFBFirestore (from `../node_modules/@react-native-firebase/firestore`)"
   - "RNFBPerf (from `../node_modules/@react-native-firebase/perf`)"
   - "RNFBRemoteConfig (from `../node_modules/@react-native-firebase/remote-config`)"
-  - "RNFlashList (from `../node_modules/@shopify/flash-list`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - "RNGoogleSignin (from `../node_modules/@react-native-google-signin/google-signin`)"
   - RNKeychain (from `../node_modules/react-native-keychain`)
@@ -2648,8 +2645,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-firebase/perf"
   RNFBRemoteConfig:
     :path: "../node_modules/@react-native-firebase/remote-config"
-  RNFlashList:
-    :path: "../node_modules/@shopify/flash-list"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNGoogleSignin:
@@ -2813,7 +2808,6 @@ SPEC CHECKSUMS:
   RNFBFirestore: fa1739cc4dc22aff2cc384808a963e809802d956
   RNFBPerf: c32ec64522c2e4d81d1562747809314e9050b75f
   RNFBRemoteConfig: 1bd86986a8372a52c95c00d83d73c44a3d61f31d
-  RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b
   RNGestureHandler: 6bd728f386096ebb26670b4dd6a604a67b14f65d
   RNGoogleSignin: a6a612cce56a45ab701c5c5c6e36f5390522d100
   RNKeychain: 4f63aada75ebafd26f4bc2c670199461eab85d94

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "dependencies": {
     "@algolia/client-search": "^4.24.0",
     "@bam.tech/react-native-config": "^1.4.5",
-    "@batch.com/react-native-plugin": "9.0.2",
+    "@batch.com/react-native-plugin": "10.1.2",
     "@emotion/is-prop-valid": "^1.3.1",
     "@gorhom/bottom-sheet": "^4",
     "@hookform/resolvers": "^2.9.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3665,12 +3665,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@batch.com/react-native-plugin@npm:9.0.2":
-  version: 9.0.2
-  resolution: "@batch.com/react-native-plugin@npm:9.0.2"
+"@batch.com/react-native-plugin@npm:10.1.2":
+  version: 10.1.2
+  resolution: "@batch.com/react-native-plugin@npm:10.1.2"
   peerDependencies:
     react-native: "*"
-  checksum: 895fa1539f48ffc44818b2ba93ca99346a49d5fa0296a292cee838178d9cd7a246fff30f7a43d2ef8b9ca6dc6d6f0a8ea59bf1b9b54b4adcaa1c1ffd8c664874
+  checksum: 9411b791814c8e829a60ccb6d89e32a19b491e28db1c049fa0e763dbf1dab9f325cc7b56ffe2b0f04b534eb1cc73d8167e692dfceb1119bc6b72fb29f8912ed7
   languageName: node
   linkType: hard
 
@@ -11091,7 +11091,7 @@ __metadata:
     "@babel/runtime": ^7.26.10
     "@bam.tech/eslint-plugin": ^1.0.1
     "@bam.tech/react-native-config": ^1.4.5
-    "@batch.com/react-native-plugin": 9.0.2
+    "@batch.com/react-native-plugin": 10.1.2
     "@chanzuckerberg/axe-storybook-testing": ^9.0.0
     "@chromatic-com/storybook": ^4.0.1
     "@emotion/is-prop-valid": ^1.3.1


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36894

## Established test plan:
- Update Batch with yarn
- Start an Android emulator in testing
- Copy the Batch installation ID
- In the [Batch testing env debug section](https://dashboard.batch.com/19363/projects/2pn8IHk/apps/35875/settings/debug), paste the Batch installation ID
- Press the "Send push test" button
- See if you have the notification on your Android emulator
- If successful, we consider the update is working

Repeat the same process on an iOS simulator.

<img width="407" height="749" alt="image" src="https://github.com/user-attachments/assets/16df0a18-7fe5-434c-b921-e467005d84f5" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-12 at 16 26 02" src="https://github.com/user-attachments/assets/3b38bbd8-3d28-4fed-89a0-86c2dd6967a5" />

## Difficulties met when testing
- When trying to send the debug push on Android, I got an error:
```
Push test has failed This push token was registered with a Sender ID that doesn't match this authorization key
```
- I tried to check the testing push config but I have an "Access Denied - You don't have access to this page"
- After asking for the admin rights to Valentine from marketing, I was able to see the testing push config (the thing that was strange is that I didn't have any issue to view the production push config, but without the admin rights I couldn't access the testing push config)
- I saw that the batch testing push config had the production firebase config for some reason, this must have been mistakenly done when the firebase split was done.
- I wanted to generate the firebase config to give to batch but didn't have the rights.
- Louis (DevOps) [did the necessary commit](https://passcultureteam.slack.com/archives/C07E6NSM7H7/p1753974836916789) to generate a firebase config with terraform. He put the generated files for testing and staging in our secret manager (keeper)
- After passing the firebase testing config to the batch testing push config I was able to get the debug push to work.
- We won't have the same issues on iOS as it would seem Batch is configured to talk to APNS directly. Android is FCM which uses firebase.

## Checklist

I have:

- [x] Made sure my feature is working on android emulator.
- [x] Made sure my feature is working on ios simulator. 

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
