### PR TITLE
(PC-37682) docs(installation): update des docs suite retour JL

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Then copy `testing.keystore` into `development.keystore` and `testing.keystore.p
 <details>
   <summary>Test login credentials</summary>
 
-See in [Keeper][1] for all testing accounts.
+See in [our password manager][1] for all testing accounts.
 
 </details>
 
@@ -148,7 +148,7 @@ For the **staging** app, use these links for [iOS][4] and [Android][5].
 
 See doc about deployment process [here](./doc/ci-cd/deployment.md) for the mobile application.
 
-[1]: https://keepersecurity.eu/vault/#
+[1]: Ask for IT
 [2]: https://appcenter.ms/orgs/pass-Culture/apps/passculture-testing-ios
 [3]: https://appcenter.ms/orgs/pass-Culture/apps/passculture-testing-android
 [4]: https://appcenter.ms/orgs/pass-Culture/apps/passculture-staging-ios

--- a/doc/installation/Android.md
+++ b/doc/installation/Android.md
@@ -18,7 +18,7 @@ Finally, open the Android Virtual Devices Manager and select (or create) a Virtu
 
 ### ✍️ Code signing
 
-- Download `testing.keystore` and `testing.keystore.properties` files from Keeper and place it inside the `/android/keystores` directory.
+- Download `testing.keystore` and `testing.keystore.properties` files from our password manager and place it inside the `/android/keystores` directory.
 
   _If you do not find `testing.keystore`, contact an admin._
 
@@ -38,7 +38,7 @@ Finally, open the Android Virtual Devices Manager and select (or create) a Virtu
 In the `.env.local` file (create the file if not exists), add
 
 ```sh
-SECRET_KEYTOOL_PASSWORD=THE_PASSWORD # replace THE_PASSWORD with the one from Keeper search for "Android keytool password"
+SECRET_KEYTOOL_PASSWORD=THE_PASSWORD # replace THE_PASSWORD with the one from our password manager search for "Android keytool password"
 ```
 
 then in your terminal run :
@@ -53,7 +53,7 @@ If it fails [see troubleshooting](./setup.md#troubleshooting)
 
 ### 🔥 Firebase setup
 
-Download the `google-services.json` files from Keeper and place them inside the `android/app/src/<env>` directories. You can also download these files from the Firebase console.
+Download the `google-services.json` files from our password manager and place them inside the `android/app/src/<env>` directories. You can also download these files from the Firebase console.
 
 ```txt
 android/

--- a/doc/installation/iOS.md
+++ b/doc/installation/iOS.md
@@ -60,8 +60,8 @@ In order to launch the app in the Simulator or on your external Apple device, yo
       bundle exec fastlane ios download_certificates --env testing
       ```
 
-   1. When required (multiple times), use the git ssh URL of the [private certificates repository](https://github.com/pass-culture/pass-culture-app-native-certificates)
-   1. Get the `match repo passphrase` on [Keeper in the "Tech" vault](https://keepersecurity.eu/vault/#detail/saH6X4El4qtxQQIDI4AzcQ).
+   1. When required (multiple times), use the git ssh URL of the private certificates repository
+   1. Get the `match repo passphrase` on our password manager in the "Tech" vault.
 
    1. It might ask your session password twice to continue, it might also ask you to do the previous step twice.
 
@@ -119,7 +119,7 @@ This error means that the sentry token you generated is invalid. Please run thro
 </details>
 
 <details>
-  <summary><strong>After the `bundle exec fastlane ios download_certificates --env testing` command, you gave the SSH [git repository](https://github.com/pass-culture/pass-culture-app-native-certificates) and it's not doing anything.</strong></summary>
+  <summary><strong>After the `bundle exec fastlane ios download_certificates --env testing` command, you gave the SSH git repository certificates and it's not doing anything.</strong></summary>
 It might be an issue with your ssh (for example if you only cloned the repository through http)
   
 1. Try to clone the repository elsewhere using ssh to see if your ssh key is working if it does try again the command.


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37682

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
