### PR TITLE
(PC-37638) fix(ThematiqueSearch): correct bottom margin

### DIFF
--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -8,9 +8,10 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
       "flexBasis": 0,
       "flexGrow": 1,
       "flexShrink": 1,
-      "marginBottom": 32,
+      "marginBottom": 96,
     }
   }
+  tabBarHeight={72}
 >
   <View
     customHeight={16}
@@ -439,12 +440,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
     handlerType="NativeViewGestureHandler"
     onGestureHandlerEvent={[Function]}
     onGestureHandlerStateChange={[Function]}
-    style={
-      {
-        "marginBottom": 24,
-        "paddingBottom": 24,
-      }
-    }
   >
     <View>
       <RCTScrollView

--- a/src/features/search/pages/ThematicSearch/ThematicSearch.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearch.tsx
@@ -24,12 +24,15 @@ import { LocationMode } from 'libs/location/types'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
 import { SubcategoryButtonListWrapper } from 'ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper'
 import { Page } from 'ui/pages/Page'
+import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 const titles = PLACEHOLDER_DATA.searchGroups.reduce((previousValue, currentValue) => {
   return { ...previousValue, [currentValue.name]: currentValue.value }
 }, {}) as Record<SearchGroupNameEnumv2, string>
 
 export const ThematicSearch: React.FC = () => {
+  const { tabBarHeight } = useCustomSafeInsets()
+
   const { params, name: currentView } = useRoute<UseRouteType<SearchStackRouteName>>()
 
   const isWeb = Platform.OS === 'web'
@@ -93,12 +96,12 @@ export const ThematicSearch: React.FC = () => {
     : undefined
 
   return (
-    <StyledPage>
+    <StyledPage tabBarHeight={tabBarHeight}>
       <ThematicSearchBar
         offerCategories={offerCategories}
         placeholder={`${titles[offerCategory]}...`}
         title={titles[offerCategory]}>
-        <StyledScrollView>
+        <ScrollView>
           <SubcategoryButtonListWrapper offerCategory={offerCategory} />
           {shouldDisplayVenuesPlaylist ? (
             <VenuePlaylist
@@ -112,17 +115,14 @@ export const ThematicSearch: React.FC = () => {
             />
           ) : null}
           {playlistsComponent[offerCategory]}
-        </StyledScrollView>
+        </ScrollView>
       </ThematicSearchBar>
     </StyledPage>
   )
 }
 
-const StyledPage = styled(Page)(({ theme }) => ({
-  marginBottom: theme.designSystem.size.spacing.xxl,
-}))
-
-const StyledScrollView = styled(ScrollView)(({ theme }) => ({
-  marginBottom: theme.designSystem.size.spacing.xl,
-  paddingBottom: theme.designSystem.size.spacing.xl,
+const StyledPage = styled(Page)<{ tabBarHeight: number }>(({ theme, tabBarHeight }) => ({
+  marginBottom: theme.isDesktopViewport
+    ? theme.contentPage.marginVertical
+    : tabBarHeight + theme.contentPage.marginVertical,
 }))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37638

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [X] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2025-08-29 at 12 35 16" src="https://github.com/user-attachments/assets/807c3b1e-dce5-46b5-8d24-d571157fb52b" />  |
| Android          |               |  <img width="1440" height="2960" alt="Screenshot_1756463707" src="https://github.com/user-attachments/assets/eddb35cc-6287-4958-a4a3-d981f7b3aa98" /> |
| Desktop - Chrome |               | <img width="514" height="577" alt="Capture d’écran 2025-08-29 à 12 34 41" src="https://github.com/user-attachments/assets/51869e53-3767-45d3-b209-f2345821436e" />  |
| Mobile - Chrome |               | <img width="216" height="471" alt="Capture d’écran 2025-08-29 à 12 33 22" src="https://github.com/user-attachments/assets/fb8143fa-3689-47b1-8b58-f9c850385a7f" />  |



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
