### PR TITLE
(PC-37400) fix(flashlight): free space

### DIFF
--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -1,10 +1,6 @@
 name: 'Flashlight Android Performance Test'
 
-on:
-  schedule:
-    - cron: '0 22 * * 0' # At 10PM every Sunday
-  pull_request:
-    types: [labeled]
+on: push
 
 permissions:
   contents: write
@@ -19,7 +15,6 @@ jobs:
     name: 'Run Flashlight Android Performance Test'
     runs-on: ubuntu-24.04
     timeout-minutes: 120
-    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'e2e perfs')
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -82,17 +82,6 @@ jobs:
       - name: Setup android keystore file
         run: echo '${{ steps.secrets.outputs.ANDROID_KEYSTORE }}' | base64 --decode > android/keystores/staging.keystore
 
-      - name: Free up disk space
-        run: |
-          echo "Initial free space:"
-          df -h
-          # Remove large pre-installed packages we don't need so we don't run into "Not enough space" issue
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          echo "Free space after cleanup:"
-          df -h
-
       - name: Run the full test script
         id: run_test
         run: |

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -136,10 +136,3 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      - name: Clean up AVD and Build Artifacts
-        if: always() # This ensures cleanup runs even if tests fail
-        run: |
-          echo "--- Deleting AVD ---"
-          avdmanager delete avd -n SDK_modern_test
-          echo "--- Cleaning Gradle project ---"
-          ./gradlew clean

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - run: df -h
+      - run: pwd
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -82,6 +82,18 @@ jobs:
       - name: Setup android keystore file
         run: echo '${{ steps.secrets.outputs.ANDROID_KEYSTORE }}' | base64 --decode > android/keystores/staging.keystore
 
+      - name: Free up disk space
+        run: |
+          echo "Initial free space:"
+          df -h
+          # Remove large pre-installed packages we don't need so we don't run into "Not enough space" issue
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          echo "Free space after cleanup:"
+          df -h
+
       - name: Run the full test script
         id: run_test
         run: |

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -90,7 +90,6 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           echo "Free space after cleanup:"
           df -h
 

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -136,3 +136,10 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Clean up AVD and Build Artifacts
+        if: always() # This ensures cleanup runs even if tests fail
+        run: |
+          echo "--- Deleting AVD ---"
+          avdmanager delete avd -n SDK_modern_test
+          echo "--- Cleaning Gradle project ---"
+          ./gradlew clean

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -86,8 +86,8 @@ jobs:
 
       - name: Check Disk Usage of Key Directories
         run: |
-          echo "--- Gradle Cache Size ---"
-          du -sh ~/.gradle/caches
+          # echo "--- Gradle Cache Size ---"
+          # du -sh ~/.gradle/caches
           echo "--- Android SDK Size ---"
           du -sh $ANDROID_SDK_ROOT
           echo "--- System Images Details ---"

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
+      - run: df -h
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -84,18 +84,6 @@ jobs:
       - name: Setup android keystore file
         run: echo '${{ steps.secrets.outputs.ANDROID_KEYSTORE }}' | base64 --decode > android/keystores/staging.keystore
 
-      - name: Check Disk Usage of Key Directories
-        run: |
-          # echo "--- Gradle Cache Size ---"
-          # du -sh ~/.gradle/caches
-          echo "--- Android SDK Size ---"
-          du -sh $ANDROID_SDK_ROOT
-          echo "--- System Images Details ---"
-          ls -lh $ANDROID_SDK_ROOT/system-images/
-          # Check for any old AVDs that weren't cleaned up
-          echo "--- AVDs ---"
-          ls -lh ~/.android/avd/
-
       - name: Run the full test script
         id: run_test
         run: |

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -84,6 +84,18 @@ jobs:
       - name: Setup android keystore file
         run: echo '${{ steps.secrets.outputs.ANDROID_KEYSTORE }}' | base64 --decode > android/keystores/staging.keystore
 
+      - name: Check Disk Usage of Key Directories
+        run: |
+          echo "--- Gradle Cache Size ---"
+          du -sh ~/.gradle/caches
+          echo "--- Android SDK Size ---"
+          du -sh $ANDROID_SDK_ROOT
+          echo "--- System Images Details ---"
+          ls -lh $ANDROID_SDK_ROOT/system-images/
+          # Check for any old AVDs that weren't cleaned up
+          echo "--- AVDs ---"
+          ls -lh ~/.android/avd/
+
       - name: Run the full test script
         id: run_test
         run: |

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -1,6 +1,10 @@
 name: 'Flashlight Android Performance Test'
 
