### PR TITLE
(PC-37103) fix(Log): inconsistency type of offerId and bookingId

### DIFF
--- a/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
@@ -276,7 +276,10 @@ describe('<BookingOfferModalComponent />', () => {
 
         await user.press(screen.getByText('Confirmer la réservation'))
 
-        expect(analytics.logBookingConfirmation).toHaveBeenCalledWith({ bookingId: "1", offerId: "20" })
+        expect(analytics.logBookingConfirmation).toHaveBeenCalledWith({
+          bookingId: '1',
+          offerId: '20',
+        })
       })
 
       it('should log conversion booking when is from search', async () => {

--- a/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
@@ -257,10 +257,10 @@ describe('<BookingOfferModalComponent />', () => {
 
         expect(analytics.logBookingConfirmation).toHaveBeenCalledWith({
           ...apiRecoParams,
-          bookingId: 1,
+          bookingId: '1',
           fromMultivenueOfferId: 1,
           fromOfferId: undefined,
-          offerId: 20,
+          offerId: '20',
           playlistType: PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS,
         })
       })
@@ -276,7 +276,7 @@ describe('<BookingOfferModalComponent />', () => {
 
         await user.press(screen.getByText('Confirmer la réservation'))
 
-        expect(analytics.logBookingConfirmation).toHaveBeenCalledWith({ bookingId: 1, offerId: 20 })
+        expect(analytics.logBookingConfirmation).toHaveBeenCalledWith({ bookingId: "1", offerId: "20" })
       })
 
       it('should log conversion booking when is from search', async () => {

--- a/src/features/bookOffer/pages/BookingOfferModal.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.tsx
@@ -74,8 +74,8 @@ export const BookingOfferModalComponent: React.FC<BookingOfferModalComponentProp
       if (offerId) {
         analytics.logBookingConfirmation({
           ...apiRecoParams,
-          offerId,
-          bookingId,
+          offerId: String(offerId),
+          bookingId: String(bookingId),
           fromOfferId: fromMultivenueOfferId ? undefined : fromOfferId,
           fromMultivenueOfferId,
           playlistType,

--- a/src/features/bookings/components/EndedBookingItem.native.test.tsx
+++ b/src/features/bookings/components/EndedBookingItem.native.test.tsx
@@ -113,7 +113,7 @@ describe('EndedBookingItem', () => {
     await userEvent.press(item)
 
     expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
-      offerId: 147874,
+      offerId: '147874',
       from: 'endedbookings',
     })
   })

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
@@ -324,7 +324,10 @@ describe('BookingDetails', () => {
         id: offerId,
         from: 'bookingdetails',
       })
-      expect(analytics.logConsultOffer).toHaveBeenCalledWith({ offerId, from: 'bookings' })
+      expect(analytics.logConsultOffer).toHaveBeenCalledWith({
+        offerId: String(offerId),
+        from: 'bookings',
+      })
     })
 
     it('should not redirect to the Offer and showSnackBarError when not connected', async () => {
@@ -690,7 +693,10 @@ describe('BookingDetails', () => {
         id: offerId,
         from: 'bookingdetails',
       })
-      expect(analytics.logConsultOffer).toHaveBeenCalledWith({ offerId, from: 'bookings' })
+      expect(analytics.logConsultOffer).toHaveBeenCalledWith({
+        offerId: String(offerId),
+        from: 'bookings',
+      })
     })
 
     it('should not redirect to the Offer and showSnackBarError when not connected', async () => {

--- a/src/features/gtlPlaylist/components/GtlPlaylist.native.test.tsx
+++ b/src/features/gtlPlaylist/components/GtlPlaylist.native.test.tsx
@@ -65,7 +65,7 @@ describe('GtlPlaylist', () => {
           from: 'venue',
           index: 0,
           moduleId: '2xUlLBRfxdk6jeYyJszunX',
-          offerId: 12,
+          offerId: '12',
           venueId: 5543,
         })
       )
@@ -135,7 +135,7 @@ describe('GtlPlaylist', () => {
           from: 'thematicsearch',
           index: 0,
           moduleId: '2xUlLBRfxdk6jeYyJszunX',
-          offerId: 12,
+          offerId: '12',
         })
       )
     })

--- a/src/features/home/components/modules/marketing/MarketingBlockExclusivity.native.test.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockExclusivity.native.test.tsx
@@ -66,7 +66,7 @@ describe('MarketingBlockExclusivity', () => {
       moduleId: '1',
       homeEntryId: 'fakeEntryId',
       moduleName: 'La nuit des temps',
-      offerId: 102280,
+      offerId: '102280',
     })
   })
 

