### PR TITLE
(PC-37425) feat(offer): add what's the club button and open chronicles writers modal

### DIFF
--- a/src/features/chronicle/components/ChronicleCardListHeader/ChronicleCardListHeader.tsx
+++ b/src/features/chronicle/components/ChronicleCardListHeader/ChronicleCardListHeader.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react'
 
+import { ChronicleVariantInfo } from 'features/offer/components/OfferContent/ChronicleSection/types'
 import { ButtonQuaternaryBlack } from 'ui/components/buttons/ButtonQuaternaryBlack'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -7,15 +8,19 @@ import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { getSpacing, Typo } from 'ui/theme'
 
 type Props = {
+  variantInfo: ChronicleVariantInfo
   onPressMoreInfo: VoidFunction
 }
 
-export const ChronicleCardListHeader: FunctionComponent<Props> = ({ onPressMoreInfo }) => {
+export const ChronicleCardListHeader: FunctionComponent<Props> = ({
+  variantInfo,
+  onPressMoreInfo,
+}) => {
   return (
     <ViewGap gap={2}>
       <Typo.Title2>Tous les avis</Typo.Title2>
       <StyledButtonQuaternaryBlack
-        wording="Qui écrit les avis&nbsp;?"
+        wording={variantInfo.modalTitle}
         icon={InfoPlain}
         onPress={onPressMoreInfo}
       />
@@ -24,6 +29,6 @@ export const ChronicleCardListHeader: FunctionComponent<Props> = ({ onPressMoreI
 }
 
 const StyledButtonQuaternaryBlack = styledButton(ButtonQuaternaryBlack)(({ theme }) => ({
-  width: getSpacing(34),
+  width: getSpacing(44),
   marginBottom: theme.designSystem.size.spacing.xl,
 }))

--- a/src/features/chronicle/pages/Chronicles/Chronicles.native.test.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.native.test.tsx
@@ -95,6 +95,20 @@ describe('Chronicles', () => {
 
       await waitFor(() => expect(mockScrollToIndex).toHaveBeenCalledTimes(1))
     })
+
+    it('should open chronicle modal when pressing "C’est quoi le Ciné Club ?" button', async () => {
+      jest.spyOn(useModal, 'useModal').mockReturnValueOnce({
+        visible: false,
+        showModal: mockShowModal,
+        hideModal: jest.fn(),
+        toggleModal: jest.fn(),
+      })
+      render(reactQueryProviderHOC(<Chronicles />))
+
+      await user.press(await screen.findByText('C’est quoi le Ciné Club ?'))
+
+      expect(mockShowModal).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('When chronicle id not defined', () => {
@@ -134,22 +148,6 @@ describe('Chronicles', () => {
       })
 
       expect(mockScrollToIndex).not.toHaveBeenCalled()
-    })
-
-    it('should open chronicle modal when pressing "Qui écrit les avis ?" button', async () => {
-      jest.spyOn(useModal, 'useModal').mockReturnValueOnce({
-        visible: false,
-        showModal: mockShowModal,
-        hideModal: jest.fn(),
-        toggleModal: jest.fn(),
-      })
-      render(reactQueryProviderHOC(<Chronicles />))
-
-      await screen.findByText('Tous les avis')
-
-      await user.press(screen.getByText('Qui écrit les avis ?'))
-
-      expect(mockShowModal).toHaveBeenCalledTimes(1)
     })
 
     describe('When modal is open', () => {

--- a/src/features/chronicle/pages/Chronicles/ChroniclesBase.tsx
+++ b/src/features/chronicle/pages/Chronicles/ChroniclesBase.tsx
@@ -85,7 +85,9 @@ export const ChroniclesBase: FunctionComponent<Props> = ({
           data={chronicleCardsData}
           horizontal={false}
           separatorSize={6}
-          headerComponent={<ChronicleCardListHeader onPressMoreInfo={showModal} />}
+          headerComponent={
+            <ChronicleCardListHeader variantInfo={variantInfo} onPressMoreInfo={showModal} />
+          }
           ref={chroniclesListRef}
           onScroll={onScroll}
           contentContainerStyle={{

--- a/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.tsx
+++ b/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.tsx
@@ -24,16 +24,12 @@ export const ChroniclesWritersModal: FunctionComponent<Props> = ({
     <AppModal
       animationOutTiming={1}
       visible={isVisible}
-      title="Qui écrit les avis&nbsp;?"
+      title={variantInfo.modalTitle}
       rightIconAccessibilityLabel="Fermer la modale"
       rightIcon={Close}
       onRightIconPress={closeModal}>
       <ViewGap gap={6}>
         <Typo.Body>{variantInfo.modalWording}</Typo.Body>
-        <Typo.Body>
-          Ils sont sélectionnés par le pass Culture pour te faire leurs meilleures recos tous les
-          mois.
-        </Typo.Body>
 
         <ButtonPrimary wording={variantInfo.modalButtonLabel} onPress={onShowRecoButtonPress} />
       </ViewGap>

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.native.test.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.native.test.tsx
@@ -2,6 +2,7 @@ import * as reactNavigationNative from '@react-navigation/native'
 import React from 'react'
 
 import { chroniclesSnap } from 'features/chronicle/fixtures/chroniclesSnap'
+import { chronicleVariantInfoFixture } from 'features/offer/fixtures/chronicleVariantInfo'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { ChronicleSection } from './ChronicleSection'
@@ -20,16 +21,16 @@ describe('ChroniclesSection', () => {
   it('should render correctly', () => {
     render(
       <ChronicleSection
-        title="title"
+        variantInfo={chronicleVariantInfoFixture}
         ctaLabel="Voir tous les avis"
         data={chroniclesSnap}
-        subtitle="subtitle"
         navigateTo={{ screen: 'Offer' }}
+        onShowChroniclesWritersModal={jest.fn()}
       />
     )
 
-    expect(screen.getByText('title')).toBeOnTheScreen()
-    expect(screen.getByText('subtitle')).toBeOnTheScreen()
+    expect(screen.getByText(chronicleVariantInfoFixture.titleSection)).toBeOnTheScreen()
+    expect(screen.getByText(chronicleVariantInfoFixture.subtitleSection)).toBeOnTheScreen()
     expect(screen.getByText('Voir tous les avis')).toBeOnTheScreen()
     expect(screen.getAllByTestId(/chronicle-card-*/).length).toBeGreaterThan(0)
   })
@@ -38,11 +39,11 @@ describe('ChroniclesSection', () => {
     jest.useFakeTimers()
     render(
       <ChronicleSection
-        title="title"
+        variantInfo={chronicleVariantInfoFixture}
         ctaLabel="Voir tous les avis"
         data={chroniclesSnap}
-        subtitle="subtitle"
         navigateTo={{ screen: 'Offer' }}
+        onShowChroniclesWritersModal={jest.fn()}
       />
     )
 

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.test.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.test.tsx
@@ -2,6 +2,7 @@ import * as reactNavigationNative from '@react-navigation/native'
 import React from 'react'
 
 import { chroniclesSnap } from 'features/chronicle/fixtures/chroniclesSnap'
+import { chronicleVariantInfoFixture } from 'features/offer/fixtures/chronicleVariantInfo'
 import { fireEvent, render, screen } from 'tests/utils/web'
 
 import { ChronicleSection } from './ChronicleSection'
@@ -16,16 +17,18 @@ describe('ChronicleSection', () => {
   it('should render correctly in mobile', () => {
     render(
       <ChronicleSection
-        title="title"
+        variantInfo={chronicleVariantInfoFixture}
         ctaLabel="Voir tous les avis"
         data={chroniclesSnap}
-        subtitle="subtitle"
         navigateTo={{ screen: 'Offer' }}
+        onShowChroniclesWritersModal={jest.fn()}
       />
     )
 
-    expect(screen.getByText('title')).toBeInTheDocument()
-    expect(screen.getByText('subtitle')).toBeInTheDocument()
+    expect(screen.getByText(chronicleVariantInfoFixture.titleSection)).toBeInTheDocument()
+    expect(
+      screen.getByText('Notre communauté de lecteurs te partagent leurs avis sur ce livre !')
+    ).toBeInTheDocument()
     expect(screen.getByText('Voir tous les avis')).toBeInTheDocument()
     expect(screen.getAllByTestId(/chronicle-card-*/).length).toBeGreaterThan(0)
   })
@@ -33,17 +36,19 @@ describe('ChronicleSection', () => {
   it('should render correctly in desktop', () => {
     render(
       <ChronicleSection
-        title="title"
+        variantInfo={chronicleVariantInfoFixture}
         ctaLabel="Voir tous les avis"
         data={chroniclesSnap}
-        subtitle="subtitle"
         navigateTo={{ screen: 'Offer' }}
+        onShowChroniclesWritersModal={jest.fn()}
       />,
       { theme: { isDesktopViewport: true } }
     )
 
-    expect(screen.getByText('title')).toBeInTheDocument()
-    expect(screen.getByText('subtitle')).toBeInTheDocument()
+    expect(screen.getByText(chronicleVariantInfoFixture.titleSection)).toBeInTheDocument()
+    expect(
+      screen.getByText('Notre communauté de lecteurs te partagent leurs avis sur ce livre !')
+    ).toBeInTheDocument()
     expect(screen.getByText('Voir tous les avis')).toBeInTheDocument()
     expect(screen.getAllByTestId(/chronicle-card-*/).length).toBeGreaterThan(0)
   })
@@ -51,11 +56,11 @@ describe('ChronicleSection', () => {
   it('should navigate', async () => {
     render(
       <ChronicleSection
-        title="title"
+        variantInfo={chronicleVariantInfoFixture}
         ctaLabel="Voir tous les avis"
         data={chroniclesSnap}
-        subtitle="subtitle"
         navigateTo={{ screen: 'Offer' }}
+        onShowChroniclesWritersModal={jest.fn()}
       />
     )
 

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.tsx
@@ -6,8 +6,11 @@ import styled from 'styled-components/native'
 import { ChronicleCardList } from 'features/chronicle/components/ChronicleCardList/ChronicleCardList'
 import { CHRONICLE_CARD_WIDTH } from 'features/chronicle/constant'
 import { ChronicleSectionBase } from 'features/offer/components/OfferContent/ChronicleSection/ChronicleSectionBase'
+import { ButtonQuaternaryBlack } from 'ui/components/buttons/ButtonQuaternaryBlack'
 import { ButtonSecondaryBlack } from 'ui/components/buttons/ButtonSecondaryBlack'
+import { styledButton } from 'ui/components/buttons/styledButton'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
+import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Show } from 'ui/svg/icons/Show'
 import { getSpacing, Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
@@ -16,34 +19,53 @@ import { ChronicleSectionProps } from './types'
 
 export const ChronicleSection = (props: ChronicleSectionProps) => {
   const { isDesktopViewport } = useTheme()
-  const { data, title, subtitle, ctaLabel, navigateTo, style, onSeeMoreButtonPress, icon } = props
+  const {
+    data,
+    variantInfo,
+    ctaLabel,
+    navigateTo,
+    style,
+    onSeeMoreButtonPress,
+    onShowChroniclesWritersModal,
+  } = props
 
-  return isDesktopViewport ? (
-    <View style={style}>
-      <Gutter>
-        <Row>
-          <StyledTitle3 {...getHeadingAttrs(3)}>{title}</StyledTitle3>
-          <InternalTouchableLink
-            as={ButtonSecondaryBlack}
-            icon={Show}
-            wording={ctaLabel}
-            navigateTo={navigateTo}
-            // If i use styled-component in that case (i.e using "as" prop), i have an error in web :'(
-            // eslint-disable-next-line react-native/no-inline-styles
-            style={{ width: 'auto', borderWidth: 0, paddingLeft: getSpacing(2) }}
+  return (
+    <React.Fragment>
+      {isDesktopViewport ? (
+        <View style={style}>
+          <Gutter>
+            <Row>
+              <StyledTitle3 {...getHeadingAttrs(3)}>{variantInfo.titleSection}</StyledTitle3>
+              <InternalTouchableLink
+                as={ButtonSecondaryBlack}
+                icon={Show}
+                wording={ctaLabel}
+                navigateTo={navigateTo}
+                // If i use styled-component in that case (i.e using "as" prop), i have an error in web :'(
+                // eslint-disable-next-line react-native/no-inline-styles
+                style={{ width: 'auto', borderWidth: 0, paddingLeft: getSpacing(2) }}
+              />
+            </Row>
+            {variantInfo.subtitleSection ? (
+              <StyledBodyAccentXs>{variantInfo.subtitleSection}</StyledBodyAccentXs>
+            ) : null}
+          </Gutter>
+          <StyledChronicleCardlist
+            data={data}
+            onSeeMoreButtonPress={onSeeMoreButtonPress}
+            shouldTruncate
+            cardIcon={variantInfo.Icon}
           />
-        </Row>
-        {subtitle ? <StyledBodyAccentXs>{subtitle}</StyledBodyAccentXs> : null}
-      </Gutter>
-      <StyledChronicleCardlist
-        data={data}
-        onSeeMoreButtonPress={onSeeMoreButtonPress}
-        shouldTruncate
-        cardIcon={icon}
-      />
-    </View>
-  ) : (
-    <ChronicleSectionBase {...props} />
+          <StyledButtonQuaternaryBlack
+            wording={variantInfo.modalTitle}
+            icon={InfoPlain}
+            onPress={onShowChroniclesWritersModal}
+          />
+        </View>
+      ) : (
+        <ChronicleSectionBase {...props} />
+      )}
+    </React.Fragment>
   )
 }
 
@@ -70,4 +92,10 @@ const StyledTitle3 = styled(Typo.Title3)(({ theme }) => ({
 
 const StyledBodyAccentXs = styled(Typo.BodyAccentXs)(({ theme }) => ({
   color: theme.designSystem.color.text.subtle,
+}))
+
+const StyledButtonQuaternaryBlack = styledButton(ButtonQuaternaryBlack)(({ theme }) => ({
+  width: getSpacing(42),
+  marginLeft: theme.designSystem.size.spacing.xl,
+  justifyContent: 'left',
 }))

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSectionBase.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSectionBase.tsx
@@ -4,8 +4,11 @@ import styled from 'styled-components/native'
 
 import { ChronicleCardList } from 'features/chronicle/components/ChronicleCardList/ChronicleCardList'
 import { CHRONICLE_CARD_WIDTH } from 'features/chronicle/constant'
+import { ButtonQuaternaryBlack } from 'ui/components/buttons/ButtonQuaternaryBlack'
 import { ButtonSecondaryBlack } from 'ui/components/buttons/ButtonSecondaryBlack'
+import { styledButton } from 'ui/components/buttons/styledButton'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
+import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
@@ -13,25 +16,26 @@ import { ChronicleSectionProps } from './types'
 
 export const ChronicleSectionBase = ({
   data,
-  title,
-  subtitle,
+  variantInfo,
   ctaLabel,
   navigateTo,
   onSeeMoreButtonPress,
+  onShowChroniclesWritersModal,
   style,
-  icon,
 }: ChronicleSectionProps) => {
   return (
     <View style={style}>
       <Gutter>
-        <Typo.Title3 {...getHeadingAttrs(3)}>{title}</Typo.Title3>
-        {subtitle ? <StyledBodyAccentXs>{subtitle}</StyledBodyAccentXs> : null}
+        <Typo.Title3 {...getHeadingAttrs(3)}>{variantInfo.titleSection}</Typo.Title3>
+        {variantInfo.subtitleSection ? (
+          <StyledBodyAccentXs>{variantInfo.subtitleSection}</StyledBodyAccentXs>
+        ) : null}
       </Gutter>
       <StyledChronicleCardlist
         data={data}
         onSeeMoreButtonPress={onSeeMoreButtonPress}
         shouldTruncate
-        cardIcon={icon}
+        cardIcon={variantInfo.Icon}
       />
       <Gutter>
         <InternalTouchableLink
@@ -41,6 +45,13 @@ export const ChronicleSectionBase = ({
           // If i use styled-component in that case (i.e using "as" prop), i have an error in web :'(
           // eslint-disable-next-line react-native/no-inline-styles
           style={{ alignSelf: 'center' }}
+        />
+      </Gutter>
+      <Gutter>
+        <StyledButtonQuaternaryBlack
+          wording={variantInfo.modalTitle}
+          icon={InfoPlain}
+          onPress={onShowChroniclesWritersModal}
         />
       </Gutter>
     </View>
@@ -62,4 +73,8 @@ const Gutter = styled.View(({ theme }) => ({
 
 const StyledBodyAccentXs = styled(Typo.BodyAccentXs)(({ theme }) => ({
   color: theme.designSystem.color.text.subtle,
+}))
+
+const StyledButtonQuaternaryBlack = styledButton(ButtonQuaternaryBlack)(({ theme }) => ({
+  marginTop: theme.designSystem.size.spacing.xl,
 }))

--- a/src/features/offer/components/OfferContent/ChronicleSection/types.ts
+++ b/src/features/offer/components/OfferContent/ChronicleSection/types.ts
@@ -1,4 +1,3 @@
-import { ReactNode } from 'react'
 import { StyleProp, ViewStyle } from 'react-native'
 
 import { ChronicleCardData } from 'features/chronicle/type'
@@ -7,13 +6,12 @@ import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 
 export type ChronicleSectionProps = {
   data: ChronicleCardData[]
-  title: string
-  subtitle?: string
   ctaLabel: string
   navigateTo: InternalNavigationProps['navigateTo']
+  variantInfo: ChronicleVariantInfo
+  onShowChroniclesWritersModal: () => void
   onSeeMoreButtonPress?: (chronicleId: number) => void
   style?: StyleProp<ViewStyle>
-  icon?: ReactNode
 }
 
 export type ChronicleVariantInfo = {

--- a/src/features/offer/components/OfferContent/ChronicleSection/types.ts
+++ b/src/features/offer/components/OfferContent/ChronicleSection/types.ts
@@ -22,6 +22,7 @@ export type ChronicleVariantInfo = {
   subtitleSection: string
   subtitleItem: string
   Icon?: React.ReactNode
+  modalTitle: string
   modalWording: string
   modalButtonLabel: string
   SmallIcon?: React.ReactNode

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -914,6 +914,7 @@ function renderOfferContent({
           subcategory={subcategory}
           chronicles={chroniclesData}
           chronicleVariantInfo={chronicleVariantInfoFixture}
+          onShowChroniclesWritersModal={jest.fn()}
         />
       </NavigationContainer>
     ),

--- a/src/features/offer/components/OfferContent/OfferContent.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.tsx
@@ -24,6 +24,7 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   defaultReaction,
   headlineOffersCount,
   onReactionButtonPress,
+  onShowChroniclesWritersModal,
   userId,
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
@@ -60,7 +61,8 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
         defaultReaction={defaultReaction}
         onReactionButtonPress={onReactionButtonPress}
         onLayout={onLayout}
-        userId={userId}>
+        userId={userId}
+        onShowChroniclesWritersModal={onShowChroniclesWritersModal}>
         {comingSoonFooterHeight ? (
           <ComingSoonFooterOffset
             testID="coming-soon-footer-offset"

--- a/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
@@ -176,6 +176,7 @@ const renderOfferContent = ({
         searchGroupList={PLACEHOLDER_DATA.searchGroups}
         subcategory={subcategory}
         chronicleVariantInfo={chronicleVariantInfoFixture}
+        onShowChroniclesWritersModal={jest.fn()}
       />
     ),
     {

--- a/src/features/offer/components/OfferContent/OfferContent.web.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.tsx
@@ -25,6 +25,7 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   chronicleVariantInfo,
   defaultReaction,
   onReactionButtonPress,
+  onShowChroniclesWritersModal,
   headlineOffersCount,
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
@@ -86,7 +87,8 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
           defaultReaction={defaultReaction}
           onReactionButtonPress={onReactionButtonPress}
           headlineOffersCount={headlineOffersCount}
-          onLayout={onLayout}>
+          onLayout={onLayout}
+          onShowChroniclesWritersModal={onShowChroniclesWritersModal}>
           {comingSoonFooterHeight ? (
             <ComingSoonFooterOffset height={comingSoonFooterHeight} />
           ) : null}

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -62,6 +62,7 @@ type OfferContentBaseProps = OfferContentProps &
   PropsWithChildren<{
     BodyWrapper: FunctionComponent
     onOfferPreviewPress: (index?: number) => void
+    onShowChroniclesWritersModal: () => void
     onSeeVideoPress?: () => void
     chronicles?: ChronicleCardData[]
     likesCount?: number
@@ -88,6 +89,7 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
   contentContainerStyle,
   defaultReaction,
   onReactionButtonPress,
+  onShowChroniclesWritersModal,
   isVideoSectionEnabled,
   BodyWrapper = React.Fragment,
   onLayout,
@@ -297,10 +299,8 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
           {chronicles?.length ? (
             <StyledSectionWithDivider visible testID="chronicles-section" gap={8}>
               <ChronicleSection
-                title={chronicleVariantInfo.titleSection}
+                variantInfo={chronicleVariantInfo}
                 ctaLabel="Voir tous les avis"
-                subtitle={chronicleVariantInfo.subtitleSection}
-                icon={chronicleVariantInfo.Icon}
                 data={chronicles}
                 // It's dirty but necessary to use from parameter for the logs
                 navigateTo={{
@@ -308,6 +308,7 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
                   params: { offerId: offer.id, from: 'chronicles' },
                 }}
                 onSeeMoreButtonPress={onSeeMoreButtonPress}
+                onShowChroniclesWritersModal={onShowChroniclesWritersModal}
               />
             </StyledSectionWithDivider>
           ) : null}

--- a/src/features/offer/constant.tsx
+++ b/src/features/offer/constant.tsx
@@ -46,7 +46,9 @@ export const CHRONICLE_VARIANT_CONFIG = [
     subtitleItem: 'Membre du Book Club',
     Icon: <BookClubIcon testID="bookClubIcon" />,
     SmallIcon: <SmallBookClubIcon />,
-    modalWording: 'Les avis du Book Club sont écrits par des jeunes passionnés de lecture.',
+    modalTitle: 'C’est quoi le Book Club\u00a0?',
+    modalWording:
+      'C’est un groupe de jeunes passionnés de lecture choisi par le pass Culture. \n\nChaque mois, ils lisent, donnent leur avis, partagent leurs coups de cœur... pour t’aider à choisir ton prochain livre\u00a0!',
     modalButtonLabel: 'Voir toutes les recos du Book Club',
   },
   {
@@ -57,7 +59,9 @@ export const CHRONICLE_VARIANT_CONFIG = [
     subtitleItem: 'Membre du Ciné Club',
     Icon: <CineClubIcon testID="cineClubIcon" />,
     SmallIcon: <SmallCineClubIcon />,
-    modalWording: 'Les avis du Ciné Club sont écrits par des jeunes passionnés de cinéma.',
+    modalTitle: 'C’est quoi le Ciné Club\u00a0?',
+    modalWording:
+      'C’est un groupe de jeunes cinéphiles choisi par le pass Culture. \n\nChaque mois, ils regardent des films, donnent leur avis et partagent ceux qui les ont fait vibrer… pour t’inspirer ta prochaine séance\u00a0!',
     modalButtonLabel: 'Voir toutes les recos du Ciné Club',
   },
 ] as const

--- a/src/features/offer/fixtures/chronicleVariantInfo.ts
+++ b/src/features/offer/fixtures/chronicleVariantInfo.ts
@@ -7,6 +7,8 @@ export const chronicleVariantInfoFixture: ChronicleVariantInfo = {
   subtitleItem: 'Membre du Book Club',
   Icon: undefined,
   SmallIcon: undefined,
+  modalTitle:
+    'C’est un groupe de jeunes passionnés de lecture choisi par le pass Culture. \n\nChaque mois, ils lisent, donnent leur avis, partagent leurs coups de cœur... pour t’aider à choisir ton prochain livre\u00a0!',
   modalWording: 'Les avis du Book Club sont écrits par des jeunes passionnés de lecture.',
   modalButtonLabel: 'Voir toutes les recos du Book Club',
 }

--- a/src/features/offer/pages/Offer/Offer.native.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.native.test.tsx
@@ -206,12 +206,26 @@ describe('<Offer />', () => {
     expect(await screen.findByText('Cinéma plein air')).toBeOnTheScreen()
   })
 
-  it('should display chronicles section when FF activated', async () => {
-    setFeatureFlags([RemoteStoreFeatureFlags.WIP_OFFER_CHRONICLE_SECTION])
+  describe('When wipOfferChronicleSection FF activated', () => {
+    beforeEach(() => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_OFFER_CHRONICLE_SECTION])
+    })
 
-    renderOfferPage({ mockOffer: offerResponseSnap })
+    it('should display chronicles section', async () => {
+      renderOfferPage({ mockOffer: offerResponseSnap })
 
-    expect(await screen.findByText('La reco du Ciné Club')).toBeOnTheScreen()
+      expect(await screen.findByText('La reco du Ciné Club')).toBeOnTheScreen()
+    })
+
+    it('should open chronicles writers modal when pressing "C’est quoi le Ciné Club\u00a0?" button', async () => {
+      renderOfferPage({ mockOffer: offerResponseSnap })
+
+      await screen.findByText('La reco du Ciné Club')
+
+      await user.press(screen.getByText('C’est quoi le Ciné Club\u00a0?'))
+
+      expect(mockShowModal).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('should display video section when FF activated', async () => {

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -1,9 +1,10 @@
-import { useRoute } from '@react-navigation/native'
+import { useNavigation, useRoute } from '@react-navigation/native'
 import React, { useCallback } from 'react'
 
 import { ReactionTypeEnum } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { UseRouteType } from 'features/navigation/RootNavigator/types'
+import { ChroniclesWritersModal } from 'features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal'
+import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { chroniclePreviewToChronicalCardData } from 'features/offer/adapters/chroniclePreviewToChronicleCardData'
 import { OfferContent } from 'features/offer/components/OfferContent/OfferContent'
 import { OfferContentPlaceholder } from 'features/offer/components/OfferContentPlaceholder/OfferContentPlaceholder'
@@ -27,6 +28,7 @@ const ANIMATION_DURATION = 700
 
 export function Offer() {
   const route = useRoute<UseRouteType<'Offer'>>()
+  const { navigate } = useNavigation<UseNavigationType>()
   const offerId = route.params?.id
 
   const hasOfferChronicleSection = useFeatureFlag(
@@ -46,7 +48,16 @@ export function Offer() {
   const { data: subcategories } = useSubcategories()
   const subcategoriesMapping = useSubcategoriesMapping()
 
-  const { visible, hideModal, showModal } = useModal(false)
+  const {
+    visible: reactionModalVisible,
+    hideModal: hideReactionModal,
+    showModal: showReactionModal,
+  } = useModal(false)
+  const {
+    visible: chroniclesWritersModalVisible,
+    hideModal: hideChroniclesWritersModal,
+    showModal: showChroniclesWritersModal,
+  } = useModal(false)
   const { data: booking } = useEndedBookingFromOfferIdQuery(offer?.id ?? -1, {
     enabled: isLoggedIn && isReactionEnabled && !!offer?.id,
   })
@@ -55,10 +66,15 @@ export function Offer() {
   const handleSaveReaction = useCallback(
     ({ offerId, reactionType }: { offerId: number; reactionType: ReactionTypeEnum }) => {
       saveReaction({ reactions: [{ offerId, reactionType }] })
-      hideModal()
+      hideReactionModal()
     },
-    [hideModal, saveReaction]
+    [hideReactionModal, saveReaction]
   )
+
+  const handleOnShowRecoButtonPress = () => {
+    hideChroniclesWritersModal()
+    navigate('ThematicHome', { homeId: '4mlVpAZySUZO6eHazWKZeV', from: 'chronicles' })
+  }
 
   const { data } = useFetchHeadlineOffersCountQuery(offer)
 
@@ -83,12 +99,19 @@ export function Offer() {
       <ReactionChoiceModal
         dateUsed={booking?.dateUsed ?? ''}
         offer={offer}
-        closeModal={hideModal}
-        visible={visible}
+        closeModal={hideReactionModal}
+        visible={reactionModalVisible}
         defaultReaction={booking?.userReaction}
         onSave={handleSaveReaction}
         from={ReactionFromEnum.ENDED_BOOKING}
         bodyType={ReactionChoiceModalBodyEnum.VALIDATION}
+      />
+
+      <ChroniclesWritersModal
+        closeModal={hideChroniclesWritersModal}
+        isVisible={chroniclesWritersModalVisible}
+        onShowRecoButtonPress={handleOnShowRecoButtonPress}
+        variantInfo={chronicleVariantInfo}
       />
 
       <OfferContent
@@ -99,8 +122,9 @@ export function Offer() {
         searchGroupList={subcategories.searchGroups}
         subcategory={subcategoriesMapping[offer.subcategoryId]}
         defaultReaction={booking?.userReaction}
-        onReactionButtonPress={booking?.canReact ? showModal : undefined}
+        onReactionButtonPress={booking?.canReact ? showReactionModal : undefined}
         userId={user?.id}
+        onShowChroniclesWritersModal={showChroniclesWritersModal}
       />
     </Page>
   )

--- a/src/features/offer/types.ts
+++ b/src/features/offer/types.ts
@@ -74,6 +74,7 @@ export type OfferContentProps = {
   searchGroupList: SearchGroupResponseModelv2[]
   chronicleVariantInfo: ChronicleVariantInfo
   subcategory: Subcategory
+  onShowChroniclesWritersModal: () => void
   chronicles?: ChronicleCardData[]
   headlineOffersCount?: number
   defaultReaction?: ReactionTypeEnum | null


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37425

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
