### PR TITLE
(PC-37425) feat(chronicle): update page title

### DIFF
--- a/src/features/chronicle/components/ChronicleCardListHeader/ChronicleCardListHeader.tsx
+++ b/src/features/chronicle/components/ChronicleCardListHeader/ChronicleCardListHeader.tsx
@@ -18,7 +18,7 @@ export const ChronicleCardListHeader: FunctionComponent<Props> = ({
 }) => {
   return (
     <ViewGap gap={2}>
-      <Typo.Title2>Tous les avis</Typo.Title2>
+      <Typo.Title2>Tous les avis du {variantInfo.labelReaction}</Typo.Title2>
       <StyledButtonQuaternaryBlack
         wording={variantInfo.modalTitle}
         icon={InfoPlain}

--- a/src/features/chronicle/pages/Chronicles/Chronicles.native.test.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.native.test.tsx
@@ -66,7 +66,7 @@ describe('Chronicles', () => {
 
       render(reactQueryProviderHOC(<Chronicles />))
 
-      await screen.findByText('Tous les avis')
+      await screen.findByText('Tous les avis du Book Club')
 
       expect(screen.getAllByTestId('bookClubIcon')[0]).toBeOnTheScreen()
     })
@@ -79,7 +79,7 @@ describe('Chronicles', () => {
 
       render(reactQueryProviderHOC(<Chronicles />))
 
-      await screen.findByText('Tous les avis')
+      await screen.findByText('Tous les avis du Ciné Club')
 
       expect(screen.getAllByTestId('cineClubIcon')[0]).toBeOnTheScreen()
     })
@@ -87,7 +87,7 @@ describe('Chronicles', () => {
     it('should scroll to selected chronicle on layout', async () => {
       render(reactQueryProviderHOC(<Chronicles />))
 
-      await screen.findByText('Tous les avis')
+      await screen.findByText('Tous les avis du Ciné Club')
 
       await act(async () => {
         fireEvent(screen.getByTestId('chronicle-list'), 'onLayout', mockOnLayout)
@@ -124,7 +124,7 @@ describe('Chronicles', () => {
     it('should render correctly', async () => {
       render(reactQueryProviderHOC(<Chronicles />))
 
-      expect(await screen.findByText('Tous les avis')).toBeOnTheScreen()
+      expect(await screen.findByText('Tous les avis du Ciné Club')).toBeOnTheScreen()
     })
 
     it('should navigate to offer page without openModalOnNavigation param when pressing back button', async () => {
@@ -141,7 +141,7 @@ describe('Chronicles', () => {
     it('should not scroll to selected chronicle on layout', async () => {
       render(reactQueryProviderHOC(<Chronicles />))
 
-      await screen.findByText('Tous les avis')
+      await screen.findByText('Tous les avis du Ciné Club')
 
       await act(async () => {
         fireEvent(screen.getByTestId('chronicle-list'), 'onLayout', mockOnLayout)

--- a/src/features/chronicle/pages/Chronicles/Chronicles.web.test.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.web.test.tsx
@@ -42,7 +42,7 @@ describe('Chronicles', () => {
           },
         })
 
-        expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
+        expect(await screen.findByText('Tous les avis du Book Club')).toBeInTheDocument()
         expect(screen.getAllByTestId(/chronicle-*/).length).toBeGreaterThan(0)
       })
 
@@ -53,7 +53,7 @@ describe('Chronicles', () => {
           },
         })
 
-        expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
+        expect(await screen.findByText('Tous les avis du Book Club')).toBeInTheDocument()
         expect(screen.queryByText("Réserver l'offre")).not.toBeInTheDocument()
       })
     })
@@ -73,7 +73,7 @@ describe('Chronicles', () => {
           },
         })
 
-        expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
+        expect(await screen.findByText('Tous les avis du Ciné Club')).toBeInTheDocument()
         expect(screen.queryByText('Trouve ta séance')).not.toBeInTheDocument()
       })
     })
@@ -95,7 +95,7 @@ describe('Chronicles', () => {
           },
         })
 
-        expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
+        expect(await screen.findByText('Tous les avis du Ciné Club')).toBeInTheDocument()
         expect(screen.getByText('Sous les étoiles de Paris - VF')).toBeInTheDocument()
         expect(screen.getByText('Dès 5,00 €')).toBeInTheDocument()
         expect(screen.getAllByTestId(/chronicle-*/).length).toBeGreaterThan(0)
@@ -108,7 +108,7 @@ describe('Chronicles', () => {
           },
         })
 
-        expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
+        expect(await screen.findByText('Tous les avis du Ciné Club')).toBeInTheDocument()
         expect(screen.getByText('Trouve ta séance')).toBeInTheDocument()
       })
 
@@ -119,7 +119,7 @@ describe('Chronicles', () => {
           },
         })
 
-        await screen.findByText('Tous les avis')
+        await screen.findByText('Tous les avis du Ciné Club')
 
         fireEvent.click(screen.getByText('Trouve ta séance'))
 

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -107,12 +107,14 @@ export function Offer() {
         bodyType={ReactionChoiceModalBodyEnum.VALIDATION}
       />
 
-      <ChroniclesWritersModal
-        closeModal={hideChroniclesWritersModal}
-        isVisible={chroniclesWritersModalVisible}
-        onShowRecoButtonPress={handleOnShowRecoButtonPress}
-        variantInfo={chronicleVariantInfo}
-      />
+      {chronicleVariantInfo ? (
+        <ChroniclesWritersModal
+          closeModal={hideChroniclesWritersModal}
+          isVisible={chroniclesWritersModalVisible}
+          onShowRecoButtonPress={handleOnShowRecoButtonPress}
+          variantInfo={chronicleVariantInfo}
+        />
+      ) : null}
 
       <OfferContent
         offer={offer}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37425

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="170" height="246" alt="Capture d’écran 2025-08-26 à 10 41 18" src="https://github.com/user-attachments/assets/283ad53a-905a-4cc6-b58a-9ed2dda08c41" /> <img width="177" height="152" alt="Capture d’écran 2025-08-26 à 10 41 38" src="https://github.com/user-attachments/assets/e112adfa-7ad1-46d0-b13a-3ae427fb8542" />|       |
| Android          |               |       |
| Phone - Chrome   |               |<img width="401" height="693" alt="Capture d’écran 2025-08-26 à 10 22 04" src="https://github.com/user-attachments/assets/b04985c9-122d-4fd5-a38c-c78a83f20a4c" /> <img width="407" height="698" alt="Capture d’écran 2025-08-26 à 10 21 29" src="https://github.com/user-attachments/assets/53f6946c-6146-41f3-b34c-71729cad721c" />|
| Desktop - Chrome |<img width="612" height="310" alt="Capture d’écran 2025-08-26 à 10 41 30" src="https://github.com/user-attachments/assets/9148ed5c-46c4-4e07-b8ec-8a8c5fe3354a" /> <img width="619" height="320" alt="Capture d’écran 2025-08-26 à 10 41 47" src="https://github.com/user-attachments/assets/965dd1aa-997c-456d-89b1-90a1ee72b7fe" />|<img width="1725" height="877" alt="Capture d’écran 2025-08-26 à 10 21 56" src="https://github.com/user-attachments/assets/c02f916a-533c-4eca-b6d0-c5c64a7532cd" /> <img width="1716" height="881" alt="Capture d’écran 2025-08-26 à 10 21 16" src="https://github.com/user-attachments/assets/45d9c9ae-99d7-4e4e-8b9f-15d7add546a6" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
