### PR TITLE
(PC-37553) feat(analytics): add searchId and artistId to ConsultArtist log

### DIFF
--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -546,8 +546,9 @@ describe('<OfferBody />', () => {
     await user.press(await screen.findByText('Stephen King'))
 
     expect(analytics.logConsultArtist).toHaveBeenNthCalledWith(1, {
-      offerId: offerResponseSnap.id,
+      offerId: offerResponseSnap.id.toString(),
       artistName: 'Stephen King',
+      artistId: '1',
       from: 'offer',
     })
   })

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -122,7 +122,13 @@ export const OfferBody: FunctionComponent<Props> = ({
   const handleArtistLinkPress = () => {
     if (!artists[0]) return
     const mainArtistName = artists[0].name
-    analytics.logConsultArtist({ offerId: offer.id, artistName: mainArtistName, from: 'offer' })
+    const mainArtistId = artists[0].id
+    analytics.logConsultArtist({
+      offerId: offer.id.toString(),
+      artistId: mainArtistId,
+      artistName: mainArtistName,
+      from: 'offer',
+    })
     navigate('Artist', { id: artists[0].id })
   }
 

--- a/src/features/search/components/SearchListHeader/ArtistSection.tsx
+++ b/src/features/search/components/SearchListHeader/ArtistSection.tsx
@@ -12,7 +12,7 @@ const TITLE = 'Les artistes'
 
 type ArtistSectionProps = {
   artists: Artist[]
-  onItemPress: (artistName: string) => void
+  onItemPress: (artistId: string, artistName: string) => void
   style?: StyleProp<ViewStyle>
 }
 

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -1156,8 +1156,10 @@ describe('SearchResultsContent component', () => {
       await user.press(screen.getByText('Artist 1'))
 
       expect(analytics.logConsultArtist).toHaveBeenCalledWith({
+        artistId: '1',
         artistName: 'Artist 1',
         from: 'search',
+        searchId,
       })
     })
   })

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -346,8 +346,13 @@ export const SearchResultsContent: React.FC<SearchResultsContentProps> = ({
     hideVenueMapLocationModal()
   }
 
-  const handleOnArtistPlaylistItemPress = (artistName: string) => {
-    analytics.logConsultArtist({ artistName, from: 'search' })
+  const handleOnArtistPlaylistItemPress = (artistId: string, artistName: string) => {
+    analytics.logConsultArtist({
+      artistId,
+      artistName,
+      searchId: searchState.searchId,
+      from: 'search',
+    })
   }
 
   if (showSkeleton) return <SearchResultsPlaceHolder />

--- a/src/features/search/components/SearchSuggestions/SearchSuggestions.tsx
+++ b/src/features/search/components/SearchSuggestions/SearchSuggestions.tsx
@@ -107,7 +107,7 @@ export const SearchSuggestions = ({
 
   const onArtistPress = (artistId: string, artistName: string) => {
     hideSuggestions()
-    analytics.logConsultArtist({ artistName, from: 'searchAutoComplete' })
+    analytics.logConsultArtist({ artistId, artistName, from: 'searchAutoComplete' })
     navigate('Artist', { id: artistId })
   }
 

--- a/src/features/venue/components/VenueOffers/VenueOffers.native.test.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffers.native.test.tsx
@@ -197,9 +197,10 @@ describe('<VenueOffers />', () => {
         await user.press(screen.getByText('Freida McFadden'))
 
         expect(analytics.logConsultArtist).toHaveBeenNthCalledWith(1, {
+          artistId: '1',
           artistName: 'Freida McFadden',
           from: 'venue',
-          venueId: venueDataTest.id,
+          venueId: venueDataTest.id.toString(),
         })
       })
 

--- a/src/features/venue/components/VenueOffers/VenueOffersList.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffersList.tsx
@@ -115,8 +115,13 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
     )
   }
 
-  const handleArtistsPlaylistPress = (artistName: string) => {
-    analytics.logConsultArtist({ artistName, from: 'venue', venueId: venue.id })
+  const handleArtistsPlaylistPress = (artistId: string, artistName: string) => {
+    analytics.logConsultArtist({
+      artistId,
+      artistName,
+      from: 'venue',
+      venueId: venue.id.toString(),
+    })
   }
 
   return (

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -205,10 +205,12 @@ export const logEventAnalytics = {
   logConsultArticleAccountDeletion: () =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_ARTICLE_ACCOUNT_DELETION }),
   logConsultArtist: (params: {
+    artistId: string
     artistName: string
     from: Referrals
-    offerId?: number
-    venueId?: number
+    offerId?: string
+    venueId?: string
+    searchId?: string
   }) => analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_ARTIST }, params),
   logConsultArtistFakeDoor: () =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_ARTIST_FAKE_DOOR }),

--- a/src/ui/components/Avatar/AvatarList.tsx
+++ b/src/ui/components/Avatar/AvatarList.tsx
@@ -11,7 +11,7 @@ import { AVATAR_LARGE } from 'ui/theme/constants'
 type AvatarListProps = {
   data: Artist[]
   avatarConfig?: AvatarProps
-  onItemPress: (artistName: string) => void
+  onItemPress: (id: string, name: string) => void
 }
 
 const AVATAR_DEFAULT_CONFIG = {

--- a/src/ui/components/Avatar/AvatarListItem.tsx
+++ b/src/ui/components/Avatar/AvatarListItem.tsx
@@ -12,7 +12,7 @@ import { getSpacing, Typo } from 'ui/theme'
 export type AvatarListItemProps = {
   id: number
   name: string
-  onItemPress: (artistName: string) => void
+  onItemPress: (id: string, name: string) => void
   image?: string
 } & AvatarProps
 
@@ -32,7 +32,7 @@ export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
           id,
         },
       }}
-      onBeforeNavigate={() => onItemPress(name)}>
+      onBeforeNavigate={() => onItemPress(id.toString(), name)}>
       <StyledView gap={2}>
         <Avatar borderWidth={6} size={size} {...props}>
           {image ? (


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37553

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
