### PR TITLE
(PC-37738) feat(ui): add new ButtonInsideText in Accessibility pages

### DIFF
--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx.native-snap
@@ -228,91 +228,23 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
         >
           La présente déclaration d’accessibilité s’applique à
            
-          <View>
-            <View
-              accessibilityLabel="l’application Android"
-              accessibilityRole="link"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": undefined,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
+          <Text
+            accessibilityLabel="l’application Android, lien externe"
+            accessibilityRole="link"
+            onPress={[Function]}
+            style={
+              {
+                "color": "#eb0055",
+                "cursor": "pointer",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 16,
+                "lineHeight": 25.6,
+                "textDecorationLine": "underline",
               }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                [
-                  [
-                    {
-                      "userSelect": "auto",
-                    },
-                    {
-                      "top": 3,
-                    },
-                  ],
-                  {
-                    "opacity": 1,
-                  },
-                ]
-              }
-              testID="l’application Android"
-            >
-              <View
-                gap={1}
-                paddingForIcon={0}
-                style={
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                    "gap": 4,
-                    "top": 0,
-                  }
-                }
-              >
-                <View
-                  accessibilityLabel="Nouvelle fenêtre"
-                  height={20}
-                  testID="button-icon"
-                  width={20}
-                >
-                  <Text>
-                    button-icon-SVG-Mock
-                  </Text>
-                </View>
-                <Text
-                  style={
-                    {
-                      "color": "#eb0055",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 16,
-                      "lineHeight": 25.6,
-                    }
-                  }
-                  typography="Button"
-                >
-                  l’application Android
-                </Text>
-              </View>
-            </View>
-          </View>
+            }
+          >
+            l’application Android
+          </Text>
            
           version 1.348.8 du pass Culture.
         </Text>
@@ -2279,90 +2211,23 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
         >
           Le pass Culture invite les personnes qui rencontreraient des difficultés à la contacter afin qu’une assistance puisse être apportée :
            
-          <View>
-            <View
-              accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
-              accessibilityRole="link"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": undefined,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
+          <Text
+            accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support, lien externe"
+            accessibilityRole="link"
+            onPress={[Function]}
+            style={
+              {
+                "color": "#eb0055",
+                "cursor": "pointer",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 16,
+                "lineHeight": 25.6,
+                "textDecorationLine": "underline",
               }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                [
-                  [
-                    {
-                      "userSelect": "auto",
-                    },
-                    {
-                      "top": 3,
-                    },
-                  ],
-                  {
-                    "opacity": 1,
-                  },
-                ]
-              }
-              testID="Ouvrir le gestionnaire mail pour contacter le support"
-            >
-              <View
-                gap={1}
-                paddingForIcon={0}
-                style={
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                    "gap": 4,
-                    "top": 0,
-                  }
-                }
-              >
-                <View
-                  height={20}
-                  testID="button-icon"
-                  width={20}
-                >
-                  <Text>
-                    button-icon-SVG-Mock
-                  </Text>
-                </View>
-                <Text
-                  style={
-                    {
-                      "color": "#eb0055",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 16,
-                      "lineHeight": 25.6,
-                    }
-                  }
-                  typography="Button"
-                >
-                  support@passculture.app
-                </Text>
-              </View>
-            </View>
-          </View>
+            }
+          >
+            support@passculture.app
+          </Text>
         </Text>
       </View>
       <View
@@ -2428,91 +2293,23 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
           >
             Écrire un message au
              
