### PR TITLE
(PC-37474) fix(OfferAbout): remove icon in Markdown text

### DIFF
--- a/src/libs/parsers/highlightLinks.tsx
+++ b/src/libs/parsers/highlightLinks.tsx
@@ -63,7 +63,7 @@ const normalizeURL = (partialURL: string): string => {
   return `http://${partialURL}`
 }
 
-export const highlightLinks = (description: string): ParsedDescription => {
+export const highlightLinks = (description: string, withIcon?: boolean): ParsedDescription => {
   const chunks = findAll({
     searchWords: [],
     findChunks: customFindUrlChunks,
@@ -73,7 +73,7 @@ export const highlightLinks = (description: string): ParsedDescription => {
   return chunks.map(({ start, end, highlight }, index) => {
     const url = normalizeURL(description.slice(start, end))
     return highlight ? (
-      <ExternalLink key={`external-link-${index}`} url={url} />
+      <ExternalLink key={`external-link-${index}`} url={url} withIcon={withIcon} />
     ) : (
       description.slice(start, end)
     )

--- a/src/ui/components/Markdown/Markdown.tsx
+++ b/src/ui/components/Markdown/Markdown.tsx
@@ -13,7 +13,7 @@ export const Markdown: FunctionComponent<PropsWithChildren> = ({ children }) => 
       {parsedText.map((part: MarkdownPartProps, index) => (
         // A text can contain several times the same part therefore has no unique identifier
         // If you have better than index you can update
-        <MarkdownPart key={`markdown-part-${index}`} {...part} />
+        <MarkdownPart key={`markdown-part-${index}`} {...part} withIcon={false} />
       ))}
     </React.Fragment>
   )

--- a/src/ui/components/MarkdownPart/MarkdownPart.tsx
+++ b/src/ui/components/MarkdownPart/MarkdownPart.tsx
@@ -4,18 +4,27 @@ import { highlightLinks } from 'libs/parsers/highlightLinks'
 import { MarkdownPartProps } from 'ui/components/types'
 import { Typo } from 'ui/theme'
 
-export const MarkdownPart: FunctionComponent<MarkdownPartProps> = ({ text, isBold, isItalic }) => {
+export const MarkdownPart: FunctionComponent<MarkdownPartProps> = ({
+  text,
+  isBold,
+  isItalic,
+  withIcon,
+}) => {
   if (isBold && !isItalic) {
-    return <Typo.BodyAccent testID="styledBodyAccent">{highlightLinks(text)}</Typo.BodyAccent>
+    return (
+      <Typo.BodyAccent testID="styledBodyAccent">{highlightLinks(text, withIcon)}</Typo.BodyAccent>
+    )
   } else if (isItalic && !isBold) {
-    return <Typo.BodyItalic testID="styledBodyItalic">{highlightLinks(text)}</Typo.BodyItalic>
+    return (
+      <Typo.BodyItalic testID="styledBodyItalic">{highlightLinks(text, withIcon)}</Typo.BodyItalic>
+    )
   } else if (isItalic && isBold) {
     return (
       <Typo.BodyItalicAccent testID="styledBodyItalicAccent">
-        {highlightLinks(text)}
+        {highlightLinks(text, withIcon)}
       </Typo.BodyItalicAccent>
     )
   }
 
-  return <Typo.Body testID="styledBody">{highlightLinks(text)}</Typo.Body>
+  return <Typo.Body testID="styledBody">{highlightLinks(text, withIcon)}</Typo.Body>
 }

--- a/src/ui/components/buttons/externalLink/ExternalLink.native.test.tsx
+++ b/src/ui/components/buttons/externalLink/ExternalLink.native.test.tsx
@@ -36,4 +36,10 @@ describe('ExternalLink', () => {
 
     expect(openURLSpy).toHaveBeenNthCalledWith(1, someUrl)
   })
+
+  it('should not display Icon when withIcon is false', () => {
+    render(<ExternalLink text="some text with several words" url={someUrl} withIcon={false} />)
+
+    expect(screen.queryByTestId('externalSiteIcon')).not.toBeOnTheScreen()
+  })
 })

--- a/src/ui/components/buttons/externalLink/ExternalLink.tsx
+++ b/src/ui/components/buttons/externalLink/ExternalLink.tsx
@@ -12,9 +12,10 @@ interface Props {
   primary?: boolean
   text?: string
   testID?: string
+  withIcon?: boolean
 }
 
-export const ExternalLink: React.FC<Props> = ({ url, text, primary, testID }) => {
+export const ExternalLink: React.FC<Props> = ({ url, text, primary, testID, withIcon = true }) => {
   const [firstWord, remainingWords] = extractExternalLinkParts(text || url)
 
   const accessibilityLabel = `Nouvelle fenêtre\u00a0: ${text || url}`
@@ -24,10 +25,10 @@ export const ExternalLink: React.FC<Props> = ({ url, text, primary, testID }) =>
       onPress={() => openUrl(url)}
       {...accessibilityAndTestId(accessibilityLabel, testID)}>
       <StyledBody>
-        <ExternalSite primary={primary} testID="externalSiteIcon" />
+        {withIcon ? <ExternalSite primary={primary} testID="externalSiteIcon" /> : null}
         {firstWord}
       </StyledBody>
-      {remainingWords}
+      {withIcon ? remainingWords : remainingWords.trim()}
     </ButtonText>
   )
 }

--- a/src/ui/components/buttons/externalLink/ExternalLink.web.test.tsx
+++ b/src/ui/components/buttons/externalLink/ExternalLink.web.test.tsx
@@ -52,4 +52,10 @@ describe('ExternalLink', () => {
     expect(screen.getByText('some')).toBeInTheDocument()
     expect(screen.getByText('text with several words')).toBeInTheDocument()
   })
+
+  it('should not display Icon when withIcon is false', () => {
+    render(<ExternalLink text="some text with several words" url={someUrl} withIcon={false} />)
+
+    expect(screen.queryByTestId('externalSiteIcon')).not.toBeInTheDocument()
+  })
 })

--- a/src/ui/components/buttons/externalLink/ExternalLink.web.tsx
+++ b/src/ui/components/buttons/externalLink/ExternalLink.web.tsx
@@ -12,9 +12,10 @@ interface Props {
   primary?: boolean
   text?: string
   testID?: string
+  withIcon?: boolean
 }
 
-export const ExternalLink: React.FC<Props> = ({ url, text, primary, testID }) => {
+export const ExternalLink: React.FC<Props> = ({ url, text, primary, testID, withIcon = true }) => {
   const [firstWord, remainingWords] = extractExternalLinkParts(text || url)
 
   const accessibilityLabel = `Nouvelle fenêtre\u00a0: ${text || url}`
@@ -26,10 +27,10 @@ export const ExternalLink: React.FC<Props> = ({ url, text, primary, testID }) =>
       testID={testID}>
       <ButtonText primary={primary}>
         <Text>
-          <ExternalSite primary={primary} testID="externalSiteIcon" />
+          {withIcon ? <ExternalSite primary={primary} testID="externalSiteIcon" /> : null}
           {firstWord}
         </Text>
-        {remainingWords}
+        {withIcon ? remainingWords : remainingWords.trim()}
       </ButtonText>
     </StyledTouchableLink>
   )

--- a/src/ui/components/types.ts
+++ b/src/ui/components/types.ts
@@ -4,6 +4,7 @@ export type MarkdownPartProps = {
   text: string
   isBold?: boolean
   isItalic?: boolean
+  withIcon?: boolean
 }
 
 export type FirstOrLastProps = {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37474

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)

## Rationale
The Icon for external link is visible in the collapsible text when collapsed as it is not a `Text`.
We can remove the icon for now, as the accessibility enhancements that are going to be done will check and fix this types of links.

