### PR TITLE
(PC-37426) feat(offer): make opinion clickable

### DIFF
--- a/src/features/offer/components/OfferContent/ChronicleSection/ChroniclesSectionWithAnchor.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChroniclesSectionWithAnchor.tsx
@@ -1,0 +1,60 @@
+import React, { FunctionComponent, useCallback, useRef } from 'react'
+import { View } from 'react-native'
+import styled from 'styled-components/native'
+
+import { OfferResponseV2 } from 'api/gen'
+import { ChronicleCardData } from 'features/chronicle/type'
+import { ChronicleSection } from 'features/offer/components/OfferContent/ChronicleSection/ChronicleSection'
+import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
+import { useRegisterAnchor } from 'ui/components/anchor/AnchorContext'
+import { SectionWithDivider } from 'ui/components/SectionWithDivider'
+
+type ChroniclesSectionWithAnchorProps = {
+  chronicles?: ChronicleCardData[]
+  chronicleVariantInfo: ChronicleVariantInfo
+  offer: OfferResponseV2
+  onSeeMoreButtonPress: (chronicleId: number) => void
+  onShowChroniclesWritersModal: () => void
+}
+
+export const ChroniclesSectionWithAnchor: FunctionComponent<ChroniclesSectionWithAnchorProps> = ({
+  chronicles,
+  chronicleVariantInfo,
+  offer,
+  onSeeMoreButtonPress,
+  onShowChroniclesWritersModal,
+}) => {
+  const chroniclesSectionRef = useRef<View>(null)
+  const registerAnchor = useRegisterAnchor()
+
+  const handleLayout = useCallback(() => {
+    if (chroniclesSectionRef.current) {
+      registerAnchor('chronicles-section', chroniclesSectionRef)
+    }
+  }, [registerAnchor])
+
+  if (!chronicles?.length) return null
+
+  return (
+    <StyledSectionWithDivider visible testID="chronicles-section" gap={8}>
+      <View ref={chroniclesSectionRef} onLayout={handleLayout} testID="chronicles-section-anchor">
+        <ChronicleSection
+          ctaLabel="Voir tous les avis"
+          variantInfo={chronicleVariantInfo}
+          data={chronicles}
+          // It's dirty but necessary to use from parameter for the logs
+          navigateTo={{
+            screen: 'Chronicles',
+            params: { offerId: offer.id, from: 'chronicles' },
+          }}
+          onSeeMoreButtonPress={onSeeMoreButtonPress}
+          onShowChroniclesWritersModal={onShowChroniclesWritersModal}
+        />
+      </View>
+    </StyledSectionWithDivider>
+  )
+}
+
+const StyledSectionWithDivider = styled(SectionWithDivider)(({ theme }) => ({
+  paddingBottom: theme.designSystem.size.spacing.xxl,
+}))

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -143,6 +143,8 @@ jest.mock('react-native-intersection-observer', () => {
 })
 
 const useScrollToAnchorSpy = jest.spyOn(AnchorContextModule, 'useScrollToAnchor')
+const mockRegisterAnchor = jest.fn()
+const useRegisterAnchorSpy = jest.spyOn(AnchorContextModule, 'useRegisterAnchor')
 const useRemoteConfigSpy = jest
   .spyOn(useRemoteConfigQuery, 'useRemoteConfigQuery')
   .mockReturnValue({
@@ -214,6 +216,8 @@ describe('<OfferContent />', () => {
     mockPosition = { latitude: 90.4773245, longitude: 90.4773245 }
     mockAuthContextWithoutUser({ persist: true })
     setFeatureFlags([RemoteStoreFeatureFlags.TARGET_XP_CINE_FROM_OFFER])
+    mockRegisterAnchor.mockClear()
+    useRegisterAnchorSpy.mockReturnValue(mockRegisterAnchor)
   })
 
   afterEach(cleanup)
@@ -816,6 +820,22 @@ describe('<OfferContent />', () => {
         expect(analytics.logConsultChronicle).toHaveBeenNthCalledWith(1, {
           offerId: 116656,
           chronicleId: 1,
+        })
+      })
+
+      it('should register chronicles-section anchor when chronicles are present', async () => {
+        renderOfferContent({
+          offer: { ...offerResponseSnap, subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER },
+        })
+
+        const anchorView = await screen.findByTestId('chronicles-section-anchor')
+
+        act(() => {
+          anchorView.props.onLayout()
+        })
+
+        await waitFor(() => {
+          expect(mockRegisterAnchor).toHaveBeenCalledWith('chronicles-section', expect.any(Object))
         })
       })
     })

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -24,7 +24,7 @@ import { ChronicleCardData } from 'features/chronicle/type'
 import { useFavorite } from 'features/favorites/hooks/useFavorite'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { OfferBody } from 'features/offer/components/OfferBody/OfferBody'
-import { ChronicleSection } from 'features/offer/components/OfferContent/ChronicleSection/ChronicleSection'
+import { ChroniclesSectionWithAnchor } from 'features/offer/components/OfferContent/ChronicleSection/ChroniclesSectionWithAnchor'
 import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
 import { OfferCTAButton } from 'features/offer/components/OfferCTAButton/OfferCTAButton'
 import { OfferContentCTAs } from 'features/offer/components/OfferFooter/OfferContentCTAs'
