### PR TITLE
(PC-37462) feat(a11y): make the QR code, illustration and svg available to the screen reader

### DIFF
--- a/.maestro/tests/subFolder/venue/AccessPreviewModule.yml
+++ b/.maestro/tests/subFolder/venue/AccessPreviewModule.yml
@@ -1,31 +1,31 @@
 appId: ${MAESTRO_APP_ID}
 ---
-- tapOn: "Livre"
+- tapOn: 'Livre'
 
 - tapOn:
     id: offerBodyImage
 
 - runFlow:
     when:
-        visible: "1/2"
+      visible: 'Illustration 1 sur 2'
     commands:
-    - assertVisible:
-        text: 1/2
-        index: 1
-    - swipe:
-        direction: LEFT
-    - assertVisible:
-        text: 2/2
-        index: 1
-    - swipe:
-        direction: RIGHT
+      - assertVisible:
+          text: Illustration 1 sur 2
+          index: 1
+      - swipe:
+          direction: LEFT
+      - assertVisible:
+          text: Illustration 2 sur 2
+          index: 1
+      - swipe:
+          direction: RIGHT
 
 - runFlow:
     when:
-        notVisible: "1/2"
+      notVisible: 'Illustration 1 sur 2'
     commands:
-    - assertVisible:
-        text: 1/1
+      - assertVisible:
+          text: Illustration 1 sur 1
 
 - tapOn: Revenir en arrière
 - tapOn: Revenir en arrière

--- a/src/features/bookings/components/Ticket/TicketBottomPart/QrCode.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/QrCode.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react'
 import QRCode from 'react-native-qrcode-svg'
 import styled from 'styled-components/native'
 
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { getSpacing } from 'ui/theme'
 
 const QR_CODE_SIZE = getSpacing(50)
@@ -12,7 +13,11 @@ type Props = {
 }
 
 export const QrCode: FunctionComponent<Props> = ({ qrCode }) => (
-  <QrCodeContainer testID="qr-code">
+  <QrCodeContainer
+    testID="qr-code"
+    accessible
+    accessibilityLabel="Code QR"
+    accessibilityRole={AccessibilityRole.IMAGE}>
     <StyledQRCode value={qrCode} />
   </QrCodeContainer>
 )

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -255,7 +255,7 @@ describe('<OfferContent />', () => {
   it('should navigate to offer preview screen when clicking on image offer', async () => {
     renderOfferContent({})
 
-    await user.press(await screen.findByLabelText('Carousel image 1'))
+    await user.press(await screen.findByLabelText('Voir l’illustration en plein écran'))
 
     expect(mockNavigate).toHaveBeenCalledWith('OfferPreview', { id: 116656, defaultIndex: 0 })
   })
@@ -267,7 +267,7 @@ describe('<OfferContent />', () => {
     }
     renderOfferContent({ offer })
 
-    await user.press(await screen.findByLabelText('Carousel image 1'))
+    await user.press(await screen.findByLabelText('Voir l’illustration en plein écran'))
 
     await waitFor(() => expect(mockNavigate).not.toHaveBeenCalled())
   })

--- a/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
@@ -150,7 +150,7 @@ describe('<OfferContent />', () => {
     }
     const { unmount } = renderOfferContent({ offer })
 
-    user.click(await screen.findByLabelText('Carousel image 1'))
+    user.click(await screen.findByLabelText('Voir l’illustration en plein écran'))
 
     expect(mockShowModal).not.toHaveBeenCalled()
 

--- a/src/features/offer/components/OfferImageCarousel/OfferImageCarousel.native.test.tsx
+++ b/src/features/offer/components/OfferImageCarousel/OfferImageCarousel.native.test.tsx
@@ -20,7 +20,7 @@ describe('OfferImageCarousel', () => {
       />
     )
 
-    await screen.findByLabelText('Carousel image 1')
+    await screen.findByLabelText('Voir l’illustration en plein écran')
 
     expect(screen.queryByTestId('carousel-dot')).not.toBeOnTheScreen()
   })
@@ -40,9 +40,8 @@ describe('OfferImageCarousel', () => {
       />
     )
 
-    await screen.findByLabelText('Carousel image 1')
+    await screen.findByLabelText('Voir le carousel de 3 illustrations en plein écran')
 
-    expect(screen.getAllByLabelText(/Carousel image/)).toHaveLength(3)
     expect(screen.getAllByTestId('carousel-dot')).toHaveLength(3)
   })
 
