### PR TITLE
(PC-34229) feat(web): update BrowserNotSupportedPage design

### DIFF
--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
 <View

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`OnboardingAgeSelectionFork should render correctly 1`] = `
 <View

--- a/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Accessibility should render correctly 1`] = `
 <View

--- a/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ProfileTutorialAgeInformationCredit /> should render correctly 1`] = `
 <View

--- a/src/cheatcodes/pages/others/CheatcodesNavigationNotScreensPages.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesNavigationNotScreensPages.tsx
@@ -8,7 +8,8 @@ import { LinkToCheatcodesScreen } from 'cheatcodes/components/LinkToCheatcodesSc
 import { CheatcodeButton } from 'cheatcodes/types'
 import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
-import { BrowserNotSupportedPage, supportedBrowsers } from 'web/SupportedBrowsersGate.web'
+import { BrowserNotSupportedPage } from 'web/BrowserNotSupportedPage.web'
+import { supportedBrowsers } from 'web/supportedBrowsers'
 
 enum Page {
   BrowserNotSupportedPage = 'BrowserNotSupportedPage',

--- a/src/ui/components/accessibility/AccessibleUnorderedList.tsx
+++ b/src/ui/components/accessibility/AccessibleUnorderedList.tsx
@@ -16,12 +16,10 @@ export const AccessibleUnorderedList: FC<Props> = ({ items, Separator }) => {
     <StyledVerticalUl>
       {items.map((item, index) => {
         return (
-          <React.Fragment key={index}>
-            <Li>
-              {item}
-              {index < itemListLength - 1 && Separator}
-            </Li>
-          </React.Fragment>
+          <Li key={index}>
+            {item}
+            {index < itemListLength - 1 && Separator}
+          </Li>
         )
       })}
     </StyledVerticalUl>

--- a/src/web/BrowserNotSupportedPage.web.tsx
+++ b/src/web/BrowserNotSupportedPage.web.tsx
@@ -1,0 +1,147 @@
+import React from 'react'
+// eslint-disable-next-line no-restricted-imports
+import { browserName } from 'react-device-detect'
+import { ScrollView } from 'react-native'
+import styled from 'styled-components/native'
+
+import { getPrimaryIllustration } from 'shared/illustrations/getPrimaryIllustration'
+import { AccessibleUnorderedList } from 'ui/components/accessibility/AccessibleUnorderedList'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { PageNotFound } from 'ui/svg/icons/PageNotFound'
+import { Validate } from 'ui/svg/icons/Validate'
+import { Spacer, Typo } from 'ui/theme'
+import { LINE_BREAK } from 'ui/theme/constants'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { supportedBrowsers } from 'web/supportedBrowsers'
+
+type SupportedBrowsers = typeof supportedBrowsers
+type BrowserMessageKey = 'NOT_SUPPORTED' | 'OUTDATED'
+
+const browserMessages: Record<
+  BrowserMessageKey,
+  (browserName: string) => { title: string; description: string; recommendation: string }
+> = {
+  NOT_SUPPORTED: (name) => ({
+    title: `Oups\u00a0!${LINE_BREAK}${name} n’est pas supporté`,
+    description:
+      'Ton navigateur ne permet pas d’afficher correctement l’application. Voici ceux que nous recommandons pour profiter pleinement du pass Culture\u00a0:',
+    recommendation:
+      'Pour profiter pleinement du pass Culture, utilise un navigateur compatible ou mets-le à jour dans tes paramètres.',
+  }),
+  OUTDATED: (name) => ({
+    title: `Oups\u00a0!${LINE_BREAK}${name} n’est pas à jour`,
+    description:
+      'Ton navigateur n’est pas à jour et l’application ne s’affiche pas correctement. Voici ceux que nous recommandons\u00a0:',
+    recommendation:
+      'Pour une expérience optimale, mets-le à jour depuis les paramètres et profite pleinement du pass Culture\u00a0!',
+  }),
+}
+
+export const BrowserNotSupportedPage: React.FC<{
+  browserVersion: number
+  supportedBrowsers: SupportedBrowsers
+  onPress: () => void
+}> = ({ browserVersion, supportedBrowsers, onPress }) => {
+  const Illustration = getPrimaryIllustration(PageNotFound)
+
+  const isBrowserSupported = browserName in supportedBrowsers
+  const minSupportedVersion = isBrowserSupported ? supportedBrowsers[browserName] : undefined
+  const isUpToDate = isBrowserSupported && browserVersion >= (minSupportedVersion ?? 0)
+
+  let messageKey: BrowserMessageKey | null = null
+  if (!isBrowserSupported) messageKey = 'NOT_SUPPORTED'
+  else if (!isUpToDate) messageKey = 'OUTDATED'
+  const message = messageKey ? browserMessages[messageKey](browserName) : null
+
+  return (
+    <Root>
+      <ContentScroll>
+        {Illustration ? (
+          <IllustrationContainer>
+            <Illustration />
+          </IllustrationContainer>
+        ) : null}
+
+        <TextContainer gap={4}>
+          <StyledTitle2 {...getHeadingAttrs(1)}>{message?.title}</StyledTitle2>
+          <Typo.Body {...getHeadingAttrs(2)}>{message?.description}</Typo.Body>
+
+          <AccessibleUnorderedList
+            Separator={<Spacer.Column numberOfSpaces={2} />}
+            items={Object.entries(supportedBrowsers).map(([browser, version]) => {
+              let displayedMessage = `${browser}`
+              if (version > 0) displayedMessage += ` (version ≥ ${version})`
+              return (
+                <ListContainer key={browser} gap={2}>
+                  <ValidateIcon />
+                  <Typo.Body>{displayedMessage}</Typo.Body>
+                </ListContainer>
+              )
+            })}
+          />
+
+          <Typo.BodyAccentS>{message?.recommendation}</Typo.BodyAccentS>
+        </TextContainer>
+      </ContentScroll>
+
+      <ButtonContainer>
+        <ButtonPrimary wording="Continuer sans mettre à jour" onPress={onPress} numberOfLines={2} />
+      </ButtonContainer>
+    </Root>
+  )
+}
+
+const Root = styled.View(({ theme }) => ({
+  height: '100%',
+  backgroundColor: theme.designSystem.color.background.default,
+  alignItems: 'center',
+}))
+
+const ContentScroll = styled(ScrollView).attrs(({ theme }) => ({
+  contentContainerStyle: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: theme.contentPage.marginHorizontal,
+    paddingTop: theme.contentPage.marginVertical,
+    paddingBottom: theme.illustrations.sizes.medium,
+  },
+}))``
+
+const IllustrationContainer = styled.View(({ theme }) => ({
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginBottom: theme.designSystem.size.spacing.m,
+}))
+
+const StyledTitle2 = styled(Typo.Title2)({
+  textAlign: 'center',
+})
+
+const ValidateIcon = styled(Validate).attrs(({ theme }) => ({
+  color: theme.designSystem.color.icon.subtle,
+  size: theme.icons.sizes.extraSmall,
+}))``
+
+const TextContainer = styled(ViewGap)(({ theme }) => ({
+  marginBottom: theme.designSystem.size.spacing.xxl,
+  maxWidth: theme.contentPage.maxWidth,
+}))
+
+const ListContainer = styled(ViewGap)(({ theme }) => ({
+  flexDirection: 'row',
+  alignItems: 'center',
+  paddingHorizontal: theme.designSystem.size.spacing.xl,
+}))
+
+const ButtonContainer = styled.View(({ theme }) => ({
+  position: 'absolute',
+  bottom: 0,
+  left: 0,
+  right: 0,
+  alignItems: 'center',
+  width: '100%',
+  paddingVertical: theme.contentPage.marginVertical,
+  paddingHorizontal: theme.contentPage.marginHorizontal,
+}))

--- a/src/web/SupportedBrowsersGate.web.test.tsx
+++ b/src/web/SupportedBrowsersGate.web.test.tsx
@@ -31,9 +31,7 @@ describe('SupportedBrowsersGate', () => {
       render(<SupportedBrowsersGate />)
 
       expect(
-        screen.queryByText(
-          `Oups ! Nous ne pouvons afficher correctement l’application car ton navigateur (${currentbrowserName} v${currentMinimalSupportedVersion}) n’est pas à jour`
-        )
+        screen.queryByText(`Oups ! ${currentbrowserName} n’est pas à jour`)
       ).not.toBeInTheDocument()
     })
 
@@ -43,11 +41,7 @@ describe('SupportedBrowsersGate', () => {
 
       render(<SupportedBrowsersGate />)
 
-      expect(
-        screen.getByText(
-          `Oups ! Nous ne pouvons afficher correctement l’application car ton navigateur (${currentbrowserName} v${unsupportedVersion}) n’est pas à jour`
-        )
-      ).toBeInTheDocument()
+      expect(screen.getByText(`Oups ! ${currentbrowserName} n’est pas à jour`)).toBeInTheDocument()
     })
   })
 })

--- a/src/web/SupportedBrowsersGate.web.tsx
+++ b/src/web/SupportedBrowsersGate.web.tsx
@@ -1,24 +1,9 @@
 import React, { PropsWithChildren } from 'react'
 // eslint-disable-next-line no-restricted-imports
 import { browserName, browserVersion } from 'react-device-detect'
-import { ScrollView, ViewStyle } from 'react-native'
-import styled from 'styled-components/native'
 
-import { ButtonSecondary } from 'ui/components/buttons/ButtonSecondary'
-import { Li } from 'ui/components/Li'
-import { VerticalUl } from 'ui/components/Ul'
-import { ViewGap } from 'ui/components/ViewGap/ViewGap'
-import { getSpacing, Typo } from 'ui/theme'
-
-// The following list was made manually using SauceLab. If it's been a while, feel free to make a new audit to update this list.
-export const supportedBrowsers = {
-  Chrome: 80,
-  Firefox: 80,
-  Edge: 80,
-  Safari: 14,
-} as const
-
-type SupportedBrowsers = typeof supportedBrowsers
+import { BrowserNotSupportedPage } from 'web/BrowserNotSupportedPage.web'
+import { supportedBrowsers } from 'web/supportedBrowsers'
 
 const isBrowserSupported = () =>
   Object.entries(supportedBrowsers).some(
@@ -27,7 +12,6 @@ const isBrowserSupported = () =>
 
 export const SupportedBrowsersGate: React.FC<PropsWithChildren> = ({ children }) => {
   const userbrowserVersion = Number(browserVersion)
-
   const [shouldDisplayApp, setShouldDisplayApp] = React.useState(() => isBrowserSupported())
 
   if (!shouldDisplayApp) {
@@ -41,82 +25,3 @@ export const SupportedBrowsersGate: React.FC<PropsWithChildren> = ({ children })
   }
   return <React.Fragment>{children}</React.Fragment>
 }
-
-export const BrowserNotSupportedPage: React.FC<{
-  browserVersion: number
-  supportedBrowsers: SupportedBrowsers
-  onPress: () => void
-}> = ({ browserVersion, supportedBrowsers, onPress }) => {
-  const title = `Oups\u00a0! Nous ne pouvons afficher correctement l’application car ton navigateur (${browserName} v${browserVersion}) n’est pas à jour`
-  return (
-    <ScrollView contentContainerStyle={contentContainerStyle}>
-      <Container>
-        <ViewGap gap={5}>
-          <Title>{title}</Title>
-          <Typo.Body>
-            Nous ne supportons pas certaines versions et/ou navigateurs qui ne permettraient pas une
-            expérience optimale.
-          </Typo.Body>
-          <Typo.Body>
-            Voici ceux que nous te conseillons pour profiter pleinement du pass Culture&nbsp;:
-          </Typo.Body>
-        </ViewGap>
-        <VerticalUl>
-          {Object.entries(supportedBrowsers).map(([browser, version]) => {
-            let displayedMessage = `- ${browser}`
-            if (version > 0) {
-              displayedMessage += ` (version > ${version})`
-            }
-            return (
-              <Li key={browser}>
-                <StyledBody>{displayedMessage}</StyledBody>
-              </Li>
-            )
-          })}
-        </VerticalUl>
-        <StyledViewGap gap={4}>
-          <Typo.BodyAccent>
-            Mets vite à jour ton navigateur en allant dans les paramètres&nbsp;!
-          </Typo.BodyAccent>
-          <Typo.BodyAccentXs>
-            Tu peux néanmoins accèder au pass Culture, sans mettre à jour ton navigateur, avec le
-            risque de ne pas bénéficier d’une expérience optimale&nbsp;:
-          </Typo.BodyAccentXs>
-        </StyledViewGap>
-        <ButtonSecondary
-          wording="Continuer quand même"
-          onPress={onPress}
-          buttonHeight="tall"
-          numberOfLines={2}
-        />
-      </Container>
-    </ScrollView>
-  )
-}
-
-const contentContainerStyle: ViewStyle = {
-  height: '100%',
-  width: '100%',
-  justifyContent: 'center',
-  alignItems: 'center',
-}
-
-const Container = styled.View({
-  flexDirection: 'column',
-  alignItems: 'center',
-  maxWidth: 520,
-  padding: getSpacing(6),
-})
-
-const Title = styled(Typo.Title3)({
-  textAlign: 'center',
-})
-
-const StyledBody = styled(Typo.Body)({
-  padding: getSpacing(5),
-})
-
-const StyledViewGap = styled(ViewGap)({
-  marginTop: getSpacing(5),
-  marginBottom: getSpacing(3),
-})

--- a/src/web/supportedBrowsers.ts
+++ b/src/web/supportedBrowsers.ts
@@ -1,0 +1,7 @@
+// The following list was made manually using SauceLab. If it's been a while, feel free to make a new audit to update this list.
+export const supportedBrowsers = {
+  Chrome: 80,
+  Firefox: 80,
+  Edge: 80,
+  Safari: 14,
+} as const


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34229

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |   <img width="500" height="998" alt="Capture d’écran 2025-08-13 à 18 05 52" src="https://github.com/user-attachments/assets/59e891c6-8c7f-4ab4-8312-3fd3166e506b" />   |   <img width="501" height="998" alt="Capture d’écran 2025-08-13 à 16 34 59" src="https://github.com/user-attachments/assets/8dd260cd-339f-468b-aa80-55d6f1e56c24" />   |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
