### PR TITLE
(BSR) feat(queryClient): disable refetchOnWindowFocus for dev and testing envs

### DIFF
--- a/src/libs/react-query/queryClient.ts
+++ b/src/libs/react-query/queryClient.ts
@@ -1,5 +1,7 @@
 import { QueryCache, QueryClient } from '@tanstack/react-query'
 
+import { env } from 'libs/environment/env'
+
 const queryCache = new QueryCache()
 // Read https://tkdodo.eu/blog/placeholder-and-initial-data-in-react-query
 export const queryClient = new QueryClient({
@@ -8,6 +10,7 @@ export const queryClient = new QueryClient({
     queries: {
       retry: 0,
       useErrorBoundary: true,
+      refetchOnWindowFocus: !(__DEV__ || env.ENV !== 'testing'),
     },
   },
 })


### PR DESCRIPTION
## Context
Every stale query is refetched when the window is focus.
In dev mode we tend to change windows very often, e.g. clicking on the devtools window and coming back to the app triggers the refetches ...

## Proposition
Disable refetchOnWindowFocus globally for `DEV` and `TESTING` environments