-on: push
+on:
+  schedule:
+    - cron: '0 22 * * 0' # At 10PM every Sunday
+  pull_request:
+    types: [labeled]
 
 permissions:
   contents: write
@@ -15,9 +19,8 @@ jobs:
     name: 'Run Flashlight Android Performance Test'
     runs-on: ubuntu-24.04
     timeout-minutes: 120
+    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'e2e perfs')
     steps:
-      - run: df -h
-      - run: pwd
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/scripts/run_flashlight_on_android.sh
+++ b/scripts/run_flashlight_on_android.sh
@@ -13,9 +13,9 @@ get_version() {
 }
 
 BUNDLE_ID=app.passculture.staging
+ANDROID_SDK_MANAGER_COMMAND_LINE_TOOLS_VERSION="12.0"
 EMULATOR_NAME="Galaxy Nexus"
 MIN_SDK_VERSION="$(get_version 'minSdkVersion')"
-ANDROID_SDK_MANAGER_COMMAND_LINE_TOOLS_VERSION="12.0"
 export ANDROID_HOME="${ANDROID_HOME:-"$HOME/Library/Android/sdk"}"
 export ANDROID_SDK_ROOT="$ANDROID_HOME"
 export ANDROID_AVD_HOME="$ANDROID_HOME/avd"

--- a/scripts/run_flashlight_on_android.sh
+++ b/scripts/run_flashlight_on_android.sh
@@ -5,17 +5,10 @@ set -o errexit -o nounset -o pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$(dirname "$SCRIPT_DIR")
 
-get_version() {
-	local FIELD="$1"
-
-	grep "$FIELD" './android/build.gradle' |
-		grep -Eo '[0-9]+(\.[0-9]+)*'
-}
-
 BUNDLE_ID=app.passculture.staging
+TARGET_SDK_VERSION="30"
 ANDROID_SDK_MANAGER_COMMAND_LINE_TOOLS_VERSION="12.0"
 EMULATOR_NAME="pixel_6"
-TARGET_SDK_VERSION="$(get_version 'targetSdkVersion')"
 export ANDROID_HOME="${ANDROID_HOME:-"$HOME/Library/Android/sdk"}"
 export ANDROID_SDK_ROOT="$ANDROID_HOME"
 export ANDROID_AVD_HOME="$ANDROID_HOME/avd"

