### PR TITLE
(PC-37481) feat(a11y): add accessibility role header in getHeadingAttrs()

### DIFF
--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
 [
@@ -281,6 +281,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                 testID="back-button-container"
               />
               <Text
+                accessibilityRole="header"
                 nativeID="testUuidV4"
                 numberOfLines={1}
                 style={

--- a/__snapshots__/features/achievements/pages/Achievements.native.test.tsx.native-snap
+++ b/__snapshots__/features/achievements/pages/Achievements.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Achievements/> should match snapshot 1`] = `
 <View
@@ -134,6 +134,7 @@ exports[`<Achievements/> should match snapshot 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -216,6 +217,7 @@ exports[`<Achievements/> should match snapshot 1`] = `
           >
             <View>
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ForgottenPassword /> should match snapshot 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -197,6 +198,7 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ReinitializePassword Page should match snapshot 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -257,6 +258,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
 <View
@@ -71,6 +71,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
           testID="back-button-container"
         />
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -212,6 +213,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",

--- a/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -204,6 +205,7 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",

--- a/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AcceptCgu/> should render correctly 1`] = `
 <View
@@ -10,6 +10,7 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
   }
 >
   <Text
+    accessibilityRole="header"
     style={
       {
         "color": "#161617",
@@ -660,6 +661,7 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
   }
 >
   <Text
+    accessibilityRole="header"
     style={
       {
         "color": "#161617",

--- a/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AccountCreated /> should render correctly 1`] = `
 <View
@@ -151,6 +151,7 @@ exports[`<AccountCreated /> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
         C’est pour bientôt !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`QuitSignupModal should render correctly 1`] = `
 <Modal
@@ -182,6 +182,7 @@ exports[`QuitSignupModal should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",
@@ -195,6 +196,7 @@ exports[`QuitSignupModal should render correctly 1`] = `
             Veux-tu abandonner l’inscription ?
           </Text>
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",

--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SetBirthday /> should render correctly 1`] = `
 <View
@@ -10,6 +10,7 @@ exports[`<SetBirthday /> should render correctly 1`] = `
   }
 >
   <Text
+    accessibilityRole="header"
     style={
       {
         "color": "#161617",
@@ -832,6 +833,7 @@ exports[`<SetBirthday /> should render correctly when account creation token and
   }
 >
   <Text
+    accessibilityRole="header"
     style={
       {
         "color": "#161617",

--- a/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SetPassword Page should render correctly 1`] = `
 <View
@@ -10,6 +10,7 @@ exports[`SetPassword Page should render correctly 1`] = `
   }
 >
   <Text
+    accessibilityRole="header"
     style={
       {
         "color": "#161617",

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<EmailResendModal /> should render correctly 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`<EmailResendModal /> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -222,6 +223,7 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -245,6 +246,7 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -893,6 +895,7 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -1057,6 +1060,7 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -1795,6 +1799,7 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -1959,6 +1964,7 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -2946,6 +2952,7 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -3110,6 +3117,7 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",

--- a/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
 <View
@@ -129,6 +129,7 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
 <View
@@ -151,6 +151,7 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -164,6 +165,7 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
         Ton compte a été réactivé
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
         Ton compte est désactivé
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
 <View
@@ -151,6 +151,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -164,6 +165,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
         Tu as 18 ans !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<BookingConfirmation /> should render correctly 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
         Réservation confirmée !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`BookingDetails OldBookingDetails : when FF WIP_NEW_BOOKING_PAGE is off should render correctly 1`] = `
 <View
@@ -280,6 +280,7 @@ exports[`BookingDetails OldBookingDetails : when FF WIP_NEW_BOOKING_PAGE is off 
                       }
                     >
                       <Text
+                        accessibilityRole="header"
                         style={
                           {
                             "color": "#161617",
@@ -341,6 +342,7 @@ exports[`BookingDetails OldBookingDetails : when FF WIP_NEW_BOOKING_PAGE is off 
                           }
                         >
                           <Text
+                            accessibilityRole="header"
                             style={
                               {
                                 "color": "#eb0055",
@@ -498,6 +500,7 @@ exports[`BookingDetails OldBookingDetails : when FF WIP_NEW_BOOKING_PAGE is off 
           </Text>
           <View>
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",

--- a/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<BookingNotFound/> should render correctly 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
         Réservation introuvable !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Bookings should render correctly 1`] = `
 <View
@@ -41,6 +41,7 @@ exports[`Bookings should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         numberOfLines={1}
         style={
           {

--- a/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CookiesConsent/> should render correctly 1`] = `
 <Modal
@@ -225,6 +225,7 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 numberOfLines={2}
                 style={
                   {

--- a/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CookiesDetails/> should render correctly 1`] = `
 <View
@@ -93,6 +93,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",
@@ -205,6 +206,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
     }
   >
     <Text
+      accessibilityRole="header"
       style={
         {
           "color": "#161617",
@@ -572,6 +574,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",
@@ -931,6 +934,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",
@@ -1290,6 +1294,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",
@@ -1652,6 +1657,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",
@@ -1820,6 +1826,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
     }
   >
     <Text
+      accessibilityRole="header"
       style={
         {
           "color": "#161617",

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CulturalSurveyIntro page When FF is disabled should render the page with correct layout and content 1`] = `
 <View
@@ -156,6 +156,7 @@ exports[`CulturalSurveyIntro page When FF is disabled should render the page wit
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -668,6 +669,7 @@ exports[`CulturalSurveyIntro page When FF is enabled should render the page with
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -681,6 +683,7 @@ exports[`CulturalSurveyIntro page When FF is enabled should render the page with
         Tu y es presque !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CulturalSurveyQuestions page should render the page with correct layout 1`] = `
 <View
@@ -203,6 +203,7 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
         </View>
       </View>
       <Text
+        accessibilityRole="header"
         numberOfLines={1}
         style={
           {
@@ -243,6 +244,7 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
   >
     <View>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CulturalSurveyThanksPage page When FF is disabled should render the page with correct layout and content 1`] = `
 <View
@@ -151,6 +151,7 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -164,6 +165,7 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
         Un grand merci pour tes réponses !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -437,6 +439,7 @@ exports[`CulturalSurveyThanksPage page When FF is enabled should render the page
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -450,6 +453,7 @@ exports[`CulturalSurveyThanksPage page When FF is enabled should render the page
         Un grand merci pour tes réponses !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/culturalSurvey/pages/FAQWebview.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/FAQWebview.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FAQVebview page should render the page with correct layout 1`] = `
 [
@@ -132,6 +132,7 @@ exports[`FAQVebview page should render the page with correct layout 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {

--- a/__snapshots__/features/errors/pages/AsyncErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/AsyncErrorBoundary.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AsyncErrorBoundary component should render 1`] = `
 <View
@@ -129,6 +129,7 @@ exports[`AsyncErrorBoundary component should render 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -142,6 +143,7 @@ exports[`AsyncErrorBoundary component should render 1`] = `
         Oups !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/errors/pages/BannedCountryError.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/BannedCountryError.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`BannedCountryError should render correctly 1`] = `
 <View
@@ -71,6 +71,7 @@ exports[`BannedCountryError should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -84,6 +85,7 @@ exports[`BannedCountryError should render correctly 1`] = `
         Tu n’es pas en France ?
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FavoritesSorts/> should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -214,6 +215,7 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
             }
           />
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             style={
               {

--- a/__snapshots__/features/favorites/pages/NotConnectedFavorites.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/NotConnectedFavorites.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NotConnectedFavorites component should render not connected favorites 1`] = `
 <View
@@ -56,6 +56,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
     }
   >
     <Text
+      accessibilityRole="header"
       style={
         {
           "color": "#161617",
@@ -69,6 +70,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
       Identifie-toi pour retrouver tes favoris
     </Text>
     <Text
+      accessibilityRole="header"
       style={
         {
           "color": "#161617",

--- a/__snapshots__/features/forceUpdate/pages/ForceUpdateWithResetErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/forceUpdate/pages/ForceUpdateWithResetErrorBoundary.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ForceUpdateWithResetErrorBoundary/> should match snapshot 1`] = `
 <View
@@ -71,6 +71,7 @@ exports[`<ForceUpdateWithResetErrorBoundary/> should match snapshot 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -84,6 +85,7 @@ exports[`<ForceUpdateWithResetErrorBoundary/> should match snapshot 1`] = `
         Mise à jour requise !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`VideoModal should render correctly if modal visible 1`] = `
 <Modal
@@ -328,6 +328,7 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
               }
             />
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",
@@ -388,6 +389,7 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
               }
             />
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",

--- a/__snapshots__/features/home/pages/GenericHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/GenericHome.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`GenericHome With not displayed skeleton by default should display real content 1`] = `
 <View
@@ -127,6 +127,7 @@ exports[`GenericHome With not displayed skeleton by default should display real 
             testID="listHeader"
           >
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",
@@ -197,6 +198,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
   >
     <View>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -4399,6 +4401,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
             testID="listHeader"
           >
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",

--- a/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Home page should render correctly 1`] = `
 <View
@@ -165,6 +165,7 @@ exports[`Home page should render correctly 1`] = `
                   }
                 >
                   <Text
+                    accessibilityRole="header"
                     numberOfLines={2}
                     style={
                       {

--- a/__snapshots__/features/home/pages/NoContentError.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/NoContentError.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NoContentError should render correctly 1`] = `
 <View
@@ -71,6 +71,7 @@ exports[`NoContentError should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -84,6 +85,7 @@ exports[`NoContentError should render correctly 1`] = `
         Oups !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ThematicHome should render correctly 1`] = `
 <View
@@ -669,6 +669,7 @@ exports[`ThematicHome should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityRole="header"
               numberOfLines={1}
               style={
                 {
@@ -684,6 +685,7 @@ exports[`ThematicHome should render correctly 1`] = `
             </Text>
           </View>
           <Text
+            accessibilityRole="header"
             numberOfLines={2}
             style={
               {

--- a/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DMSModal/> should render correctly 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`<DMSModal/> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
 <Modal
@@ -183,6 +183,7 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",
@@ -196,6 +197,7 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
             Veux-tu abandonner la vérification d’identité ?
           </Text>
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DisableActivation/> should render correctly 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<DisableActivation/> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -522,6 +523,7 @@ exports[`<DisableActivation/> with RemoteActivationBanner informations should re
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Stepper navigation should render correctly 1`] = `
 <View
@@ -43,6 +43,7 @@ exports[`Stepper navigation should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<BeneficiaryAccountCreated/> should render correctly for 18 year-old beneficiaries 1`] = `
 <View
@@ -151,6 +151,7 @@ exports[`<BeneficiaryAccountCreated/> should render correctly for 18 year-old be
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -164,6 +165,7 @@ exports[`<BeneficiaryAccountCreated/> should render correctly for 18 year-old be
         Bonne nouvelle !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -276,6 +278,7 @@ exports[`<BeneficiaryAccountCreated/> should render correctly for 18 year-old be
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#eb0055",
@@ -564,6 +567,7 @@ exports[`<BeneficiaryAccountCreated/> should render correctly for underage benef
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -577,6 +581,7 @@ exports[`<BeneficiaryAccountCreated/> should render correctly for underage benef
         Bonne nouvelle !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -689,6 +694,7 @@ exports[`<BeneficiaryAccountCreated/> should render correctly for underage benef
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#eb0055",

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
         Demande envoyée !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/confirmation/IdentityCheckHonor.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/IdentityCheckHonor.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IdentityCheckHonor/> should render correctly 1`] = `
 <View
@@ -33,6 +33,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -53,6 +54,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IdentificationFork /> should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -257,6 +258,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                 }
               >
                 <Text
+                  accessibilityRole="header"
                   style={
                     {
                       "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DMSIntroduction foreign version should render correctly 1`] = `
 <View
@@ -227,6 +227,7 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -844,6 +845,7 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IdentityCheckDMS /> should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -281,6 +282,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                 }
               >
                 <Text
+                  accessibilityRole="header"
                   style={
                     {
                       "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<EduConnectValidation /> should render EduConnectValidation component correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -248,6 +249,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NotEligibleEduConnect should render correctly 1`] = `
 <View
@@ -146,6 +146,7 @@ exports[`NotEligibleEduConnect should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ComeBackLater should render correctly 1`] = `
 <View
@@ -226,6 +226,7 @@ exports[`ComeBackLater should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ExpiredOrLostID should render correctly 1`] = `
 <View
@@ -226,6 +226,7 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IdentityCheckEnd/> should render correctly 1`] = `
 <View
@@ -61,6 +61,7 @@ exports[`<IdentityCheckEnd/> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<IdentityCheckPending/> should render correctly 1`] = `
 <View
@@ -156,6 +156,7 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SelectIDOrigin should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`SelectIDOrigin should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -273,6 +274,7 @@ exports[`SelectIDOrigin should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
@@ -141,6 +141,7 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -256,6 +257,7 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                 }
               />
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CodeNotReceivedModal /> should have a different color if one attempt remaining 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`<CodeNotReceivedModal /> should have a different color if one attempt r
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -697,6 +698,7 @@ exports[`<CodeNotReceivedModal /> should match snapshot 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
 <Modal
@@ -277,6 +277,7 @@ exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -240,6 +241,7 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
               }
             />
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
 <View
@@ -134,6 +134,7 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -249,6 +250,7 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
                 }
               >
                 <Text
+                  accessibilityRole="header"
                   style={
                     {
                       "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SetPhoneValidationCode should match snapshot 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -248,6 +249,7 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`PhoneValidationTooManyAttempts should render correctly 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`PhoneValidationTooManyAttempts should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`PhoneValidationTooManyAttempts should render correctly 1`] = `
         Trop de tentatives !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManySMSSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManySMSSent.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`PhoneValidationTooManySMSSent should render correctly 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`PhoneValidationTooManySMSSent should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`PhoneValidationTooManySMSSent should render correctly 1`] = `
         Réessaie plus tard
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/profile/ProfileInformationValidationCreate.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/ProfileInformationValidationCreate.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ProfileInformationValidationCreate should render correctly 1`] = `
 <View
@@ -134,6 +134,7 @@ exports[`ProfileInformationValidationCreate should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -241,6 +242,7 @@ exports[`ProfileInformationValidationCreate should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SetCity/> should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<SetCity/> should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -248,6 +249,7 @@ exports[`<SetCity/> should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SetName/> should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<SetName/> should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -248,6 +249,7 @@ exports[`<SetName/> should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SetProfileBookingError/> should render correctly 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<SetProfileBookingError/> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SetStatus/> should render correctly 1`] = `
 [
@@ -132,6 +132,7 @@ exports[`<SetStatus/> should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -192,7 +193,9 @@ exports[`<SetStatus/> should render correctly 1`] = `
             <Styled(View)
               numberOfSpaces={2}
             />
-            <Styled(Text)>
+            <Styled(Text)
+              accessibilityRole="header"
+            >
               Sélectionne ton statut
             </Styled(Text)>
             <Styled(View)
@@ -317,6 +320,7 @@ exports[`<SetStatus/> should render correctly 1`] = `
               }
             />
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",

--- a/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -224,6 +225,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
         >
           <View>
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",
@@ -308,6 +310,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   }
                 >
                   <Text
+                    accessibilityRole="header"
                     style={
                       {
                         "color": "#161617",
@@ -1643,6 +1646,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   }
                 >
                   <Text
+                    accessibilityRole="header"
                     style={
                       {
                         "color": "#161617",
@@ -1899,6 +1903,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   }
                 >
                   <Text
+                    accessibilityRole="header"
                     style={
                       {
                         "color": "#161617",
@@ -2684,6 +2689,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
         >
           <View>
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",
@@ -2773,6 +2779,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",

--- a/__snapshots__/features/internal/pages/UTMParameters.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/UTMParameters.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<UTMParameters /> should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<UTMParameters /> should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {

--- a/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HomeLocationModal should render correctly if modal visible 1`] = `
 <Modal
@@ -228,6 +228,7 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 numberOfLines={2}
                 style={
                   {

--- a/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SearchLocationModal should render correctly if modal visible 1`] = `
 [
@@ -252,6 +252,7 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
                 }
               >
                 <Text
+                  accessibilityRole="header"
                   numberOfLines={2}
                   style={
                     {

--- a/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
 [
@@ -289,6 +289,7 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
                 }
               >
                 <Text
+                  accessibilityRole="header"
                   numberOfLines={2}
                   style={
                     {

--- a/__snapshots__/features/maintenance/pages/Maintenance.native.test.tsx.native-snap
+++ b/__snapshots__/features/maintenance/pages/Maintenance.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Maintenance /> should match snapshot with custom message 1`] = `
 <View
@@ -71,6 +71,7 @@ exports[`<Maintenance /> should match snapshot with custom message 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -84,6 +85,7 @@ exports[`<Maintenance /> should match snapshot with custom message 1`] = `
         Maintenance en cours
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -182,6 +184,7 @@ exports[`<Maintenance /> should match snapshot with default message 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -195,6 +198,7 @@ exports[`<Maintenance /> should match snapshot with default message 1`] = `
         Maintenance en cours
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<PageNotFound/> should render correctly 1`] = `
 <View
@@ -165,6 +165,7 @@ exports[`<PageNotFound/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -178,6 +179,7 @@ exports[`<PageNotFound/> should render correctly 1`] = `
           Page introuvable !
         </Text>
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",

--- a/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`PushNotificationsModal should render properly 1`] = `
 <Modal
@@ -126,6 +126,7 @@ exports[`PushNotificationsModal should render properly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           nativeID="testUuidV4"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FavoriteAuthModal should match previous snapshot 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`FavoriteAuthModal should match previous snapshot 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/features/offer/components/NotificationAuthModal/NotificationAuthModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/NotificationAuthModal/NotificationAuthModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NotificationAuthModal should match previous snapshot 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`NotificationAuthModal should match previous snapshot 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<OfferNotFound /> should render correctly 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
         Offre introuvable !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = `
 <View
@@ -145,6 +145,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
           }
         />
         <Text
+          accessibilityRole="header"
           numberOfLines={3}
           style={
             {
@@ -174,6 +175,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
           }
         >
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",
@@ -354,6 +356,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                       }
                     />
                     <Text
+                      accessibilityRole="header"
                       style={
                         {
                           "color": "#320096",
@@ -1032,6 +1035,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
           }
         />
         <Text
+          accessibilityRole="header"
           numberOfLines={3}
           style={
             {
@@ -1061,6 +1065,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
           }
         >
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",
@@ -1456,6 +1461,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                       }
                     />
                     <Text
+                      accessibilityRole="header"
                       style={
                         {
                           "color": "#320096",

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.native.test.tsx.native-snap
@@ -138,6 +138,7 @@ exports[`OnboardingAgeSelectionFork should render correctly 1`] = `
           }
         />
         <Text
+          accessibilityRole="header"
           numberOfLines={3}
           style={
             {
@@ -258,6 +259,7 @@ exports[`OnboardingAgeSelectionFork should render correctly 1`] = `
                   >
                     J’ai 
                     <Text
+                      accessibilityRole="header"
                       style={
                         {
                           "color": "#320096",
@@ -380,6 +382,7 @@ exports[`OnboardingAgeSelectionFork should render correctly 1`] = `
                   >
                     J’ai 
                     <Text
+                      accessibilityRole="header"
                       style={
                         {
                           "color": "#320096",
@@ -501,6 +504,7 @@ exports[`OnboardingAgeSelectionFork should render correctly 1`] = `
                   >
                     J’ai 
                     <Text
+                      accessibilityRole="header"
                       style={
                         {
                           "color": "#320096",
@@ -622,6 +626,7 @@ exports[`OnboardingAgeSelectionFork should render correctly 1`] = `
                   >
                     J’ai 
                     <Text
+                      accessibilityRole="header"
                       style={
                         {
                           "color": "#320096",

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
 <View
@@ -231,6 +231,7 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -244,6 +245,7 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
         Explore, découvre, profite
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`OnboardingGeolocation should render correctly 1`] = `
 <View
@@ -151,6 +151,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -164,6 +165,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
         Découvre les offres près de chez toi
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`OnboardingNotEligible should render correctly 1`] = `
 <View
@@ -231,6 +231,7 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -244,6 +245,7 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
         Encore un peu de patience !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingWelcome.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`OnboardingWelcome should render correctly 1`] = `
 <View
@@ -110,6 +110,7 @@ exports[`OnboardingWelcome should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",

--- a/__snapshots__/features/profile/components/Modals/ExpiredCreditModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/Modals/ExpiredCreditModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ExpiredCreditModal/> should render correctly 1`] = `
 <Modal
@@ -126,6 +126,7 @@ exports[`<ExpiredCreditModal/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           nativeID="testUuidV4"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
@@ -141,6 +141,7 @@ exports[`Accessibility should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AccessibilityActionPlan should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -233,6 +234,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -530,6 +532,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -859,6 +862,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -895,6 +899,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -1667,6 +1672,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -2102,6 +2108,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -2492,6 +2499,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -3403,6 +3411,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -4572,6 +4581,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -5480,6 +5490,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx.native-snap
@@ -141,6 +141,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -336,6 +337,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -396,6 +398,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -477,6 +480,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -1788,6 +1792,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -2214,6 +2219,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -2379,6 +2385,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx.native-snap
@@ -141,6 +141,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -336,6 +337,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -396,6 +398,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -477,6 +480,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -1788,6 +1792,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -2268,6 +2273,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -2433,6 +2439,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -788,6 +789,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -976,6 +978,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
           }
         />
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -1890,6 +1893,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
           }
         />
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -4509,6 +4513,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -4651,6 +4656,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AccessibilityEngagement should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`AccessibilityEngagement should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -231,6 +232,7 @@ exports[`AccessibilityEngagement should render correctly 1`] = `
         À cet égard et afin de pérenniser la démarche, un groupe de travail transversal a été créé en interne. Il est composé d’une personne en lien avec les publics, d’ingénieurs en informatique, d’une designeuse, et d’une personne dédiée à la conception du produit.
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -262,6 +264,7 @@ exports[`AccessibilityEngagement should render correctly 1`] = `
         Ce travail pour rendre et maintenir accessibles les parcours clé de l’application web est le socle pour construire un environnement numérique inclusif et ainsi initier des échanges dédiés avec les acteurs du monde de l’accessibilité et utilisateurs en situation de handicap.
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/Accessibility/RecommendedPaths.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/RecommendedPaths.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`RecommendedPaths should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`RecommendedPaths should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {

--- a/__snapshots__/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SiteMapScreen should render correctly 1`] = `
 <View
@@ -134,6 +134,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {

--- a/__snapshots__/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SetAddress/> from mandatory udpate personal data screen should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<SetAddress/> from mandatory udpate personal data screen should render 
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -248,6 +249,7 @@ exports[`<SetAddress/> from mandatory udpate personal data screen should render 
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",
@@ -749,6 +751,7 @@ exports[`<SetAddress/> without previous screen should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -856,6 +859,7 @@ exports[`<SetAddress/> without previous screen should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ChangeCity from mandatory udpate personal data screen should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`ChangeCity from mandatory udpate personal data screen should render cor
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -247,6 +248,7 @@ exports[`ChangeCity from mandatory udpate personal data screen should render cor
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",
@@ -805,6 +807,7 @@ exports[`ChangeCity from profil personal data screen should render correctly 1`]
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -911,6 +914,7 @@ exports[`ChangeCity from profil personal data screen should render correctly 1`]
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",
@@ -1469,6 +1473,7 @@ exports[`ChangeCity without previous screen should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -1575,6 +1580,7 @@ exports[`ChangeCity without previous screen should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChangeEmail/> should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
         Oups !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -552,6 +554,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -565,6 +568,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
         Oups !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -205,6 +206,7 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",

--- a/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ChangePassword should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`ChangePassword should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {

--- a/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChangeStatus/> from mandatory udpate personal data screen should render correctly 1`] = `
 [
@@ -132,6 +132,7 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -192,7 +193,9 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
             <Styled(View)
               numberOfSpaces={2}
             />
-            <Styled(Text)>
+            <Styled(Text)
+              accessibilityRole="header"
+            >
               Sélectionne ton statut
             </Styled(Text)>
             <Styled(View)
@@ -317,6 +320,7 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
               }
             />
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",
@@ -2188,6 +2192,7 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -2248,7 +2253,9 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
             <Styled(View)
               numberOfSpaces={2}
             />
-            <Styled(Text)>
+            <Styled(Text)
+              accessibilityRole="header"
+            >
               Sélectionne ton statut
             </Styled(Text)>
             <Styled(View)
@@ -2373,6 +2380,7 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
               }
             />
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",
@@ -4244,6 +4252,7 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -4304,7 +4313,9 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
             <Styled(View)
               numberOfSpaces={2}
             />
-            <Styled(Text)>
+            <Styled(Text)
+              accessibilityRole="header"
+            >
               Sélectionne ton statut
             </Styled(Text)>
             <Styled(View)
@@ -4429,6 +4440,7 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
               }
             />
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",

--- a/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
 <View
@@ -156,6 +156,7 @@ exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ConsentSettings/> should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -223,6 +224,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
         Tu peux choisir d’accepter ou non l’activation de leur suivi.
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -590,6 +592,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",
@@ -949,6 +952,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",
@@ -1308,6 +1312,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",
@@ -1670,6 +1675,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityRole="header"
               style={
                 {
                   "color": "#161617",
@@ -1829,6 +1835,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/DebugScreen/DebugScreen.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DebugScreen/DebugScreen.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DebugScreen should render correctly 1`] = `
 <View
@@ -134,6 +134,7 @@ exports[`DebugScreen should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {

--- a/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ConfirmDeleteProfile component should render confirm delete profile 1`] = `
 <View
@@ -225,6 +225,7 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DeactivateProfileSuccess component should render delete profile success 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`DeactivateProfileSuccess component should render delete profile success
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DeleteProfileAccountHacked should render correctly 1`] = `
 <View
@@ -225,6 +225,7 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
 <View
@@ -225,6 +225,7 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DeleteProfileConfirmation should match snapshot 1`] = `
 <View
@@ -225,6 +225,7 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DeleteProfileContactSupport should render correctly 1`] = `
 <View
@@ -225,6 +225,7 @@ exports[`DeleteProfileContactSupport should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DeleteProfileEmailHacked should render correctly 1`] = `
 <View
@@ -225,6 +225,7 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DeleteProfileSuccess component should render delete profile success 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly 1`] = `
 <View
@@ -218,6 +218,7 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DeleteProfileReason /> should match snapshot 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -202,7 +203,9 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
           <Styled(View)>
             <Styled(Styled(SadFaceSvg)) />
             <Styled(View)>
-              <Styled(Text)>
+              <Styled(Text)
+                accessibilityRole="header"
+              >
                 Pourquoi souhaites-tu supprimer ton compte ?
               </Styled(Text)>
               <Styled(Text)>
@@ -355,6 +358,7 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
                 }
               >
                 <Text
+                  accessibilityRole="header"
                   style={
                     {
                       "color": "#161617",

--- a/__snapshots__/features/profile/pages/DisplayPreference/DisplayPreference.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DisplayPreference/DisplayPreference.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DisplayPreference should render correctly 1`] = `
 <View
@@ -134,6 +134,7 @@ exports[`DisplayPreference should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -253,6 +254,7 @@ exports[`DisplayPreference should render correctly 1`] = `
               >
                 <Text
                   accessibilityDescribedBy="testUuidV4"
+                  accessibilityRole="header"
                   htmlFor="testUuidV4"
                   id="testUuidV4"
                   style={

--- a/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FeedbackInApp/> should match snapshot 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -248,6 +249,7 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`LegalNotices should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`LegalNotices should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<MandatoryUpdatePersonalData /> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`<MandatoryUpdatePersonalData /> should render correctly 1`] = `
         Mets à jour ton profil
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/ProfileInformationValidationUpdate.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/ProfileInformationValidationUpdate.native.test.tsx.native-snap
@@ -71,6 +71,7 @@ exports[`ProfileInformationValidationUpdate should render correctly 1`] = `
           testID="back-button-container"
         />
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -178,6 +179,7 @@ exports[`ProfileInformationValidationUpdate should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<UpdatePersonalDataConfirmation /> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`<UpdatePersonalDataConfirmation /> should render correctly 1`] = `
         C’est noté !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<NewEmailSelection /> should match snapshot 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<NewEmailSelection /> should match snapshot 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NotificationsSettings should render correctly when user is logged in 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -206,6 +207,7 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
         }
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -646,6 +648,7 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
             }
           />
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",
@@ -2272,6 +2275,7 @@ exports[`NotificationsSettings should render correctly when user is not logged i
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -2404,6 +2408,7 @@ exports[`NotificationsSettings should render correctly when user is not logged i
           }
         />
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",
@@ -2838,6 +2843,7 @@ exports[`NotificationsSettings should render correctly when user is not logged i
             }
           />
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",

--- a/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`PersonalData should render personal data success 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`PersonalData should render personal data success 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {

--- a/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Profile component should render correctly 1`] = `
 <View
@@ -165,6 +165,7 @@ exports[`Profile component should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 numberOfLines={1}
                 style={
                   {
@@ -205,6 +206,7 @@ exports[`Profile component should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#696a6f",
@@ -695,6 +697,7 @@ exports[`Profile component should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#696a6f",
@@ -971,6 +974,7 @@ exports[`Profile component should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#696a6f",
@@ -1642,6 +1646,7 @@ exports[`Profile component should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#696a6f",
@@ -1849,6 +1854,7 @@ exports[`Profile component should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 style={
                   {
                     "color": "#696a6f",

--- a/__snapshots__/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TrackEmailChange v2 account with password should render correctly when choose new email step is active 1`] = `
 <RCTScrollView
@@ -124,6 +124,7 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
       </View>
     </View>
     <Text
+      accessibilityRole="header"
       style={
         {
           "color": "#161617",
@@ -1000,6 +1001,7 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
       </View>
     </View>
     <Text
+      accessibilityRole="header"
       style={
         {
           "color": "#161617",
@@ -1887,6 +1889,7 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
       </View>
     </View>
     <Text
+      accessibilityRole="header"
       style={
         {
           "color": "#161617",
@@ -2752,6 +2755,7 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
       </View>
     </View>
     <Text
+      accessibilityRole="header"
       style={
         {
           "color": "#161617",
@@ -3852,6 +3856,7 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
       </View>
     </View>
     <Text
+      accessibilityRole="header"
       style={
         {
           "color": "#161617",
@@ -4974,6 +4979,7 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
       </View>
     </View>
     <Text
+      accessibilityRole="header"
       style={
         {
           "color": "#161617",
@@ -6085,6 +6091,7 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
       </View>
     </View>
     <Text
+      accessibilityRole="header"
       style={
         {
           "color": "#161617",

--- a/__snapshots__/features/profile/pages/Tutorial/TutorialPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Tutorial/TutorialPage.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TutorialPage should render correctly 1`] = `
 <View
@@ -145,6 +145,7 @@ exports[`TutorialPage should render correctly 1`] = `
           }
         />
         <Text
+          accessibilityRole="header"
           numberOfLines={3}
           style={
             {

--- a/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         numberOfLines={3}
         style={
           {
@@ -63,6 +64,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         numberOfLines={3}
         style={
           {
@@ -257,6 +259,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> should render correctly 1`] = `
                       }
                     />
                     <Text
+                      accessibilityRole="header"
                       style={
                         {
                           "color": "#161617",
@@ -270,6 +273,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> should render correctly 1`] = `
                       Tu reçois
                        
                       <Text
+                        accessibilityRole="header"
                         style={
                           {
                             "color": "#320096",
@@ -574,6 +578,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> should render correctly 1`] = `
                       }
                     />
                     <Text
+                      accessibilityRole="header"
                       style={
                         {
                           "color": "#161617",
@@ -587,6 +592,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> should render correctly 1`] = `
                       Tu reçois
                        
                       <Text
+                        accessibilityRole="header"
                         style={
                           {
                             "color": "#320096",

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SearchFilter/> should render correctly 1`] = `
 <View
@@ -151,6 +151,7 @@ exports[`<SearchFilter/> should render correctly 1`] = `
             </View>
           </View>
           <Text
+            accessibilityRole="header"
             numberOfLines={1}
             style={
               {

--- a/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SearchLanding /> should render SearchLanding 1`] = `
 <View
@@ -82,6 +82,7 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                 }
               >
                 <View
+                  accessibilityRole="header"
                   style={
                     {
                       "alignItems": "center",
@@ -397,6 +398,7 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
       >
         <View>
           <Text
+            accessibilityRole="header"
             style={
               {
                 "color": "#161617",

--- a/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -82,6 +82,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                 }
               >
                 <View
+                  accessibilityRole="header"
                   style={
                     {
                       "alignItems": "center",
@@ -980,6 +981,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                     }
                   >
                     <Text
+                      accessibilityRole="header"
                       style={
                         {
                           "color": "#161617",
@@ -1002,6 +1004,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       }
                     >
                       <Text
+                        accessibilityRole="header"
                         style={
                           {
                             "color": "#696a6f",

--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1`] = `
 <View
@@ -66,6 +66,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
             }
           >
             <View
+              accessibilityRole="header"
               style={
                 {
                   "alignItems": "center",
@@ -1648,6 +1649,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                   <Text
                     accessibilityHidden={true}
                     accessibilityLabel="GTL playlist"
+                    accessibilityRole="header"
                     numberOfLines={2}
                     style={
                       {
@@ -2485,6 +2487,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     }
                   >
                     <View
+                      accessibilityRole="header"
                       renderToHardwareTextureAndroid={true}
                       shouldRasterizeIOS={true}
                       style={{}}
@@ -2768,6 +2771,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     }
                   >
                     <View
+                      accessibilityRole="header"
                       renderToHardwareTextureAndroid={true}
                       shouldRasterizeIOS={true}
                       style={{}}
@@ -3051,6 +3055,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     }
                   >
                     <View
+                      accessibilityRole="header"
                       renderToHardwareTextureAndroid={true}
                       shouldRasterizeIOS={true}
                       style={{}}
@@ -3334,6 +3339,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     }
                   >
                     <View
+                      accessibilityRole="header"
                       renderToHardwareTextureAndroid={true}
                       shouldRasterizeIOS={true}
                       style={{}}

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
 <Modal
@@ -220,6 +220,7 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
               testID="back-button-container"
             />
             <Text
+              accessibilityRole="header"
               nativeID="testUuidV4"
               numberOfLines={1}
               style={

--- a/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DatesHoursModal/> should render modal correctly after animation and with enabled submit 1`] = `
 <Modal
@@ -220,6 +220,7 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
               testID="back-button-container"
             />
             <Text
+              accessibilityRole="header"
               nativeID="testUuidV4"
               numberOfLines={1}
               style={
@@ -375,6 +376,7 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
                 >
                   <Text
                     accessibilityDescribedBy="testUuidV4"
+                    accessibilityRole="header"
                     htmlFor="testUuidV4"
                     id="testUuidV4"
                     style={
@@ -548,6 +550,7 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
                 >
                   <Text
                     accessibilityDescribedBy="testUuidV4"
+                    accessibilityRole="header"
                     htmlFor="testUuidV4"
                     id="testUuidV4"
                     style={

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<OfferDuoModal/> should render modal correctly after animation and with enabled submit 1`] = `
 <Modal
@@ -220,6 +220,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
               testID="back-button-container"
             />
             <Text
+              accessibilityRole="header"
               nativeID="testUuidV4"
               numberOfLines={1}
               style={
@@ -369,6 +370,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
               >
                 <Text
                   accessibilityDescribedBy="testUuidV4"
+                  accessibilityRole="header"
                   htmlFor="testUuidV4"
                   id="testUuidV4"
                   style={

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<PriceModal/> should render modal correctly after animation and with enabled submit 1`] = `
 <Modal
@@ -220,6 +220,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
               testID="back-button-container"
             />
             <Text
+              accessibilityRole="header"
               nativeID="testUuidV4"
               numberOfLines={1}
               style={
@@ -444,6 +445,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                 >
                   <Text
                     accessibilityDescribedBy="testUuidV4"
+                    accessibilityRole="header"
                     htmlFor="testUuidV4"
                     id="testUuidV4"
                     style={
@@ -604,6 +606,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                 >
                   <Text
                     accessibilityDescribedBy="testUuidV4"
+                    accessibilityRole="header"
                     htmlFor="testUuidV4"
                     id="testUuidV4"
                     style={

--- a/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`VenueModal should render correctly 1`] = `
 <Modal
@@ -228,6 +228,7 @@ exports[`VenueModal should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityRole="header"
                 numberOfLines={2}
                 style={
                   {

--- a/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ShareAppModal should match snapshot 1`] = `
 <Modal
@@ -193,6 +193,7 @@ exports[`ShareAppModal should match snapshot 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             style={
               {

--- a/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ShareAppModalVersionA should match snapshot 1`] = `
 <Modal
@@ -174,6 +174,7 @@ exports[`ShareAppModalVersionA should match snapshot 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ShareAppModalVersionB should match snapshot 1`] = `
 <Modal
@@ -174,6 +174,7 @@ exports[`ShareAppModalVersionB should match snapshot 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<NotificationsLoggedOutModal /> should render correctly 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`<NotificationsLoggedOutModal /> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<NotificationsSettingsModal /> should render correctly 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`<NotificationsSettingsModal /> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<OnboardingSubscriptionModal /> should display correctly 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`<OnboardingSubscriptionModal /> should display correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SubscriptionSuccessModal /> should render correctly for activites_creatives 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for activites_crea
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -798,6 +799,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for cinema 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -1387,6 +1389,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for lecture 1`] = 
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -1976,6 +1979,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for musique 1`] = 
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -2565,6 +2569,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for spectacles 1`]
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -3154,6 +3159,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for visites 1`] = 
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<UnsubscribingConfirmationModal /> should render correctly 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`<UnsubscribingConfirmationModal /> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/features/subscription/page/OnboardingSubscription.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/page/OnboardingSubscription.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`OnboardingSubscription should render correctly 1`] = `
 <View
@@ -185,6 +185,7 @@ exports[`OnboardingSubscription should render correctly 1`] = `
         onLayout={[Function]}
       >
         <Text
+          accessibilityRole="header"
           style={
             {
               "color": "#161617",

--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AccountSecurity/> with route params when user is connected and has a password should match snapshot with valid token 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -810,6 +811,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -1376,6 +1378,7 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SuspensionChoice/> should match snapshot 1`] = `
 <View
@@ -225,6 +225,7 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
         Oups !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Venue /> should match snapshot 1`] = `
 <View
@@ -158,6 +158,7 @@ exports[`<Venue /> should match snapshot 1`] = `
             >
               <Text
                 accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
+                accessibilityRole="header"
                 adjustsFontSizeToFit={true}
                 style={
                   {
@@ -755,6 +756,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                           <Text
                             accessibilityHidden={true}
                             accessibilityLabel="Toutes les offres"
+                            accessibilityRole="header"
                             numberOfLines={2}
                             style={
                               {
@@ -982,6 +984,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                             }
                           >
                             <View
+                              accessibilityRole="header"
                               renderToHardwareTextureAndroid={true}
                               shouldRasterizeIOS={true}
                               style={{}}
@@ -1183,6 +1186,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                             }
                           >
                             <View
+                              accessibilityRole="header"
                               renderToHardwareTextureAndroid={true}
                               shouldRasterizeIOS={true}
                               style={{}}
@@ -1384,6 +1388,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                             }
                           >
                             <View
+                              accessibilityRole="header"
                               renderToHardwareTextureAndroid={true}
                               shouldRasterizeIOS={true}
                               style={{}}
@@ -1773,6 +1778,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                   }
                 >
                   <Text
+                    accessibilityRole="header"
                     style={
                       {
                         "color": "#161617",
@@ -2895,6 +2901,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
             >
               <Text
                 accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
+                accessibilityRole="header"
                 adjustsFontSizeToFit={true}
                 style={
                   {
@@ -3461,6 +3468,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                   }
                 >
                   <Text
+                    accessibilityRole="header"
                     style={
                       {
                         "color": "#161617",
@@ -3809,6 +3817,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                           <Text
                             accessibilityHidden={true}
                             accessibilityLabel="Toutes les offres"
+                            accessibilityRole="header"
                             numberOfLines={2}
                             style={
                               {
@@ -4036,6 +4045,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                             }
                           >
                             <View
+                              accessibilityRole="header"
                               renderToHardwareTextureAndroid={true}
                               shouldRasterizeIOS={true}
                               style={{}}
@@ -4237,6 +4247,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                             }
                           >
                             <View
+                              accessibilityRole="header"
                               renderToHardwareTextureAndroid={true}
                               shouldRasterizeIOS={true}
                               style={{}}
@@ -4438,6 +4449,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                             }
                           >
                             <View
+                              accessibilityRole="header"
                               renderToHardwareTextureAndroid={true}
                               shouldRasterizeIOS={true}
                               style={{}}
@@ -4827,6 +4839,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                   }
                 >
                   <Text
+                    accessibilityRole="header"
                     style={
                       {
                         "color": "#161617",
@@ -5949,6 +5962,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
             >
               <Text
                 accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
+                accessibilityRole="header"
                 adjustsFontSizeToFit={true}
                 style={
                   {
@@ -7868,6 +7882,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                   }
                 >
                   <Text
+                    accessibilityRole="header"
                     style={
                       {
                         "color": "#161617",

--- a/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<VenueNotFound /> should render correctly 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
         Lieu introuvable !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/libs/location/geolocation/components/GeolocationActivationModal.native.test.tsx.native-snap
+++ b/__snapshots__/libs/location/geolocation/components/GeolocationActivationModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`GeolocationActivationModal should render properly 1`] = `
 <Modal
@@ -126,6 +126,7 @@ exports[`GeolocationActivationModal should render properly 1`] = `
         }
       >
         <Text
+          accessibilityRole="header"
           nativeID="testUuidV4"
           numberOfLines={2}
           style={

--- a/__snapshots__/libs/network/OfflinePage.native.test.tsx.native-snap
+++ b/__snapshots__/libs/network/OfflinePage.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<OfflinePage /> should match snapshot with default message 1`] = `
 <View
@@ -61,6 +61,7 @@ exports[`<OfflinePage /> should match snapshot with default message 1`] = `
       }
     />
     <Text
+      accessibilityRole="header"
       style={
         {
           "color": "#161617",
@@ -82,6 +83,7 @@ exports[`<OfflinePage /> should match snapshot with default message 1`] = `
       }
     />
     <Text
+      accessibilityRole="header"
       style={
         {
           "color": "#161617",

--- a/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ApplicationProcessingModal /> should match previous snapshot 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`<ApplicationProcessingModal /> should match previous snapshot 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AuthenticationModal /> should render correctly 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`<AuthenticationModal /> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ErrorApplicationModal /> should match previous snapshot 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`<ErrorApplicationModal /> should match previous snapshot 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FinishSubscriptionModal /> should display correct body when user needs to verify his identity to activate his eighteen year old credit 1`] = `
 <Modal
@@ -209,6 +209,7 @@ exports[`<FinishSubscriptionModal /> should display correct body when user needs
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -698,6 +699,7 @@ exports[`<FinishSubscriptionModal /> should render correctly with eighteen years
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -1187,6 +1189,7 @@ exports[`<FinishSubscriptionModal /> should render correctly with undefined depo
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<LayoutExpiredLink/> should render correctly 1`] = `
 <View
@@ -155,6 +155,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -168,6 +169,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
         Oups !
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/ui/components/modals/AppModal.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/modals/AppModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AppModal /> on big screen 1`] = `
 <Modal
@@ -214,6 +214,7 @@ exports[`<AppModal /> on big screen 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -499,6 +500,7 @@ exports[`<AppModal /> on small screen 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -738,6 +740,7 @@ exports[`<AppModal /> with backdrop disabled 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -1023,6 +1026,7 @@ exports[`<AppModal /> with backdrop enabled by default 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -1308,6 +1312,7 @@ exports[`<AppModal /> with backdrop explicitly enabled 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -1661,6 +1666,7 @@ exports[`<AppModal /> with left icon render 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -1946,6 +1952,7 @@ exports[`<AppModal /> with minimal props 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -2231,6 +2238,7 @@ exports[`<AppModal /> with right icon render 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={
@@ -2576,6 +2584,7 @@ exports[`<AppModal /> without children 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
             style={

--- a/__snapshots__/ui/components/modals/MarketingModal.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/modals/MarketingModal.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MarketingModal should render correctly 1`] = `
 <Modal
@@ -193,6 +193,7 @@ exports[`MarketingModal should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityRole="header"
             nativeID="testUuidV4"
             style={
               {

--- a/__snapshots__/ui/pages/GenericErrorPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericErrorPage.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<GenericErrorPage /> should render correctly 1`] = `
 <View
@@ -72,6 +72,7 @@ exports[`<GenericErrorPage /> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -85,6 +86,7 @@ exports[`<GenericErrorPage /> should render correctly 1`] = `
         GenericErrorPage
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<GenericInfoPage /> should render correctly 1`] = `
 <View
@@ -298,6 +298,7 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",
@@ -311,6 +312,7 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
         Title
       </Text>
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/ui/pages/GenericOfficialPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericOfficialPage.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<GenericOfficialPage /> should render correctly 1`] = `
 <View
@@ -129,6 +129,7 @@ exports[`<GenericOfficialPage /> should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/__snapshots__/ui/pages/PageWithHeader.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/PageWithHeader.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<PageWithHeader/> should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -450,6 +451,7 @@ exports[`<PageWithHeader/> should render correctly on Android, with white header
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {

--- a/__snapshots__/ui/pages/SecondaryPageWithBlurHeader.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/SecondaryPageWithBlurHeader.native.test.tsx.native-snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SecondaryPageWithBlurHeader /> should render correctly 1`] = `
 <View
@@ -141,6 +141,7 @@ exports[`<SecondaryPageWithBlurHeader /> should render correctly 1`] = `
           </View>
         </View>
         <Text
+          accessibilityRole="header"
           numberOfLines={1}
           style={
             {
@@ -197,6 +198,7 @@ exports[`<SecondaryPageWithBlurHeader /> should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityRole="header"
         style={
           {
             "color": "#161617",

--- a/src/ui/theme/typographyAttrs/getHeadingAttrs.native.test.ts
+++ b/src/ui/theme/typographyAttrs/getHeadingAttrs.native.test.ts
@@ -1,15 +1,22 @@
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 describe('getHeadingAttrs()', () => {
   it.each`
-    headingLevel | display
-    ${1}         | ${{}}
-    ${2}         | ${{}}
-    ${3}         | ${{}}
-    ${4}         | ${{}}
-    ${5}         | ${{}}
-    ${6}         | ${{}}
-  `('getHeadingAttrs($headingLevel) = $display', ({ headingLevel, display }) => {
-    expect(getHeadingAttrs(headingLevel)).toEqual(display)
-  })
+    headingLevel | accessibilityLevel | accessibilityRole
+    ${1}         | ${undefined}       | ${AccessibilityRole.HEADER}
+    ${2}         | ${undefined}       | ${AccessibilityRole.HEADER}
+    ${3}         | ${undefined}       | ${AccessibilityRole.HEADER}
+    ${4}         | ${undefined}       | ${AccessibilityRole.HEADER}
+    ${5}         | ${undefined}       | ${AccessibilityRole.HEADER}
+    ${6}         | ${undefined}       | ${AccessibilityRole.HEADER}
+  `(
+    "getHeadingAttrs($headingLevel) = {accessibilityRole: $accessibilityRole, accessibilityLevel: $accessibilityLevel, dir: 'ltr'}",
+    ({ headingLevel, accessibilityLevel, accessibilityRole }) => {
+      expect(getHeadingAttrs(headingLevel)).toEqual({
+        accessibilityRole,
+        accessibilityLevel,
+      })
+    }
+  )
 })

--- a/src/ui/theme/typographyAttrs/getHeadingAttrs.ts
+++ b/src/ui/theme/typographyAttrs/getHeadingAttrs.ts
@@ -9,5 +9,8 @@ export const getHeadingAttrs = (level: HeadingLevel) => {
         accessibilityRole: AccessibilityRole.HEADING,
         accessibilityLevel: level,
       }
-    : {}
+    : {
+        accessibilityRole: AccessibilityRole.HEADER,
+        accessibilityLevel: undefined,
+      }
 }

--- a/src/ui/theme/typographyAttrs/getHeadingAttrs.web.test.ts
+++ b/src/ui/theme/typographyAttrs/getHeadingAttrs.web.test.ts
@@ -3,18 +3,18 @@ import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 describe('getHeadingAttrs()', () => {
   it.each`
-    headingLevel | accessibilityLevel
-    ${1}         | ${1}
-    ${2}         | ${2}
-    ${3}         | ${3}
-    ${4}         | ${4}
-    ${5}         | ${5}
-    ${6}         | ${6}
+    headingLevel | accessibilityLevel | accessibilityRole
+    ${1}         | ${1}               | ${AccessibilityRole.HEADING}
+    ${2}         | ${2}               | ${AccessibilityRole.HEADING}
+    ${3}         | ${3}               | ${AccessibilityRole.HEADING}
+    ${4}         | ${4}               | ${AccessibilityRole.HEADING}
+    ${5}         | ${5}               | ${AccessibilityRole.HEADING}
+    ${6}         | ${6}               | ${AccessibilityRole.HEADING}
   `(
-    "getHeadingAttrs($headingLevel) = {accessibilityRole: 'heading', accessibilityLevel: $display, dir: 'ltr'}",
-    ({ headingLevel, accessibilityLevel }) => {
+    "getHeadingAttrs($headingLevel) = {accessibilityRole: $accessibilityRole, accessibilityLevel: $accessibilityLevel, dir: 'ltr'}",
+    ({ headingLevel, accessibilityLevel, accessibilityRole }) => {
       expect(getHeadingAttrs(headingLevel)).toEqual({
-        accessibilityRole: AccessibilityRole.HEADING,
+        accessibilityRole,
         accessibilityLevel,
       })
     }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37481

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |   <img width="987" height="723" alt="Capture d’écran 2025-08-21 à 16 31 41" src="https://github.com/user-attachments/assets/9bdaed3d-d7cf-4c60-a28f-7617d200836e" /> <img width="988" height="725" alt="Capture d’écran 2025-08-21 à 16 30 45" src="https://github.com/user-attachments/assets/6f3a2e67-8ce6-459c-903f-3a5ac2861720" /> <img width="986" height="722" alt="Capture d’écran 2025-08-21 à 16 33 07" src="https://github.com/user-attachments/assets/cd6c34ed-6fc2-4e55-bb56-706d875a5d10" /> <img width="987" height="723" alt="Capture d’écran 2025-08-21 à 16 32 00" src="https://github.com/user-attachments/assets/c9e8696f-0abc-420d-8a30-37cffc0fac99" />  |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
