### PR TITLE
(PC-37467) feat(BookingPage): add message to contact organizer when booking has a ticket

### DIFF
--- a/src/features/bookings/components/BookingDetailsContent.native.test.tsx
+++ b/src/features/bookings/components/BookingDetailsContent.native.test.tsx
@@ -265,6 +265,80 @@ describe('<BookingDetailsContent />', () => {
       screen.getByText('Tu n’as pas le droit de céder ou de revendre ton billet.')
     ).toBeOnTheScreen()
   })
+
+  it('should display message to contact organizer when booking has a ticket', async () => {
+    renderBookingDetailsContent({
+      properties: { ...mockProperties, isEvent: false },
+      booking: {
+        ...bookingsSnapV2.ongoingBookings[0],
+        stock: {
+          ...bookingsSnapV2.ongoingBookings[0].stock,
+          offer: {
+            ...bookingsSnapV2.ongoingBookings[0].stock.offer,
+            bookingContact: 'emailDeLorganisateur@emailSchema.com',
+          },
+        },
+        ticket: {
+          ...bookingsSnapV2.ongoingBookings[0].ticket,
+          display: TicketDisplayEnum.ticket,
+        },
+      },
+    })
+
+    expect(
+      screen.getByText(
+        `Si tu n’as pas reçu tes billets, contacte l’organisateur\u00a0:\n emailDeLorganisateur@emailSchema.com`
+      )
+    ).toBeOnTheScreen()
+  })
+
+  it('should not display message to contact organizer when booking has no ticket', async () => {
+    renderBookingDetailsContent({
+      properties: { ...mockProperties, isEvent: false },
+      booking: {
+        ...bookingsSnapV2.ongoingBookings[0],
+        stock: {
+          ...bookingsSnapV2.ongoingBookings[0].stock,
+          offer: {
+            ...bookingsSnapV2.ongoingBookings[0].stock.offer,
+            bookingContact: 'emailDeLorganisateur@emailSchema.com',
+          },
+        },
+        ticket: {
+          ...bookingsSnapV2.ongoingBookings[0].ticket,
+          display: TicketDisplayEnum.no_ticket,
+        },
+      },
+    })
+
+    expect(
+      screen.queryByText(
+        `Si tu n’as pas reçu tes billets, contacte l’organisateur\u00a0:\n emailDeLorganisateur@emailSchema.com`
+      )
+    ).not.toBeOnTheScreen()
+  })
+
+  it('should display organizer email when booking has no ticket', async () => {
+    renderBookingDetailsContent({
+      properties: { ...mockProperties, isEvent: false },
+      booking: {
+        ...bookingsSnapV2.ongoingBookings[0],
+        stock: {
+          ...bookingsSnapV2.ongoingBookings[0].stock,
+          offer: {
+            ...bookingsSnapV2.ongoingBookings[0].stock.offer,
+            bookingContact: 'emailDeLorganisateur@emailSchema.com',
+          },
+        },
+        ticket: {
+          ...bookingsSnapV2.ongoingBookings[0].ticket,
+          display: TicketDisplayEnum.no_ticket,
+        },
+      },
+    })
+
+    expect(screen.getByText(`emailDeLorganisateur@emailSchema.com`)).toBeOnTheScreen()
+  })
 })
 
 const renderBookingDetailsContent = ({

--- a/src/features/bookings/components/BookingDetailsContent.tsx
+++ b/src/features/bookings/components/BookingDetailsContent.tsx
@@ -78,8 +78,9 @@ export const BookingDetailsContent = ({
   const onEmailPress = () => {
     analytics.logClickEmailOrganizer()
   }
-
   const isNoTicket = booking.ticket.display === TicketDisplayEnum.no_ticket
+  const hasTicket = !isNoTicket
+
   const errorBannerMessage = `Tu n’as pas le droit de céder ou de revendre ${properties.isDuo ? 'tes billets' : 'ton billet'}.`
   return booking.ticket ? (
     <MainContainer>
@@ -117,6 +118,7 @@ export const BookingDetailsContent = ({
                     bookingContactEmail={booking.stock.offer.bookingContact}
                     withdrawalDetails={booking.ticket.withdrawal.details}
                     onEmailPress={onEmailPress}
+                    hasTicket={hasTicket}
                   />
                 ) : null}
                 <BookingDetailsCancelButton
@@ -146,6 +148,7 @@ export const BookingDetailsContent = ({
             errorBannerMessage={isNoTicket ? null : errorBannerMessage}
             cancelBooking={cancelBooking}
             showArchiveModal={showArchiveModal}
+            hasTicket={hasTicket}
           />
         )}
         <CancelBookingModal

--- a/src/features/bookings/components/BookingDetailsContentMobile.tsx
+++ b/src/features/bookings/components/BookingDetailsContentMobile.tsx
@@ -16,6 +16,7 @@ export const BookingDetailsContentMobile = ({
   errorBannerMessage,
   cancelBooking,
   showArchiveModal,
+  hasTicket,
 }: {
   topBlock: React.JSX.Element
   booking: BookingResponse
@@ -23,6 +24,7 @@ export const BookingDetailsContentMobile = ({
   errorBannerMessage: string | null
   cancelBooking: () => void
   showArchiveModal: () => void
+  hasTicket: boolean
 }) => {
   return (
     <View testID="booking_details_mobile">
@@ -45,6 +47,7 @@ export const BookingDetailsContentMobile = ({
                 bookingContactEmail={booking.stock.offer.bookingContact}
                 withdrawalDetails={booking.ticket?.withdrawal.details}
                 onEmailPress={onEmailPress}
+                hasTicket={hasTicket}
               />
             </Container>
           </SectionContainer>

--- a/src/features/bookings/components/BookingPrecision.tsx
+++ b/src/features/bookings/components/BookingPrecision.tsx
@@ -11,7 +11,8 @@ export const BookingPrecisions: React.FC<{
   withdrawalDetails?: string | null
   bookingContactEmail?: string | null
   onEmailPress: () => void
-}> = ({ bookingContactEmail, withdrawalDetails, onEmailPress }) => (
+  hasTicket: boolean
+}> = ({ bookingContactEmail, withdrawalDetails, onEmailPress, hasTicket }) => (
   <ViewGap gap={6}>
     {withdrawalDetails ? (
       <ViewGap gap={4}>
@@ -19,9 +20,16 @@ export const BookingPrecisions: React.FC<{
         <Typo.BodyS testID="withdrawalDetails">{withdrawalDetails}</Typo.BodyS>
       </ViewGap>
     ) : null}
+
     {bookingContactEmail ? (
       <EmailContainer gap={2}>
-        <CaptionNeutralInfo numberOfLines={2}>{bookingContactEmail}</CaptionNeutralInfo>
+        {hasTicket ? (
+          <CaptionNeutralInfo numberOfLines={4}>
+            {`Si tu n’as pas reçu tes billets, contacte l’organisateur\u00a0:\n${bookingContactEmail}`}
+          </CaptionNeutralInfo>
+        ) : (
+          <CaptionNeutralInfo numberOfLines={2}>{bookingContactEmail}</CaptionNeutralInfo>
+        )}
         <ExternalTouchableLink
           as={ButtonQuaternaryBlack}
           inline

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
@@ -640,6 +640,36 @@ describe('BookingDetails', () => {
       expect(screen.getByText(withdrawalDetails)).toBeOnTheScreen()
     })
 
+    it('should render message to contact organizer', async () => {
+      const organizerEmail = 'toto@email.com'
+
+      renderBookingDetailsV2({
+        ...ongoingBookingV2,
+        stock: {
+          ...ongoingBookingV2.stock,
+          offer: {
+            ...ongoingBookingV2.stock.offer,
+            bookingContact: organizerEmail,
+          },
+        },
+        ticket: {
+          ...ongoingBookingV2.ticket,
+          display: TicketDisplayEnum.email_sent,
+          withdrawal: {
+            type: WithdrawalTypeEnum.by_email,
+          },
+        },
+      })
+
+      await screen.findAllByText(ongoingBookingV2.stock.offer.name)
+
+      expect(
+        screen.getByText(
+          `Si tu n’as pas reçu tes billets, contacte l’organisateur\u00a0:\n${organizerEmail}`
+        )
+      ).toBeOnTheScreen()
+    })
+
     it("should render organizer's email", async () => {
       const organizerEmail = 'toto@email.com'
 
@@ -652,6 +682,13 @@ describe('BookingDetails', () => {
             bookingContact: organizerEmail,
           },
         },
+        ticket: {
+          ...ongoingBookingV2.ticket,
+          display: TicketDisplayEnum.no_ticket,
+          withdrawal: {
+            type: WithdrawalTypeEnum.no_ticket,
+          },
+        },
       })
 
       await screen.findAllByText(ongoingBookingV2.stock.offer.name)
@@ -659,7 +696,7 @@ describe('BookingDetails', () => {
       expect(screen.getByText(organizerEmail)).toBeOnTheScreen()
     })
 
-    it('should log analytics on email press', async () => {
+    it('should log analytics on `Contacter l’organisateur` press', async () => {
       const organizerEmail = 'toto@email.com'
       renderBookingDetailsV2({
         ...ongoingBookingV2,

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.web.test.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.web.test.tsx
@@ -84,13 +84,20 @@ describe('BookingDetails', () => {
         })
       })
 
-      it('should display details section when there is a organizer contact', async () => {
+      it('should display organizer contact when there is a organizer contact', async () => {
         renderBookingDetailsV2({
           booking: {
             ...ongoingBookingV2,
             stock: {
               ...ongoingBookingV2.stock,
               offer: { ...ongoingBookingV2.stock.offer, bookingContact: 'toto@monemail.com' },
+            },
+            ticket: {
+              ...ongoingBookingV2.ticket,
+              display: TicketDisplayEnum.no_ticket,
+              withdrawal: {
+                type: WithdrawalTypeEnum.no_ticket,
+              },
             },
           },
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37467

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | maquette | After |
| :--------------- | :-----------: | :---: |
| Android          |  <img width="184" height="380" alt="Screenshot 2025-09-08 at 16 18 53" src="https://github.com/user-attachments/assets/eacbdb16-e506-428f-aafb-88a1c3f4edd5" /> |<img width="1440" height="3120" alt="Screenshot_1757340610" src="https://github.com/user-attachments/assets/a72a9389-7d51-42a0-bc90-7335e5298455" />       |
| Phone - Chrome   |   <img width="184" height="380" alt="Screenshot 2025-09-08 at 16 18 53" src="https://github.com/user-attachments/assets/c31ebde4-e7ff-4b9d-abed-55c1f2163a22" /> | <img width="391" height="841" alt="Screenshot 2025-09-08 at 16 10 49" src="https://github.com/user-attachments/assets/2029e915-86f6-4e86-a327-17c61e824468" /> |
| Desktop - Chrome |   <img width="721" height="516" alt="Screenshot 2025-09-08 at 16 18 59" src="https://github.com/user-attachments/assets/3c224980-118d-4a14-9637-a5df3cf6c605" />|  <img width="1677" height="929" alt="Screenshot 2025-09-08 at 16 11 09" src="https://github.com/user-attachments/assets/ef757b31-964e-4ef2-8bb6-518c86c31fec" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
