### PR TITLE
(PC-37910) feat(ci): add daily scheduled workflow for automatic testing deploy

### DIFF
--- a/.github/workflows/dev_on_schedule_deploy_testing_tag.yml
+++ b/.github/workflows/dev_on_schedule_deploy_testing_tag.yml
@@ -1,0 +1,57 @@
+name: Scheduled Hard Deploy Testing
+
+on:
+  schedule:
+    - cron: '30 12 * * *' # tous les jours à 14h30 Europe/Paris
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+  actions: write
+
+jobs:
+  deploy-new-testing-tag:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Authenticate through github app ghactionci
+        uses: actions/create-github-app-token@v2
+        id: github-app-token
+        with:
+          app-id: ${{ secrets.PASSCULTURE_GITHUB_ACTION_APP_ID }}
+          private-key: ${{ secrets.PASSCULTURE_GITHUB_ACTION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            pass-culture-app-native
+          permission-contents: write
+          permission-actions: write
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api \"/users/${{ steps.github-app-token.outputs.app-slug }}[bot]\" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+      - run: |
+          git config --global user.name '${{ steps.github-app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.github-app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          git remote set-url origin https://x-access-token:${{ steps.github-app-token.outputs.token }}@github.com/${{ github.repository_owner }}/pass-culture-app-native.git
+      - name: Get latest testing tag
+        id: get_tag
+        run: |
+          TAG=$(git tag --list 'testing/v*' --sort=-v:refname | head -n 1)
+          if [ -z "$TAG" ]; then
+            echo "Aucun tag testing/v* trouvé, le job échoue."
+            exit 1
+          fi
+          VERSION=$(echo $TAG | sed 's/testing\\/v//')
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          PATCH=$((PATCH + 1))
+          echo "NEW_TAG=testing/v${MAJOR}.${MINOR}.${PATCH}" >> $GITHUB_ENV
+      - name: Create and push new tag
+        env:
+          NEW_TAG: ${{ env.NEW_TAG }}
+        run: |
+          git tag --annotate "$NEW_TAG" --message "🚀 $NEW_TAG"
+          git push origin "$NEW_TAG"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37910

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## DR

Ce changement ajoute un workflow CRON qui, chaque jour à 14h30, pose automatiquement un tag de type testing/vX.Y.Z sur le dernier commit de la branche master.

Ce tag correspond à un incrément du patch de la dernière version de testing (donc le Z) existante :
→ La version testing est ainsi mise à jour quotidiennement, sans modification de la version majeure ou mineure.

Points clés
- Le workflow incrémente uniquement le patch de la version actuelle de testing.
- Aucun bump de version majeure ou mineure, aucun bump du build number, aucun commit.
- Le tag est posé sur l’état courant de master, ce qui permet un hard-deploy en testing à jour pour l’équipe produit et les PM.
- Les notifications Slack et la distribution via AppDistribution restent inchangées.