### PR TITLE
(PC-37864) feat(profile): use reset instead navigate in UpdatePersona…

### DIFF
--- a/src/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx
+++ b/src/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useRoute } from '__mocks__/@react-navigation/native'
+import { useRoute, reset, navigate } from '__mocks__/@react-navigation/native'
 import { ActivityIdEnum } from 'api/gen'
 import { initialSubscriptionState as mockState } from 'features/identityCheck/context/reducer'
 import { ActivityTypesSnap } from 'features/identityCheck/pages/profile/fixtures/mockedActivityTypes'
@@ -135,7 +135,20 @@ describe('<ChangeStatus/>', () => {
       })
     })
 
-    it('should show snackbar on success when clicking on "Valider mon adresse"', async () => {
+    it('should navigate to PersonalData when press "Continuer"', async () => {
+      renderChangedStatus()
+      mockServer.patchApi<UserProfileResponseWithoutSurvey>('/v1/profile', beneficiaryUser)
+
+      await user.press(screen.getByText('Employé'))
+      await user.press(screen.getByText('Continuer'))
+
+      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+        screen: 'PersonalData',
+        params: undefined,
+      })
+    })
+
+    it('should show snackbar on success when clicking on "Continuer"', async () => {
       renderChangedStatus()
       mockServer.patchApi<UserProfileResponseWithoutSurvey>('/v1/profile', beneficiaryUser)
 
@@ -166,7 +179,29 @@ describe('<ChangeStatus/>', () => {
       expect(screen).toMatchSnapshot()
     })
 
-    it('should not show snackbar on success when clicking on "Valider mon adresse"', async () => {
+    it('should navigate and reset to UpdatePersonalDataConfirmation when press "Continuer"', async () => {
+      renderChangedStatus()
+      mockServer.patchApi<UserProfileResponseWithoutSurvey>('/v1/profile', beneficiaryUser)
+
+      await user.press(screen.getByText('Employé'))
+      await user.press(screen.getByText('Continuer'))
+
+      expect(reset).toHaveBeenCalledWith({
+        index: 1,
+        routes: [
+          {
+            name: 'TabNavigator',
+            params: { screen: 'Home', params: undefined },
+          },
+          {
+            name: 'ProfileStackNavigator',
+            params: { screen: 'UpdatePersonalDataConfirmation', params: undefined },
+          },
+        ],
+      })
+    })
+
+    it('should not show snackbar on success when clicking on "Continuer"', async () => {
       renderChangedStatus()
       mockServer.patchApi<UserProfileResponseWithoutSurvey>('/v1/profile', beneficiaryUser)
 

--- a/src/features/profile/pages/ChangeStatus/useSubmitChangeStatus.tsx
+++ b/src/features/profile/pages/ChangeStatus/useSubmitChangeStatus.tsx
@@ -10,6 +10,7 @@ import { useStatus } from 'features/identityCheck/pages/profile/store/statusStor
 import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
 import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { analytics } from 'libs/analytics/provider'
 import { usePatchProfileMutation } from 'queries/profile/usePatchProfileMutation'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
@@ -27,14 +28,21 @@ export const useSubmitChangeStatus = () => {
     : 'Ton statut a bien été modifié\u00a0!'
 
   const { user } = useAuthContext()
-  const { navigate } = useNavigation<UseNavigationType>()
+  const { navigate, reset } = useNavigation<UseNavigationType>()
   const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()
   const storedStatus = useStatus()
+  const [navigatorName, screenConfig] = getProfileHookConfig('UpdatePersonalDataConfirmation')
 
   const { mutate: patchProfile, isLoading } = usePatchProfileMutation({
     onSuccess: (_, variables) => {
       if (isMandatoryUpdatePersonalData) {
-        navigate(...getProfileHookConfig('UpdatePersonalDataConfirmation'))
+        reset({
+          index: 1,
+          routes: [
+            { name: homeNavigationConfig[0], params: homeNavigationConfig[1] },
+            { name: navigatorName, params: screenConfig },
+          ],
+        })
       } else {
         navigate(...getProfileHookConfig('PersonalData'))
         showSuccessSnackBar({

--- a/src/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx
+++ b/src/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
-import { navigateFromRef } from 'features/navigation/navigationRef'
+import { reset } from '__mocks__/@react-navigation/native'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { UpdatePersonalDataConfirmation } from './UpdatePersonalDataConfirmation'
@@ -29,14 +29,14 @@ describe('<UpdatePersonalDataConfirmation />', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should redirect to ProfileInformationValidationUpdate screen when "Commencer" button is clicked', async () => {
+  it('should naviate and reset to home screen when clicking on "Terminer" button', async () => {
     render(<UpdatePersonalDataConfirmation />)
 
     await user.press(await screen.findByText('Terminer'))
 
-    expect(navigateFromRef).toHaveBeenCalledWith(
-      navigateToHomeConfig.screen,
-      navigateToHomeConfig.params
-    )
+    expect(reset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: homeNavigationConfig[0] }],
+    })
   })
 })

--- a/src/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.tsx
+++ b/src/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.tsx
@@ -1,17 +1,20 @@
 import React from 'react'
 
-import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
+import { useNavigateToHomeWithReset } from 'features/navigation/helpers/useNavigateToHomeWithReset'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { HappyFace } from 'ui/svg/icons/HappyFace'
 
-export const UpdatePersonalDataConfirmation = () => (
-  <GenericInfoPage
-    illustration={HappyFace}
-    title="C’est noté&nbsp;!"
-    subtitle="Merci, tes informations ont bien été prises en compte."
-    buttonPrimary={{
-      wording: 'Terminer',
-      navigateTo: navigateToHomeConfig,
-    }}
-  />
-)
+export const UpdatePersonalDataConfirmation = () => {
+  const { navigateToHomeWithReset } = useNavigateToHomeWithReset()
+  return (
+    <GenericInfoPage
+      illustration={HappyFace}
+      title="C’est noté&nbsp;!"
+      subtitle="Merci, tes informations ont bien été prises en compte."
+      buttonPrimary={{
+        wording: 'Terminer',
+        onPress: navigateToHomeWithReset,
+      }}
+    />
+  )
+}


### PR DESCRIPTION
…lDataConfirmation and ChangeStatus

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37864

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
