### PR TITLE
(PC-37697) fix(DS): use skeleton tokens

### DIFF
--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -664,10 +664,6 @@ exports[`<SetBirthday /> should render correctly 1`] = `
               },
             },
           },
-          "uniqueColors": {
-            "backgroundColor": "#DDDDDD",
-            "foregroundColor": "#EEEEEE",
-          },
           "zIndex": {
             "background": -1,
             "bottomSheet": 60,
@@ -1508,10 +1504,6 @@ exports[`<SetBirthday /> should render correctly when account creation token and
                 "width": 146,
               },
             },
-          },
-          "uniqueColors": {
-            "backgroundColor": "#DDDDDD",
-            "foregroundColor": "#EEEEEE",
           },
           "zIndex": {
             "background": -1,

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -2558,10 +2558,6 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
                     },
                   },
                 },
-                "uniqueColors": {
-                  "backgroundColor": "#DDDDDD",
-                  "foregroundColor": "#EEEEEE",
-                },
                 "zIndex": {
                   "background": -1,
                   "bottomSheet": 60,

--- a/__snapshots__/features/home/pages/GenericHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/GenericHome.native.test.tsx.native-snap
@@ -234,7 +234,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
             height={16}
             style={
               {
-                "backgroundColor": "#DDDDDD",
+                "backgroundColor": "#cbcdd2",
                 "borderBottomLeftRadius": 8,
                 "borderBottomRightRadius": 8,
                 "borderTopLeftRadius": 8,
@@ -249,10 +249,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
             <BVLinearGradient
               colors={
                 [
-                  4292730333,
-                  4293848814,
-                  4293848814,
-                  4292730333,
+                  4291546578,
+                  4294046196,
+                  4294046196,
+                  4291546578,
                 ]
               }
               endPoint={
@@ -340,7 +340,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={288}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -355,10 +355,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -404,7 +404,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -419,10 +419,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -460,7 +460,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -475,10 +475,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -539,7 +539,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={288}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -554,10 +554,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -603,7 +603,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -618,10 +618,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -659,7 +659,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -674,10 +674,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -738,7 +738,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={288}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -753,10 +753,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -802,7 +802,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -817,10 +817,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -858,7 +858,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -873,10 +873,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -937,7 +937,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={288}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -952,10 +952,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -1001,7 +1001,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -1016,10 +1016,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -1057,7 +1057,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -1072,10 +1072,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -1130,7 +1130,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
             height={16}
             style={
               {
-                "backgroundColor": "#DDDDDD",
+                "backgroundColor": "#cbcdd2",
                 "borderBottomLeftRadius": 8,
                 "borderBottomRightRadius": 8,
                 "borderTopLeftRadius": 8,
@@ -1145,10 +1145,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
             <BVLinearGradient
               colors={
                 [
-                  4292730333,
-                  4293848814,
-                  4293848814,
-                  4292730333,
+                  4291546578,
+                  4294046196,
+                  4294046196,
+                  4291546578,
                 ]
               }
               endPoint={
@@ -1239,7 +1239,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={240}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -1254,10 +1254,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -1303,7 +1303,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -1318,10 +1318,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -1359,7 +1359,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -1374,10 +1374,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -1438,7 +1438,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={240}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -1453,10 +1453,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -1502,7 +1502,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -1517,10 +1517,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -1558,7 +1558,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -1573,10 +1573,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -1637,7 +1637,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={240}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -1652,10 +1652,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -1701,7 +1701,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -1716,10 +1716,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -1757,7 +1757,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -1772,10 +1772,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -1836,7 +1836,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={240}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -1851,10 +1851,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -1900,7 +1900,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -1915,10 +1915,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -1956,7 +1956,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -1971,10 +1971,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -2035,7 +2035,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={240}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -2050,10 +2050,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -2099,7 +2099,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -2114,10 +2114,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -2155,7 +2155,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -2170,10 +2170,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -2227,7 +2227,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
             height={304}
             style={
               {
-                "backgroundColor": "#DDDDDD",
+                "backgroundColor": "#cbcdd2",
                 "borderBottomLeftRadius": 8,
                 "borderBottomRightRadius": 8,
                 "borderTopLeftRadius": 8,
@@ -2242,10 +2242,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
             <BVLinearGradient
               colors={
                 [
-                  4292730333,
-                  4293848814,
-                  4293848814,
-                  4292730333,
+                  4291546578,
+                  4294046196,
+                  4294046196,
+                  4291546578,
                 ]
               }
               endPoint={
@@ -2295,7 +2295,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
             height={16}
             style={
               {
-                "backgroundColor": "#DDDDDD",
+                "backgroundColor": "#cbcdd2",
                 "borderBottomLeftRadius": 8,
                 "borderBottomRightRadius": 8,
                 "borderTopLeftRadius": 8,
@@ -2310,10 +2310,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
             <BVLinearGradient
               colors={
                 [
-                  4292730333,
-                  4293848814,
-                  4293848814,
-                  4292730333,
+                  4291546578,
+                  4294046196,
+                  4294046196,
+                  4291546578,
                 ]
               }
               endPoint={
@@ -2404,7 +2404,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={240}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -2419,10 +2419,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -2468,7 +2468,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -2483,10 +2483,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -2524,7 +2524,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -2539,10 +2539,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -2603,7 +2603,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={240}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -2618,10 +2618,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -2667,7 +2667,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -2682,10 +2682,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -2723,7 +2723,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -2738,10 +2738,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -2802,7 +2802,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={240}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -2817,10 +2817,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -2866,7 +2866,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -2881,10 +2881,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -2922,7 +2922,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -2937,10 +2937,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -3001,7 +3001,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={240}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -3016,10 +3016,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -3065,7 +3065,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -3080,10 +3080,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -3121,7 +3121,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -3136,10 +3136,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -3200,7 +3200,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={240}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -3215,10 +3215,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -3264,7 +3264,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -3279,10 +3279,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -3320,7 +3320,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -3335,10 +3335,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -3393,7 +3393,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
             height={16}
             style={
               {
-                "backgroundColor": "#DDDDDD",
+                "backgroundColor": "#cbcdd2",
                 "borderBottomLeftRadius": 8,
                 "borderBottomRightRadius": 8,
                 "borderTopLeftRadius": 8,
@@ -3408,10 +3408,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
             <BVLinearGradient
               colors={
                 [
-                  4292730333,
-                  4293848814,
-                  4293848814,
-                  4292730333,
+                  4291546578,
+                  4294046196,
+                  4294046196,
+                  4291546578,
                 ]
               }
               endPoint={
@@ -3499,7 +3499,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={288}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -3514,10 +3514,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -3563,7 +3563,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -3578,10 +3578,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -3619,7 +3619,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -3634,10 +3634,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -3698,7 +3698,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={288}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -3713,10 +3713,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -3762,7 +3762,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -3777,10 +3777,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -3818,7 +3818,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -3833,10 +3833,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -3897,7 +3897,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={288}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -3912,10 +3912,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -3961,7 +3961,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -3976,10 +3976,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -4017,7 +4017,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -4032,10 +4032,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -4096,7 +4096,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     height={288}
                     style={
                       {
-                        "backgroundColor": "#DDDDDD",
+                        "backgroundColor": "#cbcdd2",
                         "borderBottomLeftRadius": 8,
                         "borderBottomRightRadius": 8,
                         "borderTopLeftRadius": 8,
@@ -4111,10 +4111,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                     <BVLinearGradient
                       colors={
                         [
-                          4292730333,
-                          4293848814,
-                          4293848814,
-                          4292730333,
+                          4291546578,
+                          4294046196,
+                          4294046196,
+                          4291546578,
                         ]
                       }
                       endPoint={
@@ -4160,7 +4160,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -4175,10 +4175,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={
@@ -4216,7 +4216,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       height={12}
                       style={
                         {
-                          "backgroundColor": "#DDDDDD",
+                          "backgroundColor": "#cbcdd2",
                           "borderBottomLeftRadius": 8,
                           "borderBottomRightRadius": 8,
                           "borderTopLeftRadius": 8,
@@ -4231,10 +4231,10 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                       <BVLinearGradient
                         colors={
                           [
-                            4292730333,
-                            4293848814,
-                            4293848814,
-                            4292730333,
+                            4291546578,
+                            4294046196,
+                            4294046196,
+                            4291546578,
                           ]
                         }
                         endPoint={

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -8,7 +8,7 @@ import { ModalSpacing } from 'ui/components/modals/enum'
 import { getSpacing } from 'ui/theme'
 import { buttonHeights } from 'ui/theme/buttonHeights'
 // eslint-disable-next-line no-restricted-imports
-import { ACTIVE_OPACITY, ColorsEnum, UniqueColors } from 'ui/theme/colors'
+import { ACTIVE_OPACITY, ColorsEnum } from 'ui/theme/colors'
 import {
   BOTTOM_CONTENT_PAGE_OFFSET_TOP_HEIGHT_DESKTOP_TABLET,
   DESKTOP_CONTENT_MAX_WIDTH,
@@ -148,10 +148,6 @@ export const theme = {
     skyBlue: ColorsEnum.SKY_BLUE,
     skyBlueLight: ColorsEnum.SKY_BLUE_LIGHT,
     white: ColorsEnum.WHITE,
-  },
-  uniqueColors: {
-    backgroundColor: UniqueColors.BACKGROUND_COLOR,
-    foregroundColor: UniqueColors.FOREGROUND_COLOR,
   },
   breakpoints: {
     xxs: Breakpoints.XXS,

--- a/src/ui/components/placeholders/SkeletonTile.tsx
+++ b/src/ui/components/placeholders/SkeletonTile.tsx
@@ -43,12 +43,12 @@ const end = { x: 1, y: 0 }
 
 function UnmemoizedSkeletonTile({ width, height, borderRadius, fullWidth }: DimensionProps) {
   const translateX = useWaveAnimation(width)
-  const { uniqueColors } = useTheme()
+  const { designSystem } = useTheme()
   const colors = [
-    uniqueColors.backgroundColor,
-    uniqueColors.foregroundColor,
-    uniqueColors.foregroundColor,
-    uniqueColors.backgroundColor,
+    designSystem.color.background.skeletonGradient01,
+    designSystem.color.background.skeletonGradient02,
+    designSystem.color.background.skeletonGradient02,
+    designSystem.color.background.skeletonGradient01,
   ]
   return (
     <BackgroundContainer
@@ -78,6 +78,6 @@ const BackgroundContainer = styled.View<DimensionProps>(
     height,
     width: fullWidth ? '100%' : width,
     overflow: 'hidden',
-    backgroundColor: theme.uniqueColors.backgroundColor,
+    backgroundColor: theme.designSystem.color.background.skeletonGradient01,
   })
 )

--- a/src/ui/theme/colors.stories.tsx
+++ b/src/ui/theme/colors.stories.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components/native'
 
 import { Typo, getSpacing } from 'ui/theme'
 
-import { ColorsEnum, UniqueColors } from './colors'
+import { ColorsEnum } from './colors'
 
 export default {
   title: 'Fondations/Colors',
@@ -24,8 +24,6 @@ const Template: StoryFn<React.FC> = () => (
   <React.Fragment>
     <Typo.Title2>ColorsEnum</Typo.Title2>
     <ColorsSection colorsPalette={ColorsEnum} />
-    <Typo.Title2>UniqueColors</Typo.Title2>
-    <ColorsSection colorsPalette={UniqueColors} />
   </React.Fragment>
 )
 export const AllColors = {

--- a/src/ui/theme/colors.ts
+++ b/src/ui/theme/colors.ts
@@ -23,9 +23,4 @@ export enum ColorsEnum {
   WHITE = '#ffffff',
 }
 
-export enum UniqueColors {
-  BACKGROUND_COLOR = '#DDDDDD',
-  FOREGROUND_COLOR = '#EEEEEE',
-}
-
 export const ACTIVE_OPACITY = 0.7


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37697

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

<img width="1331" height="605" alt="Capture d’écran 2025-09-17 à 17 11 17" src="https://github.com/user-attachments/assets/6a785539-6904-4a7f-9702-93afa29a0ccd" />

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
