### PR TITLE
(PC-37912) feat(VenueMOnoOffer): add agenda tab

### DIFF
--- a/src/features/venue/components/VenueBody/VenueBody.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.tsx
@@ -9,8 +9,7 @@ import { HeadlineOfferData } from 'features/headlineOffer/type'
 import { PracticalInformation } from 'features/venue/components/PracticalInformation/PracticalInformation'
 import { TabLayout } from 'features/venue/components/TabLayout/TabLayout'
 import { VenueOffers } from 'features/venue/components/VenueOffers/VenueOffers'
-import type { VenueOffersArtists, VenueOffers as VenueOffersType } from 'features/venue/types'
-import { Tab } from 'features/venue/types'
+import { VenueOffersArtists, VenueOffers as VenueOffersType, Tab } from 'features/venue/types'
 import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog'
 import { analytics } from 'libs/analytics/provider'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
@@ -29,6 +28,7 @@ interface Props {
   headlineOfferData?: HeadlineOfferData | null
   arePlaylistsLoading: boolean
   enableAccesLibre?: boolean
+  shouldDisplayVenueCalendar?: boolean
 }
 
 export const VenueBody: FunctionComponent<Props> = ({
@@ -39,6 +39,7 @@ export const VenueBody: FunctionComponent<Props> = ({
   headlineOfferData,
   arePlaylistsLoading,
   enableAccesLibre,
+  shouldDisplayVenueCalendar,
 }) => {
   const currency = useGetCurrencyToDisplay()
   const euroToPacificFrancRate = useGetPacificFrancToEuroRate()
@@ -86,13 +87,27 @@ export const VenueBody: FunctionComponent<Props> = ({
       </React.Fragment>
     ),
     [Tab.INFOS]: <PracticalInformation venue={venue} enableAccesLibre={enableAccesLibre} />,
+    [Tab.AGENDA]: null,
+  }
+
+  const tabPanelsWithAgenda = {
+    ...tabPanels,
+    [Tab.AGENDA]: (
+      <Typo.Title3>
+        Bientôt&nbsp;: agenda présentant les dates de l’evènement unique de ce lieu
+      </Typo.Title3>
+    ),
   }
 
   return (
     <SectionContainer visible gap={6}>
       <TabLayout
-        tabPanels={tabPanels}
-        tabs={[{ key: Tab.OFFERS }, { key: Tab.INFOS }]}
+        tabPanels={shouldDisplayVenueCalendar ? tabPanelsWithAgenda : tabPanels}
+        tabs={
+          shouldDisplayVenueCalendar
+            ? [{ key: Tab.OFFERS }, { key: Tab.INFOS }, { key: Tab.AGENDA }]
+            : [{ key: Tab.OFFERS }, { key: Tab.INFOS }]
+        }
         defaultTab={Tab.OFFERS}
         onTabChange={{
           'Offres disponibles': () =>

--- a/src/features/venue/pages/Venue/Venue.native.test.tsx
+++ b/src/features/venue/pages/Venue/Venue.native.test.tsx
@@ -136,6 +136,40 @@ describe('<Venue />', () => {
     expect(await screen.findByTestId('defaultVenueBackground')).toBeOnTheScreen()
   })
 
+  it('should not display Agenda tab when ff WIP_ENABLE_VENUE_CALENDAR is on and there is more than one offer', async () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_VENUE_CALENDAR])
+    renderVenue(venueId)
+
+    expect(screen.queryByText('Agenda')).not.toBeOnTheScreen()
+  })
+
+  describe('Venue is monoOffer', () => {
+    beforeEach(() => {
+      mockUseVenueOffers.mockReturnValue({
+        isLoading: false,
+        data: { hits: [VenueOffersResponseSnap[0]], nbHits: 1 },
+      })
+    })
+
+    it('should display Agenda tab content when ff WIP_ENABLE_VENUE_CALENDAR is on and tab is selected', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_VENUE_CALENDAR])
+      renderVenue(venueId)
+      await user.press(await screen.findByText('Agenda'))
+
+      expect(
+        await screen.findByText(
+          'Bientôt : agenda présentant les dates de l’evènement unique de ce lieu'
+        )
+      ).toBeOnTheScreen()
+    })
+
+    it('should not display Agenda tab when ff WIP_ENABLE_VENUE_CALENDAR is off', async () => {
+      renderVenue(venueId)
+
+      expect(screen.queryByText('Agenda')).not.toBeOnTheScreen()
+    })
+  })
+
   describe('CTA', () => {
     it('should not display CTA if venueTypeCode is Movie', async () => {
       const mockedVenue = { ...venueDataTest, venueTypeCode: VenueTypeCodeKey.MOVIE }

--- a/src/features/venue/pages/Venue/Venue.tsx
+++ b/src/features/venue/pages/Venue/Venue.tsx
@@ -79,6 +79,8 @@ export const Venue: FunctionComponent = () => {
   const isVenueHeadlineOfferActive = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_VENUE_HEADLINE_OFFER
   )
+  const enableVenueCalendar = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ENABLE_VENUE_CALENDAR)
+  const shouldDisplayVenueCalendar = enableVenueCalendar && venueOffers?.hits.length === 1
   const enableAccesLibre = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ENABLE_ACCES_LIBRE)
 
   const headlineOfferData = isVenueHeadlineOfferActive
@@ -118,12 +120,10 @@ export const Venue: FunctionComponent = () => {
               headlineOfferData={headlineOfferData}
               arePlaylistsLoading={arePlaylistsLoading}
               enableAccesLibre={enableAccesLibre}
+              shouldDisplayVenueCalendar={shouldDisplayVenueCalendar}
             />
-
             <VenueThematicSection venue={venue} />
-
             <VenueMessagingApps venue={venue} />
-
             <EmptyBottomSection isVisible={!!isCTADisplayed} />
           </Animated.View>
         </ViewGap>

--- a/src/features/venue/types.ts
+++ b/src/features/venue/types.ts
@@ -21,6 +21,7 @@ export interface Venue {
 export enum Tab {
   OFFERS = 'Offres disponibles',
   INFOS = 'Infos pratiques',
+  AGENDA = 'Agenda',
 }
 
 export type TabProps<TabKeyType extends string> = {

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -65,6 +65,7 @@ export enum RemoteStoreFeatureFlags {
   WIP_ENABLE_GOOGLE_SSO = 'wipEnableGoogleSSO',
   WIP_ENABLE_GRID_LIST = 'wipEnableGridList',
   WIP_ENABLE_LOAN_FAKEDOOR = 'wipEnableLoanFakedoor',
+  WIP_ENABLE_VENUE_CALENDAR = 'wipEnableVenueCalendar',
   WIP_FLING_BOTTOM_SHEET_NAVIGATE_TO_VENUE = 'wipFlingBottomSheetNavigateToVenue',
   WIP_IS_OPEN_TO_PUBLIC = 'wipIsOpenToPublic',
   WIP_NEW_BOOKING_PAGE = 'wipNewBookingPage',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37912
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