-            <View>
-              <View
-                accessibilityLabel="Défenseur des droits"
-                accessibilityRole="link"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
+            <Text
+              accessibilityLabel="Défenseur des droits, lien externe"
+              accessibilityRole="link"
+              onPress={[Function]}
+              style={
+                {
+                  "color": "#eb0055",
+                  "cursor": "pointer",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                  "textDecorationLine": "underline",
                 }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "top": 3,
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Défenseur des droits"
-              >
-                <View
-                  gap={1}
-                  paddingForIcon={0}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 4,
-                      "top": 0,
-                    }
-                  }
-                >
-                  <View
-                    accessibilityLabel="Nouvelle fenêtre"
-                    height={20}
-                    testID="button-icon"
-                    width={20}
-                  >
-                    <Text>
-                      button-icon-SVG-Mock
-                    </Text>
-                  </View>
-                  <Text
-                    style={
-                      {
-                        "color": "#eb0055",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                    typography="Button"
-                  >
-                    Défenseur des droits
-                  </Text>
-                </View>
-              </View>
-            </View>
+              }
+            >
+              Défenseur des droits
+            </Text>
           </Text>
           <Text
             style={
@@ -2526,91 +2323,23 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
           >
             Contacter le délégué du
              
-            <View>
-              <View
-                accessibilityLabel="Défenseur des droits dans votre région"
-                accessibilityRole="link"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
+            <Text
+              accessibilityLabel="Défenseur des droits dans votre région, lien externe"
+              accessibilityRole="link"
+              onPress={[Function]}
+              style={
+                {
+                  "color": "#eb0055",
+                  "cursor": "pointer",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                  "textDecorationLine": "underline",
                 }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "top": 3,
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Défenseur des droits dans votre région"
-              >
-                <View
-                  gap={1}
-                  paddingForIcon={0}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 4,
-                      "top": 0,
-                    }
-                  }
-                >
-                  <View
-                    accessibilityLabel="Nouvelle fenêtre"
-                    height={20}
-                    testID="button-icon"
-                    width={20}
-                  >
-                    <Text>
-                      button-icon-SVG-Mock
-                    </Text>
-                  </View>
-                  <Text
-                    style={
-                      {
-                        "color": "#eb0055",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                    typography="Button"
-                  >
-                    Défenseur des droits dans votre région
-                  </Text>
-                </View>
-              </View>
-            </View>
+              }
+            >
+              Défenseur des droits dans votre région
+            </Text>
           </Text>
           <Text
             style={

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx.native-snap
@@ -228,91 +228,23 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
         >
           La présente déclaration d’accessibilité s’applique à
            
-          <View>
-            <View
-              accessibilityLabel="l’application iOS"
-              accessibilityRole="link"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": undefined,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
+          <Text
+            accessibilityLabel="l’application iOS, lien externe"
+            accessibilityRole="link"
+            onPress={[Function]}
+            style={
+              {
+                "color": "#eb0055",
+                "cursor": "pointer",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 16,
+                "lineHeight": 25.6,
+                "textDecorationLine": "underline",
               }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                [
-                  [
-                    {
-                      "userSelect": "auto",
-                    },
-                    {
-                      "top": 3,
-                    },
-                  ],
-                  {
-                    "opacity": 1,
-                  },
-                ]
-              }
-              testID="l’application iOS"
-            >
-              <View
-                gap={1}
-                paddingForIcon={0}
-                style={
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                    "gap": 4,
-                    "top": 0,
-                  }
-                }
-              >
-                <View
-                  accessibilityLabel="Nouvelle fenêtre"
-                  height={20}
-                  testID="button-icon"
-                  width={20}
-                >
-                  <Text>
-                    button-icon-SVG-Mock
-                  </Text>
-                </View>
-                <Text
-                  style={
-                    {
-                      "color": "#eb0055",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 16,
-                      "lineHeight": 25.6,
-                    }
-                  }
-                  typography="Button"
-                >
-                  l’application iOS
-                </Text>
-              </View>
-            </View>
-          </View>
+            }
+          >
+            l’application iOS
+          </Text>
            
           version 1.348.8 du pass Culture.
         </Text>
@@ -2333,90 +2265,23 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
         >
           Le pass Culture invite les personnes qui rencontreraient des difficultés à la contacter afin qu’une assistance puisse être apportée :
            
-          <View>
-            <View
-              accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
-              accessibilityRole="link"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": undefined,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
+          <Text
+            accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support, lien externe"
+            accessibilityRole="link"
+            onPress={[Function]}
+            style={
+              {
+                "color": "#eb0055",
+                "cursor": "pointer",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 16,
+                "lineHeight": 25.6,
+                "textDecorationLine": "underline",
               }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                [
-                  [
-                    {
-                      "userSelect": "auto",
-                    },
-                    {
-                      "top": 3,
-                    },
-                  ],
-                  {
-                    "opacity": 1,
-                  },
-                ]
-              }
-              testID="Ouvrir le gestionnaire mail pour contacter le support"
-            >
-              <View
-                gap={1}
-                paddingForIcon={0}
-                style={
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                    "gap": 4,
-                    "top": 0,
-                  }
-                }
-              >
-                <View
-                  height={20}
-                  testID="button-icon"
-                  width={20}
-                >
-                  <Text>
-                    button-icon-SVG-Mock
-                  </Text>
-                </View>
-                <Text
-                  style={
-                    {
-                      "color": "#eb0055",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 16,
-                      "lineHeight": 25.6,
-                    }
-                  }
-                  typography="Button"
-                >
-                  support@passculture.app
-                </Text>
-              </View>
-            </View>
-          </View>
+            }
+          >
+            support@passculture.app
+          </Text>
         </Text>
       </View>
       <View
@@ -2482,91 +2347,23 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
           >
             Écrire un message au
              
