### PR TITLE
(PC-37491) feat(a11y): rename messageId > errorMessage in InputError

### DIFF
--- a/src/features/auth/pages/login/Login.tsx
+++ b/src/features/auth/pages/login/Login.tsx
@@ -217,7 +217,7 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
         <Form.MaxWidth>
           <InputError
             visible={!!errorMessage}
-            messageId={errorMessage}
+            errorMessage={errorMessage}
             numberOfSpacesTop={5}
             centered
           />

--- a/src/features/auth/pages/signup/AcceptCgu/AcceptCgu.tsx
+++ b/src/features/auth/pages/signup/AcceptCgu/AcceptCgu.tsx
@@ -182,7 +182,7 @@ export const AcceptCgu: FunctionComponent<PreValidationSignupLastStepProps> = ({
         disabled={disabled}
         accessibilityHint={errorMessage ?? undefined}
       />
-      <InputError visible={!!errorMessage} messageId={errorMessage} numberOfSpacesTop={5} />
+      <InputError visible={!!errorMessage} errorMessage={errorMessage} numberOfSpacesTop={5} />
       <Spacer.Column numberOfSpaces={4} />
       <CaptionNeutralInfo>
         Lors de ton utilisation des services de la société pass Culture, nous sommes amenés à

--- a/src/features/favorites/pages/FavoritesSorts.tsx
+++ b/src/features/favorites/pages/FavoritesSorts.tsx
@@ -86,7 +86,7 @@ export const FavoritesSorts: React.FC = () => {
                   />
                   <InputError
                     visible={!!(sortBy === 'AROUND_ME' && geolocPositionError)}
-                    messageId={geolocPositionError?.message}
+                    errorMessage={geolocPositionError?.message}
                     numberOfSpacesTop={1}
                   />
                 </Li>

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
@@ -136,7 +136,7 @@ export const SetPhoneNumber = () => {
               </InputContainer>
               <InputError
                 visible={!!invalidPhoneNumberMessage}
-                messageId={invalidPhoneNumberMessage}
+                errorMessage={invalidPhoneNumberMessage}
                 numberOfSpacesTop={3}
               />
               {invalidPhoneNumberMessage ? (

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
@@ -127,7 +127,7 @@ export const SetPhoneNumberWithoutValidation = () => {
                   />
                   <InputError
                     visible={!!fieldState.error}
-                    messageId={fieldState.error?.message}
+                    errorMessage={fieldState.error?.message}
                     numberOfSpacesTop={0}
                   />
                 </ViewGap>

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.tsx
@@ -166,7 +166,11 @@ export const SetPhoneValidationCode = () => {
                 testID="Entrée pour le code reçu par sms"
               />
             </InputContainer>
-            <InputError visible={!!errorMessage} messageId={errorMessage} numberOfSpacesTop={3} />
+            <InputError
+              visible={!!errorMessage}
+              errorMessage={errorMessage}
+              numberOfSpacesTop={3}
+            />
             <Spacer.Column numberOfSpaces={4} />
             <ButtonContainer>
               <ButtonTertiaryBlack

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -141,7 +141,7 @@ export const SetAddress = () => {
                 testID="Entrée pour l’adresse"
                 searchInputID="street-address-input"
               />
-              <InputError visible={hasError} messageId={errorMessage} numberOfSpacesTop={2} />
+              <InputError visible={hasError} errorMessage={errorMessage} numberOfSpacesTop={2} />
             </Container>
           </Form.MaxWidth>
           {isLoading ? <Spinner /> : null}

--- a/src/features/identityCheck/pages/profile/SetName.tsx
+++ b/src/features/identityCheck/pages/profile/SetName.tsx
@@ -101,7 +101,7 @@ export const SetName = () => {
                 />
                 <InputError
                   visible={firstName.length > 0 && !!error}
-                  messageId={error?.message}
+                  errorMessage={error?.message}
                   numberOfSpacesTop={2}
                 />
               </React.Fragment>
@@ -126,7 +126,7 @@ export const SetName = () => {
                 />
                 <InputError
                   visible={lastName.length > 0 && !!error}
-                  messageId={error?.message}
+                  errorMessage={error?.message}
                   numberOfSpacesTop={2}
                 />
               </React.Fragment>

--- a/src/features/profile/components/CitySearchInput/CitySearchInput.tsx
+++ b/src/features/profile/components/CitySearchInput/CitySearchInput.tsx
@@ -131,7 +131,7 @@ export const CitySearchInput = ({ city, onCitySelected }: CitySearchInputProps) 
                 textContentType="postalCode"
                 searchInputID="postal-code-input"
               />
-              <InputError messageId={error?.message} numberOfSpacesTop={2} visible={!!error} />
+              <InputError errorMessage={error?.message} numberOfSpacesTop={2} visible={!!error} />
             </StyledView>
           )}
         />

--- a/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
+++ b/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
@@ -67,7 +67,7 @@ export const ChangeAddress = () => {
                   />
                 )}
               />
-              <InputError visible={hasError} messageId={errorMessage} numberOfSpacesTop={2} />
+              <InputError visible={hasError} errorMessage={errorMessage} numberOfSpacesTop={2} />
             </Container>
           </Form.MaxWidth>
           {shouldShowAddressResults ? (

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -203,7 +203,7 @@ const OnlineProfile: React.FC = () => {
                     />
                     <InputError
                       visible={!!geolocPositionError}
-                      messageId={geolocPositionError?.message}
+                      errorMessage={geolocPositionError?.message}
                       numberOfSpacesTop={1}
                     />
                   </LiWithMarginVertical>

--- a/src/features/search/components/CalendarPicker/CalendarPicker.web.tsx
+++ b/src/features/search/components/CalendarPicker/CalendarPicker.web.tsx
@@ -173,7 +173,11 @@ export const CalendarPicker: React.FC<CalendarPickerProps> = ({
           onPress={onValidate}
           adjustsFontSizeToFit
         />
-        <InputError visible={isMobileDateInvalid} messageId={errorMessage} numberOfSpacesTop={2} />
+        <InputError
+          visible={isMobileDateInvalid}
+          errorMessage={errorMessage}
+          numberOfSpacesTop={2}
+        />
         {isMobileDateInvalid ? (
           <Spacer.Column numberOfSpaces={1} />
         ) : (

--- a/src/features/search/components/PriceInputController/PriceInputController.tsx
+++ b/src/features/search/components/PriceInputController/PriceInputController.tsx
@@ -51,7 +51,7 @@ export const PriceInputController = <
           />
           <InputError
             visible={!!error}
-            messageId={error?.message}
+            errorMessage={error?.message}
             numberOfSpacesTop={getSpacing(0.5)}
           />
         </React.Fragment>

--- a/src/shared/forms/controllers/EmailInputController.tsx
+++ b/src/shared/forms/controllers/EmailInputController.tsx
@@ -39,7 +39,7 @@ export const EmailInputController = <
             onSpellingHelpPress={onSpellingHelpPress}
             {...otherEmailInputProps}
           />
-          <InputError visible={!!error} messageId={error?.message} numberOfSpacesTop={2} />
+          <InputError visible={!!error} errorMessage={error?.message} numberOfSpacesTop={2} />
         </React.Fragment>
       )}
     />

--- a/src/shared/forms/controllers/PasswordInputController.tsx
+++ b/src/shared/forms/controllers/PasswordInputController.tsx
@@ -50,7 +50,7 @@ export const PasswordInputController = <
           ) : (
             <InputError
               visible={!!error && value.length > 0}
-              messageId={error?.message}
+              errorMessage={error?.message}
               numberOfSpacesTop={getSpacing(0.5)}
             />
           )}

--- a/src/ui/components/inputs/DateInput/DatePicker/DatePickerDropDown.web.tsx
+++ b/src/ui/components/inputs/DateInput/DatePicker/DatePickerDropDown.web.tsx
@@ -25,7 +25,7 @@ export const DatePickerDropDown: FunctionComponent<DatePickerDropDownProps> = ({
         maximumDate={maximumDate}
         errorMessage={errorMessage}
       />
-      <InputError visible={!!errorMessage} messageId={errorMessage} numberOfSpacesTop={2} />
+      <InputError visible={!!errorMessage} errorMessage={errorMessage} numberOfSpacesTop={2} />
       <Spacer.Column numberOfSpaces={errorMessage ? 10 : 4} />
     </React.Fragment>
   )

--- a/src/ui/components/inputs/DateInput/DatePicker/DatePickerSpinner.tsx
+++ b/src/ui/components/inputs/DateInput/DatePicker/DatePickerSpinner.tsx
@@ -19,7 +19,7 @@ export const DatePickerSpinner: FunctionComponent<DatePickerProps> = ({
   return (
     <React.Fragment>
       <DateInputDisplay date={date} errorMessage={errorMessage} />
-      <InputError visible={!!errorMessage} messageId={errorMessage} numberOfSpacesTop={2} />
+      <InputError visible={!!errorMessage} errorMessage={errorMessage} numberOfSpacesTop={2} />
       <SpinnerDatePicker
         testID="date-picker-spinner-native"
         date={date}

--- a/src/ui/components/inputs/DateInput/DatePicker/DatePickerSpinner.web.tsx
+++ b/src/ui/components/inputs/DateInput/DatePicker/DatePickerSpinner.web.tsx
@@ -43,7 +43,7 @@ export const DatePickerSpinner: FunctionComponent<DatePickerProps> = ({
   return (
     <React.Fragment>
       <DateInputDisplay date={birthdate} errorMessage={errorMessage} />
-      <InputError visible={!!errorMessage} messageId={errorMessage} numberOfSpacesTop={2} />
+      <InputError visible={!!errorMessage} errorMessage={errorMessage} numberOfSpacesTop={2} />
       <SpinnerPickerWrapper testID="date-picker-spinner-touch">
         <StyledPicker valueGroups={date} optionGroups={optionGroups} onChange={onDateChange} />
       </SpinnerPickerWrapper>

--- a/src/ui/components/inputs/InputError.native.test.tsx
+++ b/src/ui/components/inputs/InputError.native.test.tsx
@@ -6,7 +6,7 @@ import { InputError } from './InputError'
 
 describe('InputError Component', () => {
   it('should display the given message', () => {
-    render(<InputError visible messageId="message" numberOfSpacesTop={1} />)
+    render(<InputError visible errorMessage="message" numberOfSpacesTop={1} />)
 
     const text = screen.getByText('message', { hidden: true })
 
@@ -14,7 +14,7 @@ describe('InputError Component', () => {
   })
 
   it('should hide the given message', () => {
-    render(<InputError visible={false} messageId="message" numberOfSpacesTop={1} />)
+    render(<InputError visible={false} errorMessage="message" numberOfSpacesTop={1} />)
 
     const text = screen.queryByText('message', { hidden: true })
 

--- a/src/ui/components/inputs/InputError.tsx
+++ b/src/ui/components/inputs/InputError.tsx
@@ -7,7 +7,7 @@ import { ErrorMessage } from 'ui/web/errors/ErrorMessage'
 import { InputRule } from './rules/InputRule'
 
 interface Props {
-  messageId?: string | null
+  errorMessage?: string | null
   visible: boolean
   numberOfSpacesTop: number
   centered?: boolean
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export const InputError: FC<Props> = ({
-  messageId,
+  errorMessage: messageId,
   visible,
   numberOfSpacesTop,
   centered,

--- a/src/ui/components/inputs/InputError.web.test.tsx
+++ b/src/ui/components/inputs/InputError.web.test.tsx
@@ -6,7 +6,7 @@ import { InputError } from './InputError'
 
 describe('InputError Component', () => {
   it('should display the given message', () => {
-    render(<InputError visible messageId="message" numberOfSpacesTop={1} />)
+    render(<InputError visible errorMessage="message" numberOfSpacesTop={1} />)
 
     const text = screen.queryByText('message')
 
@@ -14,7 +14,7 @@ describe('InputError Component', () => {
   })
 
   it('should hide the given message', () => {
-    render(<InputError visible={false} messageId="message" numberOfSpacesTop={1} />)
+    render(<InputError visible={false} errorMessage="message" numberOfSpacesTop={1} />)
 
     const text = screen.queryByText('message')
 

--- a/src/ui/components/inputs/LargeTextInput/LargeTextInput.tsx
+++ b/src/ui/components/inputs/LargeTextInput/LargeTextInput.tsx
@@ -52,7 +52,7 @@ const WithRefLargeTextInput: React.ForwardRefRenderFunction<RNTextInput, LargeTe
         <InputErrorContainer>
           <InputError
             visible={!!showErrorMessage}
-            messageId={computedErrorMessage}
+            errorMessage={computedErrorMessage}
             numberOfSpacesTop={0}
           />
         </InputErrorContainer>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37491

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
