### PR TITLE
(PC-37377) feat(a11y): hidden emoji in AccessibleTitle

### DIFF
--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -1501,7 +1501,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                   withMargin={true}
                 >
                   <Text
-                    accessibilityHidden={true}
                     accessibilityLabel="GTL playlist"
                     accessibilityRole="header"
                     numberOfLines={2}
@@ -1514,7 +1513,21 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                       }
                     }
                   >
-                    GTL playlist
+                    <Text
+                      accessibilityElementsHidden={true}
+                      accessibilityRole="header"
+                      importantForAccessibility="no"
+                      style={
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Bold",
+                          "fontSize": 19,
+                          "lineHeight": 30.4,
+                        }
+                      }
+                    >
+                      GTL playlist
+                    </Text>
                   </Text>
                 </View>
               </View>

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -755,7 +755,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                           withMargin={true}
                         >
                           <Text
-                            accessibilityHidden={true}
                             accessibilityLabel="Toutes les offres"
                             accessibilityRole="header"
                             numberOfLines={2}
@@ -768,7 +767,21 @@ exports[`<Venue /> should match snapshot 1`] = `
                               }
                             }
                           >
-                            Toutes les offres
+                            <Text
+                              accessibilityElementsHidden={true}
+                              accessibilityRole="header"
+                              importantForAccessibility="no"
+                              style={
+                                {
+                                  "color": "#161617",
+                                  "fontFamily": "Montserrat-Bold",
+                                  "fontSize": 19,
+                                  "lineHeight": 30.4,
+                                }
+                              }
+                            >
+                              Toutes les offres
+                            </Text>
                           </Text>
                         </View>
                       </View>
@@ -3810,7 +3823,6 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                           withMargin={true}
                         >
                           <Text
-                            accessibilityHidden={true}
                             accessibilityLabel="Toutes les offres"
                             accessibilityRole="header"
                             numberOfLines={2}
@@ -3823,7 +3835,21 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                               }
                             }
                           >
-                            Toutes les offres
+                            <Text
+                              accessibilityElementsHidden={true}
+                              accessibilityRole="header"
+                              importantForAccessibility="no"
+                              style={
+                                {
+                                  "color": "#161617",
+                                  "fontFamily": "Montserrat-Bold",
+                                  "fontSize": 19,
+                                  "lineHeight": 30.4,
+                                }
+                              }
+                            >
+                              Toutes les offres
+                            </Text>
                           </Text>
                         </View>
                       </View>

--- a/doc/decision-records/DR009 - accessibility-audit.md
+++ b/doc/decision-records/DR009 - accessibility-audit.md
@@ -23,6 +23,26 @@
 
 <details>
 
+<summary> 🟠 Critère 1.1 - Android - Chaque élément graphique de décoration est-il ignoré par les technologies d’assistance ?e</summary>
+
+**RAAM** : [Critère 1.1](https://accessibilite.public.lu/fr/raam1.1/referentiel-technique.html#crit-1-1)  
+**Ticket** : [PC-37377](https://passculture.atlassian.net/browse/PC-37377)  
+**PR** : [#8676](https://github.com/pass-culture/pass-culture-app-native/pull/8676)
+
+**Problème** 😱  
+- Les emojis étaient vocalisé sur Android car on utilisait `accessibilityHidden` qui ne fonctionne pas. 
+- Les icons qui étaient présent au début des boutons sont vocalisé "zéro" pour la même raison.
+
+**Correction** 💡  
+- Refacto du code de `AccessibleTitle` et utilisation de `accessibilityElementsHidden` (iOS) et `importantForAccessibility` (Android) via `hiddenFromScreenReader()` pour ignorer les emojis. Création d'un composant `AccessibleTitle` spécifique web qui permet de garder `aria-hidden` en web pour éviter les problèmes de compatibilité.
+- Utilisation du nouveau composant `LinkInsideText` qui ne possède pas d'emojis de lien externe. 
+
+</details>
+
+<br>
+
+<details>
+
 <summary> 🟠 Critère 1.2 - Chaque élément graphique porteur d’information possède-t-il une alternative accessible aux technologies d’assistance ?</summary>
 
 **RAAM** : [Critère 1.2](https://accessibilite.public.lu/fr/raam1.1/referentiel-technique.html#crit-1-2)  
@@ -215,6 +235,8 @@ Legend:
 `TextInput` Type Multi-layer = our custom input component `EmailInputController`.
 
 </details>
+
+<br>
 
 <details>
 

--- a/src/features/artist/components/ArtistPlaylist/ArtistPlaylist.native.test.tsx
+++ b/src/features/artist/components/ArtistPlaylist/ArtistPlaylist.native.test.tsx
@@ -21,9 +21,9 @@ describe('ArtistPlaylist', () => {
       )
     )
 
-    await screen.findByText('Toutes ses offres disponibles')
+    await screen.findByLabelText('Toutes ses offres disponibles')
 
-    expect(screen.getByText('Toutes ses offres disponibles')).toBeOnTheScreen()
+    expect(screen.getByLabelText('Toutes ses offres disponibles')).toBeOnTheScreen()
     expect(screen.getByText('Manga Série "One piece" - Tome 3')).toBeOnTheScreen()
   })
 
@@ -31,7 +31,7 @@ describe('ArtistPlaylist', () => {
     render(reactQueryProviderHOC(<ArtistPlaylist artistName="Céline Dion" items={[]} />))
 
     await waitFor(() =>
-      expect(screen.queryByText('Toutes ses offres disponibles')).not.toBeOnTheScreen()
+      expect(screen.queryByLabelText('Toutes ses offres disponibles')).not.toBeOnTheScreen()
     )
   })
 
@@ -45,7 +45,7 @@ describe('ArtistPlaylist', () => {
       )
     )
 
-    await screen.findByText('Toutes ses offres disponibles')
+    await screen.findByLabelText('Toutes ses offres disponibles')
 
     expect(screen.getByText('Poche')).toBeOnTheScreen()
   })
@@ -60,7 +60,7 @@ describe('ArtistPlaylist', () => {
       )
     )
 
-    await screen.findByText('Toutes ses offres disponibles')
+    await screen.findByLabelText('Toutes ses offres disponibles')
 
     expect(screen.getAllByText('Livre')[1]).toBeOnTheScreen()
   })

--- a/src/features/home/components/AccessibleTitle.tsx
+++ b/src/features/home/components/AccessibleTitle.tsx
@@ -1,57 +1,43 @@
 import React, { ComponentProps, ComponentType } from 'react'
-import { Platform, useWindowDimensions } from 'react-native'
 import styled from 'styled-components/native'
 
+import { separateTitleAndEmojis } from 'features/home/helpers/separateTitleAndEmojis'
+import { hiddenFromScreenReader } from 'shared/accessibility/hiddenFromScreenReader'
 import { Typo } from 'ui/theme'
+import { SPACE } from 'ui/theme/constants'
 
-type Props = {
+export type AccessibleTitleProps = {
   title: string
-  testID?: string
   TitleComponent?: ComponentType<ComponentProps<typeof Typo.Title3>>
   withMargin?: boolean
 }
 
-export const separateTitleAndEmojis = (title: string) => {
-  const titleWithoutEndSpace = title.trimEnd()
-  const emojiRegex = /(\p{Emoji})(?=\s*$)/gu
-  const titleText = titleWithoutEndSpace.replace(emojiRegex, '')
-  const titleEmoji = titleWithoutEndSpace.replace(titleText, '')
-  return { titleText, titleEmoji }
-}
-
-export const AccessibleTitle: React.FC<Props> = ({
+export const AccessibleTitle: React.FC<AccessibleTitleProps> = ({
   title,
-  testID,
   TitleComponent = Typo.Title3,
   withMargin = true,
 }) => {
-  const { width: windowWidth } = useWindowDimensions()
   const { titleText, titleEmoji } = separateTitleAndEmojis(title)
-
   const StyledTitleComponent = styled(TitleComponent || Typo.Title3)({})
-
-  return Platform.OS === 'web' ? (
-    <TitleWrapper testID={testID} windowWidth={windowWidth} withMargin={withMargin}>
-      <StyledTitleComponent numberOfLines={2}>
-        {titleText}
-        <span aria-hidden>{titleEmoji}</span>
-      </StyledTitleComponent>
-    </TitleWrapper>
-  ) : (
-    <TitleWrapper testID={testID} withMargin={withMargin}>
-      <StyledTitleComponent accessibilityHidden numberOfLines={2} accessibilityLabel={titleText}>
-        {titleText}
-        {titleEmoji}
+  return (
+    <TitleWrapper testID="playlistTitle" withMargin={withMargin}>
+      <StyledTitleComponent numberOfLines={2} accessibilityLabel={titleText}>
+        <StyledTitleComponent {...hiddenFromScreenReader()}>
+          {titleText}
+          {titleEmoji ? (
+            <React.Fragment>
+              {SPACE}
+              {titleEmoji}
+            </React.Fragment>
+          ) : null}
+        </StyledTitleComponent>
       </StyledTitleComponent>
     </TitleWrapper>
   )
 }
 
-const TitleWrapper = styled.View<{ windowWidth?: number; withMargin?: boolean }>(
-  ({ windowWidth, withMargin, theme }) => {
-    return {
-      marginHorizontal: withMargin ? theme.contentPage.marginHorizontal : undefined,
-      width: windowWidth,
-    }
+const TitleWrapper = styled.View<{ withMargin?: boolean }>(({ withMargin, theme }) => {
+  return {
+    marginHorizontal: withMargin ? theme.contentPage.marginHorizontal : undefined,
   }
-)
+})

--- a/src/features/home/components/AccessibleTitle.web.test.tsx
+++ b/src/features/home/components/AccessibleTitle.web.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { render, screen } from 'tests/utils'
+import { render, screen } from 'tests/utils/web'
 
 import { AccessibleTitle } from './AccessibleTitle'
 
@@ -8,8 +8,12 @@ describe('AccessibleTitle', () => {
   it('should expose only the text to screen readers (emoji ignored)', () => {
     render(<AccessibleTitle title="Hello 👋" />)
 
-    expect(screen.getByLabelText('Hello')).toBeTruthy()
-    expect(screen.queryByLabelText('Hello 👋')).toBeNull()
+    const emoji = screen.getByText('👋')
+
+    expect(emoji).toBeInTheDocument()
+    expect(emoji).toHaveAttribute('aria-hidden', 'true')
+
+    expect(screen.getByText('Hello')).toBeInTheDocument()
     expect(screen.queryByText('Hello 👋')).toBeNull()
   })
 })

--- a/src/features/home/components/AccessibleTitle.web.tsx
+++ b/src/features/home/components/AccessibleTitle.web.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { useWindowDimensions } from 'react-native'
+import styled from 'styled-components/native'
+
+import { AccessibleTitleProps } from 'features/home/components/AccessibleTitle'
+import { separateTitleAndEmojis } from 'features/home/helpers/separateTitleAndEmojis'
+import { Typo } from 'ui/theme'
+import { SPACE } from 'ui/theme/constants'
+
+export const AccessibleTitle: React.FC<AccessibleTitleProps> = ({
+  title,
+  TitleComponent = Typo.Title3,
+  withMargin = true,
+}) => {
+  const { width: windowWidth } = useWindowDimensions()
+  const { titleText, titleEmoji } = separateTitleAndEmojis(title)
+  const StyledTitleComponent = styled(TitleComponent || Typo.Title3)({})
+  return (
+    <TitleWrapper testID="playlistTitle" windowWidth={windowWidth} withMargin={withMargin}>
+      <StyledTitleComponent numberOfLines={2}>
+        {titleText}
+        {titleEmoji ? (
+          <span aria-hidden>
+            {SPACE}
+            {titleEmoji}
+          </span>
+        ) : null}
+      </StyledTitleComponent>
+    </TitleWrapper>
+  )
+}
+
+const TitleWrapper = styled.View<{ windowWidth?: number; withMargin?: boolean }>(
+  ({ windowWidth, withMargin, theme }) => {
+    return {
+      marginHorizontal: withMargin ? theme.contentPage.marginHorizontal : undefined,
+      width: windowWidth,
+    }
+  }
+)

--- a/src/features/home/components/modules/HomeModule.native.test.tsx
+++ b/src/features/home/components/modules/HomeModule.native.test.tsx
@@ -133,7 +133,7 @@ describe('<HomeModule />', () => {
     await act(async () => {})
 
     await waitFor(async () => {
-      expect(await screen.findByText(' L’offre du moment 💥')).toBeOnTheScreen()
+      expect(await screen.findByLabelText('L’offre du moment')).toBeOnTheScreen()
     })
   })
 
@@ -202,7 +202,7 @@ describe('<HomeModule />', () => {
   it('should display CategoryListModule', async () => {
     renderHomeModule(formattedCategoryListModule)
 
-    expect(await screen.findByText('Cette semaine sur le pass')).toBeOnTheScreen()
+    expect(await screen.findByLabelText('Cette semaine sur le pass')).toBeOnTheScreen()
   })
 
   it('should display RecommendationModule', async () => {
@@ -225,7 +225,7 @@ describe('<HomeModule />', () => {
 
     await act(async () => {})
 
-    expect(await screen.findByText('Tes évènements en ligne')).toBeOnTheScreen()
+    expect(await screen.findByLabelText('Tes évènements en ligne')).toBeOnTheScreen()
   })
 
   it('should display VideoModule', async () => {
@@ -234,7 +234,7 @@ describe('<HomeModule />', () => {
 
     renderHomeModule(videoModuleFixture)
 
-    await screen.findByText('Découvre Lujipeka')
+    await screen.findByLabelText('Découvre Lujipeka')
 
     await waitFor(async () => {
       expect(await screen.findByTestId('mobile-video-module')).toBeOnTheScreen()

--- a/src/features/home/components/modules/OffersModule.native.test.tsx
+++ b/src/features/home/components/modules/OffersModule.native.test.tsx
@@ -83,7 +83,7 @@ describe('OffersModule', () => {
   it('should not render hybrid playlist if no recommended parameters', async () => {
     renderOffersModule({ recommendationParameters: undefined })
 
-    await screen.findByText('Module title')
+    await screen.findByLabelText('Module title')
 
     expect(screen.queryByText('Un lit sous une rivière')).not.toBeOnTheScreen()
   })
@@ -157,7 +157,7 @@ describe('OffersModule', () => {
     it('should trigger logEvent "ModuleDisplayedOnHomepage" when shouldModuleBeDisplayed is true', async () => {
       renderOffersModule()
 
-      await screen.findByText('Module title')
+      await screen.findByLabelText('Module title')
 
       expect(analytics.logModuleDisplayedOnHomepage).toHaveBeenNthCalledWith(1, {
         call_id: undefined,
@@ -199,7 +199,7 @@ describe('OffersModule', () => {
 
       renderOffersModule({ recommendationParameters: { categories: ['Cinéma'] } })
 
-      await screen.findByText('Module title')
+      await screen.findByLabelText('Module title')
 
       expect(analytics.logModuleDisplayedOnHomepage).toHaveBeenNthCalledWith(1, {
         call_id: undefined,
@@ -219,7 +219,7 @@ describe('OffersModule', () => {
         recommendationParameters: { categories: ['Cinéma'] },
       })
 
-      await screen.findByText('Module title')
+      await screen.findByLabelText('Module title')
 
       expect(analytics.logModuleDisplayedOnHomepage).toHaveBeenNthCalledWith(1, {
         call_id: undefined,

--- a/src/features/home/components/modules/video/VideoModule.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoModule.native.test.tsx
@@ -80,7 +80,7 @@ describe('VideoModule', () => {
 
     const multiOfferList = screen.getByTestId('video-multi-offers-module-list')
 
-    await screen.findByText(videoModuleFixture.title)
+    await screen.findByLabelText(videoModuleFixture.title)
 
     expect(multiOfferList).toBeOnTheScreen()
   })
@@ -122,7 +122,7 @@ describe('VideoModule', () => {
 
     const seeMoreWording = screen.getByText('Voir tout')
 
-    await screen.findByText(videoModuleFixture.title)
+    await screen.findByLabelText(videoModuleFixture.title)
 
     expect(seeMoreWording).toBeOnTheScreen()
   })
@@ -135,7 +135,7 @@ describe('VideoModule', () => {
 
     const seeMoreWording = screen.queryByText('Voir tout')
 
-    await screen.findByText(videoModuleFixture.title)
+    await screen.findByLabelText(videoModuleFixture.title)
 
     expect(seeMoreWording).not.toBeOnTheScreen()
   })

--- a/src/features/home/components/modules/video/VideoModuleDesktop.tsx
+++ b/src/features/home/components/modules/video/VideoModuleDesktop.tsx
@@ -54,7 +54,7 @@ export const VideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) =
   return (
     <React.Fragment>
       <StyledTitleContainer>
-        <AccessibleTitle testID="playlistTitle" title={props.title} />
+        <AccessibleTitle title={props.title} />
         {renderTitleSeeMore()}
       </StyledTitleContainer>
       <View testID="desktop-video-module">

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -34,7 +34,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
   return (
     <Container>
       <StyledTitleContainer>
-        <AccessibleTitle testID="playlistTitle" title={props.title} />
+        <AccessibleTitle title={props.title} />
       </StyledTitleContainer>
       <View testID="mobile-video-module">
         <StyledTouchableHighlight

--- a/src/features/home/helpers/separateTitleAndEmojis.native.test.ts
+++ b/src/features/home/helpers/separateTitleAndEmojis.native.test.ts
@@ -1,0 +1,17 @@
+import { separateTitleAndEmojis } from './separateTitleAndEmojis'
+
+describe('separateTitleAndEmojis', () => {
+  it.each`
+    title                                             | expected
+    ${'Cas classique 💥'}                             | ${{ titleEmoji: '💥', titleText: 'Cas classique' }}
+    ${'Cas sans emojis'}                              | ${{ titleEmoji: '', titleText: 'Cas sans emojis' }}
+    ${'Cas avec un espace à la fin 🚀 '}              | ${{ titleEmoji: '🚀', titleText: 'Cas avec un espace à la fin' }}
+    ${'Cas avec deux emojis à la fin 🚀⭐'}           | ${{ titleEmoji: '🚀⭐', titleText: 'Cas avec deux emojis à la fin' }}
+    ${'Cas avec des accents œŒéàèêËëù ⭐'}            | ${{ titleEmoji: '⭐', titleText: 'Cas avec des accents œŒéàèêËëù' }}
+    ${'Cas avec un chiffre 3 🎸'}                     | ${{ titleEmoji: '🎸', titleText: 'Cas avec un chiffre 3' }}
+    ${`Cas avec de la ponctuation ?,;.:!" 😀`}        | ${{ titleEmoji: '😀', titleText: 'Cas avec de la ponctuation ?,;.:!"' }}
+    ${`Cas avec des caractères spéciaux €@#‰()[] 💾`} | ${{ titleEmoji: '💾', titleText: 'Cas avec des caractères spéciaux €@#‰()[]' }}
+  `('should return $expected when title is $title', ({ title, expected }) => {
+    expect(separateTitleAndEmojis(title)).toStrictEqual(expected)
+  })
+})

--- a/src/features/home/helpers/separateTitleAndEmojis.ts
+++ b/src/features/home/helpers/separateTitleAndEmojis.ts
@@ -1,0 +1,9 @@
+export const separateTitleAndEmojis = (
+  title: string
+): { titleText: string; titleEmoji?: string } => {
+  const titleWithoutEndSpace = title.trimEnd()
+  const emojiRegex = /\s*\p{Emoji}+$/u
+  const titleText = titleWithoutEndSpace.replace(emojiRegex, '')
+  const titleEmoji = titleWithoutEndSpace.slice(titleText.length).trimStart()
+  return { titleText, titleEmoji }
+}

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -295,7 +295,7 @@ describe('<OfferContent />', () => {
 
         await screen.findByText('Réserver l’offre')
 
-        expect(screen.getByText('Dans la même catégorie')).toBeOnTheScreen()
+        expect(screen.getByLabelText('Dans la même catégorie')).toBeOnTheScreen()
       })
 
       it('should trigger logSameCategoryPlaylistVerticalScroll when scrolling to the playlist', async () => {
@@ -363,7 +363,7 @@ describe('<OfferContent />', () => {
 
         await screen.findByText('Réserver l’offre')
 
-        expect(screen.getByText('Ça peut aussi te plaire')).toBeOnTheScreen()
+        expect(screen.getByLabelText('Ça peut aussi te plaire')).toBeOnTheScreen()
       })
 
       it('should trigger logOtherCategoriesPlaylistVerticalScroll when scrolling to the playlist', async () => {

--- a/src/features/offer/components/OfferPlaylist/OfferPlaylist.native.test.tsx
+++ b/src/features/offer/components/OfferPlaylist/OfferPlaylist.native.test.tsx
@@ -22,7 +22,7 @@ describe('<OfferPlaylist />', () => {
       />
     )
 
-    expect(screen.getByText('Du même auteur')).toBeOnTheScreen()
+    expect(screen.getByLabelText('Du même auteur')).toBeOnTheScreen()
   })
 
   it('should render the playlist title', () => {
@@ -37,7 +37,7 @@ describe('<OfferPlaylist />', () => {
       />
     )
 
-    expect(screen.getByText('Ça peut aussi te plaire')).toBeOnTheScreen()
+    expect(screen.getByLabelText('Ça peut aussi te plaire')).toBeOnTheScreen()
   })
 
   it('should call the list with the data from the mock', async () => {

--- a/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.native.test.tsx
+++ b/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.native.test.tsx
@@ -53,7 +53,7 @@ describe('<OfferPlaylistList />', () => {
 
         await act(() => {})
 
-        await expect(screen.queryByText('Dans la même catégorie')).not.toBeOnTheScreen()
+        await expect(screen.queryByLabelText('Dans la même catégorie')).not.toBeOnTheScreen()
       })
 
       it('should display same category playlist when offer has it', async () => {
@@ -62,9 +62,9 @@ describe('<OfferPlaylistList />', () => {
           sameCategorySimilarOffers: mockSearchHits,
         })
 
-        await screen.findByText('Dans la même catégorie')
+        await screen.findByLabelText('Dans la même catégorie')
 
-        expect(screen.getByText('Dans la même catégorie')).toBeOnTheScreen()
+        expect(screen.getByLabelText('Dans la même catégorie')).toBeOnTheScreen()
       })
 
       it('should navigate to an offer when pressing on it', async () => {
@@ -90,7 +90,7 @@ describe('<OfferPlaylistList />', () => {
 
         await act(() => {})
 
-        expect(screen.queryByText('Ça peut aussi te plaire')).not.toBeOnTheScreen()
+        expect(screen.queryByLabelText('Ça peut aussi te plaire')).not.toBeOnTheScreen()
       })
 
       it('should display other categories playlist when offer has it', async () => {
@@ -99,9 +99,9 @@ describe('<OfferPlaylistList />', () => {
           otherCategoriesSimilarOffers: mockSearchHits,
         })
 
-        await screen.findByText('Ça peut aussi te plaire')
+        await screen.findByLabelText('Ça peut aussi te plaire')
 
-        expect(screen.getByText('Ça peut aussi te plaire')).toBeOnTheScreen()
+        expect(screen.getByLabelText('Ça peut aussi te plaire')).toBeOnTheScreen()
       })
 
       it('should navigate to an offer when pressing on it', async () => {

--- a/src/features/search/pages/ThematicSearch/Book/BookPlaylists.native.test.tsx
+++ b/src/features/search/pages/ThematicSearch/Book/BookPlaylists.native.test.tsx
@@ -72,7 +72,7 @@ describe('BookPlaylists', () => {
   it('should render gtl playlists when algolia returns offers', async () => {
     renderBookPlaylists()
 
-    expect(await screen.findByText(DEFAULT_PLAYLIST_TITLE)).toBeOnTheScreen()
+    expect(await screen.findByLabelText(DEFAULT_PLAYLIST_TITLE)).toBeOnTheScreen()
   })
 
   it('should render skeleton when playlists are still loading', async () => {
@@ -95,13 +95,13 @@ describe('BookPlaylists', () => {
 
     renderBookPlaylists()
 
-    expect(screen.queryByText(DEFAULT_PLAYLIST_TITLE)).not.toBeOnTheScreen()
+    expect(screen.queryByLabelText(DEFAULT_PLAYLIST_TITLE)).not.toBeOnTheScreen()
   })
 
   it('should call useGTLPlaylists with env.ALGOLIA_OFFERS_INDEX_NAME if FF is disabled', async () => {
     renderBookPlaylists()
 
-    await screen.findByText(DEFAULT_PLAYLIST_TITLE)
+    await screen.findByLabelText(DEFAULT_PLAYLIST_TITLE)
 
     expect(useGTLPlaylistsSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -115,7 +115,7 @@ describe('BookPlaylists', () => {
     setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_REPLICA_ALGOLIA_INDEX])
     renderBookPlaylists()
 
-    await screen.findByText(DEFAULT_PLAYLIST_TITLE)
+    await screen.findByLabelText(DEFAULT_PLAYLIST_TITLE)
 
     expect(useGTLPlaylistsSpy).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/features/search/pages/ThematicSearch/Cinema/CinemaPlaylists.native.test.tsx
+++ b/src/features/search/pages/ThematicSearch/Cinema/CinemaPlaylists.native.test.tsx
@@ -40,14 +40,14 @@ describe('CinemaPlaylists', () => {
   it('should render playlist when algolia returns offers', async () => {
     renderCinema()
 
-    expect(await screen.findByText(DEFAULT_PLAYLIST_TITLE)).toBeOnTheScreen()
+    expect(await screen.findByLabelText(DEFAULT_PLAYLIST_TITLE)).toBeOnTheScreen()
   })
 
   it('should not render playlist when algolia does not return offers', async () => {
     useThematicSearchPlaylistsSpy.mockReturnValueOnce({ playlists: [], isLoading: false })
     renderCinema()
 
-    expect(screen.queryByText(DEFAULT_PLAYLIST_TITLE)).not.toBeOnTheScreen()
+    expect(screen.queryByLabelText(DEFAULT_PLAYLIST_TITLE)).not.toBeOnTheScreen()
   })
 })
 

--- a/src/features/search/pages/ThematicSearch/ConcertsAndFestivals/ConcertsAndFestivalsPlaylists.native.test.tsx
+++ b/src/features/search/pages/ThematicSearch/ConcertsAndFestivals/ConcertsAndFestivalsPlaylists.native.test.tsx
@@ -40,14 +40,14 @@ describe('ConcertsAndFestivalsPlaylists', () => {
   it('should render playlist when algolia returns offers', async () => {
     renderConcertsAndFestivals()
 
-    expect(await screen.findByText(DEFAULT_PLAYLIST_TITLE)).toBeOnTheScreen()
+    expect(await screen.findByLabelText(DEFAULT_PLAYLIST_TITLE)).toBeOnTheScreen()
   })
 
   it('should not render playlist when algolia does not return offers', async () => {
     useThematicSearchPlaylistsSpy.mockReturnValueOnce({ playlists: [], isLoading: false })
     renderConcertsAndFestivals()
 
-    expect(screen.queryByText(DEFAULT_PLAYLIST_TITLE)).not.toBeOnTheScreen()
+    expect(screen.queryByLabelText(DEFAULT_PLAYLIST_TITLE)).not.toBeOnTheScreen()
   })
 })
 

--- a/src/features/search/pages/ThematicSearch/Films/FilmsPlaylists.native.test.tsx
+++ b/src/features/search/pages/ThematicSearch/Films/FilmsPlaylists.native.test.tsx
@@ -40,14 +40,14 @@ describe('FilmsPlaylists', () => {
   it('should render playlist when algolia returns offers', async () => {
     renderFilms()
 
-    expect(await screen.findByText(DEFAULT_PLAYLIST_TITLE)).toBeOnTheScreen()
+    expect(await screen.findByLabelText(DEFAULT_PLAYLIST_TITLE)).toBeOnTheScreen()
   })
 
   it('should not render playlist when algolia does not return offers', async () => {
     useThematicSearchPlaylistsSpy.mockReturnValueOnce({ playlists: [], isLoading: false })
     renderFilms()
 
-    expect(screen.queryByText(DEFAULT_PLAYLIST_TITLE)).not.toBeOnTheScreen()
+    expect(screen.queryByLabelText(DEFAULT_PLAYLIST_TITLE)).not.toBeOnTheScreen()
   })
 })
 

--- a/src/features/search/pages/ThematicSearch/Music/MusicPlaylists.native.test.tsx
+++ b/src/features/search/pages/ThematicSearch/Music/MusicPlaylists.native.test.tsx
@@ -40,14 +40,14 @@ describe('MusicPlaylists', () => {
   it('should render playlist when algolia returns offers', async () => {
     renderMusic()
 
-    expect(await screen.findByText(DEFAULT_PLAYLIST_TITLE)).toBeOnTheScreen()
+    expect(await screen.findByLabelText(DEFAULT_PLAYLIST_TITLE)).toBeOnTheScreen()
   })
 
   it('should not render playlist when algolia does not return offers', async () => {
     useThematicSearchPlaylistsSpy.mockReturnValueOnce({ playlists: [], isLoading: false })
     renderMusic()
 
-    expect(screen.queryByText(DEFAULT_PLAYLIST_TITLE)).not.toBeOnTheScreen()
+    expect(screen.queryByLabelText(DEFAULT_PLAYLIST_TITLE)).not.toBeOnTheScreen()
   })
 })
 

--- a/src/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx
@@ -195,7 +195,7 @@ describe('<ThematicSearch/>', () => {
         render(reactQueryProviderHOC(<ThematicSearch />))
         await screen.findByText('Romans et littérature')
 
-        expect(await screen.findByText('GTL playlist')).toBeOnTheScreen()
+        expect(await screen.findByLabelText('GTL playlist')).toBeOnTheScreen()
       })
 
       it('should call useGTLPlaylists with env.ALGOLIA_OFFERS_INDEX_NAME_B if FF ENABLE_REPLICA_ALGOLIA_INDEX is on', async () => {
@@ -223,7 +223,7 @@ describe('<ThematicSearch/>', () => {
       render(reactQueryProviderHOC(<ThematicSearch />))
       await screen.findByText('Festivals')
 
-      expect(screen.queryByText('GTL playlist')).not.toBeOnTheScreen()
+      expect(screen.queryByLabelText('GTL playlist')).not.toBeOnTheScreen()
     })
   })
 

--- a/src/features/search/pages/ThematicSearch/ThematicSearchPlaylistList.native.test.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearchPlaylistList.native.test.tsx
@@ -20,10 +20,7 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 const DEFAULT_PLAYLIST_OFFERS = mockBuilder.searchResponseOffer({})
 const DEFAULT_PLAYLIST_TITLE = 'Titre de la playlist'
 const DEFAULT_PLAYLIST = { title: DEFAULT_PLAYLIST_TITLE, offers: DEFAULT_PLAYLIST_OFFERS }
-const DEFAULT_PLAYLIST_WITHOUT_HITS = {
-  title: DEFAULT_PLAYLIST_TITLE,
-  offers: { hits: [] },
-}
+const DEFAULT_PLAYLIST_WITHOUT_HITS = { title: DEFAULT_PLAYLIST_TITLE, offers: { hits: [] } }
 
 describe('ThematicSearchPlaylistList', () => {
   beforeEach(() => {
@@ -35,7 +32,7 @@ describe('ThematicSearchPlaylistList', () => {
   it('should render playlist properly', async () => {
     renderThematicSearchPlaylistList([DEFAULT_PLAYLIST])
 
-    await screen.findByText(DEFAULT_PLAYLIST_TITLE)
+    await screen.findByLabelText(DEFAULT_PLAYLIST_TITLE)
 
     expect(await screen.findByText('Harry potter à l’école des sorciers')).toBeOnTheScreen()
   })
@@ -43,7 +40,7 @@ describe('ThematicSearchPlaylistList', () => {
   it('should not return a playlist without offers', async () => {
     renderThematicSearchPlaylistList([DEFAULT_PLAYLIST_WITHOUT_HITS])
 
-    expect(screen.queryByText(DEFAULT_PLAYLIST_TITLE)).not.toBeOnTheScreen()
+    expect(screen.queryByLabelText(DEFAULT_PLAYLIST_TITLE)).not.toBeOnTheScreen()
   })
 
   it('should return skeleton when playlist is loading', async () => {

--- a/src/features/venue/components/VenueOffers/VenueOffers.native.test.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffers.native.test.tsx
@@ -112,7 +112,7 @@ describe('<VenueOffers />', () => {
   it('should display "En voir plus" button if they are more hits to see than the one displayed', async () => {
     renderVenueOffers({ playlists: [] })
 
-    await screen.findByText('Toutes les offres')
+    await screen.findByLabelText('Toutes les offres')
 
     expect(screen.getByText('En voir plus')).toBeOnTheScreen()
   })
@@ -122,7 +122,7 @@ describe('<VenueOffers />', () => {
       venueOffers: { hits: VenueOffersResponseSnap, nbHits: VenueOffersResponseSnap.length },
     })
 
-    await screen.findByText('Toutes les offres')
+    await screen.findByLabelText('Toutes les offres')
 
     expect(screen.queryByText('En voir plus')).not.toBeOnTheScreen()
   })
@@ -160,7 +160,7 @@ describe('<VenueOffers />', () => {
   it('should not display gtl playlist when gtl playlist is an empty array', async () => {
     renderVenueOffers({ playlists: [] })
 
-    await screen.findByText('Toutes les offres')
+    await screen.findByLabelText('Toutes les offres')
 
     expect(screen.queryByText('GTL playlist')).not.toBeOnTheScreen()
   })
@@ -206,7 +206,7 @@ describe('<VenueOffers />', () => {
       it('should not display artists playlist when venue offers have artists', async () => {
         renderVenueOffers({})
 
-        await screen.findByText('Toutes les offres')
+        await screen.findByLabelText('Toutes les offres')
 
         expect(screen.queryByText('Les artistes disponibles dans ce lieu')).not.toBeOnTheScreen()
       })
@@ -218,7 +218,7 @@ describe('<VenueOffers />', () => {
           venueArtists: venueOffersArtistsMock,
         })
 
-        await screen.findByText('Toutes les offres')
+        await screen.findByLabelText('Toutes les offres')
 
         expect(screen.queryByText('Les artistes disponibles dans ce lieu')).not.toBeOnTheScreen()
       })

--- a/src/ui/components/PassPlaylist.tsx
+++ b/src/ui/components/PassPlaylist.tsx
@@ -92,12 +92,7 @@ export const PassPlaylist = ({
     <StyledViewGap gap={4} noMarginBottom={noMarginBottom} {...props}>
       <ViewGap gap={1}>
         <StyledView>
-          <AccessibleTitle
-            withMargin={withMargin}
-            TitleComponent={TitleLevel2}
-            testID="playlistTitle"
-            title={title}
-          />
+          <AccessibleTitle withMargin={withMargin} TitleComponent={TitleLevel2} title={title} />
           {renderTitleSeeMore()}
         </StyledView>
         {subtitle ? <StyledSubtitle withMargin={withMargin}>{subtitle}</StyledSubtitle> : null}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37377

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |  <img width="985" height="723" alt="Capture d’écran 2025-09-15 à 16 51 33" src="https://github.com/user-attachments/assets/e2a855bc-5fae-477e-b0b0-a347c19706b7" />  |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |   <img width="521" height="938" alt="Capture d’écran 2025-09-15 à 16 50 14" src="https://github.com/user-attachments/assets/c3480b98-6fe0-458a-b2bd-604ff2dcb221" />  |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