-            <View>
-              <View
-                accessibilityLabel="Défenseur des droits"
-                accessibilityRole="link"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
+            <Text
+              accessibilityLabel="Défenseur des droits, lien externe"
+              accessibilityRole="link"
+              onPress={[Function]}
+              style={
+                {
+                  "color": "#eb0055",
+                  "cursor": "pointer",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                  "textDecorationLine": "underline",
                 }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "top": 3,
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Défenseur des droits"
-              >
-                <View
-                  gap={1}
-                  paddingForIcon={0}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 4,
-                      "top": 0,
-                    }
-                  }
-                >
-                  <View
-                    accessibilityLabel="Nouvelle fenêtre"
-                    height={20}
-                    testID="button-icon"
-                    width={20}
-                  >
-                    <Text>
-                      button-icon-SVG-Mock
-                    </Text>
-                  </View>
-                  <Text
-                    style={
-                      {
-                        "color": "#eb0055",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                    typography="Button"
-                  >
-                    Défenseur des droits
-                  </Text>
-                </View>
-              </View>
-            </View>
+              }
+            >
+              Défenseur des droits
+            </Text>
           </Text>
           <Text
             style={
@@ -2580,91 +2377,23 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
           >
             Contacter le délégué du
              
-            <View>
-              <View
-                accessibilityLabel="Défenseur des droits dans votre région"
-                accessibilityRole="link"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
+            <Text
+              accessibilityLabel="Défenseur des droits dans votre région, lien externe"
+              accessibilityRole="link"
+              onPress={[Function]}
+              style={
+                {
+                  "color": "#eb0055",
+                  "cursor": "pointer",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                  "textDecorationLine": "underline",
                 }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "top": 3,
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Défenseur des droits dans votre région"
-              >
-                <View
-                  gap={1}
-                  paddingForIcon={0}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 4,
-                      "top": 0,
-                    }
-                  }
-                >
-                  <View
-                    accessibilityLabel="Nouvelle fenêtre"
-                    height={20}
-                    testID="button-icon"
-                    width={20}
-                  >
-                    <Text>
-                      button-icon-SVG-Mock
-                    </Text>
-                  </View>
-                  <Text
-                    style={
-                      {
-                        "color": "#eb0055",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                    typography="Button"
-                  >
-                    Défenseur des droits dans votre région
-                  </Text>
-                </View>
-              </View>
-            </View>
+              }
+            >
+              Défenseur des droits dans votre région
+            </Text>
           </Text>
           <Text
             style={

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx.native-snap
@@ -285,90 +285,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Schéma pluriannuel d’accessibilité 2022 - 2025"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Schéma pluriannuel d’accessibilité 2022 - 2025"
+                    accessibilityRole="button"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Schéma pluriannuel d’accessibilité 2022 - 2025"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Schéma pluriannuel d’accessibilité 2022 - 2025
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Schéma pluriannuel d’accessibilité 2022 - 2025
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -433,90 +366,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Actions réalisées depuis 2022"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Actions réalisées depuis 2022"
+                    accessibilityRole="button"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Actions réalisées depuis 2022"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Actions réalisées depuis 2022
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Actions réalisées depuis 2022
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -581,90 +447,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Plan d’actions 2024"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Plan d’actions 2024"
+                    accessibilityRole="button"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Plan d’actions 2024"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Plan d’actions 2024
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Plan d’actions 2024
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -683,91 +482,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
       >
         Cette déclaration d’accessibilité s’applique au site internet
          
-        <View>
-          <View
-            accessibilityLabel="https://passculture.app/"
-            accessibilityRole="link"
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": undefined,
-                "expanded": undefined,
-                "selected": undefined,
-              }
+        <Text
+          accessibilityLabel="https://passculture.app/, lien externe"
+          accessibilityRole="link"
+          onPress={[Function]}
+          style={
+            {
+              "color": "#eb0055",
+              "cursor": "pointer",
+              "fontFamily": "Montserrat-Bold",
+              "fontSize": 16,
+              "lineHeight": 25.6,
+              "textDecorationLine": "underline",
             }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              [
-                [
-                  {
-                    "userSelect": "auto",
-                  },
-                  {
-                    "top": 3,
-                  },
-                ],
-                {
-                  "opacity": 1,
-                },
-              ]
-            }
-            testID="https://passculture.app/"
-          >
-            <View
-              gap={1}
-              paddingForIcon={0}
-              style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "gap": 4,
-                  "top": 0,
-                }
-              }
-            >
-              <View
-                accessibilityLabel="Nouvelle fenêtre"
-                height={20}
-                testID="button-icon"
-                width={20}
-              >
-                <Text>
-                  button-icon-SVG-Mock
-                </Text>
-              </View>
-              <Text
-                style={
-                  {
-                    "color": "#eb0055",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 16,
-                    "lineHeight": 25.6,
-                  }
-                }
-                typography="Button"
-              >
-                https://passculture.app/
-              </Text>
-            </View>
-          </View>
-        </View>
+          }
+        >
+          https://passculture.app/
+        </Text>
       </Text>
       <View
         style={
@@ -2771,91 +2502,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Accueil"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Accueil, lien externe"
+                    accessibilityRole="link"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Accueil"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          accessibilityLabel="Nouvelle fenêtre"
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Accueil
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Accueil
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -2920,91 +2583,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Connexion"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Connexion, lien externe"
+                    accessibilityRole="link"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Connexion"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          accessibilityLabel="Nouvelle fenêtre"
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Connexion
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Connexion
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -3069,91 +2664,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Inscription - Date de naissance"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Inscription - Date de naissance, lien externe"
+                    accessibilityRole="link"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Inscription - Date de naissance"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          accessibilityLabel="Nouvelle fenêtre"
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Inscription - Date de naissance
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Inscription - Date de naissance
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -3218,91 +2745,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Vérification d’identité"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Vérification d’identité, lien externe"
+                    accessibilityRole="link"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Vérification d’identité"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          accessibilityLabel="Nouvelle fenêtre"
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Vérification d’identité
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Vérification d’identité
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -3367,91 +2826,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Profil"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Profil, lien externe"
+                    accessibilityRole="link"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Profil"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          accessibilityLabel="Nouvelle fenêtre"
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Profil
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Profil
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -3516,91 +2907,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Modification de mot de passe"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Modification de mot de passe, lien externe"
+                    accessibilityRole="link"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Modification de mot de passe"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          accessibilityLabel="Nouvelle fenêtre"
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Modification de mot de passe
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Modification de mot de passe
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -3665,91 +2988,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Recherche"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Recherche, lien externe"
+                    accessibilityRole="link"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Recherche"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          accessibilityLabel="Nouvelle fenêtre"
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Recherche
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Recherche
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -3814,91 +3069,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Filtres"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Filtres, lien externe"
+                    accessibilityRole="link"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Filtres"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          accessibilityLabel="Nouvelle fenêtre"
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Filtres
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Filtres
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -3963,91 +3150,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Résultats de recherche"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Résultats de recherche, lien externe"
+                    accessibilityRole="link"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Résultats de recherche"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          accessibilityLabel="Nouvelle fenêtre"
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Résultats de recherche
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Résultats de recherche
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -4112,91 +3231,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Favoris"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Favoris, lien externe"
+                    accessibilityRole="link"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Favoris"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          accessibilityLabel="Nouvelle fenêtre"
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Favoris
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Favoris
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -4261,91 +3312,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Détails d’une offre"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Détails d’une offre, lien externe"
+                    accessibilityRole="link"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Détails d’une offre"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          accessibilityLabel="Nouvelle fenêtre"
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Détails d’une offre
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Détails d’une offre
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -4410,91 +3393,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                     }
                   }
                 >