--- a/src/features/home/components/modules/video/VideoEndView.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoEndView.native.test.tsx
@@ -51,7 +51,7 @@ describe('VideoEndView', () => {
     await waitFor(() =>
       expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
         from: 'video',
-        offerId: +mockOffer.objectID,
+        offerId: mockOffer.objectID,
         moduleId: 'abcd',
         moduleName: 'salut à tous c’est lujipeka',
         homeEntryId: 'xyz',

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.native.test.tsx
@@ -66,7 +66,7 @@ describe('VideoMonoOfferTile', () => {
     await user.press(screen.getByText(mockOffer.offer.name))
 
     expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
-      offerId: +mockOffer.objectID,
+      offerId: mockOffer.objectID,
       ...mockAnalyticsParams,
     })
   })

--- a/src/features/home/components/modules/video/VideoMultiOfferTile.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoMultiOfferTile.native.test.tsx
@@ -51,7 +51,7 @@ describe('VideoMultiOfferTile', () => {
     await user.press(screen.getByText('La nuit des temps'))
 
     expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
-      offerId: +mockOffer.objectID,
+      offerId: mockOffer.objectID,
       ...mockAnalyticsParams,
     })
   })

--- a/src/features/navigation/RootNavigator/linking/getStateFromPath.test.ts
+++ b/src/features/navigation/RootNavigator/linking/getStateFromPath.test.ts
@@ -39,7 +39,7 @@ describe('getStateFromPath()', () => {
 
     await waitFor(() => {
       expect(state).toEqual(expectedState)
-      expect(analytics.logConsultOffer).toHaveBeenCalledWith({ offerId: 777, from: 'deeplink' })
+      expect(analytics.logConsultOffer).toHaveBeenCalledWith({ offerId: '777', from: 'deeplink' })
     })
   })
 

--- a/src/features/offer/components/OfferCTAButton/OfferCTAButton.native.test.tsx
+++ b/src/features/offer/components/OfferCTAButton/OfferCTAButton.native.test.tsx
@@ -233,8 +233,8 @@ describe('<OfferCTAButton />', () => {
 
         await waitFor(() => {
           expect(analytics.logBookingConfirmation).toHaveBeenNthCalledWith(1, {
-            bookingId: 123,
-            offerId: 116656,
+            bookingId: '123',
+            offerId: '116656',
           })
         })
       })

--- a/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
@@ -327,7 +327,7 @@ describe('<OfferPlace />', () => {
     expect(analytics.logConsultOffer).toHaveBeenCalledWith({
       from: 'offer',
       fromMultivenueOfferId: 146112,
-      offerId: 2,
+      offerId: '2',
     })
   })
 

