### PR TITLE
Pc 37491 part2

### DIFF
--- a/src/features/auth/pages/login/Login.tsx
+++ b/src/features/auth/pages/login/Login.tsx
@@ -217,7 +217,7 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
         <Form.MaxWidth>
           <InputError
             visible={!!errorMessage}
-            messageId={errorMessage}
+            errorMessage={errorMessage}
             numberOfSpacesTop={5}
             centered
           />

--- a/src/features/auth/pages/signup/AcceptCgu/AcceptCgu.tsx
+++ b/src/features/auth/pages/signup/AcceptCgu/AcceptCgu.tsx
@@ -186,7 +186,7 @@ export const AcceptCgu: FunctionComponent<PreValidationSignupLastStepProps> = ({
       />
       <InputError
         visible={!!errorMessage}
-        messageId={errorMessage}
+        errorMessage={errorMessage}
         numberOfSpacesTop={5}
         relatedInputId={checkCGUErrorId}
       />

--- a/src/features/favorites/pages/FavoritesSorts.tsx
+++ b/src/features/favorites/pages/FavoritesSorts.tsx
@@ -86,7 +86,7 @@ export const FavoritesSorts: React.FC = () => {
                   />
                   <InputError
                     visible={!!(sortBy === 'AROUND_ME' && geolocPositionError)}
-                    messageId={geolocPositionError?.message}
+                    errorMessage={geolocPositionError?.message}
                     numberOfSpacesTop={1}
                   />
                 </Li>

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
@@ -139,7 +139,7 @@ export const SetPhoneNumber = () => {
               <InputError
                 relatedInputId={phoneNumberInputErrorId}
                 visible={!!invalidPhoneNumberMessage}
-                messageId={invalidPhoneNumberMessage}
+                errorMessage={invalidPhoneNumberMessage}
                 numberOfSpacesTop={3}
               />
               {invalidPhoneNumberMessage ? (

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
@@ -129,7 +129,7 @@ export const SetPhoneNumberWithoutValidation = () => {
                   />
                   <InputError
                     visible={!!fieldState.error}
-                    messageId={fieldState.error?.message}
+                    errorMessage={fieldState.error?.message}
                     numberOfSpacesTop={0}
                     relatedInputId={phoneNumberInputErrorId}
                   />

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.tsx
@@ -171,7 +171,7 @@ export const SetPhoneValidationCode = () => {
             </InputContainer>
             <InputError
               visible={!!errorMessage}
-              messageId={errorMessage}
+              errorMessage={errorMessage}
               numberOfSpacesTop={3}
               relatedInputId={validationCodeInputErrorId}
             />

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -142,7 +142,7 @@ export const SetAddress = () => {
               />
               <InputError
                 visible={hasError}
-                messageId="Ton adresse ne doit pas contenir de caractères spéciaux ou n’être composée que d’espaces."
+                errorMessage="Ton adresse ne doit pas contenir de caractères spéciaux ou n’être composée que d’espaces."
                 numberOfSpacesTop={2}
                 relatedInputId={addressInputErrorId}
               />

--- a/src/features/identityCheck/pages/profile/SetName.tsx
+++ b/src/features/identityCheck/pages/profile/SetName.tsx
@@ -104,7 +104,7 @@ export const SetName = () => {
                 />
                 <InputError
                   visible={firstName.length > 0 && !!error}
-                  messageId={error?.message}
+                  errorMessage={error?.message}
                   numberOfSpacesTop={2}
                   relatedInputId={firstNameInputErrorId}
                 />
@@ -130,7 +130,7 @@ export const SetName = () => {
                 />
                 <InputError
                   visible={lastName.length > 0 && !!error}
-                  messageId={error?.message}
+                  errorMessage={error?.message}
                   numberOfSpacesTop={2}
                   relatedInputId={lastNameInputErrorId}
                 />

--- a/src/features/profile/components/CitySearchInput/CitySearchInput.tsx
+++ b/src/features/profile/components/CitySearchInput/CitySearchInput.tsx
@@ -134,7 +134,7 @@ export const CitySearchInput = ({ city, onCitySelected }: CitySearchInputProps) 
                 searchInputID="postal-code-input"
               />
               <InputError
-                messageId={error?.message}
+                errorMessage={error?.message}
                 numberOfSpacesTop={2}
                 visible={!!error}
                 relatedInputId={postalCodeInputId}

--- a/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
+++ b/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
@@ -69,7 +69,7 @@ export const ChangeAddress = () => {
               />
               <InputError
                 visible={hasError}
-                messageId="Ton adresse ne doit pas contenir de caractères spéciaux ou n’être composée que d’espaces."
+                errorMessage="Ton adresse ne doit pas contenir de caractères spéciaux ou n’être composée que d’espaces."
                 numberOfSpacesTop={2}
                 relatedInputId={addressInputErrorId}
               />

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -205,7 +205,7 @@ const OnlineProfile: React.FC = () => {
                     />
                     <InputError
                       visible={!!geolocPositionError}
-                      messageId={geolocPositionError?.message}
+                      errorMessage={geolocPositionError?.message}
                       numberOfSpacesTop={1}
                       relatedInputId={locationActivationErrorId}
                     />

--- a/src/features/search/components/CalendarPicker/CalendarPicker.web.tsx
+++ b/src/features/search/components/CalendarPicker/CalendarPicker.web.tsx
@@ -175,7 +175,7 @@ export const CalendarPicker: React.FC<CalendarPickerProps> = ({
         />
         <InputError
           visible={isMobileDateInvalid}
-          messageId="Choisis une date dans le futur"
+          errorMessage="Choisis une date dans le futur"
           numberOfSpacesTop={2}
           relatedInputId={bookingDateChoiceErrorId}
         />

--- a/src/features/search/components/CategoriesSectionItem/CategoriesSectionItem.tsx
+++ b/src/features/search/components/CategoriesSectionItem/CategoriesSectionItem.tsx
@@ -66,7 +66,6 @@ export const CategoriesSectionItem = <N,>({
             title={item.label}
             description={getDescription(subcategoriesData, descriptionContext, k)}
             onPress={() => handleSelect(itemKey)}
-            captionId={k}
             complement={displaySearchNbFacetResults ? nbResultsFacet : undefined}
           />
         </FilterRowContainer>

--- a/src/features/search/components/FilterRow/FilterRow.tsx
+++ b/src/features/search/components/FilterRow/FilterRow.tsx
@@ -11,7 +11,6 @@ interface Props {
   icon?: React.FunctionComponent<AccessibleIcon>
   title: string
   description?: string
-  captionId?: string
   onPress: VoidFunction
   shouldColorIcon?: boolean
   complement?: string
@@ -21,7 +20,6 @@ export const FilterRow = ({
   icon: Icon,
   title,
   description,
-  captionId,
   onPress,
   shouldColorIcon,
   complement,
@@ -36,7 +34,7 @@ export const FilterRow = ({
     : undefined
 
   return (
-    <TouchableRow testID="FilterRow" onPress={onPress} accessibilityDescribedBy={captionId}>
+    <TouchableRow testID="FilterRow" onPress={onPress}>
       {StyledIcon ? (
         <IconContainer>
           <StyledIcon />

--- a/src/features/search/components/PriceInputController/PriceInputController.tsx
+++ b/src/features/search/components/PriceInputController/PriceInputController.tsx
@@ -53,7 +53,7 @@ export const PriceInputController = <
           />
           <InputError
             visible={!!error}
-            messageId={error?.message}
+            errorMessage={error?.message}
             relatedInputId={accessibilityId}
             numberOfSpacesTop={getSpacing(0.5)}
           />

--- a/src/shared/forms/controllers/EmailInputController.tsx
+++ b/src/shared/forms/controllers/EmailInputController.tsx
@@ -43,7 +43,7 @@ export const EmailInputController = <
           />
           <InputError
             visible={!!error}
-            messageId={error?.message}
+            errorMessage={error?.message}
             numberOfSpacesTop={2}
             relatedInputId={emailInputErrorId}
           />

--- a/src/shared/forms/controllers/PasswordInputController.tsx
+++ b/src/shared/forms/controllers/PasswordInputController.tsx
@@ -50,7 +50,7 @@ export const PasswordInputController = <
           ) : (
             <InputError
               visible={!!error && value.length > 0}
-              messageId={error?.message}
+              errorMessage={error?.message}
               numberOfSpacesTop={getSpacing(0.5)}
               relatedInputId={passwordInputErrorId}
             />

--- a/src/ui/components/inputs/DateInput/DatePicker/DatePickerDropDown.web.tsx
+++ b/src/ui/components/inputs/DateInput/DatePicker/DatePickerDropDown.web.tsx
@@ -31,7 +31,7 @@ export const DatePickerDropDown: FunctionComponent<DatePickerDropDownProps> = ({
       />
       <InputError
         visible={!!errorMessage}
-        messageId={errorMessage}
+        errorMessage={errorMessage}
         numberOfSpacesTop={2}
         relatedInputId={birthdateInputErrorId}
       />

--- a/src/ui/components/inputs/DateInput/DatePicker/DatePickerSpinner.tsx
+++ b/src/ui/components/inputs/DateInput/DatePicker/DatePickerSpinner.tsx
@@ -23,7 +23,7 @@ export const DatePickerSpinner: FunctionComponent<DatePickerProps> = ({
       <DateInputDisplay date={date} isError={!!errorMessage} />
       <InputError
         visible={!!errorMessage}
-        messageId={errorMessage}
+        errorMessage={errorMessage}
         numberOfSpacesTop={2}
         relatedInputId={birthdateInputErrorId}
       />

--- a/src/ui/components/inputs/DateInput/DatePicker/DatePickerSpinner.web.tsx
+++ b/src/ui/components/inputs/DateInput/DatePicker/DatePickerSpinner.web.tsx
@@ -52,7 +52,7 @@ export const DatePickerSpinner: FunctionComponent<DatePickerProps> = ({
       <DateInputDisplay date={birthdate} isError={!!errorMessage} />
       <InputError
         visible={!!errorMessage}
-        messageId={errorMessage}
+        errorMessage={errorMessage}
         numberOfSpacesTop={2}
         relatedInputId={birthdateInputErrorId}
       />

--- a/src/ui/components/inputs/InputError.native.test.tsx
+++ b/src/ui/components/inputs/InputError.native.test.tsx
@@ -9,7 +9,7 @@ describe('InputError Component', () => {
     render(
       <InputError
         visible
-        messageId="message"
+        errorMessage="message"
         numberOfSpacesTop={1}
         relatedInputId="relatedInputId"
       />
@@ -24,7 +24,7 @@ describe('InputError Component', () => {
     render(
       <InputError
         visible={false}
-        messageId="message"
+        errorMessage="message"
         numberOfSpacesTop={1}
         relatedInputId="relatedInputId"
       />

--- a/src/ui/components/inputs/InputError.tsx
+++ b/src/ui/components/inputs/InputError.tsx
@@ -7,7 +7,7 @@ import { ErrorMessage } from 'ui/web/errors/ErrorMessage'
 import { InputRule } from './rules/InputRule'
 
 interface Props {
-  messageId?: string | null
+  errorMessage?: string | null
   visible: boolean
   numberOfSpacesTop: number
   centered?: boolean
@@ -17,10 +17,10 @@ interface Props {
 export const InputError: FC<Props> = (props) => {
   return (
     <ErrorMessage relatedInputId={props.relatedInputId}>
-      {props.visible && props.messageId ? (
+      {props.visible && props.errorMessage ? (
         <Container numberOfSpacesTop={props.numberOfSpacesTop}>
           <InputRule
-            title={props.messageId}
+            title={props.errorMessage}
             type="Error"
             icon={Error}
             testIdSuffix="warn"

--- a/src/ui/components/inputs/InputError.web.test.tsx
+++ b/src/ui/components/inputs/InputError.web.test.tsx
@@ -9,7 +9,7 @@ describe('InputError Component', () => {
     render(
       <InputError
         visible
-        messageId="message"
+        errorMessage="message"
         numberOfSpacesTop={1}
         relatedInputId="relatedInputId"
       />
@@ -24,7 +24,7 @@ describe('InputError Component', () => {
     render(
       <InputError
         visible={false}
-        messageId="message"
+        errorMessage="message"
         numberOfSpacesTop={1}
         relatedInputId="relatedInputId"
       />

--- a/src/ui/components/inputs/LargeTextInput/LargeTextInput.tsx
+++ b/src/ui/components/inputs/LargeTextInput/LargeTextInput.tsx
@@ -52,7 +52,7 @@ const WithRefLargeTextInput: React.ForwardRefRenderFunction<RNTextInput, LargeTe
         <InputErrorContainer>
           <InputError
             visible={!!showErrorMessage}
-            messageId={errorMessage ?? 'Tu as atteint le nombre de caractères maximal.'}
+            errorMessage={errorMessage ?? 'Tu as atteint le nombre de caractères maximal.'}
             relatedInputId={feedbackInAppInputErrorId}
             numberOfSpacesTop={0}
           />


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
