### PR TITLE
(PC-37424) fix(venueMap): avoid label overlay pin in Android

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1526,9 +1526,9 @@ PODS:
     - React-Core
   - react-native-lottie-splash-screen (1.1.2):
     - React
-  - react-native-maps (1.23.12):
-    - react-native-maps/Maps (= 1.23.12)
-  - react-native-maps/Generated (1.23.12):
+  - react-native-maps (1.24.3):
+    - react-native-maps/Maps (= 1.24.3)
+  - react-native-maps/Generated (1.24.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1549,7 +1549,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-maps/Maps (1.23.12):
+  - react-native-maps/Maps (1.24.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2802,7 +2802,7 @@ SPEC CHECKSUMS:
   react-native-get-random-values: 2c4ff6b44cb71291dabe9a8ae87d3877dcf387da
   react-native-in-app-review: db8bb167a5f238e7ceca5c242d6b36ce8c4404a4
   react-native-lottie-splash-screen: 4e1b1fd9d6633f9cd2106d6877eb5ba0147f3e2b
-  react-native-maps: 20fecb1f385a6775e04878f482a3d3e3d1906f86
+  react-native-maps: 027b0039dcc65f1a662d0e2dafa9952457c36382
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-orientation-locker: 5819fd23ca89cbac0d736fb4314745f62716d517
   react-native-performance: 446a14bdd7b46ae78c3ae652aa7ab23ff2a93f1f

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "react-native-linear-gradient": "^2.8.3",
     "react-native-lottie-splash-screen": "^1.1.2",
     "react-native-map-clustering": "^3.4.2",
-    "react-native-maps": "1.23.12",
+    "react-native-maps": "1.24.3",
     "react-native-modal": "13.0.1",
     "react-native-orientation-locker": "^1.7.0",
     "react-native-performance": "^5.1.4",

--- a/src/features/venueMap/components/VenueMapLabel/LabelContainer.android.tsx
+++ b/src/features/venueMap/components/VenueMapLabel/LabelContainer.android.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components/native'
 
+import { MARKER_LABEL_MARGIN_TOP, MARKER_SIZE } from 'features/venueMap/constant'
 import { getSpacing } from 'ui/theme'
 
 export const LabelContainer = styled.View(({ theme }) => {
@@ -10,5 +11,7 @@ export const LabelContainer = styled.View(({ theme }) => {
     maxWidth: getSpacing(40),
     paddingHorizontal: theme.designSystem.size.spacing.s,
     paddingVertical: theme.designSystem.size.spacing.xs,
+    height: '100%',
+    marginTop: MARKER_SIZE.height + MARKER_LABEL_MARGIN_TOP,
   }
 })

--- a/src/features/venueMap/components/VenueMapView/Marker/Marker.tsx
+++ b/src/features/venueMap/components/VenueMapView/Marker/Marker.tsx
@@ -5,7 +5,7 @@ import { GeolocatedVenue } from 'features/venueMap/components/VenueMapView/types
 import { getVenueTypeIconName } from 'features/venueMap/helpers/getVenueTypeIconName/getVenueTypeIconName'
 import { Marker as MapMarker, MapMarkerProps } from 'libs/maps/maps'
 
-import { MARKER_SIZE } from '../../../constant'
+import { LABEL_HEIGHT, MARKER_SIZE } from '../../../constant'
 import { VenueMapLabel } from '../../VenueMapLabel/VenueMapLabel'
 
 const PIN_MAX_Z_INDEX = 10_000
@@ -32,6 +32,6 @@ export const Marker = ({ venue, isSelected, showLabel, ...otherProps }: MarkerPr
 
 const CustomMarker = styled(MapMarker)({
   minWidth: MARKER_SIZE.width,
-  height: MARKER_SIZE.height,
+  height: MARKER_SIZE.height + LABEL_HEIGHT,
   width: 'auto',
 })

--- a/src/features/venueMap/constant.ts
+++ b/src/features/venueMap/constant.ts
@@ -15,6 +15,7 @@ export const MARKER_LABEL_VISIBILITY_LIMIT = {
   altitude: 4000,
   zoom: 13,
 }
+export const LABEL_HEIGHT = 28
 
 export const CLUSTER_IMAGE_COLOR_NAME = {
   BLUE: 'blue',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11193,7 +11193,7 @@ __metadata:
     react-native-linear-gradient: ^2.8.3
     react-native-lottie-splash-screen: ^1.1.2
     react-native-map-clustering: ^3.4.2
-    react-native-maps: 1.23.12
+    react-native-maps: 1.24.3
     react-native-modal: 13.0.1
     react-native-orientation-locker: ^1.7.0
     react-native-performance: ^5.1.4
@@ -24942,9 +24942,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-maps@npm:1.23.12":
-  version: 1.23.12
-  resolution: "react-native-maps@npm:1.23.12"
+"react-native-maps@npm:1.24.3":
+  version: 1.24.3
+  resolution: "react-native-maps@npm:1.24.3"
   dependencies:
     "@types/geojson": ^7946.0.13
   peerDependencies:
@@ -24954,7 +24954,7 @@ __metadata:
   peerDependenciesMeta:
     react-native-web:
       optional: true
-  checksum: 5ee7790fae80691d55974c9bff57f71729b5d6cee70c5239a06067477088bffa5c948270382ecd0f95982eedfcb70e3e21f1b596a098f98c3874f74865ac2c03
+  checksum: 8f8fb52ea3a396eb1267b5eed256f4852d12c24be00d89cfc2b6a36945e8960aae0feb4f0b0fe2fc6a931611ead5346148688d1ddc883560f0e5133ecc9d22da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ce fix n'est pas optimale mais il permet tout de même d'avoir le label en dessous le pin pour Android.
Aucun changement pour iOS qui est déjà ok.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37424

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |<img width="447" height="920" alt="Capture d’écran 2025-09-02 à 14 16 03" src="https://github.com/user-attachments/assets/a2af9a78-2895-4115-bd71-352a6444a0bc" />|
| Android          |<img width="410" height="891" alt="Capture d’écran 2025-09-02 à 15 34 52" src="https://github.com/user-attachments/assets/dc9e975c-1229-4656-bc7f-2f9a008b8af0" />|<img width="417" height="901" alt="Capture d’écran 2025-09-02 à 15 36 41" src="https://github.com/user-attachments/assets/f5916f32-e4ab-45dd-98d1-5a6cdea733c0" />|
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