-                  <View>
-                    <View
-                      accessibilityLabel="Déclaration d’accessibilité"
-                      accessibilityRole="link"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
+                  <Text
+                    accessibilityLabel="Déclaration d’accessibilité, lien externe"
+                    accessibilityRole="link"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "color": "#eb0055",
+                        "cursor": "pointer",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                        "textDecorationLine": "underline",
                       }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        [
-                          [
-                            {
-                              "userSelect": "auto",
-                            },
-                            {
-                              "top": 3,
-                            },
-                          ],
-                          {
-                            "opacity": 1,
-                          },
-                        ]
-                      }
-                      testID="Déclaration d’accessibilité"
-                    >
-                      <View
-                        gap={1}
-                        paddingForIcon={0}
-                        style={
-                          {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "gap": 4,
-                            "top": 0,
-                          }
-                        }
-                      >
-                        <View
-                          accessibilityLabel="Nouvelle fenêtre"
-                          height={20}
-                          testID="button-icon"
-                          width={20}
-                        >
-                          <Text>
-                            button-icon-SVG-Mock
-                          </Text>
-                        </View>
-                        <Text
-                          style={
-                            {
-                              "color": "#eb0055",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            }
-                          }
-                          typography="Button"
-                        >
-                          Déclaration d’accessibilité
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+                    }
+                  >
+                    Déclaration d’accessibilité
+                  </Text>
                 </Text>
               </Text>
             </View>
@@ -4551,90 +3466,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
       >
         Contacter l’équipe support à l’adresse
          
