### PR TITLE
Pc 37751 copy

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,6 +5,10 @@ import { ThemeProvider } from '../src/libs/styled'
 import { SafeAreaProvider } from '../src/libs/react-native-save-area-provider'
 import { theme } from '../src/theme'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { NavigationContainer } from '@react-navigation/native'
+import { View } from 'react-native'
+import { createStackNavigator } from '@react-navigation/stack'
+import { styled } from 'styled-components/native'
 
 const preview: Preview = {
   parameters: {
@@ -36,7 +40,31 @@ const preview: Preview = {
         <Story />
       </QueryClientProvider>
     ),
+    (Story) => <NavigationContainerWithScreen component={Story} />,
   ],
 }
+
+const Stack = createStackNavigator()
+
+const NavigationContainerWithScreen = (props: { component: React.ComponentType }) => {
+  const { component: Component } = props
+
+  return (
+    <NavigationContainer>
+      <Container>
+        <Stack.Navigator
+          initialRouteName="Story"
+          screenOptions={{
+            headerShown: false,
+            cardStyle: { backgroundColor: theme.designSystem.color.background.default },
+          }}>
+          <Stack.Screen name="Story" component={Component} />
+        </Stack.Navigator>
+      </Container>
+    </NavigationContainer>
+  )
+}
+
+const Container = styled.View({ height: '100vh' })
 
 export default preview

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,9 +6,6 @@ import { SafeAreaProvider } from '../src/libs/react-native-save-area-provider'
 import { theme } from '../src/theme'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { NavigationContainer } from '@react-navigation/native'
-import { View } from 'react-native'
-import { createStackNavigator } from '@react-navigation/stack'
-import { styled } from 'styled-components/native'
 
 const preview: Preview = {
   parameters: {
@@ -40,31 +37,12 @@ const preview: Preview = {
         <Story />
       </QueryClientProvider>
     ),
-    (Story) => <NavigationContainerWithScreen component={Story} />,
+    (Story) => (
+      <NavigationContainer>
+        <Story />
+      </NavigationContainer>
+    ),
   ],
 }
-
-const Stack = createStackNavigator()
-
-const NavigationContainerWithScreen = (props: { component: React.ComponentType }) => {
-  const { component: Component } = props
-
-  return (
-    <NavigationContainer>
-      <Container>
-        <Stack.Navigator
-          initialRouteName="Story"
-          screenOptions={{
-            headerShown: false,
-            cardStyle: { backgroundColor: theme.designSystem.color.background.default },
-          }}>
-          <Stack.Screen name="Story" component={Component} />
-        </Stack.Navigator>
-      </Container>
-    </NavigationContainer>
-  )
-}
-
-const Container = styled.View({ height: '100vh' })
 
 export default preview

--- a/src/features/auth/components/AuthenticationButton/AuthenticationButton.stories.tsx
+++ b/src/features/auth/components/AuthenticationButton/AuthenticationButton.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import { Meta, StoryObj } from '@storybook/react-vite'
 import React from 'react'
 
@@ -9,13 +8,6 @@ import { AuthenticationButton } from './AuthenticationButton'
 const meta: Meta<typeof AuthenticationButton> = {
   title: 'Features/auth/AuthenticationButton',
   component: AuthenticationButton,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/bookings/components/BookingListItem.stories.tsx
+++ b/src/features/bookings/components/BookingListItem.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -10,13 +9,6 @@ import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storyboo
 const meta: Meta<typeof BookingListItem> = {
   title: 'features/booking/BookingListItem',
   component: BookingListItem,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/headlineOffer/components/HeadlineOffer/HeadlineOffer.stories.tsx
+++ b/src/features/headlineOffer/components/HeadlineOffer/HeadlineOffer.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import React from 'react'
 
@@ -9,13 +8,6 @@ import { VariantsTemplate, type Variants } from 'ui/storybook/VariantsTemplate'
 const meta: Meta<typeof HeadlineOffer> = {
   title: 'ui/HeadlineOffer',
   component: HeadlineOffer,
-  decorators: [
-    (Story: React.ComponentType) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/home/components/Trend.stories.tsx
+++ b/src/features/home/components/Trend.stories.tsx
@@ -1,7 +1,6 @@
 // @ts-ignore import is unresolved
 // eslint-disable-next-line import/no-unresolved
 
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import React from 'react'
 
@@ -12,13 +11,6 @@ import { Trend } from './Trend'
 const meta: Meta<typeof Trend> = {
   title: 'features/home/Trend',
   component: Trend,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 
 export default meta

--- a/src/features/home/components/headers/HomeHeader.native.test.tsx
+++ b/src/features/home/components/headers/HomeHeader.native.test.tsx
@@ -20,6 +20,11 @@ jest.mock('features/auth/context/AuthContext')
 jest.mock('libs/firebase/analytics/analytics')
 jest.mock('shared/user/useAvailableCredit')
 
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useRoute: jest.fn(() => ({ params: { currency: 'EUR' } })),
+}))
+
 const mockUseAvailableCredit = useAvailableCredit as jest.MockedFunction<typeof useAvailableCredit>
 mockdate.set(new Date('2022-12-01T00:00:00Z'))
 

--- a/src/features/home/components/headers/HomeHeader.native.test.tsx
+++ b/src/features/home/components/headers/HomeHeader.native.test.tsx
@@ -14,19 +14,18 @@ import { render, screen, waitFor } from 'tests/utils'
 
 import { HomeHeader } from './HomeHeader'
 
-jest.unmock('@react-navigation/native')
 jest.mock('libs/jwt/jwt')
 jest.mock('features/auth/context/AuthContext')
 jest.mock('libs/firebase/analytics/analytics')
 jest.mock('shared/user/useAvailableCredit')
 
+const mockUseAvailableCredit = useAvailableCredit as jest.MockedFunction<typeof useAvailableCredit>
+mockdate.set(new Date('2022-12-01T00:00:00Z'))
+
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useRoute: jest.fn(() => ({ params: { currency: 'EUR' } })),
 }))