@@ -63,7 +62,7 @@ describe('OfferImageCarousel', () => {
       />
     )
 
-    await user.press(screen.getByLabelText('Carousel image 3'))
+    await user.press(screen.getByLabelText('Voir le carousel de 3 illustrations en plein écran'))
 
     expect(mockOnItemPress).toHaveBeenCalledWith(2)
 

--- a/src/features/offer/components/OfferImageCarousel/OfferImageCarouselItem.tsx
+++ b/src/features/offer/components/OfferImageCarousel/OfferImageCarouselItem.tsx
@@ -23,27 +23,34 @@ export const OfferImageCarouselItem = ({
   onLoad,
   isInCarousel = false,
   children,
-}: PropsWithChildren<OfferImageCarouselItemProps>) => (
-  <TouchableOpacity
-    disabled={!onPress}
-    onPress={() => onPress?.(index)}
-    accessibilityLabel={`Carousel image ${index + 1}`}
-    accessibilityRole={AccessibilityRole.BUTTON}
-    delayPressIn={70}>
-    <OfferImageWrapper
-      imageUrl={imageURL}
-      isInCarousel={isInCarousel}
-      imageDimensions={imageDimensions}
-      shouldDisplayOfferPreview>
-      {imageURL ? (
-        <OfferBodyImage
-          imageUrl={imageURL}
-          isInCarousel={isInCarousel}
-          onLoad={onLoad}
-          imageDimensions={imageDimensions}
-        />
-      ) : null}
-      {children}
-    </OfferImageWrapper>
-  </TouchableOpacity>
-)
+}: PropsWithChildren<OfferImageCarouselItemProps>) => {
+  const numberOfIllustration = index + 1
+  const accessibilityLabel =
+    numberOfIllustration > 1
+      ? `Voir le carousel de ${numberOfIllustration} illustrations en plein écran`
+      : 'Voir l’illustration en plein écran'
+  return (
+    <TouchableOpacity
+      disabled={!onPress}
+      onPress={() => onPress?.(index)}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole={AccessibilityRole.BUTTON}
+      delayPressIn={70}>
+      <OfferImageWrapper
+        imageUrl={imageURL}
+        isInCarousel={isInCarousel}
+        imageDimensions={imageDimensions}
+        shouldDisplayOfferPreview>
+        {imageURL ? (
+          <OfferBodyImage
+            imageUrl={imageURL}
+            isInCarousel={isInCarousel}
+            onLoad={onLoad}
+            imageDimensions={imageDimensions}
+          />
+        ) : null}
+        {children}
+      </OfferImageWrapper>
+    </TouchableOpacity>
+  )
+}

--- a/src/features/offer/pages/OfferPreview/OfferPreview.native.test.tsx
+++ b/src/features/offer/pages/OfferPreview/OfferPreview.native.test.tsx
@@ -29,13 +29,13 @@ describe('<OfferPreview />', () => {
   it('should display offer preview page', () => {
     render(<OfferPreview />)
 
-    expect(screen.getByText('1/2')).toBeOnTheScreen()
+    expect(screen.getByText('Illustration 1 sur 2')).toBeOnTheScreen()
   })
 
   it('should display the right image in carousel when a default index is provided', () => {
     useRoute.mockReturnValueOnce({ params: { id: '1', defaultIndex: 1 } })
     render(<OfferPreview />)
 
-    expect(screen.getByText('2/2')).toBeOnTheScreen()
+    expect(screen.getByText('Illustration 2 sur 2')).toBeOnTheScreen()
   })
 })

