### PR TITLE
(PC-37107) fix(log): adjust type of params fromOfferId and fromMultivenueOfferId

### DIFF
--- a/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
@@ -258,7 +258,7 @@ describe('<BookingOfferModalComponent />', () => {
         expect(analytics.logBookingConfirmation).toHaveBeenCalledWith({
           ...apiRecoParams,
           bookingId: '1',
-          fromMultivenueOfferId: 1,
+          fromMultivenueOfferId: '1',
           fromOfferId: undefined,
           offerId: '20',
           playlistType: PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS,

--- a/src/features/bookOffer/pages/BookingOfferModal.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.tsx
@@ -76,7 +76,7 @@ export const BookingOfferModalComponent: React.FC<BookingOfferModalComponentProp
           ...apiRecoParams,
           offerId: offerId.toString(),
           bookingId: bookingId.toString(),
-          fromOfferId: fromMultivenueOfferId?.toString() ? undefined : fromOfferId?.toString(),
+          fromOfferId: fromMultivenueOfferId ? undefined : fromOfferId?.toString(),
           fromMultivenueOfferId: fromMultivenueOfferId?.toString(),
           playlistType,
         })

--- a/src/features/bookOffer/pages/BookingOfferModal.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.tsx
@@ -74,10 +74,10 @@ export const BookingOfferModalComponent: React.FC<BookingOfferModalComponentProp
       if (offerId) {
         analytics.logBookingConfirmation({
           ...apiRecoParams,
-          offerId: String(offerId),
-          bookingId: String(bookingId),
-          fromOfferId: fromMultivenueOfferId ? undefined : fromOfferId,
-          fromMultivenueOfferId,
+          offerId: offerId.toString(),
+          bookingId: bookingId.toString(),
+          fromOfferId: fromMultivenueOfferId?.toString() ? undefined : fromOfferId?.toString(),
+          fromMultivenueOfferId: fromMultivenueOfferId?.toString(),
           playlistType,
         })
         if (isFromSearch && algoliaOfferId) {

--- a/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
@@ -326,7 +326,7 @@ describe('<OfferPlace />', () => {
     expect(analytics.logConsultOffer).toHaveBeenCalledTimes(1)
     expect(analytics.logConsultOffer).toHaveBeenCalledWith({
       from: 'offer',
-      fromMultivenueOfferId: 146112,
+      fromMultivenueOfferId: '146112',
       offerId: '2',
     })
   })

--- a/src/features/offer/components/OfferTile/OfferTile.native.test.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.native.test.tsx
@@ -155,7 +155,7 @@ describe('OfferTile component', () => {
         offerId: String(OFFER_ID),
         from: 'similar_offer',
         moduleName: props.moduleName,
-        fromOfferId: 1,
+        fromOfferId: '1',
         playlistType: PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS,
       })
     })

--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
@@ -555,10 +555,10 @@ export const useCtaWordingAndAction = (props: UseGetCtaWordingAndActionProps) =>
     onSuccess(data) {
       analytics.logBookingConfirmation({
         ...apiRecoParams,
-        offerId: String(offerId),
-        bookingId: String(data.bookingId),
-        fromOfferId,
-        fromMultivenueOfferId,
+        offerId: offerId.toString(),
+        bookingId: data.bookingId.toString(),
+        fromOfferId: fromOfferId?.toString(),
+        fromMultivenueOfferId: fromMultivenueOfferId?.toString(),
         playlistType,
       })
 

--- a/src/libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog.ts
+++ b/src/libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog.ts
@@ -12,7 +12,9 @@ export function triggerConsultOfferLog(params: ConsultOfferLogParams) {
 
   const paramsWithStringId: ConsultOfferLogParams = {
     ...params,
-    offerId: String(params.offerId),
+    offerId: params.offerId.toString(),
+    fromOfferId: params.fromOfferId?.toString(),
+    fromMultivenueOfferId: params.fromMultivenueOfferId?.toString(),
   }
 
   analytics.logConsultOffer(paramsWithStringId)

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -103,8 +103,8 @@ export const logEventAnalytics = {
   logBookingConfirmation: (params: {
     offerId: string
     bookingId: string
-    fromOfferId?: number
-    fromMultivenueOfferId?: number
+    fromOfferId?: string
+    fromMultivenueOfferId?: string
     playlistType?: PlaylistType
   }) => analytics.logEvent({ firebase: AnalyticsEvent.BOOKING_CONFIRMATION }, params),
   logBookingDetailsScrolledToBottom: (offerId: number) =>

--- a/src/libs/analytics/types.ts
+++ b/src/libs/analytics/types.ts
@@ -35,8 +35,8 @@ export type ConsultOfferLogParams = {
   venueId?: number
   homeEntryId?: string
   searchId?: string
-  fromOfferId?: number
-  fromMultivenueOfferId?: number
+  fromOfferId?: number | string
+  fromMultivenueOfferId?: number | string
   playlistType?: PlaylistType
   offer_display_index?: number
   index?: number


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37107

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
