### PR TITLE
(BSR) feat(a11y): change role in Internal and External TouchableLink

### DIFF
--- a/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
@@ -307,8 +307,8 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
               
 
               <Text
-                accessibilityLabel="conditions générales d’utilisation"
-                accessibilityRole="button"
+                accessibilityLabel="conditions générales d’utilisation, lien externe"
+                accessibilityRole="link"
                 color="#161617"
                 onPress={[Function]}
                 style={

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
@@ -265,8 +265,8 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
           À tes 21 ans, ton compte pourra être supprimé et tu pourras faire une demande pour anonymiser tes données. Tu peux en savoir plus en
            
           <Text
-            accessibilityLabel="consultant cette page."
-            accessibilityRole="button"
+            accessibilityLabel="consultant cette page., lien externe"
+            accessibilityRole="link"
             color="#161617"
             onPress={[Function]}
             style={

--- a/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
@@ -309,8 +309,8 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
                 tes réservations seront annulées sauf pour certains cas précisés dans les
                  
                 <Text
-                  accessibilityLabel="conditions générales d’utilisation"
-                  accessibilityRole="button"
+                  accessibilityLabel="conditions générales d’utilisation, lien externe"
+                  accessibilityRole="link"
                   color="#161617"
                   onPress={[Function]}
                   style={

--- a/__snapshots__/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx.native-snap
@@ -224,8 +224,8 @@ exports[`LegalNotices should render correctly 1`] = `
           Éditeur du site :
            
           <Text
-            accessibilityLabel="https://passculture.app/accueil"
-            accessibilityRole="button"
+            accessibilityLabel="https://passculture.app/accueil, lien externe"
+            accessibilityRole="link"
             color="#161617"
             onPress={[Function]}
             style={
@@ -330,8 +330,8 @@ exports[`LegalNotices should render correctly 1`] = `
           Nous contacter :
            
           <Text
-            accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
-            accessibilityRole="button"
+            accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support, lien externe"
+            accessibilityRole="link"
             color="#161617"
             onPress={[Function]}
             style={

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -316,8 +316,8 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
                 tes réservations seront annulées sauf pour certains cas précisés dans les
                  
                 <Text
-                  accessibilityLabel="conditions générales d’utilisation"
-                  accessibilityRole="button"
+                  accessibilityLabel="conditions générales d’utilisation, lien externe"
+                  accessibilityRole="link"
                   color="#161617"
                   onPress={[Function]}
                   style={

--- a/src/cheatcodes/pages/others/CheatcodesScreenFeatureFlags.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenFeatureFlags.tsx
@@ -7,6 +7,7 @@ import {
   FeatureFlagAll,
   useCheatcodesFeatureFlagQuery,
 } from 'cheatcodes/queries/useCheatcodesFeatureFlagQuery'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { env } from 'libs/environment/env'
 import { LinkInsideText } from 'ui/components/buttons/linkInsideText/LinkInsideText'
 import { Separator } from 'ui/components/Separator'
@@ -45,6 +46,7 @@ export const CheatcodesScreenFeatureFlags = () => {
           externalNav={{
             url: 'https://app.testing.passculture.team/cheatcodes/other/feature-flags',
           }}
+          accessibilityRole={AccessibilityRole.LINK}
         />
       ) : null}
       {showStagingFeatureFlags ? (
@@ -55,6 +57,7 @@ export const CheatcodesScreenFeatureFlags = () => {
           externalNav={{
             url: 'https://app.staging.passculture.team/cheatcodes/other/feature-flags',
           }}
+          accessibilityRole={AccessibilityRole.LINK}
         />
       ) : null}
       {showProductionFeatureFlags ? (
@@ -63,6 +66,7 @@ export const CheatcodesScreenFeatureFlags = () => {
           buttonHeight="extraSmall"
           wording="Voir les feature flags production"
           externalNav={{ url: 'https://passculture.app/cheatcodes/other/feature-flags' }}
+          accessibilityRole={AccessibilityRole.LINK}
         />
       ) : null}
 

--- a/src/cheatcodes/pages/others/CheatcodesScreenRemoteConfig.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenRemoteConfig.tsx
@@ -4,6 +4,7 @@ import { FlatList } from 'react-native'
 import styled from 'styled-components/native'
 
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { env } from 'libs/environment/env'
 import { useRemoteConfigQuery } from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { GenericRemoteConfig } from 'libs/firebase/remoteConfig/remoteConfig.types'
@@ -62,6 +63,7 @@ export const CheatcodesScreenRemoteConfig = () => {
           externalNav={{
             url: 'https://app.testing.passculture.team/cheatcodes/other/remote-config',
           }}
+          accessibilityRole={AccessibilityRole.LINK}
         />
       ) : null}
       {showStagingFeatureFlags ? (
@@ -72,6 +74,7 @@ export const CheatcodesScreenRemoteConfig = () => {
           externalNav={{
             url: 'https://app.staging.passculture.team/cheatcodes/other/remote-config',
           }}
+          accessibilityRole={AccessibilityRole.LINK}
         />
       ) : null}
       {showProductionFeatureFlags ? (
@@ -80,6 +83,7 @@ export const CheatcodesScreenRemoteConfig = () => {
           buttonHeight="extraSmall"
           wording="Voir les feature flags production"
           externalNav={{ url: 'https://passculture.app/cheatcodes/other/remote-config' }}
+          accessibilityRole={AccessibilityRole.LINK}
         />
       ) : null}
 

--- a/src/features/auth/components/AuthenticationButton/AuthenticationButton.tsx
+++ b/src/features/auth/components/AuthenticationButton/AuthenticationButton.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
 import { RootNavigateParams, RootStackParamList } from 'features/navigation/RootNavigator/types'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { ColorsType } from 'theme/types'
 import { LinkInsideText } from 'ui/components/buttons/linkInsideText/LinkInsideText'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
@@ -53,6 +54,7 @@ export const AuthenticationButton: FunctionComponent<Props> = ({
           wording={wording}
           color={color}
           onBeforeNavigate={onPress}
+          accessibilityRole={AccessibilityRole.BUTTON}
         />
       </ButtonContainer>
     </AuthenticationContainer>

--- a/src/features/cookies/pages/CookiesDetails.tsx
+++ b/src/features/cookies/pages/CookiesDetails.tsx
@@ -45,7 +45,7 @@ export const CookiesDetails = (props: CookiesChoiceSettings) => {
             wording="politique de gestion des cookies"
             externalNav={{ url: env.COOKIES_POLICY_LINK }}
             typography="BodyAccentXs"
-            type={AccessibilityRole.LINK}
+            accessibilityRole={AccessibilityRole.LINK}
           />
         </StyledBodyAccentXs>
       </ViewGap>

--- a/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/FeedBackVideo.tsx
@@ -98,7 +98,7 @@ export function FeedBackVideo({ offerId, offerSubcategory, userId }: Props) {
           as={LinkInsideText}
           externalNav={{ url }}
           typography="BodyAccentXs"
-          type={AccessibilityRole.LINK}
+          accessibilityRole={AccessibilityRole.LINK}
         />
       </Container>
     )

--- a/src/features/profile/helpers/renderAccessibilityExternalLink.tsx
+++ b/src/features/profile/helpers/renderAccessibilityExternalLink.tsx
@@ -10,7 +10,7 @@ export function renderAccessibilityExternalLink(url: string) {
       as={LinkInsideText}
       wording={url}
       externalNav={{ url }}
-      type={AccessibilityRole.LINK}
+      accessibilityRole={AccessibilityRole.LINK}
     />
   )
 }

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileBase.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileBase.tsx
@@ -56,7 +56,7 @@ export function AccessibilityDeclarationMobileBase({
             as={LinkInsideText}
             wording={`l’application ${platformName}`}
             externalNav={storeLink}
-            type={AccessibilityRole.LINK}
+            accessibilityRole={AccessibilityRole.LINK}
           />
           {SPACE}version 1.348.8 du pass Culture.
         </Typo.Body>
@@ -174,7 +174,7 @@ export function AccessibilityDeclarationMobileBase({
             accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
             justifyContent="flex-start"
             externalNav={contactSupport.forGenericQuestion}
-            type={AccessibilityRole.LINK}
+            accessibilityRole={AccessibilityRole.LINK}
           />
         </Typo.Body>
       </ViewGap>
@@ -196,7 +196,7 @@ export function AccessibilityDeclarationMobileBase({
               as={LinkInsideText}
               wording="Défenseur des droits"
               externalNav={rightsDefenderUrl}
-              type={AccessibilityRole.LINK}
+              accessibilityRole={AccessibilityRole.LINK}
             />
           </Typo.Body>
           <Typo.Body>
@@ -205,7 +205,7 @@ export function AccessibilityDeclarationMobileBase({
               as={LinkInsideText}
               wording="Défenseur des droits dans votre région"
               externalNav={rightsDelegateUrl}
-              type={AccessibilityRole.LINK}
+              accessibilityRole={AccessibilityRole.LINK}
             />
           </Typo.Body>
           <Typo.Body>

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
@@ -55,7 +55,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Schéma pluriannuel d’accessibilité 2022 - 2025"
                 navigateTo={getProfilePropConfig('AccessibilityActionPlan')}
-                type={AccessibilityRole.BUTTON}
+                accessibilityRole={AccessibilityRole.BUTTON}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -65,7 +65,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Actions réalisées depuis 2022"
                 navigateTo={getProfilePropConfig('AccessibilityActionPlan')}
-                type={AccessibilityRole.BUTTON}
+                accessibilityRole={AccessibilityRole.BUTTON}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -75,7 +75,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Plan d’actions 2024"
                 navigateTo={getProfilePropConfig('AccessibilityActionPlan')}
-                type={AccessibilityRole.BUTTON}
+                accessibilityRole={AccessibilityRole.BUTTON}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -87,7 +87,7 @@ export function AccessibilityDeclarationWeb() {
           as={LinkInsideText}
           wording="https://passculture.app/"
           externalNav={webappUrl}
-          type={AccessibilityRole.LINK}
+          accessibilityRole={AccessibilityRole.LINK}
         />
       </Typo.Body>
       <StyledSeparator />
@@ -211,7 +211,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Accueil"
                 externalNav={homeUrl}
-                type={AccessibilityRole.LINK}
+                accessibilityRole={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -221,7 +221,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Connexion"
                 externalNav={loginUrl}
-                type={AccessibilityRole.LINK}
+                accessibilityRole={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -231,7 +231,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Inscription - Date de naissance"
                 externalNav={signupUrl}
-                type={AccessibilityRole.LINK}
+                accessibilityRole={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -241,7 +241,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Vérification d’identité"
                 externalNav={identityCheckUrl}
-                type={AccessibilityRole.LINK}
+                accessibilityRole={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -251,7 +251,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Profil"
                 externalNav={profileUrl}
-                type={AccessibilityRole.LINK}
+                accessibilityRole={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -261,7 +261,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Modification de mot de passe"
                 externalNav={changePasswordUrl}
-                type={AccessibilityRole.LINK}
+                accessibilityRole={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -271,7 +271,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Recherche"
                 externalNav={searchUrl}
-                type={AccessibilityRole.LINK}
+                accessibilityRole={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -281,7 +281,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Filtres"
                 externalNav={filterUrl}
-                type={AccessibilityRole.LINK}
+                accessibilityRole={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -291,7 +291,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Résultats de recherche"
                 externalNav={searchResultsUrl}
-                type={AccessibilityRole.LINK}
+                accessibilityRole={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -301,7 +301,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Favoris"
                 externalNav={favoritesUrl}
-                type={AccessibilityRole.LINK}
+                accessibilityRole={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -311,7 +311,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Détails d’une offre"
                 externalNav={offerUrl}
-                type={AccessibilityRole.LINK}
+                accessibilityRole={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -321,7 +321,7 @@ export function AccessibilityDeclarationWeb() {
                 as={LinkInsideText}
                 wording="Déclaration d’accessibilité"
                 externalNav={accessibilityUrl}
-                type={AccessibilityRole.LINK}
+                accessibilityRole={AccessibilityRole.LINK}
               />
             </Typo.BodyXs>
           </BulletListItem>
@@ -346,7 +346,7 @@ export function AccessibilityDeclarationWeb() {
           accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
           justifyContent="flex-start"
           externalNav={contactSupport.forGenericQuestion}
-          type={AccessibilityRole.LINK}
+          accessibilityRole={AccessibilityRole.LINK}
         />
       </Typo.Body>
 
@@ -368,7 +368,7 @@ export function AccessibilityDeclarationWeb() {
               as={LinkInsideText}
               wording="Défenseur des droits"
               externalNav={rightsDefenderUrl}
-              type={AccessibilityRole.LINK}
+              accessibilityRole={AccessibilityRole.LINK}
             />
           </Typo.Body>
           <Typo.Body>
@@ -377,7 +377,7 @@ export function AccessibilityDeclarationWeb() {
               as={LinkInsideText}
               wording="Défenseur des droits dans votre région"
               externalNav={rightsDelegateUrl}
-              type={AccessibilityRole.LINK}
+              accessibilityRole={AccessibilityRole.LINK}
             />
           </Typo.Body>
           <Typo.Body>

--- a/src/features/profile/pages/Accessibility/AccessibilityEngagement.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityEngagement.tsx
@@ -91,7 +91,7 @@ export function AccessibilityEngagement() {
           wording="notre centre d’aide"
           typography="BodyAccentXs"
           externalNav={{ url: env.FAQ_LINK }}
-          type={AccessibilityRole.LINK}
+          accessibilityRole={AccessibilityRole.LINK}
         />
       </StyledBodyAccentXs>
       <Spacer.BottomScreen />

--- a/src/features/profile/pages/Accessibility/RecommendedPaths.tsx
+++ b/src/features/profile/pages/Accessibility/RecommendedPaths.tsx
@@ -36,7 +36,7 @@ export function RecommendedPaths() {
             typography="BodyAccentXs"
             wording="Démarches simplifiées"
             externalNav={{ url: 'https://www.demarches-simplifiees.fr/' }}
-            type={AccessibilityRole.LINK}
+            accessibilityRole={AccessibilityRole.LINK}
           />
         </BulletListItem>
       </VerticalUl>

--- a/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
+++ b/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
@@ -81,7 +81,7 @@ export const ConsentSettings = () => {
           wording="politique de gestion des cookies"
           externalNav={{ url: env.COOKIES_POLICY_LINK }}
           typography="BodyAccentXs"
-          type={AccessibilityRole.LINK}
+          accessibilityRole={AccessibilityRole.LINK}
         />
       </StyledBodyAccentXs>
       <SaveButton wording="Enregistrer mes choix" onPress={saveChoice} center />

--- a/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx
@@ -98,7 +98,7 @@ describe('ConfirmDeleteProfile component', () => {
   it('should open CGU when clicking on "conditions générales d’utilisation"', async () => {
     renderConfirmDeleteProfile()
 
-    await user.press(screen.getByLabelText('conditions générales d’utilisation'))
+    await user.press(screen.getByText('conditions générales d’utilisation'))
 
     expect(openUrl).toHaveBeenNthCalledWith(1, env.CGU_LINK, undefined, true)
   })

--- a/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.tsx
+++ b/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 
 import { useAccountSuspendMutation } from 'features/auth/queries/useAccountSuspendMutation'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
 import { BulletListItem } from 'ui/components/BulletListItem'
@@ -70,6 +71,7 @@ export function ConfirmDeleteProfile() {
             as={LinkInsideTextBlack}
             wording="conditions générales d’utilisation"
             externalNav={{ url: env.CGU_LINK }}
+            accessibilityRole={AccessibilityRole.LINK}
           />
         </BulletListItem>
         <BulletListItem text="si tu as un dossier en cours, tu ne pourras pas en déposer un nouveau" />

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components/native'
 import { getProfileHookConfig } from 'features/navigation/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getTabHookConfig } from 'features/navigation/TabBar/getTabHookConfig'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { env } from 'libs/environment/env'
 import { LinkInsideText } from 'ui/components/buttons/linkInsideText/LinkInsideText'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
@@ -44,6 +45,7 @@ export const DeleteProfileAccountNotDeletable: FC = () => {
             as={LinkInsideTextBlack}
             wording="consultant cette page."
             externalNav={{ url: env.FAQ_LINK_RIGHT_TO_ERASURE }}
+            accessibilityRole={AccessibilityRole.LINK}
           />
         </Typo.BodyS>
         <Typo.BodyS>

--- a/src/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.tsx
+++ b/src/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 
 import { useAccountSuspendForHackSuspicionMutation } from 'features/auth/queries/useAccountSuspendForHackSuspicionMutation'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
 import { BulletListItem } from 'ui/components/BulletListItem'
@@ -63,6 +64,7 @@ export const SuspendAccountConfirmationWithoutAuthentication: FC = () => {
               as={LinkInsideTextBlack}
               wording="conditions générales d’utilisation"
               externalNav={{ url: env.CGU_LINK }}
+              accessibilityRole={AccessibilityRole.LINK}
             />
           </Typo.Body>
         </BulletListItem>

--- a/src/features/profile/pages/LegalNotices/LegalNotices.tsx
+++ b/src/features/profile/pages/LegalNotices/LegalNotices.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 import { contactSupport } from 'features/auth/helpers/contactSupport'
 import { getTabHookConfig } from 'features/navigation/TabBar/getTabHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { env } from 'libs/environment/env'
 import { LinkInsideText } from 'ui/components/buttons/linkInsideText/LinkInsideText'
 import { SectionRow } from 'ui/components/SectionRow'
@@ -31,6 +32,7 @@ export function LegalNotices() {
             wording="https://passculture.app/accueil"
             externalNav={{ url: 'https://passculture.app/accueil' }}
             icon={ExternalSiteFilled}
+            accessibilityRole={AccessibilityRole.LINK}
           />
         </Typo.Body>
         {/* eslint-disable-next-line local-rules/no-currency-symbols */}
@@ -55,6 +57,7 @@ export function LegalNotices() {
             wording="support@passculture.app"
             accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
             externalNav={contactSupport.forGenericQuestion}
+            accessibilityRole={AccessibilityRole.LINK}
           />
         </Typo.Body>
 

--- a/src/features/trustedDevice/pages/SuspensionChoice.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { useSuspendForSuspiciousLoginMutation } from 'features/trustedDevice/queries/useSuspendForSuspiciousLoginMutation'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
 import { useLogTypeFromRemoteConfig } from 'libs/hooks/useLogTypeFromRemoteConfig'
@@ -81,6 +82,7 @@ export const SuspensionChoice = () => {
               as={LinkInsideTextBlack}
               wording="conditions générales d’utilisation"
               externalNav={{ url: env.CGU_LINK }}
+              accessibilityRole={AccessibilityRole.LINK}
             />
           </Typo.Body>
         </BulletListItem>

--- a/src/ui/components/buttons/linkInsideText/LinkInsideText.native.test.tsx
+++ b/src/ui/components/buttons/linkInsideText/LinkInsideText.native.test.tsx
@@ -37,7 +37,7 @@ describe('LinkInsideText', () => {
     })
 
     it('should have correct accessibilityRole role when link type provided', async () => {
-      render(<LinkInsideText wording={wording} type={AccessibilityRole.LINK} />)
+      render(<LinkInsideText wording={wording} accessibilityRole={AccessibilityRole.LINK} />)
 
       const linkBanner = await screen.findByRole(AccessibilityRole.LINK)
 

--- a/src/ui/components/buttons/linkInsideText/LinkInsideText.tsx
+++ b/src/ui/components/buttons/linkInsideText/LinkInsideText.tsx
@@ -14,17 +14,18 @@ export function LinkInsideText({
   onLongPress,
   accessibilityLabel,
   color,
-  type = AccessibilityRole.BUTTON,
+  accessibilityRole = AccessibilityRole.BUTTON,
 }: LinkInsideTextProps) {
   const Text = typography === 'BodyAccentXs' ? StyledBodyAccentXs : StyledBody
-  const accessibilityLabelLink = type === AccessibilityRole.LINK ? ', lien externe' : ''
+  const accessibilityLabelLink =
+    accessibilityRole === AccessibilityRole.LINK ? ', lien externe' : ''
   const computedAccessibilityLabel = `${accessibilityLabel ?? wording}${accessibilityLabelLink}`
 
   return (
     <Text
       onPress={onPress as AppButtonEventNative}
       onLongPress={onLongPress as AppButtonEventNative}
-      accessibilityRole={type}
+      accessibilityRole={accessibilityRole}
       accessibilityLabel={computedAccessibilityLabel}
       color={color}>
       {wording}

--- a/src/ui/components/buttons/linkInsideText/LinkInsideText.web.tsx
+++ b/src/ui/components/buttons/linkInsideText/LinkInsideText.web.tsx
@@ -17,7 +17,7 @@ export function LinkInsideText({
   onLongPress,
   href,
   target,
-  type = AccessibilityRole.BUTTON,
+  accessibilityRole = AccessibilityRole.BUTTON,
   accessibilityLabel,
   color,
 }: LinkInsideTextProps) {
@@ -43,7 +43,7 @@ export function LinkInsideText({
     <Text
       onClick={onClick}
       onDoubleClick={onDoubleClick}
-      type={href ? undefined : type}
+      type={href ? undefined : accessibilityRole}
       href={href}
       target={target}
       accessibilityLabel={accessibilityLabel}

--- a/src/ui/components/buttons/linkInsideText/types.ts
+++ b/src/ui/components/buttons/linkInsideText/types.ts
@@ -9,7 +9,7 @@ export type LinkInsideTextProps = {
   color?: ColorsType
   onLongPress?: AppButtonEventWeb | AppButtonEventNative
   onPress?: AppButtonEventWeb | AppButtonEventNative
-  type?: AccessibilityRole.LINK | AccessibilityRole.BUTTON
+  accessibilityRole?: AccessibilityRole.LINK | AccessibilityRole.BUTTON
   href?: string
   target?: string
 }


### PR DESCRIPTION
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