@@ -297,20 +297,13 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
           </BodyWrapper>
 
           {chronicles?.length ? (
-            <StyledSectionWithDivider visible testID="chronicles-section" gap={8}>
-              <ChronicleSection
-                variantInfo={chronicleVariantInfo}
-                ctaLabel="Voir tous les avis"
-                data={chronicles}
-                // It's dirty but necessary to use from parameter for the logs
-                navigateTo={{
-                  screen: 'Chronicles',
-                  params: { offerId: offer.id, from: 'chronicles' },
-                }}
-                onSeeMoreButtonPress={onSeeMoreButtonPress}
-                onShowChroniclesWritersModal={onShowChroniclesWritersModal}
-              />
-            </StyledSectionWithDivider>
+            <ChroniclesSectionWithAnchor
+              chronicles={chronicles}
+              chronicleVariantInfo={chronicleVariantInfo}
+              offer={offer}
+              onSeeMoreButtonPress={onSeeMoreButtonPress}
+              onShowChroniclesWritersModal={onShowChroniclesWritersModal}
+            />
           ) : null}
           <StyledSectionWithDivider
             visible

--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
@@ -6,6 +6,8 @@ import { InfoCounter } from 'features/offer/components/InfoCounter/InfoCounter'
 import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
 import { formatLikesCounter } from 'features/offer/helpers/formatLikesCounter/formatLikesCounter'
 import { getRecommendationText } from 'features/offer/helpers/getRecommendationText/getRecommendationText'
+import { useScrollToAnchor } from 'ui/components/anchor/AnchorContext'
+import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
 import { Star } from 'ui/svg/Star'
@@ -25,6 +27,7 @@ export const OfferReactionSection: FunctionComponent<Props> = ({
   chronicleVariantInfo,
   chronicles,
 }) => {
+  const scrollToAnchor = useScrollToAnchor()
   const hasPublishedChronicles = (chronicles?.length ?? 0) > 0
   const hasUnpublishedChronicles = (chroniclesCount ?? 0) - (chronicles?.length ?? 0) > 0
 
@@ -32,13 +35,19 @@ export const OfferReactionSection: FunctionComponent<Props> = ({
     <LikesInfoCounter text={formatLikesCounter(likesCount)} />
   ) : null
 
+  const handleChroniclesPress = () => {
+    scrollToAnchor('chronicles-section')
+  }
+
   const getChroniclesCounterElement = (): React.ReactNode => {
     if (hasPublishedChronicles) {
       return (
-        <ChroniclesInfoCounter
-          text={`${chronicles?.length ?? 0} avis`}
-          icon={chronicleVariantInfo.SmallIcon}
-        />
+        <TouchableOpacity onPress={handleChroniclesPress} testID="chroniclesCounter">
+          <ChroniclesInfoCounter
+            text={`${chronicles?.length ?? 0} avis`}
+            icon={chronicleVariantInfo.SmallIcon}
+          />
+        </TouchableOpacity>
       )
     }
     if (hasUnpublishedChronicles) {

--- a/src/ui/components/anchor/anchor-name.ts
+++ b/src/ui/components/anchor/anchor-name.ts
@@ -2,3 +2,4 @@ export type AnchorName =
   | 'movie-calendar'
   | 'offer-cine-availabilities'
   | 'venue-cine-availabilities'
+  | 'chronicles-section'


### PR DESCRIPTION
 ## 🎯 Objectif

  Rendre cliquables les mentions "X avis" sur les pages d'offres culturelles pour permettre aux utilisateurs d'accéder facilement aux avis détaillés de la communauté.

  ## 📝 Description

  Sur les pages d'offres culturelles, les mentions "X avis" étaient affichées de manière statique. Les utilisateurs ne pouvaient pas interagir avec cet élément pour accéder aux avis détaillés, ce qui
  limitait l'exploration et la découverte de contenu.

  Cette PR implémente un comportement de scroll automatique vers la section des avis (Book Club/Ciné Club) lors du clic sur les mentions "X avis".

  ## ✨ Changements apportés

  ### Fonctionnalité principale
  - **Rendre cliquables** les mentions "X avis" dans `OfferReactionSection`
  - **Scroll automatique** vers la section chronicles correspondante
  - **Différenciation automatique** du comportement selon le type d'offre :
    - Livres → section Book Club
    - Films → section Ciné Club

  ### Implémentation technique
  - Ajout de l'ancre `'chronicles-section'` au système d'ancres existant
  - Utilisation de `useScrollToAnchor` au lieu de la navigation
  - Création du composant `ChroniclesSectionWithAnchor` pour gérer l'enregistrement de l'ancre
  - Gestion robuste de l'enregistrement d'ancre avec timeout et fallback

  ### Tests
  - ✅ 3 nouveaux tests pour `OfferReactionSection` (scroll sur avis publiés/non publiés, absence du bouton)
  - ✅ 1 nouveau test pour l'enregistrement d'ancre dans `OfferContent`
  - ✅ Tous les tests existants préservés

  ## 🔧 Fichiers modifiés

  **Composants principaux :**
  - `src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx`
  - `src/features/offer/components/OfferContent/OfferContentBase.tsx`

  **Types :**
  - `src/ui/components/anchor/anchor-name.ts` - Ajout de `'chronicles-section'`

  **Tests :**
  - `src/features/offer/components/OfferReactionSection/OfferReactionSection.native.test.tsx`
  - `src/features/offer/components/OfferContent/OfferContent.native.test.tsx`