### PR TITLE
(PC-37485) feat(accessibility): add focus outline in Accordin component

### DIFF
--- a/src/ui/components/Accordion.tsx
+++ b/src/ui/components/Accordion.tsx
@@ -165,17 +165,26 @@ const SwitchContainer = styled.View({
   alignItems: 'center',
 })
 
-const StyledTouchableOpacity = styled(TouchableOpacity).attrs({ activeOpacity: 1 })<{
+const StyledTouchableOpacity = styled(TouchableOpacity).attrs({
+  activeOpacity: 1,
+})<{
   isFocus?: boolean
-}>(({ theme, isFocus }) => ({ flex: 1, ...touchableFocusOutline(theme, isFocus) }))
+}>(({ theme, isFocus }) => ({
+  flex: 1,
+  ...touchableFocusOutline({ theme, isFocus }),
+}))
 
-const StyledTitle = styled(Typo.Title4)({ flexShrink: 1 })
+const StyledTitle = styled(Typo.Title4)({
+  flexShrink: 1,
+})
 
 const StyledArrowAnimatedView = styled(Animated.View)({
   marginLeft: getSpacing(2),
 })
 
-const StyledAnimatedView = styled(Animated.View)({ overflow: 'hidden' })
+const StyledAnimatedView = styled(Animated.View)({
+  overflow: 'hidden',
+})
 
 const ArrowNext = styled(DefaultArrowNext).attrs(({ theme }) => ({
   size: theme.icons.sizes.smaller,

--- a/src/ui/components/TouchableOpacity.tsx
+++ b/src/ui/components/TouchableOpacity.tsx
@@ -66,7 +66,7 @@ const addStyled = (Component: typeof RNTouchableOpacity | typeof GestureTouchabl
     activeOpacity: activeOpacity ?? theme.activeOpacity,
   }))<StyledProps>(({ theme, unselectable, isFocus }) => ({
     userSelect: unselectable ? 'none' : 'auto',
-    ...touchableFocusOutline(theme, isFocus),
+    ...touchableFocusOutline({ theme, isFocus }),
   }))
 const StyledRNTouchableOpacity = addStyled(RNTouchableOpacity)
 const StyledGestureTouchableOpacity = addStyled(GestureTouchableOpacity)

--- a/src/ui/components/touchableLink/TouchableLink.tsx
+++ b/src/ui/components/touchableLink/TouchableLink.tsx
@@ -105,7 +105,7 @@ const StyledTouchableOpacity = styled(TouchableOpacity)<{
   isHover?: boolean
   hoverUnderlineColor?: ColorsType
 }>(({ theme, isFocus, isHover, hoverUnderlineColor }) => ({
-  ...touchableFocusOutline(theme, isFocus),
+  ...touchableFocusOutline({ theme, isFocus }),
   ...getHoverStyle({
     underlineColor: hoverUnderlineColor ?? theme.designSystem.color.text.default,
     isHover,
@@ -118,7 +118,7 @@ const StyledTouchableHighlight = styled.TouchableHighlight<{
   hoverUnderlineColor?: ColorsType
 }>(({ theme, isFocus, isHover, hoverUnderlineColor }) => ({
   textDecoration: 'none',
-  ...touchableFocusOutline(theme, isFocus),
+  ...touchableFocusOutline({ theme, isFocus }),
   ...getHoverStyle({
     underlineColor: hoverUnderlineColor ?? theme.designSystem.color.text.default,
     isHover,

--- a/src/ui/theme/customFocusOutline/customFocusOutline.ts
+++ b/src/ui/theme/customFocusOutline/customFocusOutline.ts
@@ -1,3 +1,3 @@
-import { Argument } from 'ui/theme/customFocusOutline/type'
+import { CustomFocusOutlineProps } from 'ui/theme/customFocusOutline/type'
 
-export const customFocusOutline = (_argument: Argument) => ({})
+export const customFocusOutline = (_argument: CustomFocusOutlineProps) => ({})

--- a/src/ui/theme/customFocusOutline/customFocusOutline.web.ts
+++ b/src/ui/theme/customFocusOutline/customFocusOutline.web.ts
@@ -3,7 +3,7 @@ import { isSafari, browserVersion } from 'react-device-detect'
 
 // eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
-import { Argument } from 'ui/theme/customFocusOutline/type'
+import { CustomFocusOutlineProps } from 'ui/theme/customFocusOutline/type'
 
 /*
  * The ':focus-visible' pseudo-class support starting with Safari 15.4 (https://caniuse.com/css-focus-visible)
@@ -12,7 +12,12 @@ import { Argument } from 'ui/theme/customFocusOutline/type'
  */
 const focus = isSafari && Number(browserVersion) < 15.4 ? '&:focus' : '&:focus-visible'
 
-export function customFocusOutline({ color, width, isFocus, noOffset = false }: Argument) {
+export function customFocusOutline({
+  color,
+  width,
+  isFocus,
+  noOffset = false,
+}: CustomFocusOutlineProps) {
   const outlineRules = {
     outlineColor: color ?? theme.designSystem.color.outline.default,
     outlineWidth: width ?? theme.outline.width,

--- a/src/ui/theme/customFocusOutline/touchableFocusOutline.native.test.tsx
+++ b/src/ui/theme/customFocusOutline/touchableFocusOutline.native.test.tsx
@@ -1,0 +1,12 @@
+import { DefaultTheme } from 'styled-components/native'
+
+import { theme } from 'theme'
+import { touchableFocusOutline } from 'ui/theme/customFocusOutline/touchableFocusOutline'
+
+describe('touchableFocusOutline', () => {
+  it('should return an empty object when is native', () => {
+    const result = touchableFocusOutline({ theme: theme as DefaultTheme })
+
+    expect(result).toMatchObject({})
+  })
+})

--- a/src/ui/theme/customFocusOutline/touchableFocusOutline.tsx
+++ b/src/ui/theme/customFocusOutline/touchableFocusOutline.tsx
@@ -1,25 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import { isFirefox, isSafari } from 'react-device-detect'
-import { Platform } from 'react-native'
-import { DefaultTheme } from 'styled-components/native'
+import { TouchableFocusOutlineProps } from 'ui/theme/customFocusOutline/type'
 
-const defaultFocus = {
-  outlineOffset: 0,
-}
-const firefoxFocus = {
-  outlineOffset: '-2px',
-}
-const safariFocus = {
-  outlineOffset: '-3px',
-}
-
-const focusStyle = () => {
-  if (isFirefox) return firefoxFocus
-  if (isSafari) return safariFocus
-  return defaultFocus
-}
-
-export const touchableFocusOutline = (theme: DefaultTheme, isFocus?: boolean) =>
-  Platform.OS === 'web' && isFocus
-    ? { ...focusStyle(), outlineColor: theme.designSystem.color.outline.default }
-    : {}
+export const touchableFocusOutline = (_argument: TouchableFocusOutlineProps) => ({})

--- a/src/ui/theme/customFocusOutline/touchableFocusOutline.web.test.tsx
+++ b/src/ui/theme/customFocusOutline/touchableFocusOutline.web.test.tsx
@@ -1,0 +1,27 @@
+import { DefaultTheme } from 'styled-components/native'
+
+import { theme } from 'theme'
+
+import { touchableFocusOutline } from './touchableFocusOutline'
+
+jest.mock('react-device-detect', () => ({ isFirefox: false, isSafari: false }))
+const mockTheme = theme as DefaultTheme
+
+describe('touchableFocusOutline (web)', () => {
+  it('should return empty object when isFocus is false', () => {
+    const result = touchableFocusOutline({ theme: mockTheme, isFocus: false })
+
+    expect(result).toEqual({})
+  })
+
+  it('should return default focus style when isFocus is true', () => {
+    const result = touchableFocusOutline({ theme: mockTheme, isFocus: true })
+
+    expect(result).toMatchObject({
+      outlineColor: theme.designSystem.color.outline.default,
+      outlineStyle: 'solid',
+      outlineWidth: 2,
+      outlineOffset: 0,
+    })
+  })
+})

--- a/src/ui/theme/customFocusOutline/touchableFocusOutline.web.tsx
+++ b/src/ui/theme/customFocusOutline/touchableFocusOutline.web.tsx
@@ -1,0 +1,30 @@
+// eslint-disable-next-line no-restricted-imports
+import { isFirefox, isSafari } from 'react-device-detect'
+
+import { TouchableFocusOutlineProps } from 'ui/theme/customFocusOutline/type'
+
+const defaultFocus = {
+  outlineOffset: 0,
+}
+const firefoxFocus = {
+  outlineOffset: '-2px',
+}
+const safariFocus = {
+  outlineOffset: '-3px',
+}
+
+const focusStyle = () => {
+  if (isFirefox) return firefoxFocus
+  if (isSafari) return safariFocus
+  return defaultFocus
+}
+
+export const touchableFocusOutline = ({ theme, isFocus }: TouchableFocusOutlineProps) =>
+  isFocus
+    ? {
+        ...focusStyle(),
+        outlineColor: theme.designSystem.color.outline.default,
+        outlineStyle: 'solid',
+        outlineWidth: 2,
+      }
+    : {}

--- a/src/ui/theme/customFocusOutline/type.ts
+++ b/src/ui/theme/customFocusOutline/type.ts
@@ -1,8 +1,15 @@
+import { DefaultTheme } from 'styled-components/native'
+
 import { ColorsType } from 'theme/types'
 
-export type Argument = {
+export type CustomFocusOutlineProps = {
   color?: ColorsType
   width?: number
   isFocus?: boolean
   noOffset?: boolean
+}
+
+export type TouchableFocusOutlineProps = {
+  theme: DefaultTheme
+  isFocus?: boolean
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37485

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |     |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |   <img width="500" height="934" alt="Capture d’écran 2025-09-04 à 16 07 11" src="https://github.com/user-attachments/assets/0733dbda-708e-4a48-85fd-6af968e7fa08" />    |   <img width="499" height="934" alt="Capture d’écran 2025-09-04 à 16 06 53" src="https://github.com/user-attachments/assets/f0775871-05fb-4476-b03c-ab4c7ad30c85" />  |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
