### PR TITLE
(PC-37430) chore(deps): bump lottie-react-native

### DIFF
--- a/ios/AppDelegate.mm
+++ b/ios/AppDelegate.mm
@@ -63,10 +63,8 @@
 
     // register LottieSplashScreen to RNSplashScreen
     [RNSplashScreen showLottieSplash:animationUIView inRootView:rootView];
-    // casting UIView type to AnimationView type
-    AnimationView *animationView = (AnimationView *) animationUIView;
     // play lottie animation
-    [t playWithAnimationView:animationView];
+    [t playWithAnimationView:animationUIView];
     // We want the animation layout to be forced to remove when hide is called, so we use this
     [RNSplashScreen setAnimationFinished:true];
   }

--- a/ios/Dynamic.swift
+++ b/ios/Dynamic.swift
@@ -4,19 +4,17 @@ import Lottie
 
 @objc class Dynamic: NSObject {
 
-  @objc func createAnimationView(rootView: UIView, lottieName: String) -> AnimationView {
-    let animationView = AnimationView(name: lottieName)
+  @objc func createAnimationView(rootView: UIView, lottieName: String) -> UIView {
+    let animationView = LottieAnimationView(name: lottieName)
     animationView.frame = rootView.frame
     animationView.center = rootView.center
     animationView.backgroundColor = UIColor.white;
     return animationView;
   }
 
-  @objc func play(animationView: AnimationView) {
-    animationView.play(
-      fromProgress: 0.0,
-      toProgress: 1.0,
-      loopMode: LottieLoopMode.loop
-    );
+  @objc func play(animationView: UIView) {
+    guard let lottieView = animationView as? LottieAnimationView else { return }
+    lottieView.loopMode = LottieLoopMode.loop
+    lottieView.play();
   }
 }

--- a/ios/PassCulture.xcodeproj/project.pbxproj
+++ b/ios/PassCulture.xcodeproj/project.pbxproj
@@ -353,6 +353,8 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/boost/boost_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/glog/glog_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/leveldb-library/leveldb_Privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/lottie-ios/LottiePrivacyInfo.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/lottie-react-native/Lottie_React_Native_Privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/nanopb/nanopb_Privacy.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
@@ -389,6 +391,8 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/boost_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/glog_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/leveldb_Privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/LottiePrivacyInfo.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Lottie_React_Native_Privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/nanopb_Privacy.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -241,10 +241,29 @@ PODS:
   - libwebp/sharpyuv (1.5.0)
   - libwebp/webp (1.5.0):
     - libwebp/sharpyuv
-  - lottie-ios (3.4.4)
-  - lottie-react-native (5.1.6):
-    - lottie-ios (~> 3.4.0)
+  - lottie-ios (4.5.0)
+  - lottie-react-native (7.3.2):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - lottie-ios (= 4.5.0)
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -2718,8 +2737,8 @@ SPEC CHECKSUMS:
   JWT: ef71dfb03e1f842081e64dc42eef0e164f35d251
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
-  lottie-ios: 8f97d3271e155c2d688875c29cd3c74908aef5f8
-  lottie-react-native: 8f9d4be452e23f6e5ca0fdc11669dc99ab52be81
+  lottie-ios: a881093fab623c467d3bce374367755c272bdd59
+  lottie-react-native: db1c1d7a2c8104b540d3712e1d27f07fc81f6beb
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "jwt-decode": "^3.1.2",
     "libphonenumber-js": "^1.12.6",
     "lodash": "^4.17.21",
-    "lottie-react-native": "5.1.6",
+    "lottie-react-native": "^7.3.2",
     "patch-package": "^8.0.0",
     "prop-types": "^15.7.2",
     "react": "18.3.1",

--- a/src/features/subscription/components/buttons/SubscribeButton.tsx
+++ b/src/features/subscription/components/buttons/SubscribeButton.tsx
@@ -39,7 +39,7 @@ export const SubscribeButton = ({ active, onPress, label, size }: Props) => {
   const AnimatedBellIcon = useCallback(
     () => (
       <StyledLottieView
-        progress={animationProgress.current}
+        progress={animationProgress.current as unknown as number}
         source={NotificationAnimation}
         loop={false}
       />

--- a/yarn.lock
+++ b/yarn.lock
@@ -11242,7 +11242,7 @@ __metadata:
     knip: ^5.43.6
     libphonenumber-js: ^1.12.6
     lodash: ^4.17.21
-    lottie-react-native: 5.1.6
+    lottie-react-native: ^7.3.2
     mailparser: ^3.6.3
     mockdate: ^3.0.2
     msw: ^2.7.3
@@ -21836,7 +21836,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lottie-react-native@npm:5.1.6, lottie-react-native@npm:^5.1.3":
+"lottie-react-native@npm:^5.1.3":
   version: 5.1.6
   resolution: "lottie-react-native@npm:5.1.6"
   dependencies:
@@ -21851,6 +21851,23 @@ __metadata:
     react-native-windows:
       optional: true
   checksum: e051e3c3e50b6d0c766895ac122cdccdd1acb76daec6eac9538a2892d8e52ab9e0b5580ab258c37d04b1924bc9962c9b8fdcced0a81d332a6076bfa045783f50
+  languageName: node
+  linkType: hard
+
+"lottie-react-native@npm:^7.3.2":
+  version: 7.3.2
+  resolution: "lottie-react-native@npm:7.3.2"
+  peerDependencies:
+    "@lottiefiles/dotlottie-react": ^0.6.5
+    react: "*"
+    react-native: ">=0.46"
+    react-native-windows: ">=0.63.x"
+  peerDependenciesMeta:
+    "@lottiefiles/dotlottie-react":
+      optional: true
+    react-native-windows:
+      optional: true
+  checksum: 60d3d1c8d4ccd998cb09b556f666167d55b0d2076be23e8cf7faf5bcf9466adaebb24f5045d2158b428df4a0a20b69a012ce340026d9d9d4db9498be54bb2ba5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
