### PR TITLE
(PC-37978) feat(ubble): add no retry in useIdentificationUrlMutation

### DIFF
--- a/src/features/identityCheck/queries/useIdentificationUrlMutation.native.test.ts
+++ b/src/features/identityCheck/queries/useIdentificationUrlMutation.native.test.ts
@@ -1,0 +1,52 @@
+import { navigate } from '__mocks__/@react-navigation/native'
+import * as API from 'api/api'
+import { ApiError } from 'api/ApiError'
+import { SubscriptionStep } from 'api/gen'
+import { useGetStepperInfoQuery } from 'features/identityCheck/queries/useGetStepperInfoQuery'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { renderHook, waitFor } from 'tests/utils'
+
+import { useIdentificationUrlMutation } from './useIdentificationUrlMutation'
+
+jest.mock('features/identityCheck/queries/useGetStepperInfoQuery', () => ({
+  useGetStepperInfoQuery: jest.fn(),
+}))
+const mockUseGetStepperInfo = useGetStepperInfoQuery as jest.Mock
+mockUseGetStepperInfo.mockImplementation(() => ({
+  data: { nextSubscriptionStep: SubscriptionStep['email-validation'] },
+}))
+
+const postIdentificationSpy = jest
+  .spyOn(API.api, 'postNativeV1UbbleIdentification')
+  .mockImplementation()
+
+describe('useIdentificationUrlMutation', () => {
+  it('should set identificationUrl when API resolves', async () => {
+    postIdentificationSpy.mockResolvedValueOnce({ identificationUrl: 'http://ubble.test' })
+
+    const { result } = renderHook(() => useIdentificationUrlMutation(), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+
+    await waitFor(() => {
+      expect(result.current).toEqual('http://ubble.test')
+    })
+  })
+
+  it('should navigate to IdentityCheckPending when IDCHECK_ALREADY_PROCESSED error', async () => {
+    postIdentificationSpy.mockRejectedValueOnce(
+      new ApiError(400, { code: 'IDCHECK_ALREADY_PROCESSED' })
+    )
+
+    renderHook(() => useIdentificationUrlMutation(), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith('SubscriptionStackNavigator', {
+        params: undefined,
+        screen: 'IdentityCheckPending',
+      })
+    })
+  })
+})

--- a/src/features/identityCheck/queries/useIdentificationUrlMutation.ts
+++ b/src/features/identityCheck/queries/useIdentificationUrlMutation.ts
@@ -31,7 +31,8 @@ export const useIdentificationUrlMutation = () => {
           replace(...getSubscriptionHookConfig('IdentityCheckUnavailable', { withDMS }))
         }
       }
-    }
+    },
+    { retry: false }
   )
 
   useEffect(() => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37978

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4