### PR TITLE
(PC-37654) doc(android): put `google-services.json` per folder per env

### DIFF
--- a/doc/installation/Android.md
+++ b/doc/installation/Android.md
@@ -53,7 +53,19 @@ If it fails [see troubleshooting](./setup.md#troubleshooting)
 
 ### 🔥 Firebase setup
 
-Download the `google-services.json` file from Keeper and place it inside the `android/app` directory. You can also download this file from the Firebase console.
+Download the `google-services.json` files from Keeper and place them inside the `android/app/src/<env>` directories. You can also download these files from the Firebase console.
+
+```txt
+android/
+    app/
+        src/
+            production/
+                google-services.json
+            staging/
+                google-services.json
+            apptesting/
+                google-services.json
+```
 
 ### 🚀 Run the app
 


### PR DESCRIPTION
I used to make a symbolic link of the real file

I messed it up

I got this message in the middle of the log of the build

```txt
* What went wrong:
Execution failed for task ':app:processApptestingDebugGoogleServices'.
> File google-services.json is missing. The Google Services Plugin cannot function without it.
   Searched Location:
  /Users/eb/Project/pass-culture/pass-culture-app-native/android/app/src/apptesting/debug/google-services.json
  /Users/eb/Project/pass-culture/pass-culture-app-native/android/app/src/debug/apptesting/google-services.json
  /Users/eb/Project/pass-culture/pass-culture-app-native/android/app/src/apptesting/google-services.json
  /Users/eb/Project/pass-culture/pass-culture-app-native/android/app/src/debug/google-services.json
  /Users/eb/Project/pass-culture/pass-culture-app-native/android/app/src/apptestingDebug/google-services.json
  /Users/eb/Project/pass-culture/pass-culture-app-native/android/app/google-services.json
```

So, maybe we could put specific `google-services.json` per env per folder instead of overwriting the existing one at each build

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] `yarn android:prod`
- [x] `yarn android:staging`
- [x] `yarn android:testing`