--- a/scripts/run_flashlight_on_android.sh
+++ b/scripts/run_flashlight_on_android.sh
@@ -14,7 +14,7 @@ get_version() {
 
 BUNDLE_ID=app.passculture.staging
 ANDROID_SDK_MANAGER_COMMAND_LINE_TOOLS_VERSION="12.0"
-EMULATOR_NAME="Galaxy Nexus"
+EMULATOR_NAME="pixel_6"
 MIN_SDK_VERSION="$(get_version 'minSdkVersion')"
 export ANDROID_HOME="${ANDROID_HOME:-"$HOME/Library/Android/sdk"}"
 export ANDROID_SDK_ROOT="$ANDROID_HOME"
@@ -93,7 +93,7 @@ image_for_sdk() {
     else
         ARCHITECTURE_SUFFIX="x86_64"
     fi
-    echo "system-images;android-$SDK_VERSION;default;$ARCHITECTURE_SUFFIX"
+    echo "system-images;android-$SDK_VERSION;google_apis;$ARCHITECTURE_SUFFIX"
 }
 
 install_flashlight() {

--- a/scripts/run_flashlight_on_android.sh
+++ b/scripts/run_flashlight_on_android.sh
@@ -186,6 +186,16 @@ recreate_emulator() {
     echo "--- Show available AVDs ---"
     emulator -list-avds
 
+    log_info "Free up space"
+    df -h
+    # Remove .NET SDKs
+    sudo rm -rf /usr/share/dotnet
+    # Remove Swift toolchain
+    sudo rm -rf /usr/share/swift
+    # Remove Haskell (ghc)
+    sudo rm -rf /opt/ghc
+    df -h
+
     local EMULATOR_LOG_FILE="emulator-boot.log"
     log_info "Starting emulator '$EMULATOR_NAME' in the background (log: ${EMULATOR_LOG_FILE})..."
     emulator \

--- a/scripts/run_flashlight_on_android.sh
+++ b/scripts/run_flashlight_on_android.sh
@@ -85,7 +85,7 @@ image_for_sdk() {
     else
         ARCHITECTURE_SUFFIX="x86_64"
     fi
-    echo "system-images;android-$SDK_VERSION;google_apis;$ARCHITECTURE_SUFFIX"
+    echo "system-images;android-$SDK_VERSION;default;$ARCHITECTURE_SUFFIX"
 }
 
 install_flashlight() {

--- a/scripts/run_flashlight_on_android.sh
+++ b/scripts/run_flashlight_on_android.sh
@@ -168,6 +168,18 @@ recreate_emulator() {
     echo "Disk usage"
     df -h
 
+    echo "--- Gradle Cache Size ---"
+    du -sh ~/.gradle/caches
+
+    echo "--- Android SDK Size ---"
+    du -sh $ANDROID_SDK_ROOT
+
+    echo "--- System Images Details ---"
+    ls -lh $ANDROID_SDK_ROOT/system-images/
+
+    echo "--- AVDs ---"
+    ls -lh ~/.android/avd/
+
     local EMULATOR_LOG_FILE="emulator-boot.log"
     log_info "Starting emulator '$EMULATOR_NAME' in the background (log: ${EMULATOR_LOG_FILE})..."
     emulator \

--- a/scripts/run_flashlight_on_android.sh
+++ b/scripts/run_flashlight_on_android.sh
@@ -180,6 +180,9 @@ recreate_emulator() {
     echo "--- AVDs ---"
     ls -lh ~/.android/avd/ || true
 
+    echo "--- Show available AVDs ---"
+    emulator -list-avds
+
     local EMULATOR_LOG_FILE="emulator-boot.log"
     log_info "Starting emulator '$EMULATOR_NAME' in the background (log: ${EMULATOR_LOG_FILE})..."
     emulator \

--- a/scripts/run_flashlight_on_android.sh
+++ b/scripts/run_flashlight_on_android.sh
@@ -158,27 +158,6 @@ recreate_emulator() {
             --device "$DEVICE_NAME" \
             --force
 
-    echo "Disk usage"
-    df -h
-
-    echo "--- Gradle Cache Size ---"
-    du -sh ~/.gradle/caches || true
-
-    echo "--- Android SDK Size ---"
-    du -sh $ANDROID_SDK_ROOT || true
-
-    echo "--- System Images Details ---"
-    ls -lh $ANDROID_SDK_ROOT/system-images/ || true
-    
-    echo "--- System Images disk usage ---"
-    du -h -d 1 $ANDROID_SDK_ROOT/system-images | sort -hr || true
-
-    echo "--- AVDs ---"
-    ls -lh ~/.android/avd/ || true
-
-    echo "--- Show available AVDs ---"
-    emulator -list-avds
-
     log_info "Free up space"
     df -h
     # Remove .NET SDKs

--- a/scripts/run_flashlight_on_android.sh
+++ b/scripts/run_flashlight_on_android.sh
@@ -5,8 +5,16 @@ set -o errexit -o nounset -o pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$(dirname "$SCRIPT_DIR")
 
+get_version() {
+	local FIELD="$1"
+
+	grep "$FIELD" './android/build.gradle' |
+		grep -Eo '[0-9]+(\.[0-9]+)*'
+}
+
 BUNDLE_ID=app.passculture.staging
-MIN_SDK_VERSION="30"
+EMULATOR_NAME="Galaxy Nexus"
+MIN_SDK_VERSION="$(get_version 'minSdkVersion')"
 ANDROID_SDK_MANAGER_COMMAND_LINE_TOOLS_VERSION="12.0"
 export ANDROID_HOME="${ANDROID_HOME:-"$HOME/Library/Android/sdk"}"
 export ANDROID_SDK_ROOT="$ANDROID_HOME"
@@ -230,7 +238,7 @@ if [ -z "$APK_PATH" ]; then
 fi
 log_success "APK found at: $APK_PATH"
 
-recreate_emulator "SDK_modern_test" "$MIN_SDK_VERSION" "pixel_6"
+recreate_emulator "SDK_modern_test" "$MIN_SDK_VERSION" "$EMULATOR_NAME"
 
 log_and_run "Waiting up to 10 minutes for emulator to fully boot" \
     timeout 600 adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 5; done; echo "Emulator booted."'

--- a/scripts/run_flashlight_on_android.sh
+++ b/scripts/run_flashlight_on_android.sh
@@ -15,7 +15,7 @@ get_version() {
 BUNDLE_ID=app.passculture.staging
 ANDROID_SDK_MANAGER_COMMAND_LINE_TOOLS_VERSION="12.0"
 EMULATOR_NAME="pixel_6"
-MIN_SDK_VERSION="$(get_version 'minSdkVersion')"
+TARGET_SDK_VERSION="$(get_version 'targetSdkVersion')"
 export ANDROID_HOME="${ANDROID_HOME:-"$HOME/Library/Android/sdk"}"
 export ANDROID_SDK_ROOT="$ANDROID_HOME"
 export ANDROID_AVD_HOME="$ANDROID_HOME/avd"
@@ -269,7 +269,7 @@ if [ -z "$APK_PATH" ]; then
 fi
 log_success "APK found at: $APK_PATH"
 
-recreate_emulator "SDK_modern_test" "$MIN_SDK_VERSION" "$EMULATOR_NAME"
+recreate_emulator "SDK_modern_test" "$TARGET_SDK_VERSION" "$EMULATOR_NAME"
 
 log_and_run "Waiting up to 10 minutes for emulator to fully boot" \
     timeout 600 adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 5; done; echo "Emulator booted."'

--- a/scripts/run_flashlight_on_android.sh
+++ b/scripts/run_flashlight_on_android.sh
@@ -165,6 +165,9 @@ recreate_emulator() {
             --device "$DEVICE_NAME" \
             --force
 
+    echo "Disk usage"
+    df -h
+
     local EMULATOR_LOG_FILE="emulator-boot.log"
     log_info "Starting emulator '$EMULATOR_NAME' in the background (log: ${EMULATOR_LOG_FILE})..."
     emulator \

--- a/scripts/run_flashlight_on_android.sh
+++ b/scripts/run_flashlight_on_android.sh
@@ -169,16 +169,16 @@ recreate_emulator() {
     df -h
 
     echo "--- Gradle Cache Size ---"
-    du -sh ~/.gradle/caches
+    du -sh ~/.gradle/caches || true
 
     echo "--- Android SDK Size ---"
-    du -sh $ANDROID_SDK_ROOT
+    du -sh $ANDROID_SDK_ROOT || true
 
     echo "--- System Images Details ---"
-    ls -lh $ANDROID_SDK_ROOT/system-images/
+    ls -lh $ANDROID_SDK_ROOT/system-images/ || true
 
     echo "--- AVDs ---"
-    ls -lh ~/.android/avd/
+    ls -lh ~/.android/avd/ || true
 
     local EMULATOR_LOG_FILE="emulator-boot.log"
     log_info "Starting emulator '$EMULATOR_NAME' in the background (log: ${EMULATOR_LOG_FILE})..."

--- a/scripts/run_flashlight_on_android.sh
+++ b/scripts/run_flashlight_on_android.sh
@@ -176,6 +176,9 @@ recreate_emulator() {
 
     echo "--- System Images Details ---"
     ls -lh $ANDROID_SDK_ROOT/system-images/ || true
+    
+    echo "--- System Images disk usage ---"
+    du -h -d 1 $ANDROID_SDK_ROOT/system-images | sort -hr || true
 
     echo "--- AVDs ---"
     ls -lh ~/.android/avd/ || true


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37400

Learnings:
- The job started failing because the runner was out of disk space (see more details below in dedicated section).
- This test becomes flaky under certain conditions (see more details below in dedicated section).

# Understanding why the runner suddenly started running out of space
If we look at the job that worked, we had this (from "Set up job"):
```
Runner Image
  Image: ubuntu-24.04
  Version: 20250720.1.0
```
And the job that failed:
```
Runner Image
  Image: ubuntu-24.04
  Version: 20250728.1.0
```
The version was bumped.

In the job that worked, we can see a link to the Image Release:
https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250720.1

Click "Compare" and type the new version "20250728" and select: `ubuntu24/20250728.1`

If we compare the versions:
https://github.com/actions/runner-images/compare/ubuntu24/20250720.1...ubuntu24/20250728.1

The main difference that could be impactful is the addition of a new Android SDK: `android-36-ext18 (rev 1)`. This SDK probably takes several GB, probably explaining why after the inclusion of this SDK, the job fails.

# Flakiness
I tried using the SDK 35, [in this run](https://github.com/pass-culture/pass-culture-app-native/actions/runs/17261517811/job/48983857844)

But NO iterations finished successfully:
```sh
Flashlight test FAILED ❌: Max number of retries reached.
```

So I came back to SDK 30 [in this run](https://github.com/pass-culture/pass-culture-app-native/actions/runs/17262727425/job/48987709776). And it seems like the iterations are all working! So for some reason, my tests because flaky with the SDK 35.

The device used also has an impact on the test. When attempting to use "Nexus Galaxy" for the test [in this run](https://github.com/pass-culture/pass-culture-app-native/actions/runs/17239033475/job/48910873285), certain elements were not found on screen:

`NavigateFromHomeToN1AndSearchResult.yml` : in this test we attempt to scroll until "En voir plus" is visible.
```
No visible element found: "En voir plus"
```