### PR TITLE
(PC-37217) feat(location): use approximative geolocation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>

--- a/ios/PassCulture/Info.plist
+++ b/ios/PassCulture/Info.plist
@@ -141,5 +141,7 @@
 	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSLocationDefaultAccuracyReduced</key>
+	<true/>
 </dict>
 </plist>

--- a/src/libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.android.test.ts
+++ b/src/libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.android.test.ts
@@ -1,50 +1,39 @@
 /* eslint-disable local-rules/independent-mocks */
 import { Platform } from 'react-native'
-import { checkMultiple, Permission, PERMISSIONS } from 'react-native-permissions'
+import * as RNPermissions from 'react-native-permissions'
 
 import { checkGeolocPermission } from 'libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.android'
-import { GeolocPermissionState } from 'libs/location/geolocation/enums'
 
-type PermissionValue = 'unavailable' | 'blocked' | 'denied' | 'granted' | 'limited'
-type Permissions = Record<Permission, PermissionValue>
-jest.mock('react-native-permissions', () => ({
-  checkMultiple: jest.fn(),
-  PERMISSIONS: {
-    ANDROID: {
-      ACCESS_FINE_LOCATION: 'android.permission.ACCESS_FINE_LOCATION',
-      ACCESS_COARSE_LOCATION: 'android.permission.ACCESS_COARSE_LOCATION',
-    },
-  },
-}))
-const mockCheckMultiple = jest.mocked(checkMultiple)
+const permissionsCheckSpy = jest.spyOn(RNPermissions, 'check')
 
 describe('checkGeolocPermission()', () => {
   Platform.OS = 'android'
 
-  it.each`
-    ACCESS_FINE_LOCATION | ACCESS_COARSE_LOCATION | expectedState
-    ${'granted'}         | ${'granted'}           | ${GeolocPermissionState.GRANTED}
-    ${'granted'}         | ${'denied'}            | ${GeolocPermissionState.GRANTED}
-    ${'denied'}          | ${'granted'}           | ${GeolocPermissionState.GRANTED}
-    ${'denied'}          | ${'denied'}            | ${GeolocPermissionState.NEVER_ASK_AGAIN}
-  `(
-    'should return $expectedState when ACCESS_FINE_LOCATION=$ACCESS_FINE_LOCATION and ACCESS_COARSE_LOCATION=$ACCESS_COARSE_LOCATION',
-    async ({
-      ACCESS_FINE_LOCATION,
-      ACCESS_COARSE_LOCATION,
-      expectedState,
-    }: {
-      ACCESS_FINE_LOCATION: PermissionValue
-      ACCESS_COARSE_LOCATION: PermissionValue
-      expectedState: GeolocPermissionState
-    }) => {
-      mockCheckMultiple.mockResolvedValue({
-        [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION]: ACCESS_FINE_LOCATION,
-        [PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION]: ACCESS_COARSE_LOCATION,
-      } as Permissions)
-      const permission = await checkGeolocPermission()
+  it('should return granted when COARSE_LOCATION permission is granted', async () => {
+    permissionsCheckSpy.mockResolvedValueOnce('granted')
+    const permission = await checkGeolocPermission()
 
-      expect(permission).toEqual(expectedState)
-    }
-  )
+    expect(permission).toEqual('granted')
+  })
+
+  it('should return never_ask_again when COARSE_LOCATION permission is denied', async () => {
+    permissionsCheckSpy.mockResolvedValueOnce('denied')
+    const permission = await checkGeolocPermission()
+
+    expect(permission).toEqual('never_ask_again')
+  })
+
+  it('should return never_ask_again when COARSE_LOCATION permission is blocked', async () => {
+    permissionsCheckSpy.mockResolvedValueOnce('blocked')
+    const permission = await checkGeolocPermission()
+
+    expect(permission).toEqual('never_ask_again')
+  })
+
+  it('should return never_ask_again when COARSE_LOCATION permission is unavailable', async () => {
+    permissionsCheckSpy.mockResolvedValueOnce('unavailable')
+    const permission = await checkGeolocPermission()
+
+    expect(permission).toEqual('never_ask_again')
+  })
 })

--- a/src/libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.android.test.ts
+++ b/src/libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.android.test.ts
@@ -2,6 +2,7 @@
 import { Platform } from 'react-native'
 import * as RNPermissions from 'react-native-permissions'
 
