### PR TITLE
(PC-37104) refactor(venue): force venueId as string in ConsultVenue log

### DIFF
--- a/src/features/bookings/components/BookingDetailsContent.native.test.tsx
+++ b/src/features/bookings/components/BookingDetailsContent.native.test.tsx
@@ -92,7 +92,7 @@ describe('<BookingDetailsContent />', () => {
     const venueBlock = screen.getByText('Maison de la Brique')
     await user.press(venueBlock)
 
-    expect(analytics.logConsultVenue).toHaveBeenCalledWith({ venueId: 2185, from: 'bookings' })
+    expect(analytics.logConsultVenue).toHaveBeenCalledWith({ venueId: '2185', from: 'bookings' })
   })
 
   it('should not navigate to Venue page when venue is not OpenToPublic', async () => {

--- a/src/features/bookings/components/Ticket/Ticket.tsx
+++ b/src/features/bookings/components/Ticket/Ticket.tsx
@@ -59,7 +59,7 @@ export const Ticket = ({
   const venueBlockAddress = getAddress(offer.address)
 
   const handleOnSeeVenuePress = () => {
-    analytics.logConsultVenue({ venueId: offer.venue.id, from: 'bookings' })
+    analytics.logConsultVenue({ venueId: offer.venue.id.toString(), from: 'bookings' })
     navigate('Venue', { id: offer.venue.id })
   }
   const expirationDateFormated = ({ prefix }: { prefix: string }) => {

--- a/src/features/home/components/modules/venues/VenueTile.native.test.tsx
+++ b/src/features/home/components/modules/venues/VenueTile.native.test.tsx
@@ -5,7 +5,7 @@ import { venuesSearchFixture } from 'libs/algolia/fixtures/venuesSearchFixture'
 import { analytics } from 'libs/analytics/provider'
 import { ILocationContext, LocationMode } from 'libs/location/types'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { userEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { VenueTile, VenueTileProps } from './VenueTile'
 
@@ -57,7 +57,7 @@ describe('VenueTile component', () => {
     await user.press(screen.getByTestId(/Lieu/))
 
     expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
-      venueId: venue.id,
+      venueId: venue.id.toString(),
       from: 'home',
       moduleName: 'le nom du module',
       moduleId: 'module-id',
@@ -70,7 +70,7 @@ describe('VenueTile component', () => {
     await user.press(screen.getByTestId(/Lieu/))
 
     expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
-      venueId: venue.id,
+      venueId: venue.id.toString(),
       from: 'home',
       moduleName: 'le nom du module',
       moduleId: 'module-id',

--- a/src/features/home/components/modules/venues/VenueTile.tsx
+++ b/src/features/home/components/modules/venues/VenueTile.tsx
@@ -58,7 +58,7 @@ const UnmemoizedVenueTile = (props: VenueTileProps) => {
     // We pre-populate the query-cache with the data from the search result for a smooth transition
     queryClient.setQueryData([QueryKeys.VENUE, venue.id], mergeVenueData(venue))
     analytics.logConsultVenue({
-      venueId: venue.id,
+      venueId: venue.id.toString(),
       moduleId: props.moduleId,
       moduleName: props.moduleName,
       from: 'home',

--- a/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
@@ -417,7 +417,7 @@ describe('<OfferPlace />', () => {
       await user.press(screen.getByTestId('RightFilled'))
 
       expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
-        venueId: mockOffer.venue.id,
+        venueId: mockOffer.venue.id.toString(),
         from: 'offer',
       })
     })

--- a/src/features/offer/components/OfferPlace/OfferPlace.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.tsx
@@ -137,7 +137,7 @@ export function OfferPlace({ offer, subcategory, distance }: Readonly<OfferPlace
   const handleOnSeeVenuePress = useCallback(() => {
     // We pre-populate the query-cache with the data from the search result for a smooth transition
     queryClient.setQueryData([QueryKeys.VENUE, offer.venue.id], mergeVenueData(offer.venue))
-    analytics.logConsultVenue({ venueId: offer.venue.id, from: 'offer' })
+    analytics.logConsultVenue({ venueId: offer.venue.id.toString(), from: 'offer' })
     navigate('Venue', { id: offer.venue.id })
   }, [navigate, queryClient, offer.venue])
 

--- a/src/features/offer/components/OfferVenueButton/OfferVenueButton.native.test.tsx
+++ b/src/features/offer/components/OfferVenueButton/OfferVenueButton.native.test.tsx
@@ -42,7 +42,7 @@ describe('<OfferVenueButton />', () => {
     await user.press(screen.getByTestId('Accéder à la page du lieu PATHE BEAUGRENELLE'))
 
     expect(analytics.logConsultVenue).toHaveBeenCalledWith({
-      venueId: offerResponseSnap.venue.id,
+      venueId: offerResponseSnap.venue.id.toString(),
       from: 'offer',
     })
   })

--- a/src/features/offer/components/OfferVenueButton/OfferVenueButton.tsx
+++ b/src/features/offer/components/OfferVenueButton/OfferVenueButton.tsx
@@ -25,7 +25,9 @@ export function OfferVenueButton({ venue }: Readonly<Props>) {
         <LocationBuildingFilled color={designSystem.color.icon.default} size={icons.sizes.small} />
       }
       navigateTo={{ screen: 'Venue', params: { id: venue.id } }}
-      onBeforeNavigate={() => analytics.logConsultVenue({ venueId: venue.id, from: 'offer' })}
+      onBeforeNavigate={() =>
+        analytics.logConsultVenue({ venueId: venue.id.toString(), from: 'offer' })
+      }
       accessibilityLabel={`Accéder à la page du lieu ${venue.name}`}
     />
   )

--- a/src/features/search/components/SearchSuggestions/SearchSuggestions.tsx
+++ b/src/features/search/components/SearchSuggestions/SearchSuggestions.tsx
@@ -101,7 +101,7 @@ export const SearchSuggestions = ({
 
   const onVenuePress = (venueId: number) => {
     hideSuggestions()
-    analytics.logConsultVenue({ venueId, from: 'searchAutoComplete' })
+    analytics.logConsultVenue({ venueId: venueId.toString(), from: 'searchAutoComplete' })
     navigate('Venue', { id: venueId })
   }
 

--- a/src/features/search/components/SearchVenueItems/SearchVenueItem.native.test.tsx
+++ b/src/features/search/components/SearchVenueItems/SearchVenueItem.native.test.tsx
@@ -96,7 +96,7 @@ describe('<SearchVenueItem />', () => {
     await user.press(screen.getByTestId(/Lieu/))
 
     expect(analytics.logConsultVenue).toHaveBeenCalledWith({
-      venueId: Number(mockAlgoliaVenue.objectID),
+      venueId: mockAlgoliaVenue.objectID,
       searchId,
       from: 'searchVenuePlaylist',
     })

--- a/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
+++ b/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
@@ -61,7 +61,7 @@ const UnmemoizedSearchVenueItem = ({
 
   const handlePressVenue = () => {
     analytics.logConsultVenue({
-      venueId: Number(venue.objectID),
+      venueId: venue.objectID,
       searchId,
       from: 'searchVenuePlaylist',
     })

--- a/src/features/search/pages/SearchLanding/SearchLanding.native.test.tsx
+++ b/src/features/search/pages/SearchLanding/SearchLanding.native.test.tsx
@@ -312,7 +312,7 @@ describe('<SearchLanding />', () => {
 
       expect(analytics.logConsultVenue).toHaveBeenCalledWith({
         from: 'searchAutoComplete',
-        venueId: 1,
+        venueId: '1',
       })
     })
 

--- a/src/features/search/pages/SearchResults/SearchResults.native.test.tsx
+++ b/src/features/search/pages/SearchResults/SearchResults.native.test.tsx
@@ -328,7 +328,7 @@ describe('<SearchResults/>', () => {
 
       expect(analytics.logConsultVenue).toHaveBeenCalledWith({
         from: 'searchAutoComplete',
-        venueId: 1,
+        venueId: '1',
       })
     })
 

--- a/src/features/venue/pages/Venue/Venue.native.test.tsx
+++ b/src/features/venue/pages/Venue/Venue.native.test.tsx
@@ -189,7 +189,7 @@ describe('<Venue />', () => {
 
         await waitFor(() => {
           expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
-            venueId,
+            venueId: venueId.toString(),
             from,
           })
         })

--- a/src/features/venue/pages/Venue/Venue.tsx
+++ b/src/features/venue/pages/Venue/Venue.tsx
@@ -96,7 +96,7 @@ export const Venue: FunctionComponent = () => {
 
   useEffect(() => {
     if ((params.from === 'deeplink' || params.from === 'venueMap') && venue?.id) {
-      analytics.logConsultVenue({ venueId: venue.id, from: params.from })
+      analytics.logConsultVenue({ venueId: venue.id.toString(), from: params.from })
     }
   }, [params.from, venue?.id])
 

--- a/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.native.test.tsx
@@ -325,7 +325,7 @@ describe('VenueMapViewContainer', () => {
     ])
 
     expect(analytics.logConsultVenue).toHaveBeenCalledWith({
-      venueId: venuesFixture[0].venueId,
+      venueId: venuesFixture[0].venueId.toString(),
       from: 'venueMap',
     })
   })

--- a/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.tsx
@@ -183,7 +183,10 @@ export const VenueMapViewContainer: FunctionComponent = () => {
   }
 
   const onNavigateToVenuePress = (venueId: number) => {
-    analytics.logConsultVenue({ venueId, from: camelCase(routeName) as Referrals })
+    analytics.logConsultVenue({
+      venueId: venueId.toString(),
+      from: camelCase(routeName) as Referrals,
+    })
   }
 
   const handleBottomSheetAnimation = useCallback(

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -252,7 +252,7 @@ export const logEventAnalytics = {
   logConsultTutorial: (params: { from: string; age?: number }) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_TUTORIAL }, params),
   logConsultVenue: (params: {
-    venueId: number
+    venueId: string
     from: Referrals
     moduleName?: string
     moduleId?: string


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37104

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
