### PR TITLE
(PC-37738) feat(ui): update PageHeaderWithoutPlaceholder header

### DIFF
--- a/__snapshots__/features/achievements/pages/Achievements.native.test.tsx.native-snap
+++ b/__snapshots__/features/achievements/pages/Achievements.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<Achievements/> should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<Achievements/> should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -127,6 +126,7 @@ exports[`<Achievements/> should match snapshot 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -152,12 +152,10 @@ exports[`<Achievements/> should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -64,6 +63,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -89,12 +89,10 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<AccountCreated /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<AccountCreated /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<AccountCreated /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
@@ -74,6 +74,7 @@ exports[`QuitSignupModal should render correctly 1`] = `
               "flexDirection": "row",
               "justifyContent": "space-between",
               "minHeight": 48,
+              "paddingHorizontal": 24,
               "width": "100%",
             }
           }
@@ -82,13 +83,11 @@ exports[`QuitSignupModal should render correctly 1`] = `
             positionInHeader="left"
             style={
               {
-                "alignItems": "center",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
+                "alignItems": "flex-start",
                 "justifyContent": "flex-start",
-                "maxWidth": 40,
-                "paddingHorizontal": 24,
+                "marginLeft": 0,
+                "marginRight": 8,
+                "minWidth": 40,
               }
             }
             testID="back-button-container"
@@ -98,12 +97,10 @@ exports[`QuitSignupModal should render correctly 1`] = `
             style={
               {
                 "alignItems": "center",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "maxWidth": 40,
-                "paddingHorizontal": 24,
+                "marginLeft": 8,
+                "marginRight": 0,
+                "minWidth": 40,
               }
             }
             testID="close-button-container"

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -793,6 +791,7 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -801,13 +800,11 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -885,6 +882,7 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -910,12 +908,10 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -1694,6 +1690,7 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -1702,13 +1699,11 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -1786,6 +1781,7 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -1811,12 +1807,10 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -2844,6 +2838,7 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -2852,13 +2847,11 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -2936,6 +2929,7 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -2961,12 +2955,10 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`CulturalSurveyIntro page When FF is disabled should render the page wit
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`CulturalSurveyIntro page When FF is disabled should render the page wit
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`CulturalSurveyIntro page When FF is disabled should render the page wit
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -549,6 +546,7 @@ exports[`CulturalSurveyIntro page When FF is enabled should render the page with
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -557,13 +555,11 @@ exports[`CulturalSurveyIntro page When FF is enabled should render the page with
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -573,12 +569,10 @@ exports[`CulturalSurveyIntro page When FF is enabled should render the page with
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -324,6 +321,7 @@ exports[`CulturalSurveyThanksPage page When FF is enabled should render the page
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -332,13 +330,11 @@ exports[`CulturalSurveyThanksPage page When FF is enabled should render the page
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -348,12 +344,10 @@ exports[`CulturalSurveyThanksPage page When FF is enabled should render the page
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/culturalSurvey/pages/FAQWebview.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/FAQWebview.native.test.tsx.native-snap
@@ -33,6 +33,7 @@ exports[`FAQVebview page should render the page with correct layout 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -41,13 +42,11 @@ exports[`FAQVebview page should render the page with correct layout 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -125,6 +124,7 @@ exports[`FAQVebview page should render the page with correct layout 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -150,12 +150,10 @@ exports[`FAQVebview page should render the page with correct layout 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
@@ -75,6 +75,7 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
               "flexDirection": "row",
               "justifyContent": "space-between",
               "minHeight": 48,
+              "paddingHorizontal": 24,
               "width": "100%",
             }
           }
@@ -83,13 +84,11 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
             positionInHeader="left"
             style={
               {
-                "alignItems": "center",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
+                "alignItems": "flex-start",
                 "justifyContent": "flex-start",
-                "maxWidth": 40,
-                "paddingHorizontal": 24,
+                "marginLeft": 0,
+                "marginRight": 8,
+                "minWidth": 40,
               }
             }
             testID="back-button-container"
@@ -99,12 +98,10 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
             style={
               {
                 "alignItems": "center",
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "maxWidth": 40,
-                "paddingHorizontal": 24,
+                "marginLeft": 8,
+                "marginRight": 0,
+                "minWidth": 40,
               }
             }
             testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<DisableActivation/> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<DisableActivation/> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<DisableActivation/> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -404,6 +401,7 @@ exports[`<DisableActivation/> with RemoteActivationBanner informations should re
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -412,13 +410,11 @@ exports[`<DisableActivation/> with RemoteActivationBanner informations should re
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -428,12 +424,10 @@ exports[`<DisableActivation/> with RemoteActivationBanner informations should re
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`BeneficiaryAccountCreated should render correctly for 18 year-old benef
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`BeneficiaryAccountCreated should render correctly for 18 year-old benef
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`BeneficiaryAccountCreated should render correctly for 18 year-old benef
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -452,6 +449,7 @@ exports[`BeneficiaryAccountCreated should render correctly for underage benefici
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -460,13 +458,11 @@ exports[`BeneficiaryAccountCreated should render correctly for underage benefici
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -476,12 +472,10 @@ exports[`BeneficiaryAccountCreated should render correctly for underage benefici
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -141,12 +140,10 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -654,6 +651,7 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -662,13 +660,11 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -748,12 +744,10 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
@@ -91,10 +91,10 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
         class="css-view-175oi2r r-height-10ptun7"
       />
       <div
-        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-minHeight-1pl7oy7 r-width-13qz1uu"
+        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-minHeight-1pl7oy7 r-paddingInline-cxgwc0 r-width-13qz1uu"
       >
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-1h0z5md r-maxWidth-i8lcd2 r-paddingInline-cxgwc0"
+          class="css-view-175oi2r r-alignItems-1habvwh r-justifyContent-1h0z5md r-marginLeft-11wrixw r-marginRight-uyseuv r-minWidth-vkv6oe"
           data-testid="back-button-container"
         >
           <button
@@ -125,7 +125,7 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
           </button>
         </div>
         <div
-          class="css-view-175oi2r r-flexShrink-1wbh5a2"
+          class="css-view-175oi2r r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
         >
           <h1
             aria-level="1"
@@ -137,7 +137,7 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
           </h1>
         </div>
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-17s6mgv r-maxWidth-i8lcd2 r-paddingInline-cxgwc0"
+          class="css-view-175oi2r r-alignItems-1awozwy r-justifyContent-17s6mgv r-marginLeft-18ry08z r-marginRight-61z16t r-minWidth-vkv6oe"
           data-testid="close-button-container"
         />
       </div>

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
@@ -91,10 +91,10 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
         class="css-view-175oi2r r-height-10ptun7"
       />
       <div
-        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-minHeight-1pl7oy7 r-width-13qz1uu"
+        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-minHeight-1pl7oy7 r-paddingInline-cxgwc0 r-width-13qz1uu"
       >
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-1h0z5md r-maxWidth-i8lcd2 r-paddingInline-cxgwc0"
+          class="css-view-175oi2r r-alignItems-1habvwh r-justifyContent-1h0z5md r-marginLeft-11wrixw r-marginRight-uyseuv r-minWidth-vkv6oe"
           data-testid="back-button-container"
         >
           <button
@@ -125,7 +125,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
           </button>
         </div>
         <div
-          class="css-view-175oi2r r-flexShrink-1wbh5a2"
+          class="css-view-175oi2r r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
         >
           <h1
             aria-level="1"
@@ -137,7 +137,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
           </h1>
         </div>
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-17s6mgv r-maxWidth-i8lcd2 r-paddingInline-cxgwc0"
+          class="css-view-175oi2r r-alignItems-1awozwy r-justifyContent-17s6mgv r-marginLeft-18ry08z r-marginRight-61z16t r-minWidth-vkv6oe"
           data-testid="close-button-container"
         />
       </div>

--- a/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`NotEligibleEduConnect should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`NotEligibleEduConnect should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`NotEligibleEduConnect should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`ComeBackLater should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`ComeBackLater should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -141,12 +140,10 @@ exports[`ComeBackLater should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -141,12 +140,10 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`SelectIDOrigin should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`SelectIDOrigin should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`SelectIDOrigin should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`SelectIDOrigin should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.test.tsx.web-snap
@@ -52,10 +52,10 @@ exports[`SelectPhoneStatus should render correctly 1`] = `
         class="css-view-175oi2r r-height-10ptun7"
       />
       <div
-        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-minHeight-1pl7oy7 r-width-13qz1uu"
+        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-minHeight-1pl7oy7 r-paddingInline-cxgwc0 r-width-13qz1uu"
       >
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-1h0z5md r-maxWidth-i8lcd2 r-paddingInline-cxgwc0"
+          class="css-view-175oi2r r-alignItems-1habvwh r-justifyContent-1h0z5md r-marginLeft-11wrixw r-marginRight-uyseuv r-minWidth-vkv6oe"
           data-testid="back-button-container"
         >
           <button
@@ -86,7 +86,7 @@ exports[`SelectPhoneStatus should render correctly 1`] = `
           </button>
         </div>
         <div
-          class="css-view-175oi2r r-flexShrink-1wbh5a2"
+          class="css-view-175oi2r r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
         >
           <h1
             aria-level="1"
@@ -98,7 +98,7 @@ exports[`SelectPhoneStatus should render correctly 1`] = `
           </h1>
         </div>
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-17s6mgv r-maxWidth-i8lcd2 r-paddingInline-cxgwc0"
+          class="css-view-175oi2r r-alignItems-1awozwy r-justifyContent-17s6mgv r-marginLeft-18ry08z r-marginRight-61z16t r-minWidth-vkv6oe"
           data-testid="close-button-container"
         />
       </div>

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -127,6 +126,7 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -152,12 +152,10 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`PhoneValidationTooManyAttempts should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`PhoneValidationTooManyAttempts should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`PhoneValidationTooManyAttempts should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManySMSSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManySMSSent.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`PhoneValidationTooManySMSSent should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`PhoneValidationTooManySMSSent should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`PhoneValidationTooManySMSSent should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/profile/ProfileInformationValidationCreate.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/ProfileInformationValidationCreate.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`ProfileInformationValidationCreate should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`ProfileInformationValidationCreate should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -127,6 +126,7 @@ exports[`ProfileInformationValidationCreate should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -152,12 +152,10 @@ exports[`ProfileInformationValidationCreate should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<SetCity/> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<SetCity/> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<SetCity/> should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<SetCity/> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<SetName/> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<SetName/> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<SetName/> should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<SetName/> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<SetProfileBookingError/> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<SetProfileBookingError/> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<SetProfileBookingError/> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
@@ -33,6 +33,7 @@ exports[`<SetStatus/> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -41,13 +42,11 @@ exports[`<SetStatus/> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -125,6 +124,7 @@ exports[`<SetStatus/> should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -150,12 +150,10 @@ exports[`<SetStatus/> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/internal/pages/UTMParameters.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/UTMParameters.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<UTMParameters /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<UTMParameters /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<UTMParameters /> should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<UTMParameters /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
@@ -57,6 +57,7 @@ exports[`<PageNotFound/> should render correctly 1`] = `
             "flexDirection": "row",
             "justifyContent": "space-between",
             "minHeight": 48,
+            "paddingHorizontal": 24,
             "width": "100%",
           }
         }
@@ -65,13 +66,11 @@ exports[`<PageNotFound/> should render correctly 1`] = `
           positionInHeader="left"
           style={
             {
-              "alignItems": "center",
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
+              "alignItems": "flex-start",
               "justifyContent": "flex-start",
-              "maxWidth": 40,
-              "paddingHorizontal": 24,
+              "marginLeft": 0,
+              "marginRight": 8,
+              "minWidth": 40,
             }
           }
           testID="back-button-container"
@@ -81,12 +80,10 @@ exports[`<PageNotFound/> should render correctly 1`] = `
           style={
             {
               "alignItems": "center",
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "flex-end",
-              "maxWidth": 40,
-              "paddingHorizontal": 24,
+              "marginLeft": 8,
+              "marginRight": 0,
+              "minWidth": 40,
             }
           }
           testID="close-button-container"

--- a/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`Accessibility should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`Accessibility should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`Accessibility should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`Accessibility should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`AccessibilityEngagement should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`AccessibilityEngagement should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`AccessibilityEngagement should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`AccessibilityEngagement should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/Accessibility/RecommendedPaths.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/RecommendedPaths.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`RecommendedPaths should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`RecommendedPaths should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`RecommendedPaths should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`RecommendedPaths should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`SiteMapScreen should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -127,6 +126,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -152,12 +152,10 @@ exports[`SiteMapScreen should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<SetAddress/> from mandatory udpate personal data screen should render 
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<SetAddress/> from mandatory udpate personal data screen should render 
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<SetAddress/> from mandatory udpate personal data screen should render 
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<SetAddress/> from mandatory udpate personal data screen should render 
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -649,6 +647,7 @@ exports[`<SetAddress/> without previous screen should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -657,13 +656,11 @@ exports[`<SetAddress/> without previous screen should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -741,6 +738,7 @@ exports[`<SetAddress/> without previous screen should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -766,12 +764,10 @@ exports[`<SetAddress/> without previous screen should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`ChangeCity from mandatory udpate personal data screen should render cor
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`ChangeCity from mandatory udpate personal data screen should render cor
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`ChangeCity from mandatory udpate personal data screen should render cor
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`ChangeCity from mandatory udpate personal data screen should render cor
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -705,6 +703,7 @@ exports[`ChangeCity from profil personal data screen should render correctly 1`]
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -713,13 +712,11 @@ exports[`ChangeCity from profil personal data screen should render correctly 1`]
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -797,6 +794,7 @@ exports[`ChangeCity from profil personal data screen should render correctly 1`]
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -822,12 +820,10 @@ exports[`ChangeCity from profil personal data screen should render correctly 1`]
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -1368,6 +1364,7 @@ exports[`ChangeCity without previous screen should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -1376,13 +1373,11 @@ exports[`ChangeCity without previous screen should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -1460,6 +1455,7 @@ exports[`ChangeCity without previous screen should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -1485,12 +1481,10 @@ exports[`ChangeCity without previous screen should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
@@ -107,10 +107,10 @@ exports[`ChangeCity should render correctly 1`] = `
         class="css-view-175oi2r r-height-10ptun7"
       />
       <div
-        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-minHeight-1pl7oy7 r-width-13qz1uu"
+        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-minHeight-1pl7oy7 r-paddingInline-cxgwc0 r-width-13qz1uu"
       >
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-1h0z5md r-maxWidth-i8lcd2 r-paddingInline-cxgwc0"
+          class="css-view-175oi2r r-alignItems-1habvwh r-justifyContent-1h0z5md r-marginLeft-11wrixw r-marginRight-uyseuv r-minWidth-vkv6oe"
           data-testid="back-button-container"
         >
           <button
@@ -141,7 +141,7 @@ exports[`ChangeCity should render correctly 1`] = `
           </button>
         </div>
         <div
-          class="css-view-175oi2r r-flexShrink-1wbh5a2"
+          class="css-view-175oi2r r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
         >
           <h1
             aria-level="1"
@@ -153,7 +153,7 @@ exports[`ChangeCity should render correctly 1`] = `
           </h1>
         </div>
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-17s6mgv r-maxWidth-i8lcd2 r-paddingInline-cxgwc0"
+          class="css-view-175oi2r r-alignItems-1awozwy r-justifyContent-17s6mgv r-marginLeft-18ry08z r-marginRight-61z16t r-minWidth-vkv6oe"
           data-testid="close-button-container"
         />
       </div>

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -435,6 +432,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -443,13 +441,11 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -459,12 +455,10 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`ChangePassword should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`ChangePassword should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`ChangePassword should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`ChangePassword should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
@@ -33,6 +33,7 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -41,13 +42,11 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -125,6 +124,7 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -150,12 +150,10 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -2090,6 +2088,7 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -2098,13 +2097,11 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -2182,6 +2179,7 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -2207,12 +2205,10 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -4147,6 +4143,7 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -4155,13 +4152,11 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -4239,6 +4234,7 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -4264,12 +4260,10 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/DebugScreen/DebugScreen.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DebugScreen/DebugScreen.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`DebugScreen should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`DebugScreen should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -127,6 +126,7 @@ exports[`DebugScreen should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -152,12 +152,10 @@ exports[`DebugScreen should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -141,12 +140,10 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`DeactivateProfileSuccess component should render delete profile success
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`DeactivateProfileSuccess component should render delete profile success
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`DeactivateProfileSuccess component should render delete profile success
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -141,12 +140,10 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -141,12 +140,10 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -141,12 +140,10 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`DeleteProfileContactSupport should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`DeleteProfileContactSupport should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -141,12 +140,10 @@ exports[`DeleteProfileContactSupport should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -141,12 +140,10 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,12 +133,10 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/DisplayPreference/DisplayPreference.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DisplayPreference/DisplayPreference.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`DisplayPreference should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`DisplayPreference should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -127,6 +126,7 @@ exports[`DisplayPreference should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -152,12 +152,10 @@ exports[`DisplayPreference should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`LegalNotices should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`LegalNotices should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`LegalNotices should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`LegalNotices should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<MandatoryUpdatePersonalData /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<MandatoryUpdatePersonalData /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<MandatoryUpdatePersonalData /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/ProfileInformationValidationUpdate.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/ProfileInformationValidationUpdate.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`ProfileInformationValidationUpdate should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`ProfileInformationValidationUpdate should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -64,6 +63,7 @@ exports[`ProfileInformationValidationUpdate should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -89,12 +89,10 @@ exports[`ProfileInformationValidationUpdate should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<UpdatePersonalDataConfirmation /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<UpdatePersonalDataConfirmation /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<UpdatePersonalDataConfirmation /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<NewEmailSelection /> should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<NewEmailSelection /> should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<NewEmailSelection /> should match snapshot 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<NewEmailSelection /> should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -2173,6 +2171,7 @@ exports[`NotificationsSettings should render correctly when user is not logged i
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -2181,13 +2180,11 @@ exports[`NotificationsSettings should render correctly when user is not logged i
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -2265,6 +2262,7 @@ exports[`NotificationsSettings should render correctly when user is not logged i
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -2290,12 +2288,10 @@ exports[`NotificationsSettings should render correctly when user is not logged i
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -104,10 +104,10 @@ exports[`NotificationsSettings should render correctly 1`] = `
         class="css-view-175oi2r r-height-10ptun7"
       />
       <div
-        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-minHeight-1pl7oy7 r-width-13qz1uu"
+        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-minHeight-1pl7oy7 r-paddingInline-cxgwc0 r-width-13qz1uu"
       >
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-1h0z5md r-maxWidth-i8lcd2 r-paddingInline-cxgwc0"
+          class="css-view-175oi2r r-alignItems-1habvwh r-justifyContent-1h0z5md r-marginLeft-11wrixw r-marginRight-uyseuv r-minWidth-vkv6oe"
           data-testid="back-button-container"
         >
           <button
@@ -138,7 +138,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
           </button>
         </div>
         <div
-          class="css-view-175oi2r r-flexShrink-1wbh5a2"
+          class="css-view-175oi2r r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
         >
           <h1
             aria-level="1"
@@ -150,7 +150,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
           </h1>
         </div>
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-17s6mgv r-maxWidth-i8lcd2 r-paddingInline-cxgwc0"
+          class="css-view-175oi2r r-alignItems-1awozwy r-justifyContent-17s6mgv r-marginLeft-18ry08z r-marginRight-61z16t r-minWidth-vkv6oe"
           data-testid="close-button-container"
         />
       </div>

--- a/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`PersonalData should render personal data success 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`PersonalData should render personal data success 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`PersonalData should render personal data success 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`PersonalData should render personal data success 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -52,6 +52,7 @@ exports[`<SearchFilter/> should render correctly 1`] = `
             "flexDirection": "row",
             "justifyContent": "space-between",
             "minHeight": 48,
+            "paddingHorizontal": 24,
             "width": "100%",
           }
         }
@@ -60,13 +61,11 @@ exports[`<SearchFilter/> should render correctly 1`] = `
           positionInHeader="left"
           style={
             {
-              "alignItems": "center",
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
+              "alignItems": "flex-start",
               "justifyContent": "flex-start",
-              "maxWidth": 40,
-              "paddingHorizontal": 24,
+              "marginLeft": 0,
+              "marginRight": 8,
+              "minWidth": 40,
             }
           }
           testID="back-button-container"
@@ -144,6 +143,7 @@ exports[`<SearchFilter/> should render correctly 1`] = `
         <View
           style={
             {
+              "flexGrow": 1,
               "flexShrink": 1,
             }
           }
@@ -169,12 +169,10 @@ exports[`<SearchFilter/> should render correctly 1`] = `
           style={
             {
               "alignItems": "center",
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "flex-end",
-              "maxWidth": 40,
-              "paddingHorizontal": 24,
+              "marginLeft": 8,
+              "marginRight": 0,
+              "minWidth": 40,
             }
           }
           testID="close-button-container"

--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -692,6 +689,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -700,13 +698,11 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -716,12 +712,10 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -1248,6 +1242,7 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -1256,13 +1251,11 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -1272,12 +1265,10 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -141,12 +140,10 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -71,12 +70,10 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
@@ -47,6 +47,7 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -55,13 +56,11 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,12 +133,10 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/ui/pages/PageWithHeader.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/PageWithHeader.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"
@@ -349,6 +347,7 @@ exports[`<PageWithHeader/> should render correctly on Android, with white header
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -357,13 +356,11 @@ exports[`<PageWithHeader/> should render correctly on Android, with white header
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -441,6 +438,7 @@ exports[`<PageWithHeader/> should render correctly on Android, with white header
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -466,12 +464,10 @@ exports[`<PageWithHeader/> should render correctly on Android, with white header
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/__snapshots__/ui/pages/PageWithHeader.web.test.tsx.web-snap
+++ b/__snapshots__/ui/pages/PageWithHeader.web.test.tsx.web-snap
@@ -52,10 +52,10 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
         class="css-view-175oi2r r-height-10ptun7"
       />
       <div
-        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-minHeight-1pl7oy7 r-width-13qz1uu"
+        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-minHeight-1pl7oy7 r-paddingInline-cxgwc0 r-width-13qz1uu"
       >
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-1h0z5md r-maxWidth-i8lcd2 r-paddingInline-cxgwc0"
+          class="css-view-175oi2r r-alignItems-1habvwh r-justifyContent-1h0z5md r-marginLeft-11wrixw r-marginRight-uyseuv r-minWidth-vkv6oe"
           data-testid="back-button-container"
         >
           <button
@@ -86,7 +86,7 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
           </button>
         </div>
         <div
-          class="css-view-175oi2r r-flexShrink-1wbh5a2"
+          class="css-view-175oi2r r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
         >
           <h1
             aria-level="1"
@@ -98,7 +98,7 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
           </h1>
         </div>
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-17s6mgv r-maxWidth-i8lcd2 r-paddingInline-cxgwc0"
+          class="css-view-175oi2r r-alignItems-1awozwy r-justifyContent-17s6mgv r-marginLeft-18ry08z r-marginRight-61z16t r-minWidth-vkv6oe"
           data-testid="close-button-container"
         />
       </div>

--- a/__snapshots__/ui/pages/SecondaryPageWithBlurHeader.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/SecondaryPageWithBlurHeader.native.test.tsx.native-snap
@@ -42,6 +42,7 @@ exports[`<SecondaryPageWithBlurHeader /> should render correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "space-between",
           "minHeight": 48,
+          "paddingHorizontal": 24,
           "width": "100%",
         }
       }
@@ -50,13 +51,11 @@ exports[`<SecondaryPageWithBlurHeader /> should render correctly 1`] = `
         positionInHeader="left"
         style={
           {
-            "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "alignItems": "flex-start",
             "justifyContent": "flex-start",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 0,
+            "marginRight": 8,
+            "minWidth": 40,
           }
         }
         testID="back-button-container"
@@ -134,6 +133,7 @@ exports[`<SecondaryPageWithBlurHeader /> should render correctly 1`] = `
       <View
         style={
           {
+            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -159,12 +159,10 @@ exports[`<SecondaryPageWithBlurHeader /> should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "flex-end",
-            "maxWidth": 40,
-            "paddingHorizontal": 24,
+            "marginLeft": 8,
+            "marginRight": 0,
+            "minWidth": 40,
           }
         }
         testID="close-button-container"

--- a/src/ui/components/headers/PageHeaderWithoutPlaceholder.tsx
+++ b/src/ui/components/headers/PageHeaderWithoutPlaceholder.tsx
@@ -73,6 +73,7 @@ const Header = styled(View)(({ theme }) => ({
 }))
 
 const TitleContainer = styled.View({
+  flexGrow: 1,
   flexShrink: 1,
 })
 
@@ -83,20 +84,25 @@ const Title = styled(Typo.Title4).attrs(() => ({
   textAlign: 'center',
 })
 
-const Container = styled.View({
+const Container = styled.View(({ theme }) => ({
   alignItems: 'center',
   flexDirection: 'row',
   justifyContent: 'space-between',
   minHeight: HEADER_HEIGHT,
   width: '100%',
-})
+  paddingHorizontal: theme.contentPage.marginHorizontal,
+}))
 
 const ButtonContainer = styled.View<{ positionInHeader: 'left' | 'right' }>(
-  ({ positionInHeader = 'left', theme }) => ({
-    alignItems: 'center',
-    justifyContent: positionInHeader === 'left' ? 'flex-start' : 'flex-end',
-    paddingHorizontal: theme.contentPage.marginHorizontal,
-    maxWidth: BACK_BUTTON_MAX_SIZE,
-    flex: 1,
-  })
+  ({ positionInHeader = 'left', theme }) => {
+    const isLeftComponent = positionInHeader === 'left'
+    const marginHorizontal = theme.designSystem.size.spacing.s
+    return {
+      alignItems: isLeftComponent ? 'flex-start' : 'center',
+      justifyContent: isLeftComponent ? 'flex-start' : 'flex-end',
+      minWidth: BACK_BUTTON_MAX_SIZE,
+      marginLeft: isLeftComponent ? 0 : marginHorizontal,
+      marginRight: isLeftComponent ? marginHorizontal : 0,
+    }
+  }
 )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
