### PR TITLE
(PC-37591) fix(app): padding horizontal for venue playlist

### DIFF
--- a/src/features/home/components/modules/venues/VenuesModule.tsx
+++ b/src/features/home/components/modules/venues/VenuesModule.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect } from 'react'
-import styled from 'styled-components/native'
 
 import { VenueTile } from 'features/home/components/modules/venues/VenueTile'
 import { ModuleData } from 'features/home/types'
@@ -8,7 +7,7 @@ import { analytics } from 'libs/analytics/provider'
 import { ContentTypes, DisplayParametersFields } from 'libs/contentful/types'
 import { PassPlaylist } from 'ui/components/PassPlaylist'
 import { CustomListRenderItem } from 'ui/components/Playlist'
-import { LENGTH_S } from 'ui/theme'
+import { LENGTH_S, getSpacing } from 'ui/theme'
 
 type VenuesModuleProps = {
   moduleId: string
@@ -64,23 +63,18 @@ export const VenuesModule = ({
 
   if (!shouldModuleBeDisplayed) return null
   return (
-    <PlaylistContainer>
-      <PassPlaylist
-        testID="offersModuleList"
-        title={displayParameters.title}
-        subtitle={displayParameters.subtitle}
-        data={playlistItems || []}
-        itemHeight={ITEM_HEIGHT}
-        itemWidth={ITEM_WIDTH}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
-        tileType="venue"
-        withMargin={false}
-      />
-    </PlaylistContainer>
+    <PassPlaylist
+      testID="offersModuleList"
+      title={displayParameters.title}
+      subtitle={displayParameters.subtitle}
+      data={playlistItems || []}
+      itemHeight={ITEM_HEIGHT}
+      itemWidth={ITEM_WIDTH}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      tileType="venue"
+      withMargin
+      contentContainerStyle={{ paddingHorizontal: getSpacing(6) }}
+    />
   )
 }
-
-const PlaylistContainer = styled.View(({ theme }) => ({
-  marginHorizontal: theme.designSystem.size.spacing.xl,
-}))

--- a/src/features/search/components/VenuePlaylist/VenuePlaylist.tsx
+++ b/src/features/search/components/VenuePlaylist/VenuePlaylist.tsx
@@ -24,7 +24,7 @@ import { useModal } from 'ui/components/modals/useModal'
 import { Playlist } from 'ui/components/Playlist'
 import { Separator } from 'ui/components/Separator'
 import { Map } from 'ui/svg/icons/Map'
-import { LENGTH_XS, LENGTH_XXS, Typo } from 'ui/theme'
+import { getSpacing, LENGTH_XS, LENGTH_XXS, Typo } from 'ui/theme'
 
 export const VENUE_ITEM_HEIGHT = LENGTH_XXS
 export const VENUE_ITEM_WIDTH = LENGTH_XS
@@ -126,18 +126,20 @@ export const VenuePlaylist: React.FC<Props> = ({
   return (
     <React.Fragment>
       <Container style={style}>
-        <Typo.Title3 numberOfLines={isWeb ? 1 : undefined}>{venuePlaylistTitle}</Typo.Title3>
-        {shouldDisplaySeeOnMapButton ? (
-          <ButtonContainer>
-            <ButtonTertiaryBlack
-              icon={Map}
-              wording="Voir sur la carte"
-              onPress={handleSeeMapPress}
-            />
-          </ButtonContainer>
-        ) : (
-          <NumberOfResults nbHits={venues?.length ?? 0} />
-        )}
+        <HeaderPlaylistContainer>
+          <Typo.Title3 numberOfLines={isWeb ? 1 : undefined}>{venuePlaylistTitle}</Typo.Title3>
+          {shouldDisplaySeeOnMapButton ? (
+            <ButtonContainer>
+              <ButtonTertiaryBlack
+                icon={Map}
+                wording="Voir sur la carte"
+                onPress={handleSeeMapPress}
+              />
+            </ButtonContainer>
+          ) : (
+            <NumberOfResults nbHits={venues?.length ?? 0} />
+          )}
+        </HeaderPlaylistContainer>
         <Playlist
           data={venues ?? []}
           scrollButtonOffsetY={VENUE_ITEM_HEIGHT / 2 + 4}
@@ -151,6 +153,7 @@ export const VenuePlaylist: React.FC<Props> = ({
           keyExtractor={keyExtractor}
           testID="search-venue-list"
           onEndReached={logAllTilesSeenOnce}
+          contentContainerStyle={{ paddingHorizontal: getSpacing(6) }}
         />
       </Container>
       {shouldDisplaySeparator ? <StyledSeparator testID="venue-playlist-separator" /> : null}
@@ -165,7 +168,10 @@ export const VenuePlaylist: React.FC<Props> = ({
 
 const Container = styled.View(({ theme }) => ({
   marginBottom: theme.designSystem.size.spacing.xxl,
-  marginHorizontal: theme.designSystem.size.spacing.xl,
+}))
+
+const HeaderPlaylistContainer = styled.View(({ theme }) => ({
+  marginLeft: theme.designSystem.size.spacing.xl,
 }))
 
 const StyledSeparator = styled(Separator.Horizontal)(({ theme }) => ({

--- a/src/ui/components/PassPlaylist.tsx
+++ b/src/ui/components/PassPlaylist.tsx
@@ -1,5 +1,6 @@
 import { FlashList } from '@shopify/flash-list'
 import React, { ComponentProps, Ref, useCallback } from 'react'
+import { StyleProp, ViewStyle } from 'react-native'
 import { FlatList, FlatList as RNGHFlatList } from 'react-native-gesture-handler'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -35,6 +36,7 @@ type Props = Pick<
   playlistRef?: Ref<FlatList>
   FlatListComponent?: typeof FlashList | typeof RNGHFlatList
   withMargin?: boolean
+  contentContainerStyle?: StyleProp<ViewStyle>
 }
 
 export const PassPlaylist = ({
@@ -57,6 +59,7 @@ export const PassPlaylist = ({
   noMarginBottom,
   FlatListComponent,
   withMargin = true,
+  contentContainerStyle,
   ...props
 }: Props) => {
   const { isTouch } = useTheme()
@@ -114,6 +117,7 @@ export const PassPlaylist = ({
         ref={playlistRef}
         onViewableItemsChanged={onViewableItemsChanged}
         FlatListComponent={FlatListComponent}
+        contentContainerStyle={contentContainerStyle}
       />
     </StyledViewGap>
   )

--- a/src/ui/components/Playlist.tsx
+++ b/src/ui/components/Playlist.tsx
@@ -1,8 +1,15 @@
 /* We use many `any` on purpose in this module, so we deactivate the following rule : */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ListRenderItemInfo, FlashList } from '@shopify/flash-list'
+import { FlashList, ListRenderItemInfo } from '@shopify/flash-list'
 import React, { forwardRef, useCallback, useImperativeHandle, useMemo, useRef } from 'react'
-import { FlatListProps, Platform, useWindowDimensions, ViewabilityConfig } from 'react-native'
+import {
+  FlatListProps,
+  Platform,
+  StyleProp,
+  useWindowDimensions,
+  ViewabilityConfig,
+  ViewStyle,
+} from 'react-native'
 import { FlatList, FlatList as RNGHFlatList } from 'react-native-gesture-handler'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -43,6 +50,7 @@ type Props = Pick<FlatListProps<unknown>, 'onViewableItemsChanged'> & {
   FlatListComponent?: typeof FlashList | typeof RNGHFlatList
   itemSeparatorSize?: number
   horizontalMargin?: number
+  contentContainerStyle?: StyleProp<ViewStyle>
 }
 
 const isWeb = Platform.OS === 'web' ? true : undefined
@@ -73,6 +81,7 @@ const InnerPlaylist = forwardRef<FlatList, Props>(function Playlist(props, ref) 
     tileType = 'offer',
     itemSeparatorSize = ITEM_SEPARATOR_WIDTH,
     horizontalMargin = HORIZONTAL_MARGIN,
+    contentContainerStyle,
   } = props
 
   const { isTouch, tiles } = useTheme()
@@ -203,6 +212,7 @@ const InnerPlaylist = forwardRef<FlatList, Props>(function Playlist(props, ref) 
         onEndReachedThreshold={0.2}
         viewabilityConfig={PLAYLIST_VIEWABILITY_CONFIG}
         onViewableItemsChanged={onViewableItemsChanged}
+        contentContainerStyle={contentContainerStyle}
       />
     </FlatListContainer>
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37591

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="449" height="935" alt="Capture d’écran 2025-09-03 à 14 38 02" src="https://github.com/user-attachments/assets/37ab540b-db6f-459e-8402-808fc0134e8c" /> <img width="446" height="926" alt="Capture d’écran 2025-09-03 à 14 38 13" src="https://github.com/user-attachments/assets/c78a1c79-0d6a-486b-b733-a6a5cbf74cec" /> <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-09-03 at 14 47 13" src="https://github.com/user-attachments/assets/1e6a9e88-1686-4be4-b304-fd4edcecec30" /> <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-09-03 at 14 47 22" src="https://github.com/user-attachments/assets/a08c3ed4-8013-4bce-8045-5cea0947601a" />|<img width="445" height="938" alt="Capture d’écran 2025-09-03 à 14 28 16" src="https://github.com/user-attachments/assets/f81f0c8f-d391-44f8-bd32-198083e71f39" /> <img width="454" height="928" alt="Capture d’écran 2025-09-03 à 14 28 27" src="https://github.com/user-attachments/assets/b5d0746c-df69-4ee1-96b2-1da8eeb457d7" /> <img width="444" height="920" alt="Capture d’écran 2025-09-03 à 14 45 37" src="https://github.com/user-attachments/assets/39310dc8-91a6-429f-ad5b-282a204492cc" /> <img width="443" height="924" alt="Capture d’écran 2025-09-03 à 14 46 10" src="https://github.com/user-attachments/assets/c69c095b-dcbe-44b3-8e24-515918cfd59b" />|
| Android          |<img width="420" height="891" alt="Capture d’écran 2025-09-03 à 14 37 47" src="https://github.com/user-attachments/assets/2e4a5549-94d8-4c44-932d-aaf1b1a251f8" /> <img width="426" height="895" alt="Capture d’écran 2025-09-03 à 14 37 55" src="https://github.com/user-attachments/assets/70d67842-5b76-47f5-8a76-b35769bf914b" /> <img width="1080" height="2400" alt="Screenshot_1756903653" src="https://github.com/user-attachments/assets/6dcf664c-98cd-470b-ad3c-9a9d0840feb0" /> <img width="1080" height="2400" alt="Screenshot_1756903656" src="https://github.com/user-attachments/assets/6ef17a6e-0018-4032-9bb7-6020fbdb1d8b" />|<img width="419" height="902" alt="Capture d’écran 2025-09-03 à 14 36 33" src="https://github.com/user-attachments/assets/80640e7a-25af-4d84-8253-4a313081d4f7" /> <img width="426" height="892" alt="Capture d’écran 2025-09-03 à 14 36 49" src="https://github.com/user-attachments/assets/a0c6a4df-bca3-4d82-a98d-3295af77df06" /> <img width="427" height="904" alt="Capture d’écran 2025-09-03 à 14 45 15" src="https://github.com/user-attachments/assets/41c9004f-1083-4f4f-b44f-f06a21663089" /> <img width="423" height="898" alt="Capture d’écran 2025-09-03 à 14 45 23" src="https://github.com/user-attachments/assets/af350454-63ad-4e68-90ab-c6af26e6abcf" />|
| Phone - Chrome   |<img width="390" height="696" alt="Capture d’écran 2025-09-03 à 14 37 14" src="https://github.com/user-attachments/assets/a262034b-d142-4201-8781-8958783481bd" /> <img width="389" height="690" alt="Capture d’écran 2025-09-03 à 14 37 37" src="https://github.com/user-attachments/assets/c25fc17d-452a-437f-8942-edefbb5bea11" /> <img width="399" height="694" alt="Capture d’écran 2025-09-03 à 14 46 28" src="https://github.com/user-attachments/assets/ce26ebc2-3952-4b90-b8bd-1a5950fe5d2c" /> <img width="402" height="689" alt="Capture d’écran 2025-09-03 à 14 46 39" src="https://github.com/user-attachments/assets/b0bb4e87-f0f3-42b6-b630-b54d22d5d32c" />|<img width="391" height="695" alt="Capture d’écran 2025-09-03 à 14 27 36" src="https://github.com/user-attachments/assets/67ec55da-157f-4ccd-bade-14a96765f886" /> <img width="394" height="691" alt="Capture d’écran 2025-09-03 à 14 28 02" src="https://github.com/user-attachments/assets/1db3e049-cb5f-4235-9848-fc316fbfd24d" /> <img width="402" height="698" alt="Capture d’écran 2025-09-03 à 14 44 51" src="https://github.com/user-attachments/assets/1164ec63-fe4b-444e-b810-1eb6cd63424a" /> <img width="397" height="688" alt="Capture d’écran 2025-09-03 à 14 45 01" src="https://github.com/user-attachments/assets/06e4cb9c-0a72-4577-ad42-85846a0e71e7" />|
| Desktop - Chrome |<img width="1725" height="886" alt="Capture d’écran 2025-09-03 à 14 37 06" src="https://github.com/user-attachments/assets/8f5921c7-b9d8-4cd1-b3c5-ea11d336f0e4" /> <img width="1723" height="884" alt="Capture d’écran 2025-09-03 à 14 37 27" src="https://github.com/user-attachments/assets/41b3d2b8-a96c-4ea5-956b-bf57e894bf52" /> <img width="1726" height="886" alt="Capture d’écran 2025-09-03 à 14 46 57" src="https://github.com/user-attachments/assets/81dc2b2d-cf6d-4c53-9008-1847dd35e5de" /> <img width="1728" height="878" alt="Capture d’écran 2025-09-03 à 14 47 08" src="https://github.com/user-attachments/assets/b8e6badd-af98-4604-947c-80a7cdbd47be" />|<img width="1728" height="885" alt="Capture d’écran 2025-09-03 à 14 27 30" src="https://github.com/user-attachments/assets/22792941-7b84-48d5-97d3-16d94f290e2c" /> <img width="1726" height="887" alt="Capture d’écran 2025-09-03 à 14 28 09" src="https://github.com/user-attachments/assets/2662d5dd-5661-45f9-badf-78e2cf8446fb" /> <img width="1727" height="884" alt="Capture d’écran 2025-09-03 à 14 44 25" src="https://github.com/user-attachments/assets/c2cdb78e-7b0d-48a9-a49b-b0db7225d186" /> <img width="1725" height="882" alt="Capture d’écran 2025-09-03 à 14 44 36" src="https://github.com/user-attachments/assets/4e95a55d-155e-4a3c-9157-af854e30c6f9" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