--- a/src/features/venue/pages/VenuePreviewCarousel/VenuePreviewCarousel.native.test.tsx
+++ b/src/features/venue/pages/VenuePreviewCarousel/VenuePreviewCarousel.native.test.tsx
@@ -22,7 +22,7 @@ describe('VenuePreviewCarousel', () => {
 
     render(<VenuePreviewCarousel />)
 
-    expect(screen.getByText('1/1')).toBeOnTheScreen()
+    expect(screen.getByText('Illustration 1 sur 1')).toBeOnTheScreen()
   })
 
   it('should render null when bannerUrl not defined', () => {
@@ -33,6 +33,6 @@ describe('VenuePreviewCarousel', () => {
 
     render(<VenuePreviewCarousel />)
 
-    expect(screen.queryByText('1/1')).toBeNull()
+    expect(screen.queryByText('Illustration 1 sur 1')).toBeNull()
   })
 })

--- a/src/ui/components/ImagesCarousel/ImagesCarousel.native.test.tsx
+++ b/src/ui/components/ImagesCarousel/ImagesCarousel.native.test.tsx
@@ -27,7 +27,7 @@ describe('<ImagesCarousel />', () => {
   it('should display the correct index in the header', () => {
     render(<ImagesCarousel images={images} goBack={jest.fn()} defaultIndex={1} />)
 
-    expect(screen.getByText('2/2')).toBeOnTheScreen()
+    expect(screen.getByText('Illustration 2 sur 2')).toBeOnTheScreen()
   })
 
   it('should not render dots when there is only one image', () => {

--- a/src/ui/components/ImagesCarousel/ImagesCarousel.tsx
+++ b/src/ui/components/ImagesCarousel/ImagesCarousel.tsx
@@ -38,10 +38,12 @@ export const ImagesCarousel: FunctionComponent<Props> = ({
 
   const carouselDotId = uuidv4()
 
+  const numberOfIllustration = index + 1
+  const title = `Illustration ${numberOfIllustration} sur ${images.length}`
+
   return (
     <Container>
-      <StyledHeader title={`${index + 1}/${images.length}`} onGoBack={goBack} />
-
+      <StyledHeader title={title} onGoBack={goBack} />
       <Carousel
         vertical={false}
         height={screenHeight}

--- a/src/ui/svg/AccessibleSvg.tsx
+++ b/src/ui/svg/AccessibleSvg.tsx
@@ -11,9 +11,9 @@ export const AccessibleSvg: React.FunctionComponent<SvgProps> = ({
 }) => {
   return (
     <Svg
+      accessible={!!accessibilityLabel}
       accessibilityLabel={accessibilityLabel}
       accessibilityRole={accessibilityLabel ? AccessibilityRole.IMAGE : undefined}
-      accessibilityHidden={!accessibilityLabel}
       {...props}>
       {children}
     </Svg>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |   <img width="1020" height="786" alt="Capture d’écran 2025-09-10 à 17 29 19" src="https://github.com/user-attachments/assets/fd4e3638-17fb-4ee4-ad36-3edc76a1031b" /> <img width="1020" height="787" alt="Capture d’écran 2025-09-10 à 17 28 59" src="https://github.com/user-attachments/assets/1965c857-10ae-4ab3-b7b9-2d5cf6278a11" /> <img width="1019" height="788" alt="Capture d’écran 2025-09-10 à 17 28 33" src="https://github.com/user-attachments/assets/bbd21a9a-a6ad-4bf4-a059-5c64f8055e93" /> <img width="1019" height="784" alt="Capture d’écran 2025-09-10 à 17 28 20" src="https://github.com/user-attachments/assets/227bbd8d-27ad-4fc7-8e20-8d2d94f70c5b" />    |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
