### PR TITLE
(PC-37326) fix(UbbleWebView): replace stack with IdentityCheckUnavailable when error Ubble

### DIFF
--- a/src/features/identityCheck/queries/useIdentificationUrlMutation.ts
+++ b/src/features/identityCheck/queries/useIdentificationUrlMutation.ts
@@ -11,10 +11,10 @@ import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getSubscriptionHookConfig } from 'features/navigation/SubscriptionStackNavigator/getSubscriptionHookConfig'
 import { MutationKeys } from 'libs/queryKeys'
 
-export function useIdentificationUrlMutation() {
+export const useIdentificationUrlMutation = () => {
   const { data: subscription } = useGetStepperInfoQuery()
   const [identificationUrl, setIdentificationUrl] = useState<string | undefined>()
-  const { navigate } = useNavigation<UseNavigationType>()
+  const { navigate, replace } = useNavigation<UseNavigationType>()
 
   const { mutate: postIdentificationUrl } = useMutation(
     [MutationKeys.IDENTIFICATION_URL],
@@ -28,7 +28,7 @@ export function useIdentificationUrlMutation() {
           navigate(...getSubscriptionHookConfig('IdentityCheckPending'))
         } else {
           const withDMS = subscription?.maintenancePageType === MaintenancePageType['with-dms']
-          navigate(...getSubscriptionHookConfig('IdentityCheckUnavailable', { withDMS }))
+          replace(...getSubscriptionHookConfig('IdentityCheckUnavailable', { withDMS }))
         }
       }
     }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37326

## Problem

When there is an error in the `UbbleWebview` the `IdentityCheckUnavailable` screen is pushed in the stack. However, the `UbbleWebview` loads on repeat even if it is not the screen to be displayed but being still in the stack history, leading to new calls to ubble backend route and new errors. 

## Proposed solution

The fix proposed is tested in web (NOT in MOBILE):
 - use replace instead of navigate to erase the stack and push the `IdentityCheckUnavailable` screen
 - the back button in web still works and resets the stack to the step just before `UbbleWebview`
 - anyway the history does not seem to be very important in that case since we propose the user to go back to the root of the app.

## Caveats

 - [ ] NOT TESTED IN MOBILE (but we can expect the same behavior)
 - [ ] the solution is only a quick fix to the problem and does not address the root cause which seems to be on the `UbbleWebview` (`iframe` in web / `Webview` in mobile): it would be better to know why the problem is here
 - [ ] the script js for iframe seems to be old and could be upgraded as per the documentation
