### PR TITLE
(PC-37942) feat(ci): add timeout to maestro cloud action

### DIFF
--- a/.github/workflows/dev_on_workflow_call_e2e_android.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_android.yml
@@ -25,8 +25,9 @@ permissions:
 
 jobs:
   maestro-cloud:
+    name: 'Build & Test Android Staging'
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - name: Enable Corepack
         run: corepack enable
@@ -97,7 +98,7 @@ jobs:
       - name: Build android apk
         run: cd android && for i in {1..3}; do ENVFILE=.env.staging ./gradlew assembleDebug && break || sleep 2; done
 
-      - name: Generate Robin Android upload name
+      - name: Generate Maestro Android upload name
         id: generate_name
         run: |
           DATE=$(date +"%d/%m/%Y")
@@ -109,7 +110,7 @@ jobs:
           fi
           echo "CUSTOM_NAME=$CUSTOM_NAME" >> $GITHUB_OUTPUT
 
-      - name: Upload and run android tests with Robin
+      - name: Upload and run android tests with Maestro cloud
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.8
         with:
           api-key: ${{ steps.secrets.outputs.ROBIN_API_KEY }}
@@ -120,6 +121,7 @@ jobs:
           android-api-level: 34
           workspace: .maestro/tests/
           include-tags: ${{ inputs.test_tags }}
+          timeout: 120
           env: |
             MAESTRO_APP_ID=app.passculture.staging
             MAESTRO_PASSWORD=${{ steps.secrets.outputs.MAESTRO_PASSWORD }}

--- a/.github/workflows/dev_on_workflow_call_e2e_ios.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_ios.yml
@@ -25,9 +25,9 @@ permissions:
 
 jobs:
   build_e2e:
-    name: 'Build E2E Staging'
+    name: 'Build & Test iOS Staging'
     runs-on: macos-14
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -108,7 +108,7 @@ jobs:
         run: |
           APP_PATH=$(find /Users/runner/Library/Developer/Xcode/Archives/ -name "*.app" | head -n 1)
           echo "APP_PATH=$APP_PATH" >> $GITHUB_OUTPUT
-      - name: Generate Robin iOS upload name
+      - name: Generate Maestro iOS upload name
         id: generate_name
         run: |
           DATE=$(date +"%d/%m/%Y")
@@ -119,7 +119,7 @@ jobs:
             CUSTOM_NAME="${{ inputs.upload_name_prefix }}[iOS] Staging du ${DATE} (${COMMIT_HASH})"
           fi
           echo "CUSTOM_NAME=$CUSTOM_NAME" >> $GITHUB_OUTPUT
-      - name: Upload and run ios tests with Robin
+      - name: Upload and run ios tests with Maestro cloud
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.8
         with:
           api-key: ${{ steps.secrets.outputs.ROBIN_API_KEY }}
@@ -131,6 +131,7 @@ jobs:
           device-os: iOS-17-5
           device-model: iPhone-11
           include-tags: ${{ inputs.test_tags }}
+          timeout: 120
           env: |
             MAESTRO_APP_ID=app.passculture.staging
             MAESTRO_PASSWORD=${{ steps.secrets.outputs.MAESTRO_PASSWORD }}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37942

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Description

- Ajout d'un timeout pour la CI attendent la fin de l'exécution des tests E2E avant de valider le job