### PR TITLE
(BSR) refactor(ui): remove unused flexGrow in PageHeaderWithoutPlaceholder

### DIFF
--- a/__snapshots__/features/achievements/pages/Achievements.native.test.tsx.native-snap
+++ b/__snapshots__/features/achievements/pages/Achievements.native.test.tsx.native-snap
@@ -126,7 +126,6 @@ exports[`<Achievements/> should match snapshot 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -63,7 +63,6 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -882,7 +881,6 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -1781,7 +1779,6 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -2929,7 +2926,6 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/culturalSurvey/pages/FAQWebview.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/FAQWebview.native.test.tsx.native-snap
@@ -124,7 +124,6 @@ exports[`FAQVebview page should render the page with correct layout 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
@@ -125,7 +125,7 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
           </button>
         </div>
         <div
-          class="css-view-175oi2r r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          class="css-view-175oi2r r-flexShrink-1wbh5a2"
         >
           <h1
             aria-level="1"

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
@@ -125,7 +125,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
           </button>
         </div>
         <div
-          class="css-view-175oi2r r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          class="css-view-175oi2r r-flexShrink-1wbh5a2"
         >
           <h1
             aria-level="1"

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`SelectIDOrigin should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.test.tsx.web-snap
@@ -86,7 +86,7 @@ exports[`SelectPhoneStatus should render correctly 1`] = `
           </button>
         </div>
         <div
-          class="css-view-175oi2r r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          class="css-view-175oi2r r-flexShrink-1wbh5a2"
         >
           <h1
             aria-level="1"

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
@@ -126,7 +126,6 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/identityCheck/pages/profile/ProfileInformationValidationCreate.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/ProfileInformationValidationCreate.native.test.tsx.native-snap
@@ -126,7 +126,6 @@ exports[`ProfileInformationValidationCreate should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<SetCity/> should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<SetName/> should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
@@ -124,7 +124,6 @@ exports[`<SetStatus/> should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/internal/pages/UTMParameters.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/UTMParameters.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<UTMParameters /> should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`Accessibility should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`AccessibilityEngagement should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/Accessibility/RecommendedPaths.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/RecommendedPaths.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`RecommendedPaths should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx.native-snap
@@ -126,7 +126,6 @@ exports[`SiteMapScreen should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<SetAddress/> from mandatory udpate personal data screen should render 
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -738,7 +737,6 @@ exports[`<SetAddress/> without previous screen should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`ChangeCity from mandatory udpate personal data screen should render cor
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -794,7 +793,6 @@ exports[`ChangeCity from profil personal data screen should render correctly 1`]
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -1455,7 +1453,6 @@ exports[`ChangeCity without previous screen should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
@@ -141,7 +141,7 @@ exports[`ChangeCity should render correctly 1`] = `
           </button>
         </div>
         <div
-          class="css-view-175oi2r r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          class="css-view-175oi2r r-flexShrink-1wbh5a2"
         >
           <h1
             aria-level="1"

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`ChangePassword should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
@@ -124,7 +124,6 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -2179,7 +2178,6 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -4234,7 +4232,6 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/DebugScreen/DebugScreen.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DebugScreen/DebugScreen.native.test.tsx.native-snap
@@ -126,7 +126,6 @@ exports[`DebugScreen should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/DisplayPreference/DisplayPreference.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DisplayPreference/DisplayPreference.native.test.tsx.native-snap
@@ -126,7 +126,6 @@ exports[`DisplayPreference should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`LegalNotices should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/ProfileInformationValidationUpdate.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/ProfileInformationValidationUpdate.native.test.tsx.native-snap
@@ -63,7 +63,6 @@ exports[`ProfileInformationValidationUpdate should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<NewEmailSelection /> should match snapshot 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -2262,7 +2261,6 @@ exports[`NotificationsSettings should render correctly when user is not logged i
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -138,7 +138,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
           </button>
         </div>
         <div
-          class="css-view-175oi2r r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          class="css-view-175oi2r r-flexShrink-1wbh5a2"
         >
           <h1
             aria-level="1"

--- a/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`PersonalData should render personal data success 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -143,7 +143,6 @@ exports[`<SearchFilter/> should render correctly 1`] = `
         <View
           style={
             {
-              "flexGrow": 1,
               "flexShrink": 1,
             }
           }

--- a/__snapshots__/ui/pages/PageWithHeader.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/PageWithHeader.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }
@@ -438,7 +437,6 @@ exports[`<PageWithHeader/> should render correctly on Android, with white header
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/__snapshots__/ui/pages/PageWithHeader.web.test.tsx.web-snap
+++ b/__snapshots__/ui/pages/PageWithHeader.web.test.tsx.web-snap
@@ -86,7 +86,7 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
           </button>
         </div>
         <div
-          class="css-view-175oi2r r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          class="css-view-175oi2r r-flexShrink-1wbh5a2"
         >
           <h1
             aria-level="1"

--- a/__snapshots__/ui/pages/SecondaryPageWithBlurHeader.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/SecondaryPageWithBlurHeader.native.test.tsx.native-snap
@@ -133,7 +133,6 @@ exports[`<SecondaryPageWithBlurHeader /> should render correctly 1`] = `
       <View
         style={
           {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }

--- a/src/ui/components/headers/PageHeaderWithoutPlaceholder.tsx
+++ b/src/ui/components/headers/PageHeaderWithoutPlaceholder.tsx
@@ -73,7 +73,6 @@ const Header = styled(View)(({ theme }) => ({
 }))
 
 const TitleContainer = styled.View({
-  flexGrow: 1,
   flexShrink: 1,
 })
 


### PR DESCRIPTION
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
