### PR TITLE
PC(37569) fix(cineOffer): use actual cinema and not entry offer to calculate distance

### DIFF
--- a/src/features/offer/components/OfferCine/CineBlock.tsx
+++ b/src/features/offer/components/OfferCine/CineBlock.tsx
@@ -10,6 +10,8 @@ import { OfferEventCardList } from 'features/offer/components/OfferEventCardList
 import { useVenueBlock } from 'features/offer/components/OfferVenueBlock/useVenueBlock'
 import { VenueBlock } from 'features/offer/components/OfferVenueBlock/VenueBlock'
 import { getAddress, getVenue } from 'features/offer/helpers/getVenueBlockProps'
+import { useLocation } from 'libs/location'
+import { getDistance } from 'libs/location/getDistance'
 import { useSubcategoriesMapping } from 'libs/subcategories'
 
 export type CineBlockProps = {
@@ -17,7 +19,6 @@ export type CineBlockProps = {
   onSeeVenuePress?: VoidFunction
   nextDate?: Date
   withDivider?: boolean
-  distance?: string | null
 }
 
 export const CineBlock: FunctionComponent<CineBlockProps> = ({
@@ -25,9 +26,17 @@ export const CineBlock: FunctionComponent<CineBlockProps> = ({
   onSeeVenuePress,
   nextDate,
   withDivider,
-  distance,
 }) => {
   const { selectedDate, goToDate } = useMovieCalendar()
+
+  const { userLocation, selectedPlace, selectedLocationMode } = useLocation()
+  const venue = getVenue(offer.venue)
+  const distance = venue.coordinates
+    ? getDistance(
+        { lat: venue.coordinates.latitude, lng: venue.coordinates.longitude },
+        { userLocation, selectedPlace, selectedLocationMode }
+      )
+    : null
 
   const subcategoriesMapping = useSubcategoriesMapping()
 

--- a/src/features/offer/components/OfferCine/OfferCineBlock.tsx
+++ b/src/features/offer/components/OfferCine/OfferCineBlock.tsx
@@ -21,12 +21,11 @@ type Props = {
   title: string
   offer: OfferResponseV2
   onSeeVenuePress?: VoidFunction
-  distance?: string | null
 }
 
 const cinemaCTAButtonName = 'Accéder aux séances'
 
-export const OfferCineBlock: FC<Props> = ({ title, onSeeVenuePress, offer, distance }) => {
+export const OfferCineBlock: FC<Props> = ({ title, onSeeVenuePress, offer }) => {
   const theme = useTheme()
   const route = useRoute<UseRouteType<'Chronicles'>>()
   const from = route.params?.from
@@ -63,7 +62,7 @@ export const OfferCineBlock: FC<Props> = ({ title, onSeeVenuePress, offer, dista
         </InView>
       </Anchor>
       <MovieCalendarProvider initialDates={next15Dates} containerStyle={getCalendarStyle(theme)}>
-        <OfferCineContent offer={offer} onSeeVenuePress={onSeeVenuePress} distance={distance} />
+        <OfferCineContent offer={offer} onSeeVenuePress={onSeeVenuePress} />
       </MovieCalendarProvider>
     </Container>
   )

--- a/src/features/offer/components/OfferCine/OfferCineContent.tsx
+++ b/src/features/offer/components/OfferCine/OfferCineContent.tsx
@@ -24,10 +24,9 @@ import { Typo } from 'ui/theme'
 type Props = {
   offer: OfferResponseV2
   onSeeVenuePress?: VoidFunction
-  distance?: string | null
 }
 
-export const OfferCineContent: FC<Props> = ({ offer, onSeeVenuePress, distance }) => {
+export const OfferCineContent: FC<Props> = ({ offer, onSeeVenuePress }) => {
   const { designSystem } = useTheme()
 
   const { data: offers, isInitialLoading: isLoading } = useOffersStocksFromOfferQuery(offer)
@@ -57,7 +56,6 @@ export const OfferCineContent: FC<Props> = ({ offer, onSeeVenuePress, distance }
             onSeeVenuePress={onSeeVenuePress}
             nextDate={item.nextDate}
             withDivider
-            distance={distance}
           />
         )}
       />

--- a/src/features/offer/components/OfferPlace/OfferPlace.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.tsx
@@ -162,7 +162,6 @@ export function OfferPlace({ offer, subcategory, distance }: Readonly<OfferPlace
             title={venueSectionTitle}
             offer={offer}
             onSeeVenuePress={canSeeVenue ? handleOnSeeVenuePress : undefined}
-            distance={distance}
           />
         ) : (
           <OfferVenueBlock


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37569

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |<video src="https://github.com/user-attachments/assets/0111904d-80ae-4111-b472-de6fa0becd92"/>|<video src="https://github.com/user-attachments/assets/be3f3c90-3fce-4b35-8265-f8e80da1a7f7"/>|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