+import { GeolocPermissionState } from 'libs/location'
 import { checkGeolocPermission } from 'libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.android'
 
 const permissionsCheckSpy = jest.spyOn(RNPermissions, 'check')
@@ -13,27 +14,27 @@ describe('checkGeolocPermission()', () => {
     permissionsCheckSpy.mockResolvedValueOnce('granted')
     const permission = await checkGeolocPermission()
 
-    expect(permission).toEqual('granted')
+    expect(permission).toEqual(GeolocPermissionState.GRANTED)
   })
 
   it('should return never_ask_again when COARSE_LOCATION permission is denied', async () => {
     permissionsCheckSpy.mockResolvedValueOnce('denied')
     const permission = await checkGeolocPermission()
 
-    expect(permission).toEqual('never_ask_again')
+    expect(permission).toEqual(GeolocPermissionState.NEVER_ASK_AGAIN)
   })
 
   it('should return never_ask_again when COARSE_LOCATION permission is blocked', async () => {
     permissionsCheckSpy.mockResolvedValueOnce('blocked')
     const permission = await checkGeolocPermission()
 
-    expect(permission).toEqual('never_ask_again')
+    expect(permission).toEqual(GeolocPermissionState.NEVER_ASK_AGAIN)
   })
 
   it('should return never_ask_again when COARSE_LOCATION permission is unavailable', async () => {
     permissionsCheckSpy.mockResolvedValueOnce('unavailable')
     const permission = await checkGeolocPermission()
 
-    expect(permission).toEqual('never_ask_again')
+    expect(permission).toEqual(GeolocPermissionState.NEVER_ASK_AGAIN)
   })
 })

--- a/src/libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.android.ts
+++ b/src/libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.android.ts
@@ -1,18 +1,12 @@
-import { checkMultiple, PERMISSIONS } from 'react-native-permissions'
+import { check, PERMISSIONS } from 'react-native-permissions'
 
-import { GeolocPermissionState } from 'libs/location/geolocation/enums'
 import { ReadGeolocPermission } from 'libs/location/types'
 
+import { GeolocPermissionState } from '../enums'
+
 export const checkGeolocPermission: ReadGeolocPermission = async () => {
-  const permissions = await checkMultiple([
-    PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
-    PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION,
-  ])
-  const finePermission = permissions[PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION]
-  const coarsePermission = permissions[PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION]
-  if (finePermission === 'granted' || coarsePermission === 'granted')
-    return GeolocPermissionState.GRANTED
-  // on Android, we only have access to information actived: yes/no
-  // in that case 'no', we want to display our custom modale, so we return NEVER_ASK_AGAIN
-  return GeolocPermissionState.NEVER_ASK_AGAIN
+  const status = await check(PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION)
+  return status === 'granted'
+    ? GeolocPermissionState.GRANTED
+    : GeolocPermissionState.NEVER_ASK_AGAIN
 }

--- a/src/libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.android.ts
+++ b/src/libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.android.ts
@@ -1,3 +1,4 @@
+import { PermissionsAndroid } from 'react-native'
 import { check, PERMISSIONS } from 'react-native-permissions'
 
 import { ReadGeolocPermission } from 'libs/location/types'
@@ -6,7 +7,7 @@ import { GeolocPermissionState } from '../enums'
 
 export const checkGeolocPermission: ReadGeolocPermission = async () => {
   const status = await check(PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION)
-  return status === 'granted'
+  return status === PermissionsAndroid.RESULTS.GRANTED
     ? GeolocPermissionState.GRANTED
     : GeolocPermissionState.NEVER_ASK_AGAIN
 }

--- a/src/libs/location/geolocation/requestGeolocPermission/requestGeolocPermission.android.test.ts
+++ b/src/libs/location/geolocation/requestGeolocPermission/requestGeolocPermission.android.test.ts
@@ -1,34 +1,27 @@
-import { Permission, PermissionsAndroid, PermissionStatus, Platform } from 'react-native'
+import { PermissionsAndroid, Platform } from 'react-native'
 
 import { GeolocPermissionState } from '../enums'
 
 import { requestGeolocPermission } from './requestGeolocPermission.android'
 
