### PR TITLE
PC-37529

### DIFF
--- a/src/features/home/components/modules/HomeModule.tsx
+++ b/src/features/home/components/modules/HomeModule.tsx
@@ -49,13 +49,14 @@ const UnmemoizedModule = ({
   onModuleViewableItemsChanged?: ModuleViewableItemsChangedHandler
 }) => {
   const handleOnViewableItemsChanged = useCallback(
-    (viewableItems: Pick<ViewToken, 'key' | 'index'>[]) => {
+    (viewableItems: Pick<ViewToken, 'key' | 'index'>[], callId?: string) => {
       onModuleViewableItemsChanged?.({
         index,
         moduleId: item.id,
         moduleType: item.type,
         viewableItems,
         homeEntryId,
+        callId,
       })
     },
     // Changing onViewableItemsChanged on the fly is not supported

--- a/src/features/home/components/modules/OffersModule.tsx
+++ b/src/features/home/components/modules/OffersModule.tsx
@@ -1,10 +1,10 @@
-import { useFocusEffect } from '@react-navigation/native'
-import React, { useCallback, useEffect, useMemo, useRef } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 import { ViewToken } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useHomeRecommendedOffers } from 'features/home/api/useHomeRecommendedOffers'
+import { ObservedPlaylist } from 'features/home/components/parsers/ObservedPlaylist'
 import {
   ModuleData,
   OffersModule as OffersModuleType,
@@ -18,7 +18,6 @@ import { getPlaylistItemDimensionsFromLayout } from 'libs/contentful/getPlaylist
 import { ContentTypes } from 'libs/contentful/types'
 import useFunctionOnce from 'libs/hooks/useFunctionOnce'
 import { useLocation } from 'libs/location'
-import { IntersectionObserver } from 'shared/IntersectionObserver/IntersectionObserver'
 import { Offer } from 'shared/offer/types'
 import { PassPlaylist } from 'ui/components/PassPlaylist'
 import { CustomListRenderItem, ItemDimensions, RenderFooterItem } from 'ui/components/Playlist'
@@ -51,7 +50,6 @@ export const OffersModule = (props: OffersModuleProps) => {
   const adaptedPlaylistParameters = useAdaptOffersPlaylistParameters()
   const { user } = useAuthContext()
   const { userLocation } = useLocation()
-  const isInView = useRef(false)
 
   const { offers: recommandationOffers, recommendationApiParams } = useHomeRecommendedOffers(
     userLocation,
@@ -177,68 +175,28 @@ export const OffersModule = (props: OffersModuleProps) => {
     shouldModuleBeDisplayed,
   ])
 
-  const listRef = useRef<FlatList>(null)
-  const lastViewableItems = useRef<ViewToken[]>([])
-
-  const handleViewableItemsChanged = useCallback(
-    ({ viewableItems }: { viewableItems: ViewToken[] }) => {
-      if (isInView.current) {
-        onViewableItemsChanged?.(viewableItems.map(({ key, index }) => ({ key, index })))
-        lastViewableItems.current = viewableItems
-      }
-    },
-    // We cannot change onViewableItemsChanged on the fly
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  )
-
-  const handleIntersectionObserverChange = useCallback(
-    (value: boolean) => {
-      isInView.current = value
-      if (value) {
-        if (lastViewableItems.current?.length) {
-          handleViewableItemsChanged({
-            viewableItems: lastViewableItems.current,
-          })
-        } else {
-          listRef.current?.recordInteraction()
-        }
-      }
-    },
-    [handleViewableItemsChanged]
-  )
-
-  useFocusEffect(
-    useCallback(() => {
-      if (lastViewableItems.current?.length) {
-        handleViewableItemsChanged({
-          viewableItems: lastViewableItems.current,
-        })
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
-  )
-
   if (!shouldModuleBeDisplayed) return null
 
   return (
-    <IntersectionObserver onChange={handleIntersectionObserverChange}>
-      <PassPlaylist
-        title={displayParameters.title}
-        subtitle={displayParameters.subtitle}
-        data={offersToDisplay}
-        itemHeight={itemHeight}
-        itemWidth={itemWidth}
-        onPressSeeMore={onPressSeeMore}
-        titleSeeMoreLink={{ ...searchTabConfig }}
-        renderItem={renderItem}
-        renderFooter={renderFooter}
-        keyExtractor={keyExtractor}
-        onEndReached={logHasSeenAllTilesOnce}
-        playlistRef={listRef}
-        FlatListComponent={FlatList}
-        onViewableItemsChanged={handleViewableItemsChanged}
-      />
-    </IntersectionObserver>
+    <ObservedPlaylist onViewableItemsChanged={onViewableItemsChanged}>
+      {({ listRef, handleViewableItemsChanged }) => (
+        <PassPlaylist
+          title={displayParameters.title}
+          subtitle={displayParameters.subtitle}
+          data={offersToDisplay}
+          itemHeight={itemHeight}
+          itemWidth={itemWidth}
+          onPressSeeMore={onPressSeeMore}
+          titleSeeMoreLink={{ ...searchTabConfig }}
+          renderItem={renderItem}
+          renderFooter={renderFooter}
+          keyExtractor={keyExtractor}
+          onEndReached={logHasSeenAllTilesOnce}
+          playlistRef={listRef}
+          FlatListComponent={FlatList}
+          onViewableItemsChanged={handleViewableItemsChanged}
+        />
+      )}
+    </ObservedPlaylist>
   )
 }

--- a/src/features/home/components/modules/OffersModule.tsx
+++ b/src/features/home/components/modules/OffersModule.tsx
@@ -4,7 +4,7 @@ import { FlatList } from 'react-native-gesture-handler'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useHomeRecommendedOffers } from 'features/home/api/useHomeRecommendedOffers'
-import { ObservedPlaylist } from 'features/home/components/parsers/ObservedPlaylist'
+import { ObservedList } from 'features/home/components/parsers/ObservedList'
 import {
   ModuleData,
   OffersModule as OffersModuleType,
@@ -178,7 +178,7 @@ export const OffersModule = (props: OffersModuleProps) => {
   if (!shouldModuleBeDisplayed) return null
 
   return (
-    <ObservedPlaylist onViewableItemsChanged={onViewableItemsChanged}>
+    <ObservedList<FlatList> onViewableItemsChanged={onViewableItemsChanged}>
       {({ listRef, handleViewableItemsChanged }) => (
         <PassPlaylist
           title={displayParameters.title}
@@ -197,6 +197,6 @@ export const OffersModule = (props: OffersModuleProps) => {
           onViewableItemsChanged={handleViewableItemsChanged}
         />
       )}
-    </ObservedPlaylist>
+    </ObservedList>
   )
 }

--- a/src/features/home/components/modules/RecommendationModule.tsx
+++ b/src/features/home/components/modules/RecommendationModule.tsx
@@ -1,9 +1,10 @@
+import { ObservedList } from 'features/home/components/parsers/ObservedList'
 import React, { useCallback, useEffect } from 'react'
 import { ViewToken } from 'react-native'
+import { FlatList } from 'react-native-gesture-handler'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useHomeRecommendedOffers } from 'features/home/api/useHomeRecommendedOffers'
-import { ObservedPlaylist } from 'features/home/components/parsers/ObservedPlaylist'
 import { RecommendedOffersModule } from 'features/home/types'
 import { OfferTileWrapper } from 'features/offer/components/OfferTile/OfferTileWrapper'
 import { analytics } from 'libs/analytics/provider'
@@ -93,7 +94,7 @@ export const RecommendationModule = (props: RecommendationModuleProps) => {
 
   if (!shouldModuleBeDisplayed) return null
   return (
-    <ObservedPlaylist onViewableItemsChanged={handleOnViewableItemsChanged}>
+    <ObservedList<FlatList> onViewableItemsChanged={handleOnViewableItemsChanged}>
       {({ listRef, handleViewableItemsChanged }) => (
         <PassPlaylist
           testID="recommendationModuleList"
@@ -109,6 +110,6 @@ export const RecommendationModule = (props: RecommendationModuleProps) => {
           onViewableItemsChanged={handleViewableItemsChanged}
         />
       )}
-    </ObservedPlaylist>
+    </ObservedList>
   )
 }

--- a/src/features/home/components/modules/venues/VenuesModule.tsx
+++ b/src/features/home/components/modules/venues/VenuesModule.tsx
@@ -1,7 +1,9 @@
 import React, { useCallback, useEffect } from 'react'
-import styled from 'styled-components/native'
+import { ViewToken } from 'react-native'
+import { styled } from 'styled-components/native'
 
 import { VenueTile } from 'features/home/components/modules/venues/VenueTile'
+import { ObservedPlaylist } from 'features/home/components/parsers/ObservedPlaylist'
 import { ModuleData } from 'features/home/types'
 import { VenueHit } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics/provider'
@@ -16,6 +18,7 @@ type VenuesModuleProps = {
   homeEntryId: string | undefined
   index: number
   data?: ModuleData
+  onViewableItemsChanged?: (items: Pick<ViewToken, 'key' | 'index'>[]) => void
 }
 
 const ITEM_HEIGHT = LENGTH_S
@@ -29,6 +32,7 @@ export const VenuesModule = ({
   index,
   homeEntryId,
   data,
+  onViewableItemsChanged,
 }: VenuesModuleProps) => {
   const moduleName = displayParameters.title
   const { playlistItems = [] } = data ?? { playlistItems: [] }
@@ -63,21 +67,28 @@ export const VenuesModule = ({
   }, [shouldModuleBeDisplayed])
 
   if (!shouldModuleBeDisplayed) return null
+
   return (
-    <PlaylistContainer>
-      <PassPlaylist
-        testID="offersModuleList"
-        title={displayParameters.title}
-        subtitle={displayParameters.subtitle}
-        data={playlistItems || []}
-        itemHeight={ITEM_HEIGHT}
-        itemWidth={ITEM_WIDTH}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
-        tileType="venue"
-        withMargin={false}
-      />
-    </PlaylistContainer>
+    <ObservedPlaylist onViewableItemsChanged={onViewableItemsChanged}>
+      {({ listRef, handleViewableItemsChanged }) => (
+        <PlaylistContainer>
+          <PassPlaylist
+            testID="venuesModuleList"
+            title={displayParameters.title}
+            subtitle={displayParameters.subtitle}
+            data={playlistItems || []}
+            itemHeight={ITEM_HEIGHT}
+            itemWidth={ITEM_WIDTH}
+            renderItem={renderItem}
+            keyExtractor={keyExtractor}
+            tileType="venue"
+            withMargin={false}
+            onViewableItemsChanged={handleViewableItemsChanged}
+            playlistRef={listRef}
+          />
+        </PlaylistContainer>
+      )}
+    </ObservedPlaylist>
   )
 }
 

--- a/src/features/home/components/modules/venues/VenuesModule.tsx
+++ b/src/features/home/components/modules/venues/VenuesModule.tsx
@@ -1,9 +1,10 @@
+import { ObservedList } from 'features/home/components/parsers/ObservedList'
 import React, { useCallback, useEffect } from 'react'
 import { ViewToken } from 'react-native'
+import { FlatList } from 'react-native-gesture-handler'
 import { styled } from 'styled-components/native'
 
 import { VenueTile } from 'features/home/components/modules/venues/VenueTile'
-import { ObservedPlaylist } from 'features/home/components/parsers/ObservedPlaylist'
 import { ModuleData } from 'features/home/types'
 import { VenueHit } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics/provider'
@@ -69,7 +70,7 @@ export const VenuesModule = ({
   if (!shouldModuleBeDisplayed) return null
 
   return (
-    <ObservedPlaylist onViewableItemsChanged={onViewableItemsChanged}>
+    <ObservedList<FlatList> onViewableItemsChanged={onViewableItemsChanged}>
       {({ listRef, handleViewableItemsChanged }) => (
         <PlaylistContainer>
           <PassPlaylist
@@ -88,7 +89,7 @@ export const VenuesModule = ({
           />
         </PlaylistContainer>
       )}
-    </ObservedPlaylist>
+    </ObservedList>
   )
 }
 

--- a/src/features/home/components/parsers/ObservedList.tsx
+++ b/src/features/home/components/parsers/ObservedList.tsx
@@ -1,20 +1,19 @@
 import { useFocusEffect } from '@react-navigation/native'
 import React, { Ref, useCallback, useRef } from 'react'
 import { ViewToken } from 'react-native'
-import { FlatList } from 'react-native-gesture-handler'
 
 import { IntersectionObserver } from 'shared/IntersectionObserver/IntersectionObserver'
 
-type ObservedPlaylistProps = {
+type ObservedListProps<T> = {
   children: (props: {
-    listRef: Ref<FlatList>
+    listRef: Ref<T>
     handleViewableItemsChanged: ({ viewableItems }: { viewableItems: ViewToken[] }) => void
   }) => React.ReactNode
   onViewableItemsChanged?: (items: Pick<ViewToken, 'key' | 'index'>[]) => void
 }
 
-export const ObservedPlaylist = ({ children, onViewableItemsChanged }: ObservedPlaylistProps) => {
-  const listRef = useRef<FlatList>(null)
+export const ObservedList = <T,>({ children, onViewableItemsChanged }: ObservedListProps<T>) => {
+  const listRef = useRef<T>(null)
   const lastViewableItems = useRef<ViewToken[]>([])
   const isInView = useRef(false)
 
@@ -46,7 +45,8 @@ export const ObservedPlaylist = ({ children, onViewableItemsChanged }: ObservedP
         if (lastViewableItems.current?.length) {
           handleViewableItemsChanged({ viewableItems: lastViewableItems.current })
         } else {
-          listRef.current?.recordInteraction()
+          // @ts-expect-error : recordInteraction peut ne pas exister selon la liste
+          listRef.current?.recordInteraction?.()
         }
       }
     },

--- a/src/features/home/components/parsers/ObservedListWithRef.tsx
+++ b/src/features/home/components/parsers/ObservedListWithRef.tsx
@@ -1,0 +1,32 @@
+import React, { forwardRef, useCallback, useImperativeHandle, useRef } from 'react'
+import type { ViewToken } from 'react-native'
+
+type ObservedListWithRefProps<T> = {
+  onViewableItemsChanged?: (items: Pick<ViewToken, 'key' | 'index'>[]) => void
+  children: (params: {
+    listRef: React.RefObject<T>
+    handleViewableItemsChanged: (info: { viewableItems: ViewToken[] }) => void
+  }) => React.ReactNode
+}
+
+export const ObservedListWithRef = forwardRef(function ObservedListWithRef<T>(
+  { onViewableItemsChanged, children }: ObservedListWithRefProps<T>,
+  ref: React.ForwardedRef<T>
+) {
+  const innerRef = useRef<T>(null)
+
+  useImperativeHandle(ref, () => innerRef.current as T)
+
+  const handleViewableItemsChanged = useCallback(
+    ({ viewableItems }: { viewableItems: ViewToken[] }) => {
+      onViewableItemsChanged?.(viewableItems.map(({ key, index }) => ({ key, index })))
+    },
+    [onViewableItemsChanged]
+  )
+
+  return (
+    <React.Fragment>{children({ listRef: innerRef, handleViewableItemsChanged })}</React.Fragment>
+  )
+}) as <T>(
+  p: ObservedListWithRefProps<T> & { ref?: React.ForwardedRef<T> }
+) => React.ReactElement | null

--- a/src/features/home/components/parsers/ObservedPlaylist.tsx
+++ b/src/features/home/components/parsers/ObservedPlaylist.tsx
@@ -1,0 +1,61 @@
+import { useFocusEffect } from '@react-navigation/native'
+import React, { Ref, useCallback, useRef } from 'react'
+import { ViewToken } from 'react-native'
+import { FlatList } from 'react-native-gesture-handler'
+
+import { IntersectionObserver } from 'shared/IntersectionObserver/IntersectionObserver'
+
+type ObservedPlaylistProps = {
+  children: (props: {
+    listRef: Ref<FlatList>
+    handleViewableItemsChanged: ({ viewableItems }: { viewableItems: ViewToken[] }) => void
+  }) => React.ReactNode
+  onViewableItemsChanged?: (items: Pick<ViewToken, 'key' | 'index'>[]) => void
+}
+
+export const ObservedPlaylist = ({ children, onViewableItemsChanged }: ObservedPlaylistProps) => {
+  const listRef = useRef<FlatList>(null)
+  const lastViewableItems = useRef<ViewToken[]>([])
+  const isInView = useRef(false)
+
+  useFocusEffect(
+    useCallback(() => {
+      if (lastViewableItems.current?.length) {
+        handleViewableItemsChanged({
+          viewableItems: lastViewableItems.current,
+        })
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+  )
+
+  const handleViewableItemsChanged = useCallback(
+    ({ viewableItems }: { viewableItems: ViewToken[] }) => {
+      if (isInView.current) {
+        onViewableItemsChanged?.(viewableItems.map(({ key, index }) => ({ key, index })))
+        lastViewableItems.current = viewableItems
+      }
+    },
+    [onViewableItemsChanged]
+  )
+
+  const handleIntersectionObserverChange = useCallback(
+    (value: boolean) => {
+      isInView.current = value
+      if (value) {
+        if (lastViewableItems.current?.length) {
+          handleViewableItemsChanged({ viewableItems: lastViewableItems.current })
+        } else {
+          listRef.current?.recordInteraction()
+        }
+      }
+    },
+    [handleViewableItemsChanged]
+  )
+
+  return (
+    <IntersectionObserver onChange={handleIntersectionObserverChange}>
+      {children({ listRef, handleViewableItemsChanged })}
+    </IntersectionObserver>
+  )
+}

--- a/src/features/home/pages/GenericHome.tsx
+++ b/src/features/home/pages/GenericHome.tsx
@@ -81,6 +81,7 @@ const handleViewableItemsChanged: ModuleViewableItemsChangedHandler = ({
   moduleType,
   viewableItems,
   homeEntryId,
+  callId,
 }) => {
   setPlaylistTrackingInfo({
     index,
@@ -89,7 +90,7 @@ const handleViewableItemsChanged: ModuleViewableItemsChangedHandler = ({
     items: viewableItems,
     itemType: getItemTypeFromModuleType(moduleType),
     extra: { homeEntryId },
-    callId: '',
+    callId: callId ?? '',
   })
 }
 

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -3,7 +3,7 @@ import { Animated, ViewToken } from 'react-native'
 import { VenueAccessibilityModel, VenueContactModel, VenueTypeCodeKey } from 'api/gen'
 import { PlaylistOffersParams, VenueHit } from 'libs/algolia/types'
 import { OfferAnalyticsParams } from 'libs/analytics/types'
-import { ContentfulLabelCategories, ContentTypes, Layout } from 'libs/contentful/types'
+import { ContentTypes, ContentfulLabelCategories, Layout } from 'libs/contentful/types'
 import { GtlLevel } from 'shared/gtl/types'
 import { Offer } from 'shared/offer/types'
 
@@ -368,12 +368,14 @@ export type ModuleViewableItemsChangedHandler = ({
   index,
   viewableItems,
   homeEntryId,
+  callId,
 }: {
   homeEntryId: string
   index: number
   moduleId: string
   viewableItems: Pick<ViewToken, 'key' | 'index'>[]
   moduleType: string
+  callId?: string
 }) => void
 
 export const isVenuesModule = (module: HomepageModule): module is VenuesModule => {

--- a/src/features/search/components/SearchList/SearchList.tsx
+++ b/src/features/search/components/SearchList/SearchList.tsx
@@ -2,6 +2,7 @@ import { FlashList, FlashListRef } from '@shopify/flash-list'
 import React from 'react'
 import { useTheme } from 'styled-components/native'
 
+import { ObservedListWithRef } from 'features/home/components/parsers/ObservedListWithRef'
 import { SearchListHeader } from 'features/search/components/SearchListHeader/SearchListHeader'
 import { GridListLayout, SearchListProps } from 'features/search/types'
 import { Offer } from 'shared/offer/types'
@@ -28,41 +29,51 @@ export const SearchList = React.forwardRef<FlashListRef<Offer>, SearchListProps>
       setGridListLayout,
       isGridLayout,
       shouldDisplayGridList,
+      onViewableItemsChanged,
     },
     ref
   ) => {
     const { tabBar } = useTheme()
+
     return (
-      <FlashList
-        ref={ref}
-        key={isGridLayout ? 'grid_search_results' : 'list_search_results'}
-        testID="searchResultsFlashlist"
-        data={hits.offers}
-        keyExtractor={keyExtractor}
-        ListHeaderComponent={
-          <SearchListHeader
-            nbHits={nbHits}
-            userData={userData}
-            venues={hits.venues}
-            artistSection={artistSection}
-            venuesUserData={venuesUserData}
-            setGridListLayout={setGridListLayout}
-            selectedGridListLayout={isGridLayout ? GridListLayout.GRID : GridListLayout.LIST}
-            shouldDisplayGridList={shouldDisplayGridList}
+      <ObservedListWithRef<FlashListRef<Offer>>
+        onViewableItemsChanged={onViewableItemsChanged}
+        ref={ref} // forward la ref externe
+      >
+        {({ handleViewableItemsChanged, listRef }) => (
+          <FlashList
+            ref={listRef}
+            key={isGridLayout ? 'grid_search_results' : 'list_search_results'}
+            testID="searchResultsFlashlist"
+            data={hits.offers}
+            keyExtractor={keyExtractor}
+            ListHeaderComponent={
+              <SearchListHeader
+                nbHits={nbHits}
+                userData={userData}
+                venues={hits.venues}
+                artistSection={artistSection}
+                venuesUserData={venuesUserData}
+                setGridListLayout={setGridListLayout}
+                selectedGridListLayout={isGridLayout ? GridListLayout.GRID : GridListLayout.LIST}
+                shouldDisplayGridList={shouldDisplayGridList}
+              />
+            }
+            ItemSeparatorComponent={isGridLayout ? undefined : LineSeparator}
+            renderItem={renderItem}
+            numColumns={isGridLayout ? numColumns : undefined}
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            onEndReached={autoScrollEnabled ? onEndReached : undefined}
+            scrollEnabled={nbHits > 0}
+            onScroll={onScroll}
+            onViewableItemsChanged={handleViewableItemsChanged}
+            contentContainerStyle={{ paddingBottom: tabBar.height + getSpacing(10) }}
+            keyboardShouldPersistTaps="handled"
+            keyboardDismissMode="on-drag"
           />
-        }
-        ItemSeparatorComponent={isGridLayout ? undefined : LineSeparator}
-        renderItem={renderItem}
-        numColumns={isGridLayout ? numColumns : undefined}
-        refreshing={refreshing}
-        onRefresh={onRefresh}
-        onEndReached={autoScrollEnabled ? onEndReached : undefined}
-        scrollEnabled={nbHits > 0}
-        onScroll={onScroll}
-        contentContainerStyle={{ paddingBottom: tabBar.height + getSpacing(10) }}
-        keyboardShouldPersistTaps="handled"
-        keyboardDismissMode="on-drag"
-      />
+        )}
+      </ObservedListWithRef>
     )
   }
 )

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -2,7 +2,7 @@ import { useFocusEffect, useIsFocused } from '@react-navigation/native'
 import { FlashListRef } from '@shopify/flash-list'
 import { debounce } from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { FlatList, Platform, useWindowDimensions, View } from 'react-native'
+import { FlatList, Platform, useWindowDimensions, View, ViewToken } from 'react-native'
 import styled from 'styled-components/native'
 
 import { AccessibilityFiltersModal } from 'features/accessibility/components/AccessibilityFiltersModal'
@@ -58,6 +58,7 @@ import { useLocation } from 'libs/location'
 import { LocationMode } from 'libs/location/types'
 import { plural } from 'libs/plural'
 import { Offer } from 'shared/offer/types'
+import { setPlaylistTrackingInfo } from 'store/tracking/playlistTrackingStore'
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
 import { FilterButtonList } from 'ui/components/FilterButtonList'
 import { Li } from 'ui/components/Li'
@@ -350,6 +351,22 @@ export const SearchResultsContent: React.FC<SearchResultsContentProps> = ({
     analytics.logConsultArtist({ artistName, from: 'search' })
   }
 
+  const handleOnViewableItemsChanged = useCallback(
+    (viewableItems: Pick<ViewToken, 'key' | 'index'>[]) => {
+      console.log({ viewableItems })
+      setPlaylistTrackingInfo({
+        index: viewableItems[0]?.index ?? 0,
+        moduleId: 'moduleId', // moduleId and moduleType are not used in search results context
+        viewedAt: new Date(),
+        items: viewableItems,
+        itemType: 'searchResults',
+      })
+    },
+    // Changing onViewableItemsChanged on the fly is not supported
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
   if (showSkeleton) return <SearchResultsPlaceHolder />
 
   const numberOfResults =
@@ -397,6 +414,7 @@ export const SearchResultsContent: React.FC<SearchResultsContentProps> = ({
         isGridLayout={isGridLayout}
         shouldDisplayGridList={shouldDisplayGridList}
         setGridListLayout={setGridListLayout}
+        onViewableItemsChanged={handleOnViewableItemsChanged}
       />
     ),
     [Tab.MAP]: selectedLocationMode === LocationMode.EVERYWHERE ? null : <VenueMapViewContainer />,

--- a/src/features/search/components/VenuePlaylist/VenuePlaylist.tsx
+++ b/src/features/search/components/VenuePlaylist/VenuePlaylist.tsx
@@ -1,10 +1,11 @@
 import { useNavigation } from '@react-navigation/native'
+import { ObservedList } from 'features/home/components/parsers/ObservedList'
 import React, { useCallback, useEffect } from 'react'
 import { Platform, StyleProp, ViewStyle, ViewToken } from 'react-native'
+import { FlatList } from 'react-native-gesture-handler'
 import styled from 'styled-components/native'
 
 import { SearchGroupNameEnumv2 } from 'api/gen'
-import { ObservedPlaylist } from 'features/home/components/parsers/ObservedPlaylist'
 import { VenueMapLocationModal } from 'features/location/components/VenueMapLocationModal'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { SearchStackParamList } from 'features/navigation/SearchStackNavigator/SearchStackTypes'
@@ -155,7 +156,7 @@ export const VenuePlaylist: React.FC<Props> = ({
         ) : (
           <NumberOfResults nbHits={venues?.length ?? 0} />
         )}
-        <ObservedPlaylist onViewableItemsChanged={onViewableItemsChanged}>
+        <ObservedList<FlatList> onViewableItemsChanged={onViewableItemsChanged}>
           {({ listRef, handleViewableItemsChanged }) => (
             <Playlist
               data={venues ?? []}
@@ -174,7 +175,7 @@ export const VenuePlaylist: React.FC<Props> = ({
               ref={listRef}
             />
           )}
-        </ObservedPlaylist>
+        </ObservedList>
       </Container>
       {shouldDisplaySeparator ? <StyledSeparator testID="venue-playlist-separator" /> : null}
       <VenueMapLocationModal

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -1,5 +1,6 @@
 import { SearchResponse } from '@algolia/client-search'
 import React, { ReactNode } from 'react'
+import { ViewToken } from 'react-native'
 
 import {
   GenreType,
@@ -101,6 +102,7 @@ export interface SearchListProps {
   isGridLayout?: boolean
   shouldDisplayGridList?: boolean
   setGridListLayout?: React.Dispatch<React.SetStateAction<GridListLayout>>
+  onViewableItemsChanged?: (items: Pick<ViewToken, 'key' | 'index'>[]) => void
 }
 
 export type CreateHistoryItem = {

--- a/src/libs/analytics/provider.ts
+++ b/src/libs/analytics/provider.ts
@@ -19,6 +19,7 @@ export const analytics: AnalyticsProvider = {
     firebaseAnalytics.logScreenView(screenName, locationType)
   },
   logEvent: async (eventName, params) => {
+    console.log('Logging event:', { eventName, params }) // Debug log
     if (eventName.firebase) {
       const locationType = (await storage.readString('location_type')) ?? 'undefined'
       firebaseAnalytics.logEvent(eventName.firebase, { ...params, locationType })

--- a/src/shared/analytics/logViewItem.ts
+++ b/src/shared/analytics/logViewItem.ts
@@ -43,13 +43,14 @@ export const logViewItem = async (trackingInfo: PageTrackingInfo) => {
   try {
     const { playlists, pageLocation } = trackingInfo
     for (const current of playlists) {
-      const { items, extra, moduleId, index, viewedAt, itemType } = current
+      const { items, extra, moduleId, index, viewedAt, itemType, callId } = current
       const data = {
         origin: pageLocation.toLowerCase(),
         viewedAt: viewedAt.toISOString(),
         moduleId,
         itemType,
         index,
+        callId,
         ...getItemStringChunks(items.map((item) => `${item.index ?? -1}:${item.key}`)),
         ...extra,
       }

--- a/src/store/tracking/types.ts
+++ b/src/store/tracking/types.ts
@@ -1,6 +1,6 @@
 export type PlaylistTrackingInfo = {
   moduleId: string
-  itemType: 'offer' | 'venue' | 'artist' | 'unknown'
+  itemType: 'offer' | 'venue' | 'artist' | 'searchResults' | 'unknown'
   callId: string
   index: number
   viewedAt: Date


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
