### PR TITLE
(PC-37477) fix(Modules): increase horizontal margin

### DIFF
--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1`] = `
 <View
@@ -1638,11 +1638,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                 }
               >
                 <View
-                  style={
-                    {
-                      "marginHorizontal": 24,
-                    }
-                  }
+                  style={{}}
                   testID="playlistTitle"
                 >
                   <Text

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Venue /> should match snapshot 1`] = `
 <View
@@ -745,11 +745,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                         }
                       >
                         <View
-                          style={
-                            {
-                              "marginHorizontal": 24,
-                            }
-                          }
+                          style={{}}
                           testID="playlistTitle"
                         >
                           <Text
@@ -3799,11 +3795,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                         }
                       >
                         <View
-                          style={
-                            {
-                              "marginHorizontal": 24,
-                            }
-                          }
+                          style={{}}
                           testID="playlistTitle"
                         >
                           <Text

--- a/src/features/home/components/AccessibleTitle.tsx
+++ b/src/features/home/components/AccessibleTitle.tsx
@@ -4,6 +4,13 @@ import styled from 'styled-components/native'
 
 import { Typo } from 'ui/theme'
 
+type Props = {
+  title: string
+  testID?: string
+  TitleComponent?: ComponentType<ComponentProps<typeof Typo.Title3>>
+  withMargin?: boolean
+}
+
 export const separateTitleAndEmojis = (title: string) => {
   const titleWithoutEndSpace = title.trimEnd()
   const emojiRegex = /(\p{Emoji})(?=\s*$)/gu
@@ -12,14 +19,11 @@ export const separateTitleAndEmojis = (title: string) => {
   return { titleText, titleEmoji }
 }
 
-export const AccessibleTitle = ({
+export const AccessibleTitle: React.FC<Props> = ({
   title,
   testID,
   TitleComponent = Typo.Title3,
-}: {
-  title: string
-  testID?: string
-  TitleComponent?: ComponentType<ComponentProps<typeof Typo.Title3>>
+  withMargin = true,
 }) => {
   const { width: windowWidth } = useWindowDimensions()
   const { titleText, titleEmoji } = separateTitleAndEmojis(title)
@@ -27,7 +31,7 @@ export const AccessibleTitle = ({
   const StyledTitleComponent = styled(TitleComponent || Typo.Title3)({})
 
   return Platform.OS === 'web' ? (
-    <TitleWrapper testID={testID} windowWidth={windowWidth}>
+    <TitleWrapper testID={testID} windowWidth={windowWidth} withMargin={withMargin}>
       <StyledTitleComponent numberOfLines={2}>
         {titleText}
         <span aria-hidden>{titleEmoji}</span>
@@ -43,9 +47,11 @@ export const AccessibleTitle = ({
   )
 }
 
-const TitleWrapper = styled.View<{ windowWidth?: number }>(({ windowWidth, theme }) => {
-  return {
-    marginHorizontal: theme.contentPage.marginHorizontal,
-    width: windowWidth,
+const TitleWrapper = styled.View<{ windowWidth?: number; withMargin?: boolean }>(
+  ({ windowWidth, withMargin, theme }) => {
+    return {
+      marginHorizontal: withMargin ? theme.contentPage.marginHorizontal : undefined,
+      width: windowWidth,
+    }
   }
-})
+)

--- a/src/features/home/components/modules/venues/VenuesModule.tsx
+++ b/src/features/home/components/modules/venues/VenuesModule.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect } from 'react'
+import styled from 'styled-components/native'
 
 import { VenueTile } from 'features/home/components/modules/venues/VenueTile'
 import { ModuleData } from 'features/home/types'
@@ -63,16 +64,23 @@ export const VenuesModule = ({
 
   if (!shouldModuleBeDisplayed) return null
   return (
-    <PassPlaylist
-      testID="offersModuleList"
-      title={displayParameters.title}
-      subtitle={displayParameters.subtitle}
-      data={playlistItems || []}
-      itemHeight={ITEM_HEIGHT}
-      itemWidth={ITEM_WIDTH}
-      renderItem={renderItem}
-      keyExtractor={keyExtractor}
-      tileType="venue"
-    />
+    <PlaylistContainer>
+      <PassPlaylist
+        testID="offersModuleList"
+        title={displayParameters.title}
+        subtitle={displayParameters.subtitle}
+        data={playlistItems || []}
+        itemHeight={ITEM_HEIGHT}
+        itemWidth={ITEM_WIDTH}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        tileType="venue"
+        withMargin={false}
+      />
+    </PlaylistContainer>
   )
 }
+
+const PlaylistContainer = styled.View(({ theme }) => ({
+  marginHorizontal: theme.designSystem.size.spacing.xl,
+}))

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -89,7 +89,11 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
   )
 }
 
-const StyledView = styled.View(({ theme }) => ({ paddingTop: theme.designSystem.size.spacing.l }))
+const StyledView = styled.View(({ theme }) => ({
+  paddingTop: theme.designSystem.size.spacing.l,
+  marginHorizontal: theme.designSystem.size.spacing.xl,
+}))
+
 const Container = styled.View(({ theme }) => ({
   paddingBottom: theme.home.spaceBetweenModules,
 }))

--- a/src/ui/components/PassPlaylist.tsx
+++ b/src/ui/components/PassPlaylist.tsx
@@ -34,6 +34,7 @@ type Props = Pick<
   titleSeeMoreLink?: InternalNavigationProps['navigateTo']
   playlistRef?: Ref<FlatList>
   FlatListComponent?: typeof FlashList | typeof RNGHFlatList
+  withMargin?: boolean
 }
 
 export const PassPlaylist = ({
@@ -55,6 +56,7 @@ export const PassPlaylist = ({
   testID: _testID,
   noMarginBottom,
   FlatListComponent,
+  withMargin = true,
   ...props
 }: Props) => {
   const { isTouch } = useTheme()
@@ -87,10 +89,15 @@ export const PassPlaylist = ({
     <StyledViewGap gap={4} noMarginBottom={noMarginBottom} {...props}>
       <ViewGap gap={1}>
         <StyledView>
-          <AccessibleTitle TitleComponent={TitleLevel2} testID="playlistTitle" title={title} />
+          <AccessibleTitle
+            withMargin={withMargin}
+            TitleComponent={TitleLevel2}
+            testID="playlistTitle"
+            title={title}
+          />
           {renderTitleSeeMore()}
         </StyledView>
-        {subtitle ? <StyledSubtitle>{subtitle}</StyledSubtitle> : null}
+        {subtitle ? <StyledSubtitle withMargin={withMargin}>{subtitle}</StyledSubtitle> : null}
       </ViewGap>
       <Playlist
         testID="offersModuleList"
@@ -120,10 +127,13 @@ const StyledViewGap = styled(ViewGap)<{ noMarginBottom?: boolean }>(
 
 const TitleLevel2 = styled(Typo.Title3).attrs(getHeadingAttrs(2))``
 
-const StyledSubtitle = styled(Typo.BodyAccentXs).attrs({
+const StyledSubtitle = styled(Typo.BodyAccentXs).attrs<{
+  windowWidth?: number
+  withMargin?: boolean
+}>({
   numberOfLines: 2,
-})(({ theme }) => ({
-  marginHorizontal: theme.contentPage.marginHorizontal,
+})(({ withMargin, theme }) => ({
+  marginHorizontal: withMargin ? theme.contentPage.marginHorizontal : undefined,
   color: theme.designSystem.color.text.subtle,
 }))
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37477

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome | <img width="219" height="472" alt="Capture d’écran 2025-08-21 à 12 55 19" src="https://github.com/user-attachments/assets/84472e3e-0b14-49ca-8a43-4b65f153f19b" /> | <img width="221" height="472" alt="Capture d’écran 2025-08-21 à 12 45 15" src="https://github.com/user-attachments/assets/395c929f-2698-46b0-a360-d122fc78463e" /> |
| Desktop - Chrome | <img width="223" height="475" alt="Capture d’écran 2025-08-21 à 12 54 50" src="https://github.com/user-attachments/assets/2a704364-9779-4b1a-a389-972839ed2cdf" /> | <img width="223" height="473" alt="Capture d’écran 2025-08-21 à 12 48 56" src="https://github.com/user-attachments/assets/37eae555-f46d-4974-ab58-9016693992f9" /> |




[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