-
-const mockUseAvailableCredit = useAvailableCredit as jest.MockedFunction<typeof useAvailableCredit>
-mockdate.set(new Date('2022-12-01T00:00:00Z'))
 
 describe('HomeHeader', () => {
   beforeEach(() => {

--- a/src/features/home/components/headers/HomeHeader.native.test.tsx
+++ b/src/features/home/components/headers/HomeHeader.native.test.tsx
@@ -14,6 +14,7 @@ import { render, screen, waitFor } from 'tests/utils'
 
 import { HomeHeader } from './HomeHeader'
 
+jest.unmock('@react-navigation/native')
 jest.mock('libs/jwt/jwt')
 jest.mock('features/auth/context/AuthContext')
 jest.mock('libs/firebase/analytics/analytics')
@@ -21,11 +22,6 @@ jest.mock('shared/user/useAvailableCredit')
 
 const mockUseAvailableCredit = useAvailableCredit as jest.MockedFunction<typeof useAvailableCredit>
 mockdate.set(new Date('2022-12-01T00:00:00Z'))
-
-jest.mock('@react-navigation/native', () => ({
-  ...jest.requireActual('@react-navigation/native'),
-  useRoute: jest.fn(() => ({ params: { currency: 'EUR' } })),
-}))
 
 describe('HomeHeader', () => {
   beforeEach(() => {

--- a/src/features/home/components/modules/ThematicHighlightModule.stories.tsx
+++ b/src/features/home/components/modules/ThematicHighlightModule.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import mockDate from 'mockdate'
 import React from 'react'
@@ -13,13 +12,6 @@ mockDate.set(CURRENT_DATE)
 const meta: Meta<typeof ThematicHighlightModule> = {
   title: 'Features/home/ThematicHighlightModule',
   component: ThematicHighlightModule,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/home/components/modules/TrendsModule.stories.tsx
+++ b/src/features/home/components/modules/TrendsModule.stories.tsx
@@ -1,7 +1,6 @@
 // @ts-ignore import is unresolved
 // eslint-disable-next-line import/no-unresolved
 
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -14,13 +13,7 @@ import { TrendsModule } from './TrendsModule'
 const meta: Meta<typeof TrendsModule> = {
   title: 'features/home/TrendsModule',
   component: TrendsModule,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
+
   parameters: {
     useQuery: {
       featureFlags: { get: () => ({ minimalBuildNumber: 1000000 }) },

--- a/src/features/home/components/modules/categories/CategoryListModule.stories.tsx
+++ b/src/features/home/components/modules/categories/CategoryListModule.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -10,13 +9,6 @@ import { CategoryListModule } from './CategoryListModule'
 const meta: Meta<typeof CategoryListModule> = {
   title: 'features/home/CategoryListModule',
   component: CategoryListModule,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/home/components/modules/marketing/MarketingBlockExclusivity.stories.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockExclusivity.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -12,13 +11,7 @@ import { MarketingBlockExclusivity } from './MarketingBlockExclusivity'
 const meta: Meta<typeof MarketingBlockExclusivity> = {
   title: 'features/home/MarketingBlock/MarketingBlockExclusivity',
   component: MarketingBlockExclusivity,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
+
   parameters: {
     useQuery: {
       subcategories: PLACEHOLDER_DATA,

--- a/src/features/home/components/modules/marketing/MarketingBlockHighlight.stories.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockHighlight.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -10,13 +9,6 @@ import { MarketingBlockHighlight } from './MarketingBlockHighlight'
 const meta: Meta<typeof MarketingBlockHighlight> = {
   title: 'features/home/MarketingBlock/MarketingBlockHighlight',
   component: MarketingBlockHighlight,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/home/components/modules/venues/VenueTile.stories.tsx
+++ b/src/features/home/components/modules/venues/VenueTile.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -15,9 +14,7 @@ const meta: Meta<typeof VenueTile> = {
   decorators: [
     (Story) => (
       <ReactQueryClientProvider>
-        <NavigationContainer>
-          <Story />
-        </NavigationContainer>
+        <Story />
       </ReactQueryClientProvider>
     ),
   ],

--- a/src/features/home/components/modules/video/VideoModule.stories.old.tsx
+++ b/src/features/home/components/modules/video/VideoModule.stories.old.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react'
 import React from 'react'
 
@@ -13,9 +12,7 @@ const meta: Meta<typeof VideoModule> = {
   decorators: [
     (Story: React.ComponentType) => (
       <ReactQueryClientProvider>
-        <NavigationContainer>
-          <Story />
-        </NavigationContainer>
+        <Story />
       </ReactQueryClientProvider>
     ),
   ],

--- a/src/features/identityCheck/components/SecondButtonList.stories.old.tsx
+++ b/src/features/identityCheck/components/SecondButtonList.stories.old.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react'
 import React from 'react'
 
@@ -8,13 +7,6 @@ import { Smartphone } from 'ui/svg/icons/Smartphone'
 const meta: Meta<typeof SecondButtonList> = {
   title: 'ui/SecondButtonList',
   component: SecondButtonList,
-  decorators: [
-    (Story: React.ComponentType) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/location/components/LocationSearchWidget.stories.tsx
+++ b/src/features/location/components/LocationSearchWidget.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -10,11 +9,9 @@ const meta: Meta<typeof LocationSearchWidget> = {
   component: LocationSearchWidget,
   decorators: [
     (Story) => (
-      <NavigationContainer>
-        <SearchWrapper>
-          <Story />
-        </SearchWrapper>
-      </NavigationContainer>
+      <SearchWrapper>
+        <Story />
+      </SearchWrapper>
     ),
   ],
 }

--- a/src/features/location/components/LocationWidget.stories.tsx
+++ b/src/features/location/components/LocationWidget.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -9,13 +8,6 @@ import { LocationWidget } from './LocationWidget'
 const meta: Meta<typeof LocationWidget> = {
   title: 'Features/location/LocationWidget',
   component: LocationWidget,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/offer/components/OfferMessagingApps/OfferMessagingApps.stories.tsx
+++ b/src/features/offer/components/OfferMessagingApps/OfferMessagingApps.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -12,11 +11,9 @@ const meta: Meta<typeof OfferMessagingApps> = {
   component: OfferMessagingApps,
   decorators: [
     (Story) => (
-      <NavigationContainer>
-        <ReactQueryClientProvider>
-          <Story />
-        </ReactQueryClientProvider>
-      </NavigationContainer>
+      <ReactQueryClientProvider>
+        <Story />
+      </ReactQueryClientProvider>
     ),
   ],
 }

--- a/src/features/offer/components/OfferTile/OfferTile.stories.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -12,13 +11,6 @@ import { OfferTile } from './OfferTile'
 const meta: Meta<typeof OfferTile> = {
   title: 'ui/tiles/OfferTile',
   component: OfferTile,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/offer/components/OfferVenueButton/OfferVenueButton.stories.tsx
+++ b/src/features/offer/components/OfferVenueButton/OfferVenueButton.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -9,13 +8,6 @@ import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storyboo
 const meta: Meta<typeof OfferVenueButton> = {
   title: 'features/offer/OfferVenueButton',
   component: OfferVenueButton,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/onboarding/components/AgeButton.stories.tsx
+++ b/src/features/onboarding/components/AgeButton.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 import styled from 'styled-components/native'
@@ -43,13 +42,6 @@ const meta: Meta<typeof AgeButton> = {
       },
     },
   },
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/profile/components/Buttons/EditButton/EditButton.stories.tsx
+++ b/src/features/profile/components/Buttons/EditButton/EditButton.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -9,13 +8,6 @@ import { EditButton } from './EditButton'
 const meta: Meta<typeof EditButton> = {
   title: 'features/profile/buttons/EditButton',
   component: EditButton,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/profile/components/EditableFiled/EditableField.stories.tsx
+++ b/src/features/profile/components/EditableFiled/EditableField.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -9,13 +8,6 @@ import { EditableField } from './EditableField'
 const meta: Meta<typeof EditableField> = {
   title: 'Features/Profile/EditableField',
   component: EditableField,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/profile/components/Header/CreditHeader/CreditHeader.stories.tsx
+++ b/src/features/profile/components/Header/CreditHeader/CreditHeader.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -13,13 +12,6 @@ import { CreditHeader } from './CreditHeader'
 const meta: Meta<typeof CreditHeader> = {
   title: 'features/profile/CreditHeader',
   component: CreditHeader,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/profile/components/Header/HeaderWithGreyContainer/HeaderWithGreyContainer.stories.tsx
+++ b/src/features/profile/components/Header/HeaderWithGreyContainer/HeaderWithGreyContainer.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 import styled from 'styled-components/native'
@@ -12,13 +11,6 @@ import { HeaderWithGreyContainer } from './HeaderWithGreyContainer'
 const meta: Meta<typeof HeaderWithGreyContainer> = {
   title: 'features/Profile/HeaderWithGreyContainer',
   component: HeaderWithGreyContainer,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/profile/components/Header/LoggedOutHeader/LoggedOutHeader.stories.tsx
+++ b/src/features/profile/components/Header/LoggedOutHeader/LoggedOutHeader.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -9,13 +8,6 @@ import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storyboo
 const meta: Meta<typeof LoggedOutHeader> = {
   title: 'features/Profile/Headers/LoggedOutHeader',
   component: LoggedOutHeader,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/profile/components/SectionWithSwitch/SectionWithSwitch.stories.tsx
+++ b/src/features/profile/components/SectionWithSwitch/SectionWithSwitch.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import React from 'react'
 
@@ -12,13 +11,6 @@ const meta: Meta<typeof SectionWithSwitch> = {
   parameters: {
     chromatic: { viewports: [theme.breakpoints.sm, theme.breakpoints.md, theme.breakpoints.lg] },
   },
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/search/components/CategoriesListDumb/CategoriesListDumb.stories.tsx
+++ b/src/features/search/components/CategoriesListDumb/CategoriesListDumb.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import React from 'react'
 import { View } from 'react-native'
@@ -26,11 +25,9 @@ export const Default: Story = {
   name: 'CategoriesButtons',
   render: (props) => (
     <BodyWrapper>
-      <NavigationContainer>
-        <Container>
-          <CategoriesListDumb {...props} />
-        </Container>
-      </NavigationContainer>
+      <Container>
+        <CategoriesListDumb {...props} />
+      </Container>
     </BodyWrapper>
   ),
   args: {

--- a/src/features/search/components/FilterSwitchWithLabel/FilterSwitchWithLabel.stories.tsx
+++ b/src/features/search/components/FilterSwitchWithLabel/FilterSwitchWithLabel.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -8,13 +7,6 @@ import { Variants, VariantsStory, VariantsTemplate } from 'ui/storybook/Variants
 const meta: Meta<typeof FilterSwitchWithLabel> = {
   title: 'Features/search/FilterSwitchWithLabel',
   component: FilterSwitchWithLabel,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/search/components/SearchVenueItems/SearchVenueItem.stories.tsx
+++ b/src/features/search/components/SearchVenueItems/SearchVenueItem.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -12,13 +11,6 @@ import { SearchVenueItem } from './SearchVenueItem'
 const meta: Meta<typeof SearchVenueItem> = {
   title: 'features/search/SearchVenueItem',
   component: SearchVenueItem,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/search/pages/SearchFilter/SearchFilter.native.test.tsx
+++ b/src/features/search/pages/SearchFilter/SearchFilter.native.test.tsx
@@ -79,6 +79,7 @@ jest.useFakeTimers()
 
 describe('<SearchFilter/>', () => {
   beforeEach(() => {
+    useRoute.mockReturnValueOnce({ params: { currency: 'EUR' } })
     mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', subcategoriesDataTest)
     setFeatureFlags()
   })
@@ -134,6 +135,7 @@ describe('<SearchFilter/>', () => {
 
     useRoute.mockReturnValueOnce({
       params: {
+        currency: 'EUR',
         locationFilter: {
           locationType: LocationMode.AROUND_ME,
         },
@@ -160,11 +162,7 @@ describe('<SearchFilter/>', () => {
       selectedLocationMode: LocationMode.EVERYWHERE,
     })
     useRoute.mockReturnValueOnce({
-      params: {
-        locationFilter: {
-          locationType: LocationMode.AROUND_ME,
-        },
-      },
+      params: { locationFilter: { locationType: LocationMode.AROUND_ME } },
     })
 
     renderSearchFilter()

--- a/src/features/search/pages/SearchFilter/SearchFilter.native.test.tsx
+++ b/src/features/search/pages/SearchFilter/SearchFilter.native.test.tsx
@@ -79,7 +79,6 @@ jest.useFakeTimers()
 
 describe('<SearchFilter/>', () => {
   beforeEach(() => {
-    useRoute.mockReturnValueOnce({ params: { currency: 'EUR' } })
     mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', subcategoriesDataTest)
     setFeatureFlags()
   })
@@ -135,7 +134,6 @@ describe('<SearchFilter/>', () => {
 
     useRoute.mockReturnValueOnce({
       params: {
-        currency: 'EUR',
         locationFilter: {
           locationType: LocationMode.AROUND_ME,
         },
@@ -162,7 +160,11 @@ describe('<SearchFilter/>', () => {
       selectedLocationMode: LocationMode.EVERYWHERE,
     })
     useRoute.mockReturnValueOnce({
-      params: { locationFilter: { locationType: LocationMode.AROUND_ME } },
+      params: {
+        locationFilter: {
+          locationType: LocationMode.AROUND_ME,
+        },
+      },
     })
 
     renderSearchFilter()

--- a/src/features/subscription/components/SubscriptionThematicIllustration.stories.tsx
+++ b/src/features/subscription/components/SubscriptionThematicIllustration.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import React from 'react'
 import styled from 'styled-components/native'
@@ -11,13 +10,6 @@ import { SubscriptionThematicIllustration } from './SubscriptionThematicIllustra
 const meta: Meta<typeof SubscriptionThematicIllustration> = {
   title: 'Features/subscription/SubscriptionThematicIllustration',
   component: SubscriptionThematicIllustration,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/subscription/components/ThematicSubscriptionBlock.stories.tsx
+++ b/src/features/subscription/components/ThematicSubscriptionBlock.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -10,13 +9,6 @@ import { ThematicSubscriptionBlock } from './ThematicSubscriptionBlock'
 const meta: Meta<typeof ThematicSubscriptionBlock> = {
   title: 'Features/subscription/ThematicSubscriptionBlock',
   component: ThematicSubscriptionBlock,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.stories.tsx
+++ b/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -9,13 +8,6 @@ import { VenueMapPreview } from './VenueMapPreview'
 const meta: Meta<typeof VenueMapPreview> = {
   title: 'features/venueMap/VenueMapPreview',
   component: VenueMapPreview,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/shared/currency/useCurrencyParam.ts
+++ b/src/shared/currency/useCurrencyParam.ts
@@ -1,0 +1,14 @@
+import { Platform } from 'react-native'
+
+import { CurrencyEnum } from 'api/gen'
+
+const isWeb = Platform.OS === 'web'
+
+export function getCurrencyFromParam(): CurrencyEnum {
+  if (isWeb) {
+    const searchParams = new URLSearchParams(window.location.search)
+    const currency = searchParams.get('currency')
+    if (currency === CurrencyEnum.XPF) return CurrencyEnum.XPF
+  }
+  return CurrencyEnum.EUR
+}

--- a/src/shared/currency/useCurrencyParam.ts
+++ b/src/shared/currency/useCurrencyParam.ts
@@ -4,11 +4,11 @@ import { CurrencyEnum } from 'api/gen'
 
 const isWeb = Platform.OS === 'web'
 
-export function getCurrencyFromParam(): CurrencyEnum {
+export function getCurrencyFromParam(): CurrencyEnum | undefined {
   if (isWeb) {
     const searchParams = new URLSearchParams(window.location.search)
     const currency = searchParams.get('currency')
     if (currency === CurrencyEnum.XPF) return CurrencyEnum.XPF
   }
-  return CurrencyEnum.EUR
+  return undefined
 }

--- a/src/shared/currency/useGetCurrencyToDisplay.native.test.ts
+++ b/src/shared/currency/useGetCurrencyToDisplay.native.test.ts
@@ -16,9 +16,6 @@ const mockUseGeolocation = jest.mocked(useLocation)
 const NOUMEA_DEFAULT_POSITION = { longitude: 166.445742, latitude: -22.26308 }
 const PARIS_DEFAULT_POSITION = { latitude: 48.859, longitude: 2.347 }
 
-jest.mock('features/auth/context/AuthContext')
-const mockUseAuthContext = jest.mocked(useAuthContext)
-
 jest.mock('@react-navigation/native')
 const mockUseRoute = jest.mocked(useRoute)
 const createRoute = (params): RouteProp<ParamListBase> => ({
@@ -26,6 +23,9 @@ const createRoute = (params): RouteProp<ParamListBase> => ({
   name: 'TestScreen',
   params,
 })
+
+jest.mock('features/auth/context/AuthContext')
+const mockUseAuthContext = jest.mocked(useAuthContext)
 
 describe('useGetCurrencyToDisplay', () => {
   beforeEach(() => {

--- a/src/shared/currency/useGetCurrencyToDisplay.native.test.ts
+++ b/src/shared/currency/useGetCurrencyToDisplay.native.test.ts
@@ -1,3 +1,5 @@
+import { ParamListBase, RouteProp, useRoute } from '@react-navigation/native'
+
 import { CurrencyEnum } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { beneficiaryUser } from 'fixtures/user'
@@ -17,6 +19,14 @@ const PARIS_DEFAULT_POSITION = { latitude: 48.859, longitude: 2.347 }
 jest.mock('features/auth/context/AuthContext')
 const mockUseAuthContext = jest.mocked(useAuthContext)
 
+jest.mock('@react-navigation/native')
+const mockUseRoute = jest.mocked(useRoute)
+const createRoute = (params): RouteProp<ParamListBase> => ({
+  key: 'test-key',
+  name: 'TestScreen',
+  params,
+})
+
 describe('useGetCurrencyToDisplay', () => {
   beforeEach(() => {
     setFeatureFlags()
@@ -34,6 +44,40 @@ describe('useGetCurrencyToDisplay', () => {
     const { result } = renderHook(() => useGetCurrencyToDisplay())
 
     expect(result.current).toBe('€')
+  })
+
+  describe('when currency params is provided', () => {
+    it('should return Euro if currency param is EUR', () => {
+      mockUseRoute.mockReturnValueOnce(createRoute({ currency: CurrencyEnum.EUR }))
+
+      const { result } = renderHook(() => useGetCurrencyToDisplay('short'))
+
+      expect(result.current).toBe('€')
+    })
+
+    it('should return Pacific Franc short if currency param is XPF', () => {
+      mockUseRoute.mockReturnValueOnce(createRoute({ currency: CurrencyEnum.XPF }))
+
+      const { result } = renderHook(() => useGetCurrencyToDisplay('short'))
+
+      expect(result.current).toBe('F')
+    })
+
+    it('should return Euro if currency param is missing', () => {
+      mockUseRoute.mockReturnValueOnce(createRoute({}))
+
+      const { result } = renderHook(() => useGetCurrencyToDisplay('short'))
+
+      expect(result.current).toBe('€')
+    })
+
+    it('should return Euro if params is undefined', () => {
+      mockUseRoute.mockReturnValueOnce(createRoute(undefined))
+
+      const { result } = renderHook(() => useGetCurrencyToDisplay('short'))
+
+      expect(result.current).toBe('€')
+    })
   })
 
   describe('when location mode is EVERYWHERE', () => {

--- a/src/shared/currency/useGetCurrencyToDisplay.native.test.ts
+++ b/src/shared/currency/useGetCurrencyToDisplay.native.test.ts
@@ -1,5 +1,3 @@
-import { ParamListBase, RouteProp, useRoute } from '@react-navigation/native'
-
 import { CurrencyEnum } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { beneficiaryUser } from 'fixtures/user'
@@ -15,14 +13,6 @@ jest.mock('libs/location/location')
 const mockUseGeolocation = jest.mocked(useLocation)
 const NOUMEA_DEFAULT_POSITION = { longitude: 166.445742, latitude: -22.26308 }
 const PARIS_DEFAULT_POSITION = { latitude: 48.859, longitude: 2.347 }
-
-jest.mock('@react-navigation/native')
-const mockUseRoute = jest.mocked(useRoute)
-const createRoute = (params): RouteProp<ParamListBase> => ({
-  key: 'test-key',
-  name: 'TestScreen',
-  params,
-})
 
 jest.mock('features/auth/context/AuthContext')
 const mockUseAuthContext = jest.mocked(useAuthContext)
@@ -44,40 +34,6 @@ describe('useGetCurrencyToDisplay', () => {
     const { result } = renderHook(() => useGetCurrencyToDisplay())
 
     expect(result.current).toBe('€')
-  })
-
-  describe('when currency params is provided', () => {
-    it('should return Euro if currency param is EUR', () => {
-      mockUseRoute.mockReturnValueOnce(createRoute({ currency: CurrencyEnum.EUR }))
-
-      const { result } = renderHook(() => useGetCurrencyToDisplay('short'))
-
-      expect(result.current).toBe('€')
-    })
-
-    it('should return Pacific Franc short if currency param is XPF', () => {
-      mockUseRoute.mockReturnValueOnce(createRoute({ currency: CurrencyEnum.XPF }))
-
-      const { result } = renderHook(() => useGetCurrencyToDisplay('short'))
-
-      expect(result.current).toBe('F')
-    })
-
-    it('should return Euro if currency param is missing', () => {
-      mockUseRoute.mockReturnValueOnce(createRoute({}))
-
-      const { result } = renderHook(() => useGetCurrencyToDisplay('short'))
-
-      expect(result.current).toBe('€')
-    })
-
-    it('should return Euro if params is undefined', () => {
-      mockUseRoute.mockReturnValueOnce(createRoute(undefined))
-
-      const { result } = renderHook(() => useGetCurrencyToDisplay('short'))
-
-      expect(result.current).toBe('€')
-    })
   })
 
   describe('when location mode is EVERYWHERE', () => {

--- a/src/shared/currency/useGetCurrencyToDisplay.ts
+++ b/src/shared/currency/useGetCurrencyToDisplay.ts
@@ -14,16 +14,17 @@ export enum Currency {
   PACIFIC_FRANC_FULL = 'francs\u00a0Pacifique',
 }
 
+type CurrencyRouteParams = {
+  currency?: CurrencyEnum.EUR | CurrencyEnum.XPF
+}
+
 type CurrencyDisplayFormat = 'short' | 'full'
 
 export const useGetCurrencyToDisplay = (
   displayFormat: CurrencyDisplayFormat = 'short'
 ): Currency => {
-  const route =
-    useRoute<
-      RouteProp<Record<string, { currency?: CurrencyEnum.EUR | CurrencyEnum.XPF }>, string>
-    >()
-  const currencyParam = route.params?.currency
+  const { params } = useRoute<RouteProp<Record<string, Partial<CurrencyRouteParams>>, string>>()
+  const currencyParam = params?.currency
 
   const enablePacificFrancCurrency = useFeatureFlag(featureFlags.ENABLE_PACIFIC_FRANC_CURRENCY)
   const disablePacificFrancCurrency = !enablePacificFrancCurrency

--- a/src/shared/currency/useGetCurrencyToDisplay.ts
+++ b/src/shared/currency/useGetCurrencyToDisplay.ts
@@ -1,12 +1,11 @@
 /* eslint-disable local-rules/no-currency-symbols */
-import { RouteProp, useRoute } from '@react-navigation/native'
-
 import { CurrencyEnum } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags as featureFlags } from 'libs/firebase/firestore/types'
 import { useLocation } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
+import { getCurrencyFromParam } from 'shared/currency/useCurrencyParam'
 
 export enum Currency {
   EURO = '€',
@@ -14,18 +13,11 @@ export enum Currency {
   PACIFIC_FRANC_FULL = 'francs\u00a0Pacifique',
 }
 
-type CurrencyRouteParams = {
-  currency?: CurrencyEnum.EUR | CurrencyEnum.XPF
-}
-
 type CurrencyDisplayFormat = 'short' | 'full'
 
 export const useGetCurrencyToDisplay = (
   displayFormat: CurrencyDisplayFormat = 'short'
 ): Currency => {
-  const { params } = useRoute<RouteProp<Record<string, Partial<CurrencyRouteParams>>, string>>()
-  const currencyParam = params?.currency
-
   const enablePacificFrancCurrency = useFeatureFlag(featureFlags.ENABLE_PACIFIC_FRANC_CURRENCY)
   const disablePacificFrancCurrency = !enablePacificFrancCurrency
 
@@ -35,6 +27,7 @@ export const useGetCurrencyToDisplay = (
   const pacificFrancCurrency =
     displayFormat === 'full' ? Currency.PACIFIC_FRANC_FULL : Currency.PACIFIC_FRANC_SHORT
 
+  const currencyParam = getCurrencyFromParam()
   if (currencyParam === CurrencyEnum.EUR) return Currency.EURO
   if (currencyParam === CurrencyEnum.XPF) return pacificFrancCurrency
 

--- a/src/shared/currency/useGetCurrencyToDisplay.ts
+++ b/src/shared/currency/useGetCurrencyToDisplay.ts
@@ -1,4 +1,6 @@
 /* eslint-disable local-rules/no-currency-symbols */
+import { RouteProp, useRoute } from '@react-navigation/native'
+
 import { CurrencyEnum } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
@@ -17,28 +19,38 @@ type CurrencyDisplayFormat = 'short' | 'full'
 export const useGetCurrencyToDisplay = (
   displayFormat: CurrencyDisplayFormat = 'short'
 ): Currency => {
+  const route =
+    useRoute<
+      RouteProp<Record<string, { currency?: CurrencyEnum.EUR | CurrencyEnum.XPF }>, string>
+    >()
+  const currencyParam = route.params?.currency
+
   const enablePacificFrancCurrency = useFeatureFlag(featureFlags.ENABLE_PACIFIC_FRANC_CURRENCY)
   const disablePacificFrancCurrency = !enablePacificFrancCurrency
 
   const { user } = useAuthContext()
-  const isUserRegisteredInEuroRegion = user?.currency === CurrencyEnum.EUR
-  const isUserRegisteredInPacificFrancRegion = user?.currency === CurrencyEnum.XPF
-
   const { selectedPlace, selectedLocationMode } = useLocation()
-  const isNewCaledonianLocationSelected = selectedPlace?.info === 'Nouvelle-Calédonie'
-  const isNotNewCaledonianLocationSelected = selectedPlace?.info !== 'Nouvelle-Calédonie'
-  const isEverywhereLocationMode = selectedLocationMode === LocationMode.EVERYWHERE
 
   const pacificFrancCurrency =
     displayFormat === 'full' ? Currency.PACIFIC_FRANC_FULL : Currency.PACIFIC_FRANC_SHORT
 
+  if (currencyParam === CurrencyEnum.EUR) return Currency.EURO
+  if (currencyParam === CurrencyEnum.XPF) return pacificFrancCurrency
+
   if (disablePacificFrancCurrency) return Currency.EURO
+
+  const isEverywhereLocationMode = selectedLocationMode === LocationMode.EVERYWHERE
+  const isNotNewCaledonianLocationSelected = selectedPlace?.info !== 'Nouvelle-Calédonie'
+  const isNewCaledonianLocationSelected = selectedPlace?.info === 'Nouvelle-Calédonie'
 
   if (selectedPlace) {
     if (isEverywhereLocationMode) return Currency.EURO
     if (isNotNewCaledonianLocationSelected) return Currency.EURO
     if (isNewCaledonianLocationSelected) return pacificFrancCurrency
   }
+
+  const isUserRegisteredInEuroRegion = user?.currency === CurrencyEnum.EUR
+  const isUserRegisteredInPacificFrancRegion = user?.currency === CurrencyEnum.XPF
 
   if (user) {
     if (isUserRegisteredInEuroRegion) return Currency.EURO

--- a/src/shared/currency/useGetCurrencyToDisplay.web.test.ts
+++ b/src/shared/currency/useGetCurrencyToDisplay.web.test.ts
@@ -1,0 +1,41 @@
+import { CurrencyEnum } from 'api/gen'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { useLocation } from 'libs/location/location'
+import { ILocationContext } from 'libs/location/types'
+import { getCurrencyFromParam } from 'shared/currency/useCurrencyParam'
+import { renderHook } from 'tests/utils/web'
+
+import { useGetCurrencyToDisplay } from './useGetCurrencyToDisplay'
+
+jest.mock('shared/currency/useCurrencyParam')
+const mockGetCurrencyFromParam = jest.mocked(getCurrencyFromParam)
+
+jest.mock('libs/location/location')
+const mockUseGeolocation = jest.mocked(useLocation)
+
+jest.mock('features/auth/context/AuthContext')
+
+describe('useGetCurrencyToDisplay', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+    mockUseGeolocation.mockReturnValue({ userLocation: null } as ILocationContext)
+  })
+
+  describe('when currency params is provided', () => {
+    it('should return Euro if currency param is EUR', () => {
+      mockGetCurrencyFromParam.mockReturnValueOnce(CurrencyEnum.EUR)
+
+      const { result } = renderHook(() => useGetCurrencyToDisplay('short'))
+
+      expect(result.current).toBe('€')
+    })
+
+    it('should return Pacific Franc short if currency param is XPF', () => {
+      mockGetCurrencyFromParam.mockReturnValueOnce(CurrencyEnum.XPF)
+
+      const { result } = renderHook(() => useGetCurrencyToDisplay('short'))
+
+      expect(result.current).toBe('F')
+    })
+  })
+})

--- a/src/ui/components/Accordion.stories.tsx
+++ b/src/ui/components/Accordion.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -11,13 +10,6 @@ import { Accordion } from './Accordion'
 const meta: Meta<typeof Accordion> = {
   title: 'ui/Accordion',
   component: Accordion,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/ui/components/FilterSwitch.stories.tsx
+++ b/src/ui/components/FilterSwitch.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -9,13 +8,6 @@ import FilterSwitch from './FilterSwitch'
 const meta: Meta<typeof FilterSwitch> = {
   title: 'ui/FilterSwitch',
   component: FilterSwitch,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/ui/components/SectionRow.stories.tsx
+++ b/src/ui/components/SectionRow.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -22,13 +21,6 @@ const meta: Meta<typeof SectionRow> = {
       },
     },
   },
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/ui/components/StepButton/StepButton.stories.tsx
+++ b/src/ui/components/StepButton/StepButton.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -19,13 +18,6 @@ const DisabledIdCardIcon: React.FC<AccessibleIcon> = () => (
 const meta: Meta<typeof StepButton> = {
   title: 'ui/StepButton',
   component: StepButton,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/ui/components/Tooltip.stories.tsx
+++ b/src/ui/components/Tooltip.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import React from 'react'
 
@@ -11,13 +10,6 @@ const TOOLTIP_WIDTH = getSpacing(58)
 const meta: Meta<typeof Tooltip> = {
   title: 'ui/Tooltip',
   component: Tooltip,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/ui/components/buttons/HeroButtonList.stories.tsx
+++ b/src/ui/components/buttons/HeroButtonList.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -14,13 +13,6 @@ import { iconSizes } from 'ui/theme/iconSizes'
 const meta: Meta<typeof HeroButtonList> = {
   title: 'ui/buttons/HeroButtonList',
   component: HeroButtonList,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonList.stories.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonList.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import React from 'react'
 
@@ -19,13 +18,6 @@ const createSubcategoryButtonItem = (label: string, nativeCategory: NativeCatego
 const meta: Meta<typeof SubcategoryButtonList> = {
   title: 'ui/buttons/SubcategoryButtonList',
   component: SubcategoryButtonList,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/ui/components/inputs/Checkbox/Checkbox.stories.tsx
+++ b/src/ui/components/inputs/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -12,13 +11,6 @@ import { Checkbox } from './Checkbox'
 const meta: Meta<typeof Checkbox> = {
   title: 'design system/inputs/Checkbox',
   component: Checkbox,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 

--- a/src/ui/components/radioButtons/RadioButton.stories.tsx
+++ b/src/ui/components/radioButtons/RadioButton.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -12,13 +11,7 @@ import { RadioButton } from './RadioButton'
 const meta: Meta<typeof RadioButton> = {
   title: 'ui/inputs/RadioButton',
   component: RadioButton,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
+
   argTypes: {
     icon: {
       options: ['Email', 'EditPen', 'VideoGame'],

--- a/src/ui/components/radioSelector/RadioSelector.stories.tsx
+++ b/src/ui/components/radioSelector/RadioSelector.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import type { Meta } from '@storybook/react-vite'
 import React from 'react'
 
@@ -22,13 +21,6 @@ const meta: Meta<typeof RadioSelector> = {
   argTypes: {
     onPress: { control: { disable: true } },
   },
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
 }
 export default meta
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