--- a/src/features/offer/components/OfferTile/OfferTile.native.test.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.native.test.tsx
@@ -129,7 +129,7 @@ describe('OfferTile component', () => {
       await user.press(screen.getByTestId('tileImage'))
 
       expect(analytics.logConsultOffer).toHaveBeenCalledWith({
-        offerId: OFFER_ID,
+        offerId: String(OFFER_ID),
         from: 'home',
         moduleName: props.moduleName,
       })
@@ -152,7 +152,7 @@ describe('OfferTile component', () => {
 
       expect(analytics.logConsultOffer).toHaveBeenCalledWith({
         ...apiRecoParams,
-        offerId: OFFER_ID,
+        offerId: String(OFFER_ID),
         from: 'similar_offer',
         moduleName: props.moduleName,
         fromOfferId: 1,
@@ -165,7 +165,7 @@ describe('OfferTile component', () => {
       await user.press(screen.getByTestId('tileImage'))
 
       expect(analytics.logConsultOffer).toHaveBeenCalledWith({
-        offerId: OFFER_ID,
+        offerId: String(OFFER_ID),
         from: 'home',
         moduleName: props.moduleName,
         homeEntryId: 'abcd',
@@ -195,7 +195,7 @@ describe('OfferTile component', () => {
       await user.press(screen.getByTestId('tileImage'))
 
       expect(analytics.logConsultOffer).toHaveBeenCalledWith({
-        offerId: OFFER_ID,
+        offerId: String(OFFER_ID),
         from: 'venue',
         venueId: 1,
         searchId,
@@ -217,7 +217,7 @@ describe('OfferTile component', () => {
 
       expect(analytics.logConsultOffer).toHaveBeenCalledWith({
         from: 'thematicsearch',
-        offerId: OFFER_ID,
+        offerId: String(OFFER_ID),
         searchId: propsFromThematicSearchGtlPlaylist.searchId,
         moduleName: propsFromThematicSearchGtlPlaylist.moduleName,
         fromOfferId: undefined,
@@ -244,7 +244,7 @@ describe('OfferTile component', () => {
 
       expect(analytics.logConsultOffer).toHaveBeenCalledWith({
         from: 'artist',
-        offerId: OFFER_ID,
+        offerId: String(OFFER_ID),
         playlistType: propsFromArtistPagePlaylist.playlistType,
         artistName: 'Céline Dion',
         searchId: undefined,

--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
@@ -555,8 +555,8 @@ export const useCtaWordingAndAction = (props: UseGetCtaWordingAndActionProps) =>
     onSuccess(data) {
       analytics.logBookingConfirmation({
         ...apiRecoParams,
-        offerId,
-        bookingId: data.bookingId,
+        offerId: String(offerId),
+        bookingId: String(data.bookingId),
         fromOfferId,
         fromMultivenueOfferId,
         playlistType,

--- a/src/features/search/pages/ThematicSearch/ThematicSearchPlaylist.native.test.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearchPlaylist.native.test.tsx
@@ -30,7 +30,7 @@ describe('ThematicSearchPlaylist', () => {
     expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
       from: 'thematicsearch',
       index: 0,
-      offerId: 1,
+      offerId: '1',
     })
   })
 })

--- a/src/features/venue/components/VenueBody/VenueBody.native.test.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.native.test.tsx
@@ -120,7 +120,7 @@ describe('<VenueBody />', () => {
     await user.press(screen.getByText('One Piece Tome 108'))
 
     expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
-      offerId: Number(HEADLINE_OFFER_DATA.id),
+      offerId: HEADLINE_OFFER_DATA.id,
       from: 'venue',
       venueId: venueDataTest.id,
       isHeadline: true,

--- a/src/libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog.test.ts
+++ b/src/libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog.test.ts
@@ -5,7 +5,7 @@ import { eventMonitoring } from 'libs/monitoring/services'
 
 describe('triggerConsultOfferLog', () => {
   it('should trigger ConsultOffer log when offerId defined', () => {
-    const params: ConsultOfferLogParams = { offerId: 123, from: 'home' }
+    const params: ConsultOfferLogParams = { offerId: '123', from: 'home' }
 
     triggerConsultOfferLog(params)
 

--- a/src/libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog.ts
+++ b/src/libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog.ts
@@ -10,5 +10,10 @@ export function triggerConsultOfferLog(params: ConsultOfferLogParams) {
     return
   }
 
-  analytics.logConsultOffer(params)
+  const paramsWithStringId: ConsultOfferLogParams = {
+    ...params,
+    offerId: String(params.offerId),
+  }
+
+  analytics.logConsultOffer(paramsWithStringId)
 }

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -101,8 +101,8 @@ export const logEventAnalytics = {
   logBackToHomeFromEduconnectError: (params: { fromError: string }) =>
     analytics.logEvent({ firebase: AnalyticsEvent.BACK_TO_HOME_FROM_EDUCONNECT_ERROR }, params),
   logBookingConfirmation: (params: {
-    offerId: number
-    bookingId: number
+    offerId: string
+    bookingId: string
     fromOfferId?: number
     fromMultivenueOfferId?: number
     playlistType?: PlaylistType

--- a/src/libs/analytics/types.ts
+++ b/src/libs/analytics/types.ts
@@ -27,7 +27,7 @@ export type OfferAnalyticsParams = {
 }
 
 export type ConsultOfferLogParams = {
-  offerId: number
+  offerId: number | string
   from: Referrals
   moduleId?: string
   moduleName?: string

--- a/src/ui/components/eventCard/EventCard.native.test.tsx
+++ b/src/ui/components/eventCard/EventCard.native.test.tsx
@@ -23,7 +23,7 @@ describe('EventCard', () => {
       await user.press(eventCard)
 
       expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
-        offerId: 1,
+        offerId: '1',
         from: 'venue',
       })
     })

--- a/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
@@ -126,7 +126,7 @@ describe('HorizontalOfferTile component', () => {
 
     expect(analytics.logConsultOffer).toHaveBeenCalledTimes(1)
     expect(analytics.logConsultOffer).toHaveBeenCalledWith({
-      offerId,
+      offerId: String(offerId),
       from: 'searchresults',
       query: '',
       index: 0,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37103

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