-        <View>
-          <View
-            accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
-            accessibilityRole="link"
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": undefined,
-                "expanded": undefined,
-                "selected": undefined,
-              }
+        <Text
+          accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support, lien externe"
+          accessibilityRole="link"
+          onPress={[Function]}
+          style={
+            {
+              "color": "#eb0055",
+              "cursor": "pointer",
+              "fontFamily": "Montserrat-Bold",
+              "fontSize": 16,
+              "lineHeight": 25.6,
+              "textDecorationLine": "underline",
             }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              [
-                [
-                  {
-                    "userSelect": "auto",
-                  },
-                  {
-                    "top": 3,
-                  },
-                ],
-                {
-                  "opacity": 1,
-                },
-              ]
-            }
-            testID="Ouvrir le gestionnaire mail pour contacter le support"
-          >
-            <View
-              gap={1}
-              paddingForIcon={0}
-              style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "gap": 4,
-                  "top": 0,
-                }
-              }
-            >
-              <View
-                height={20}
-                testID="button-icon"
-                width={20}
-              >
-                <Text>
-                  button-icon-SVG-Mock
-                </Text>
-              </View>
-              <Text
-                style={
-                  {
-                    "color": "#eb0055",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 16,
-                    "lineHeight": 25.6,
-                  }
-                }
-                typography="Button"
-              >
-                support@passculture.app
-              </Text>
-            </View>
-          </View>
-        </View>
+          }
+        >
+          support@passculture.app
+        </Text>
       </Text>
       <View
         style={
@@ -4703,91 +3551,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
           >
             Écrire un message au
              
-            <View>
-              <View
-                accessibilityLabel="Défenseur des droits"
-                accessibilityRole="link"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
+            <Text
+              accessibilityLabel="Défenseur des droits, lien externe"
+              accessibilityRole="link"
+              onPress={[Function]}
+              style={
+                {
+                  "color": "#eb0055",
+                  "cursor": "pointer",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                  "textDecorationLine": "underline",
                 }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "top": 3,
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Défenseur des droits"
-              >
-                <View
-                  gap={1}
-                  paddingForIcon={0}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 4,
-                      "top": 0,
-                    }
-                  }
-                >
-                  <View
-                    accessibilityLabel="Nouvelle fenêtre"
-                    height={20}
-                    testID="button-icon"
-                    width={20}
-                  >
-                    <Text>
-                      button-icon-SVG-Mock
-                    </Text>
-                  </View>
-                  <Text
-                    style={
-                      {
-                        "color": "#eb0055",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                    typography="Button"
-                  >
-                    Défenseur des droits
-                  </Text>
-                </View>
-              </View>
-            </View>
+              }
+            >
+              Défenseur des droits
+            </Text>
           </Text>
           <Text
             style={
@@ -4801,91 +3581,23 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
           >
             Contacter le délégué du
              
-            <View>
-              <View
-                accessibilityLabel="Défenseur des droits dans votre région"
-                accessibilityRole="link"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
+            <Text
+              accessibilityLabel="Défenseur des droits dans votre région, lien externe"
+              accessibilityRole="link"
+              onPress={[Function]}
+              style={
+                {
+                  "color": "#eb0055",
+                  "cursor": "pointer",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                  "textDecorationLine": "underline",
                 }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "top": 3,
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Défenseur des droits dans votre région"
-              >
-                <View
-                  gap={1}
-                  paddingForIcon={0}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 4,
-                      "top": 0,
-                    }
-                  }
-                >
-                  <View
-                    accessibilityLabel="Nouvelle fenêtre"
-                    height={20}
-                    testID="button-icon"
-                    width={20}
-                  >
-                    <Text>
-                      button-icon-SVG-Mock
-                    </Text>
-                  </View>
-                  <Text
-                    style={
-                      {
-                        "color": "#eb0055",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                    typography="Button"
-                  >
-                    Défenseur des droits dans votre région
-                  </Text>
-                </View>
-              </View>
-            </View>
+              }
+            >
+              Défenseur des droits dans votre région
+            </Text>
           </Text>
           <Text
             style={

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
@@ -417,91 +417,23 @@ exports[`AccessibilityEngagement should render correctly 1`] = `
       >
         Vous pouvez retrouver également toutes nos fiches d’aide pour vous inscrire sur le pass Culture directement dans
          
-        <View>
-          <View
-            accessibilityLabel="notre centre d’aide"
-            accessibilityRole="link"
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": undefined,
-                "expanded": undefined,
-                "selected": undefined,
-              }
+        <Text
+          accessibilityLabel="notre centre d’aide, lien externe"
+          accessibilityRole="link"
+          onPress={[Function]}
+          style={
+            {
+              "color": "#eb0055",
+              "cursor": "pointer",
+              "fontFamily": "Montserrat-SemiBold",
+              "fontSize": 12,
+              "lineHeight": 19.2,
+              "textDecorationLine": "underline",
             }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              [
-                [
-                  {
-                    "userSelect": "auto",
-                  },
-                  {
-                    "top": 3,
-                  },
-                ],
-                {
-                  "opacity": 1,
-                },
-              ]
-            }
-            testID="notre centre d’aide"
-          >
-            <View
-              gap={1}
-              paddingForIcon={0}
-              style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "gap": 4,
-                  "top": 0,
-                }
-              }
-            >
-              <View
-                accessibilityLabel="Nouvelle fenêtre"
-                height={16}
-                testID="button-icon"
-                width={16}
-              >
-                <Text>
-                  button-icon-SVG-Mock
-                </Text>
-              </View>
-              <Text
-                style={
-                  {
-                    "color": "#eb0055",
-                    "fontFamily": "Montserrat-SemiBold",
-                    "fontSize": 12,
-                    "lineHeight": 19.2,
-                  }
-                }
-                typography="BodyAccentXs"
-              >
-                notre centre d’aide
-              </Text>
-            </View>
-          </View>
-        </View>
+          }
+        >
+          notre centre d’aide
+        </Text>
       </Text>
       <View
         customHeight={8}

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx
@@ -34,7 +34,7 @@ describe('AccessibilityDeclarationMobileAndroid', () => {
   `('should open $url when $title is clicked', async ({ url, title }) => {
     render(<AccessibilityDeclarationMobileAndroid />)
 
-    const link = screen.getByTestId(title)
+    const link = screen.getByText(title)
     await user.press(link)
 
     expect(openURLSpy).toHaveBeenCalledWith(url, undefined, true)

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileBase.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileBase.tsx
@@ -4,15 +4,14 @@ import styled from 'styled-components/native'
 import { contactSupport } from 'features/auth/helpers/contactSupport'
 import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { BulletListItem } from 'ui/components/BulletListItem'
-import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
+import { ButtonInsideTextV2 } from 'ui/components/buttons/buttonInsideText/ButtonInsideTextV2'
 import { Separator } from 'ui/components/Separator'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { VerticalUl } from 'ui/components/Ul'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { SecondaryPageWithBlurHeader } from 'ui/pages/SecondaryPageWithBlurHeader'
-import { EmailFilled } from 'ui/svg/icons/EmailFilled'
-import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Spacer, Typo } from 'ui/theme'
 import { SPACE } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
@@ -54,10 +53,10 @@ export function AccessibilityDeclarationMobileBase({
         <Typo.Body>
           La présente déclaration d’accessibilité s’applique à{SPACE}
           <ExternalTouchableLink
-            as={ButtonInsideText}
+            as={ButtonInsideTextV2}
             wording={`l’application ${platformName}`}
-            icon={ExternalSiteFilled}
             externalNav={storeLink}
+            type={AccessibilityRole.LINK}
           />
           {SPACE}version 1.348.8 du pass Culture.
         </Typo.Body>
@@ -170,12 +169,12 @@ export function AccessibilityDeclarationMobileBase({
           Le pass Culture invite les personnes qui rencontreraient des difficultés à la contacter
           afin qu’une assistance puisse être apportée&nbsp;:{SPACE}
           <ExternalTouchableLink
-            as={ButtonInsideText}
+            as={ButtonInsideTextV2}
             wording="support@passculture.app"
             accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
             justifyContent="flex-start"
             externalNav={contactSupport.forGenericQuestion}
-            icon={EmailFilled}
+            type={AccessibilityRole.LINK}
           />
         </Typo.Body>
       </ViewGap>
@@ -194,19 +193,19 @@ export function AccessibilityDeclarationMobileBase({
           <Typo.Body>
             Écrire un message au{SPACE}
             <ExternalTouchableLink
-              as={ButtonInsideText}
+              as={ButtonInsideTextV2}
               wording="Défenseur des droits"
-              icon={ExternalSiteFilled}
               externalNav={rightsDefenderUrl}
+              type={AccessibilityRole.LINK}
             />
           </Typo.Body>
           <Typo.Body>
             Contacter le délégué du{SPACE}
             <ExternalTouchableLink
-              as={ButtonInsideText}
+              as={ButtonInsideTextV2}
               wording="Défenseur des droits dans votre région"
-              icon={ExternalSiteFilled}
               externalNav={rightsDelegateUrl}
+              type={AccessibilityRole.LINK}
             />
           </Typo.Body>
           <Typo.Body>

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx
@@ -34,7 +34,7 @@ describe('AccessibilityDeclarationMobileIOS', () => {
   `('should open $url when $title is clicked', async ({ url, title }) => {
     render(<AccessibilityDeclarationMobileIOS />)
 
-    const link = screen.getByTestId(title)
+    const link = screen.getByText(title)
     await user.press(link)
 
     expect(openURLSpy).toHaveBeenCalledWith(url, undefined, true)

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx
@@ -41,7 +41,7 @@ describe('AccessibilityDeclarationWeb', () => {
   `('should open $url when $title is clicked', async ({ url, title }) => {
     render(<AccessibilityDeclarationWeb />)
 
-    const link = screen.getByTestId(title)
+    const link = screen.getByText(title)
     await user.press(link)
 
     expect(openURLSpy).toHaveBeenCalledWith(url, undefined, true)

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
@@ -5,18 +5,16 @@ import { contactSupport } from 'features/auth/helpers/contactSupport'
 import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { getProfilePropConfig } from 'features/navigation/ProfileStackNavigator/getProfilePropConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { WEBAPP_V2_URL } from 'libs/environment/useWebAppUrl'
 import { BulletListItem } from 'ui/components/BulletListItem'
-import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
+import { ButtonInsideTextV2 } from 'ui/components/buttons/buttonInsideText/ButtonInsideTextV2'
 import { Separator } from 'ui/components/Separator'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { VerticalUl } from 'ui/components/Ul'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { SecondaryPageWithBlurHeader } from 'ui/pages/SecondaryPageWithBlurHeader'
-import { EmailFilled } from 'ui/svg/icons/EmailFilled'
-import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
-import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { DOUBLE_LINE_BREAK, SPACE } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
@@ -54,9 +52,8 @@ export function AccessibilityDeclarationWeb() {
           <BulletListItem>
             <Typo.BodyXs>
               <InternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Schéma pluriannuel d’accessibilité 2022 - 2025"
-                icon={PlainArrowNext}
                 navigateTo={getProfilePropConfig('AccessibilityActionPlan')}
               />
             </Typo.BodyXs>
@@ -64,9 +61,8 @@ export function AccessibilityDeclarationWeb() {
           <BulletListItem>
             <Typo.BodyXs>
               <InternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Actions réalisées depuis 2022"
-                icon={PlainArrowNext}
                 navigateTo={getProfilePropConfig('AccessibilityActionPlan')}
               />
             </Typo.BodyXs>
@@ -74,9 +70,8 @@ export function AccessibilityDeclarationWeb() {
           <BulletListItem>
             <Typo.BodyXs>
               <InternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Plan d’actions 2024"
-                icon={PlainArrowNext}
                 navigateTo={getProfilePropConfig('AccessibilityActionPlan')}
               />
             </Typo.BodyXs>
@@ -86,10 +81,10 @@ export function AccessibilityDeclarationWeb() {
       <Typo.Body>
         Cette déclaration d’accessibilité s’applique au site internet{SPACE}
         <ExternalTouchableLink
-          as={ButtonInsideText}
+          as={ButtonInsideTextV2}
           wording="https://passculture.app/"
-          icon={ExternalSiteFilled}
           externalNav={webappUrl}
+          type={AccessibilityRole.LINK}
         />
       </Typo.Body>
       <StyledSeparator />
@@ -210,120 +205,120 @@ export function AccessibilityDeclarationWeb() {
           <BulletListItem>
             <Typo.BodyXs>
               <ExternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Accueil"
-                icon={ExternalSiteFilled}
                 externalNav={homeUrl}
+                type={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
           <BulletListItem>
             <Typo.BodyXs>
               <ExternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Connexion"
-                icon={ExternalSiteFilled}
                 externalNav={loginUrl}
+                type={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
           <BulletListItem>
             <Typo.BodyXs>
               <ExternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Inscription - Date de naissance"
-                icon={ExternalSiteFilled}
                 externalNav={signupUrl}
+                type={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
           <BulletListItem>
             <Typo.BodyXs>
               <ExternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Vérification d’identité"
-                icon={ExternalSiteFilled}
                 externalNav={identityCheckUrl}
+                type={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
           <BulletListItem>
             <Typo.BodyXs>
               <ExternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Profil"
-                icon={ExternalSiteFilled}
                 externalNav={profileUrl}
+                type={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
           <BulletListItem>
             <Typo.BodyXs>
               <ExternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Modification de mot de passe"
-                icon={ExternalSiteFilled}
                 externalNav={changePasswordUrl}
+                type={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
           <BulletListItem>
             <Typo.BodyXs>
               <ExternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Recherche"
-                icon={ExternalSiteFilled}
                 externalNav={searchUrl}
+                type={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
           <BulletListItem>
             <Typo.BodyXs>
               <ExternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Filtres"
-                icon={ExternalSiteFilled}
                 externalNav={filterUrl}
+                type={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
           <BulletListItem>
             <Typo.BodyXs>
               <ExternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Résultats de recherche"
-                icon={ExternalSiteFilled}
                 externalNav={searchResultsUrl}
+                type={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
           <BulletListItem>
             <Typo.BodyXs>
               <ExternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Favoris"
-                icon={ExternalSiteFilled}
                 externalNav={favoritesUrl}
+                type={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
           <BulletListItem>
             <Typo.BodyXs>
               <ExternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Détails d’une offre"
-                icon={ExternalSiteFilled}
                 externalNav={offerUrl}
+                type={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
           <BulletListItem>
             <Typo.BodyXs>
               <ExternalTouchableLink
-                as={ButtonInsideText}
+                as={ButtonInsideTextV2}
                 wording="Déclaration d’accessibilité"
-                icon={ExternalSiteFilled}
                 externalNav={accessibilityUrl}
+                type={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -343,12 +338,12 @@ export function AccessibilityDeclarationWeb() {
       <Typo.Body>
         Contacter l’équipe support à l’adresse{SPACE}
         <ExternalTouchableLink
-          as={ButtonInsideText}
+          as={ButtonInsideTextV2}
           wording="support@passculture.app"
           accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
           justifyContent="flex-start"
           externalNav={contactSupport.forGenericQuestion}
-          icon={EmailFilled}
+          type={AccessibilityRole.LINK}
         />
       </Typo.Body>
 
@@ -367,19 +362,19 @@ export function AccessibilityDeclarationWeb() {
           <Typo.Body>
             Écrire un message au{SPACE}
             <ExternalTouchableLink
-              as={ButtonInsideText}
+              as={ButtonInsideTextV2}
               wording="Défenseur des droits"
-              icon={ExternalSiteFilled}
               externalNav={rightsDefenderUrl}
+              type={AccessibilityRole.LINK}
             />
           </Typo.Body>
           <Typo.Body>
             Contacter le délégué du{SPACE}
             <ExternalTouchableLink
-              as={ButtonInsideText}
+              as={ButtonInsideTextV2}
               wording="Défenseur des droits dans votre région"
-              icon={ExternalSiteFilled}
               externalNav={rightsDelegateUrl}
+              type={AccessibilityRole.LINK}
             />
           </Typo.Body>
           <Typo.Body>

--- a/src/features/profile/pages/Accessibility/AccessibilityEngagement.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityEngagement.tsx
@@ -4,11 +4,11 @@ import styled from 'styled-components/native'
 import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { ContactSupportButton } from 'features/profile/components/Buttons/ContactSupportButton/ContactSupportButton'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { env } from 'libs/environment/env'
-import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
+import { ButtonInsideTextV2 } from 'ui/components/buttons/buttonInsideText/ButtonInsideTextV2'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { SecondaryPageWithBlurHeader } from 'ui/pages/SecondaryPageWithBlurHeader'
-import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
 import { DOUBLE_LINE_BREAK, LINE_BREAK } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
@@ -87,11 +87,11 @@ export function AccessibilityEngagement() {
         Vous pouvez retrouver également toutes nos fiches d’aide pour vous inscrire sur le pass
         Culture directement dans{' '}
         <ExternalTouchableLink
-          as={ButtonInsideText}
+          as={ButtonInsideTextV2}
           wording="notre centre d’aide"
           typography="BodyAccentXs"
-          icon={ExternalSiteFilled}
           externalNav={{ url: env.FAQ_LINK }}
+          type={AccessibilityRole.LINK}
         />
       </StyledBodyAccentXs>
       <Spacer.BottomScreen />

--- a/src/ui/components/buttons/buttonInsideText/ButtonInsideText.stories.tsx
+++ b/src/ui/components/buttons/buttonInsideText/ButtonInsideText.stories.tsx
@@ -57,6 +57,6 @@ const RandomText = (props: ButtonInsideTexteProps) => {
 export const Template: VariantsStory<typeof RandomText> = {
   name: 'ButtonInsideText',
   render: (props) => (
-    <VariantsTemplate variants={variantConfig} Component={ButtonInsideText} defaultProps={props} />
+    <VariantsTemplate variants={variantConfig} Component={RandomText} defaultProps={props} />
   ),
 }

--- a/src/ui/components/buttons/buttonInsideText/ButtonInsideTextV2.native.test.tsx
+++ b/src/ui/components/buttons/buttonInsideText/ButtonInsideTextV2.native.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import { render, screen } from 'tests/utils'
+import { theme } from 'theme'
+
+import { ButtonInsideTextV2 } from './ButtonInsideTextV2'
+
+const wording = 'Wording'
+
+describe('ButtonInsideTextV2', () => {
+  describe('* typography property', () => {
+    it('should display ButtonText font family when not provided', () => {
+      render(<ButtonInsideTextV2 wording={wording} />)
+
+      expect(screen.getByText(wording)).toHaveStyle({
+        fontFamily: theme.designSystem.typography.button.fontFamily,
+      })
+    })
+
+    it('should display Caption font family when Caption provided', () => {
+      render(<ButtonInsideTextV2 wording={wording} typography="BodyAccentXs" />)
+
+      expect(screen.getByText(wording)).toHaveStyle({
+        fontFamily: theme.designSystem.typography.bodyAccentXs.fontFamily,
+      })
+    })
+  })
+
+  describe('* role property', () => {
+    it('should have correct accessibilityRole when not provided', async () => {
+      render(<ButtonInsideTextV2 wording={wording} />)
+
+      const linkBanner = await screen.findByRole(AccessibilityRole.BUTTON)
+
+      expect(linkBanner).toBeTruthy()
+    })
+
+    it('should have correct accessibilityRole role when link type provided', async () => {
+      render(<ButtonInsideTextV2 wording={wording} type={AccessibilityRole.LINK} />)
+
+      const linkBanner = await screen.findByRole(AccessibilityRole.LINK)
+
+      expect(linkBanner).toBeTruthy()
+    })
+  })
+})

--- a/src/ui/components/buttons/buttonInsideText/ButtonInsideTextV2.stories.tsx
+++ b/src/ui/components/buttons/buttonInsideText/ButtonInsideTextV2.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta } from '@storybook/react-vite'
+import React from 'react'
+
+import { ButtonInsideTextV2Props } from 'ui/components/buttons/buttonInsideText/types'
+import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
+import { Typo } from 'ui/theme'
+
+import { ButtonInsideTextV2 } from './ButtonInsideTextV2'
+
+const meta: Meta<typeof ButtonInsideTextV2> = {
+  title: 'ui/buttons/ButtonInsideTextV2',
+  component: ButtonInsideTextV2,
+}
+export default meta
+
+const variantConfig: Variants<typeof ButtonInsideTextV2> = [
+  {
+    label: 'ButtonInsideTextV2 default',
+    props: { wording: 'wording' },
+  },
+  {
+    label: 'ButtonInsideTextV2 BodyAccentXs',
+    props: {
+      wording: 'wording',
+      typography: 'BodyAccentXs',
+    },
+  },
+]
+
+const RandomText = (props: ButtonInsideTextV2Props) => {
+  const startText = 'Lorem ipsum dolor '
+  const endText = ' sit amet consectetur adipisicing elit.'
+  const TypoComponent = props.typography ? Typo[props.typography] : Typo.Body
+
+  return (
+    <TypoComponent>
+      {startText}
+      <ButtonInsideTextV2 {...props} />
+      {endText}
+    </TypoComponent>
+  )
+}
+
+export const Template: VariantsStory<typeof RandomText> = {
+  name: 'ButtonInsideTextV2',
+  render: (props) => (
+    <VariantsTemplate variants={variantConfig} Component={RandomText} defaultProps={props} />
+  ),
+}

--- a/src/ui/components/buttons/buttonInsideText/ButtonInsideTextV2.tsx
+++ b/src/ui/components/buttons/buttonInsideText/ButtonInsideTextV2.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import styled, { DefaultTheme } from 'styled-components/native'
+
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import { AppButtonEventNative } from 'ui/components/buttons/AppButton/types'
+import { ButtonInsideTextV2Props } from 'ui/components/buttons/buttonInsideText/types'
+import { Typo } from 'ui/theme'
+
+export function ButtonInsideTextV2({
+  wording,
+  typography = 'Button',
+  onPress,
+  onLongPress,
+  accessibilityLabel,
+  type = AccessibilityRole.BUTTON,
+}: ButtonInsideTextV2Props) {
+  const Text = typography === 'BodyAccentXs' ? StyledBodyAccentXs : StyledBody
+  const accessibilityLabelLink = type === AccessibilityRole.LINK ? ', lien externe' : ''
+  const computedAccessibilityLabel = `${accessibilityLabel ?? wording}${accessibilityLabelLink}`
+
+  return (
+    <Text
+      onPress={onPress as AppButtonEventNative}
+      onLongPress={onLongPress as AppButtonEventNative}
+      accessibilityRole={type}
+      accessibilityLabel={computedAccessibilityLabel}>
+      {wording}
+    </Text>
+  )
+}
+
+const commonTextStyle = ({ theme }: { theme: DefaultTheme }) => ({
+  color: theme.designSystem.color.icon.brandPrimary,
+  textDecorationLine: 'underline',
+  cursor: 'pointer',
+})
+
+const StyledBody = styled(Typo.Button)(commonTextStyle)
+const StyledBodyAccentXs = styled(Typo.BodyAccentXs)(commonTextStyle)

--- a/src/ui/components/buttons/buttonInsideText/ButtonInsideTextV2.web.tsx
+++ b/src/ui/components/buttons/buttonInsideText/ButtonInsideTextV2.web.tsx
@@ -1,0 +1,79 @@
+import React, { MouseEventHandler, useCallback } from 'react'
+import styled, { CSSObject, DefaultTheme } from 'styled-components'
+
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import {
+  AppButtonEventWeb,
+  TouchableOpacityButtonProps,
+} from 'ui/components/buttons/AppButton/types'
+import { ButtonInsideTexteProps } from 'ui/components/buttons/buttonInsideText/types'
+import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
+
+export function ButtonInsideTextV2({
+  wording,
+  typography = 'Button',
+  onPress,
+  onLongPress,
+  href,
+  target,
+  type = AccessibilityRole.BUTTON,
+  accessibilityLabel,
+}: ButtonInsideTexteProps) {
+  const Text = (href ? Link : Button) as React.ElementType
+
+  const pressHandler = onPress as AppButtonEventWeb
+  const onClick: MouseEventHandler<HTMLButtonElement> = useCallback(
+    (event) => {
+      if (type === 'submit' && pressHandler) event.preventDefault()
+      if (pressHandler) pressHandler(event)
+    },
+    [type, pressHandler]
+  )
+
+  const longPressHandler = onLongPress as AppButtonEventWeb
+  const onDoubleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
+    (event) => {
+      if (type === 'submit' && longPressHandler) event.preventDefault()
+      if (longPressHandler) longPressHandler(event)
+    },
+    [type, longPressHandler]
+  )
+
+  return (
+    <Text
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+      type={href ? undefined : type}
+      href={href}
+      target={target}
+      accessibilityLabel={accessibilityLabel}
+      typography={typography}>
+      {wording}
+    </Text>
+  )
+}
+
+const webStyle = ({ theme, typography }: { theme: DefaultTheme; typography?: string }) =>
+  ({
+    border: 'none',
+    cursor: 'pointer',
+    outline: 'none',
+    boxSizing: 'border-box',
+    backgroundColor: 'transparent',
+    width: 'fit-content',
+    margin: 0,
+    padding: 0,
+    color: theme.designSystem.color.text.brandPrimary,
+    ...customFocusOutline({ color: theme.designSystem.color.text.brandPrimary }),
+    ...(typography === 'BodyAccentXs'
+      ? theme.designSystem.typography.bodyAccentXs
+      : theme.designSystem.typography.button),
+  }) as CSSObject
+
+const Button = styled.button<
+  TouchableOpacityButtonProps & Pick<ButtonInsideTexteProps, 'buttonColor'>
+>(webStyle)
+
+const Link = styled.a<TouchableOpacityButtonProps & Pick<ButtonInsideTexteProps, 'buttonColor'>>(
+  webStyle
+)

--- a/src/ui/components/buttons/buttonInsideText/types.ts
+++ b/src/ui/components/buttons/buttonInsideText/types.ts
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react'
-import { AccessibilityRole } from 'react-native'
 
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { ColorsType } from 'theme/types'
 import { AppButtonEventNative, AppButtonEventWeb } from 'ui/components/buttons/AppButton/types'
 import { AccessibleIcon } from 'ui/svg/icons/types'
@@ -18,4 +18,13 @@ export type ButtonInsideTexteProps = {
   type?: 'button' | 'submit' | 'reset'
   testID?: string
   accessibilityLabel?: string
+}
+
+export type ButtonInsideTextV2Props = {
+  wording: string
+  accessibilityLabel?: string
+  typography?: 'Button' | 'BodyAccentXs'
+  onLongPress?: AppButtonEventWeb | AppButtonEventNative
+  onPress?: AppButtonEventWeb | AppButtonEventNative
+  type?: AccessibilityRole.LINK | AccessibilityRole.BUTTON
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37738

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |    <img width="1170" height="2532" alt="Simulator Screenshot - iPhone 14 - 2025-09-03 at 19 50 43" src="https://github.com/user-attachments/assets/4a9cb60f-fedf-4737-9375-fb36ed0daafc" />  |   <img width="1170" height="2532" alt="Simulator Screenshot - iPhone 14 - 2025-09-03 at 17 07 24" src="https://github.com/user-attachments/assets/374c85ce-b80f-4b9b-8408-14d7eb775ec9" />  |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
