### PR TITLE
(PC-36788) feat(home): centered trends module when max 4

### DIFF
--- a/src/features/home/components/modules/TrendsModule.native.test.tsx
+++ b/src/features/home/components/modules/TrendsModule.native.test.tsx
@@ -5,6 +5,7 @@ import { TrendsModule } from 'features/home/components/modules/TrendsModule'
 import { formattedTrendsModule } from 'features/home/fixtures/homepage.fixture'
 import * as useVenueMapStore from 'features/venueMap/store/venueMapStore'
 import { analytics } from 'libs/analytics/provider'
+import { ContentTypes } from 'libs/contentful/types'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { LocationMode } from 'libs/location/types'
 import { SuggestedPlace } from 'libs/place/types'
@@ -166,6 +167,37 @@ describe('TrendsModule', () => {
       moduleId: '6dn0unOv4tRBNfOebVHOOy',
       toEntryId: '7qcfqY5zFesLVO5fMb4cqm',
     })
+  })
+
+  it('should display static trends module when items length is less than or equal to 4', async () => {
+    renderTrendsModule()
+
+    expect(await screen.findByTestId('static-trends-module')).toBeOnTheScreen()
+  })
+
+  it('should display scrollable trends module when items length is more than 4', async () => {
+    render(
+      reactQueryProviderHOC(
+        <TrendsModule
+          {...formattedTrendsModule}
+          {...trackingProps}
+          items={[
+            ...formattedTrendsModule.items,
+            {
+              homeEntryId: '7qcfqY5zFesLVO5fMb4cqm',
+              id: '16ZgVwnOXvVc0N8ko9Kius',
+              image: {
+                uri: 'https://images.ctfassets.net/2bg01iqy0isv/635psakQQwLtNuOFcf1jx2/5d779586de44d247145c8808d48a91ed/recos.png',
+              },
+              title: 'Tendance 4',
+              type: ContentTypes.TREND_BLOCK,
+            },
+          ]}
+        />
+      )
+    )
+
+    expect(await screen.findByTestId('scrollable-trends-module')).toBeOnTheScreen()
   })
 })
 

--- a/src/features/home/components/modules/TrendsModule.stories.tsx
+++ b/src/features/home/components/modules/TrendsModule.stories.tsx
@@ -6,6 +6,7 @@ import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
 import { formattedTrendsModule } from 'features/home/fixtures/homepage.fixture'
+import { ContentTypes } from 'libs/contentful/types'
 import { Variants, VariantsStory, VariantsTemplate } from 'ui/storybook/VariantsTemplate'
 
 import { TrendsModule } from './TrendsModule'
@@ -33,6 +34,24 @@ const variantConfig: Variants<typeof TrendsModule> = [
   {
     label: 'TrendsModule with domain credit V3',
     props: { ...formattedTrendsModule },
+  },
+  {
+    label: 'TrendsModule with scroll view',
+    props: {
+      ...formattedTrendsModule,
+      items: [
+        ...formattedTrendsModule.items,
+        {
+          homeEntryId: '7qcfqY5zFesLVO5fMb4cqm',
+          id: '16ZgVwnOXvVc0N8ko9Kius',
+          image: {
+            uri: 'https://images.ctfassets.net/2bg01iqy0isv/635psakQQwLtNuOFcf1jx2/5d779586de44d247145c8808d48a91ed/recos.png',
+          },
+          title: 'Tendance 4',
+          type: ContentTypes.TREND_BLOCK,
+        },
+      ],
+    },
   },
 ]
 

--- a/src/features/home/components/modules/TrendsModule.tsx
+++ b/src/features/home/components/modules/TrendsModule.tsx
@@ -80,16 +80,31 @@ export const TrendsModule = ({ index, moduleId, homeEntryId, items }: Trends) =>
     }
   }
 
+  const renderTrends = (
+    items: TrendBlock[],
+    moduleId: string,
+    getNavigationProps: (props: TrendBlock) => TrendNavigationProps
+  ) =>
+    items.map((props) => (
+      <Trend key={props.title} moduleId={moduleId} {...props} {...getNavigationProps(props)} />
+    ))
+
   return (
     <React.Fragment>
-      <ScrollContainer
-        horizontal
-        isSmallScreen={isSmallScreen}
-        contentContainerStyle={{ paddingLeft: getSpacing(4) }}>
-        {items.map((props) => (
-          <Trend key={props.title} moduleId={moduleId} {...props} {...getNavigationProps(props)} />
-        ))}
-      </ScrollContainer>
+      {items.length <= 4 ? (
+        <Container isSmallScreen={isSmallScreen} testID="static-trends-module">
+          {renderTrends(items, moduleId, getNavigationProps)}
+        </Container>
+      ) : (
+        <ScrollContainer
+          horizontal
+          isSmallScreen={isSmallScreen}
+          contentContainerStyle={{ paddingLeft: getSpacing(4) }}
+          testID="scrollable-trends-module">
+          {renderTrends(items, moduleId, getNavigationProps)}
+        </ScrollContainer>
+      )}
+
       <VenueMapLocationModal
         visible={venueMapLocationModalVisible}
         dismissModal={hideVenueMapLocationModal}
@@ -111,3 +126,15 @@ const ScrollContainer = styled.ScrollView<{ isSmallScreen: boolean }>(
     }
   }
 )
+
+const Container = styled.View<{ isSmallScreen: boolean }>(({ isSmallScreen, theme }) => {
+  const mobileGap = isSmallScreen
+    ? theme.designSystem.size.spacing.xs
+    : theme.designSystem.size.spacing.s
+  return {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: theme.isDesktopViewport ? theme.designSystem.size.spacing.l : mobileGap,
+    paddingBottom: theme.home.spaceBetweenModules,
+  }
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-36788

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