+const requestSpy = jest.spyOn(PermissionsAndroid, 'request')
+
 describe('requestGeolocPermission android', () => {
   beforeAll(() => (Platform.OS = 'android'))
 
   it('should ask for android permission and return right state if granted', async () => {
-    // eslint-disable-next-line local-rules/independent-mocks
-    jest.spyOn(PermissionsAndroid, 'requestMultiple').mockResolvedValue({
-      'android.permission.ACCESS_FINE_LOCATION': 'granted',
-      'android.permission.ACCESS_COARSE_LOCATION': 'granted',
-    } as { [key in Permission]: PermissionStatus })
+    requestSpy.mockResolvedValueOnce(PermissionsAndroid.RESULTS.GRANTED)
 
     const permissionState = await requestGeolocPermission()
 
-    expect(PermissionsAndroid.requestMultiple).toHaveBeenCalledWith([
-      PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
-      PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION,
-    ])
+    expect(PermissionsAndroid.request).toHaveBeenCalledWith(
+      PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION
+    )
     expect(permissionState).toEqual(GeolocPermissionState.GRANTED)
   })
 
   it('should return right state if permission not granted', async () => {
-    // eslint-disable-next-line local-rules/independent-mocks
-    jest.spyOn(PermissionsAndroid, 'requestMultiple').mockResolvedValue({
-      'android.permission.ACCESS_FINE_LOCATION': 'denied',
-      'android.permission.ACCESS_COARSE_LOCATION': 'denied',
-    } as { [key in Permission]: PermissionStatus })
+    requestSpy.mockResolvedValueOnce(PermissionsAndroid.RESULTS.DENIED)
 
     const permissionState = await requestGeolocPermission()
 
@@ -36,11 +29,7 @@ describe('requestGeolocPermission android', () => {
   })
 
   it('should return right state if permission not granted and ask for never_ask_again', async () => {
-    // eslint-disable-next-line local-rules/independent-mocks
-    jest.spyOn(PermissionsAndroid, 'requestMultiple').mockResolvedValue({
-      'android.permission.ACCESS_FINE_LOCATION': 'never_ask_again',
-      'android.permission.ACCESS_COARSE_LOCATION': 'never_ask_again',
-    } as { [key in Permission]: PermissionStatus })
+    requestSpy.mockResolvedValueOnce(PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN)
 
     const permissionState = await requestGeolocPermission()
 

--- a/src/libs/location/geolocation/requestGeolocPermission/requestGeolocPermission.android.ts
+++ b/src/libs/location/geolocation/requestGeolocPermission/requestGeolocPermission.android.ts
@@ -4,26 +4,17 @@ import { AskGeolocPermission } from 'libs/location/types'
 
 import { GeolocPermissionState } from '../enums'
 
-const ACCESS_FINE_LOCATION = 'android.permission.ACCESS_FINE_LOCATION'
-const ACCESS_COARSE_LOCATION = 'android.permission.ACCESS_COARSE_LOCATION'
+export const requestGeolocPermission: AskGeolocPermission = async () => {
+  const status = await PermissionsAndroid.request(
+    PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION
+  )
 
-const requestGeolocPermissionSystem: AskGeolocPermission = async () => {
-  const permissions = await PermissionsAndroid.requestMultiple([
-    ACCESS_FINE_LOCATION,
-    ACCESS_COARSE_LOCATION,
-  ])
-  if (
-    permissions[ACCESS_FINE_LOCATION] === 'granted' ||
-    permissions[ACCESS_COARSE_LOCATION] === 'granted'
-  ) {
-    return GeolocPermissionState.GRANTED
-  } else if (
-    permissions[ACCESS_FINE_LOCATION] === 'never_ask_again' ||
-    permissions[ACCESS_COARSE_LOCATION] === 'never_ask_again'
-  ) {
-    return GeolocPermissionState.NEVER_ASK_AGAIN
+  switch (status) {
+    case PermissionsAndroid.RESULTS.GRANTED:
+      return GeolocPermissionState.GRANTED
+    case PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN:
+      return GeolocPermissionState.NEVER_ASK_AGAIN
+    default:
+      return GeolocPermissionState.DENIED
   }
-  return GeolocPermissionState.DENIED
 }
-
-export const requestGeolocPermission = requestGeolocPermissionSystem


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37217

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
