### PR TITLE
(PC-37339) fix(offer): display YouTube player on web

### DIFF
--- a/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
@@ -226,6 +226,8 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
             style={
               {
                 "backgroundColor": "#161617",
+                "height": 421.875,
+                "width": 750,
               }
             }
             width={750}

--- a/src/features/home/components/modules/video/YoutubePlayer/YoutubePlayer.tsx
+++ b/src/features/home/components/modules/video/YoutubePlayer/YoutubePlayer.tsx
@@ -110,12 +110,14 @@ export const YoutubePlayer = forwardRef(function YoutubePlayer(
 })
 
 const Container = styled.View.attrs<{ height: number; width?: number | string }>(
-  ({ height, width = '100%' }) => ({
+  ({ height, width }) => ({
     height,
-    width,
+    width: width ?? '100%',
   })
-)<{ height: number; width?: number | string }>(({ theme }) => ({
+)<{ height: number; width?: number | string }>(({ theme, width, height }) => ({
   backgroundColor: theme.designSystem.color.background.lockedInverted,
+  width,
+  height,
 }))
 
 const ThumbnailOverlay = styled(View)({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37339

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |<img width="438" height="881" alt="Capture d’écran 2025-08-11 à 15 16 08" src="https://github.com/user-attachments/assets/4f992c2d-bd56-4dc6-b11c-e67720698103" /> <img width="462" height="929" alt="Capture d’écran 2025-08-11 à 15 16 24" src="https://github.com/user-attachments/assets/588cc1f9-dbe3-4bbe-9d60-467ae868d802" />|
| Android          |               |<img width="433" height="888" alt="Capture d’écran 2025-08-11 à 15 15 40" src="https://github.com/user-attachments/assets/e6a08b4f-4d19-40fd-a010-e6d4c7ca6639" /> <img width="423" height="896" alt="Capture d’écran 2025-08-11 à 15 15 47" src="https://github.com/user-attachments/assets/754d3182-bc95-4316-bb08-57ee9e1e508a" />|
| Phone - Chrome   |<img width="394" height="688" alt="Capture d’écran 2025-08-11 à 15 13 16" src="https://github.com/user-attachments/assets/7397820f-287d-4b79-aece-46fb631a5a8d" /> <img width="393" height="685" alt="Capture d’écran 2025-08-11 à 15 13 23" src="https://github.com/user-attachments/assets/2dc209ac-e660-4d10-b4bf-e1b159f9c591" />|<img width="390" height="678" alt="Capture d’écran 2025-08-11 à 15 14 54" src="https://github.com/user-attachments/assets/7576d1c7-8ce6-4449-8543-df06fb78b93a" /> <img width="390" height="686" alt="Capture d’écran 2025-08-11 à 15 14 48" src="https://github.com/user-attachments/assets/52ffe11f-7613-4a43-9774-7c24dd56a4f8" />|
| Desktop - Chrome |<img width="1725" height="878" alt="Capture d’écran 2025-08-11 à 15 12 33" src="https://github.com/user-attachments/assets/04bcb4e7-ee0c-4223-8f2c-81c2952ac354" /> <img width="1724" height="878" alt="Capture d’écran 2025-08-11 à 15 12 41" src="https://github.com/user-attachments/assets/36fdeb00-a3f1-44cb-8cf3-543a231f3b16" />|<img width="1914" height="930" alt="Capture d’écran 2025-08-11 à 15 15 07" src="https://github.com/user-attachments/assets/eaeb1440-bbfa-4e57-bc0a-8597c8b82059" /> <img width="1914" height="934" alt="Capture d’écran 2025-08-11 à 15 15 15" src="https://github.com/user-attachments/assets/2d065980-de4a-4872-9102-44f659e58357" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
