### PR TITLE
(PC-37971) fix(OfferVideo): to be more precise on log video

### DIFF
--- a/src/features/home/components/modules/video/YoutubePlayer/YoutubePlayer.tsx
+++ b/src/features/home/components/modules/video/YoutubePlayer/YoutubePlayer.tsx
@@ -1,5 +1,5 @@
 import colorAlpha from 'color-alpha'
-import React, { ReactElement, forwardRef, useRef, useState } from 'react'
+import React, { ReactElement, forwardRef, useCallback, useRef, useState } from 'react'
 import {
   ActivityIndicator,
   LayoutChangeEvent,
@@ -30,6 +30,7 @@ type YoutubePlayerProps = YoutubeRendererProps & {
   onLayout?: (event: LayoutChangeEvent) => void
   noThumbnail?: boolean
   duration?: Duration
+  onPlayPress?: () => void
 }
 
 const PRESSABLE_STYLE = ({ pressed }: PressableStateCallbackType) => ({
@@ -47,6 +48,7 @@ export const YoutubePlayer = forwardRef(function YoutubePlayer(
     onLayout,
     play = true,
     duration,
+    onPlayPress,
     ...playerProps
   }: YoutubePlayerProps,
   ref: React.ForwardedRef<YoutubePlayerRef>
@@ -54,6 +56,7 @@ export const YoutubePlayer = forwardRef(function YoutubePlayer(
   const { designSystem } = useTheme()
   const innerVideoRef = React.useRef<YoutubeRendererRef>(null)
   const containerRef = useRef<View>(null)
+  const [hasLaunched, setHasLaunched] = useState(false)
 
   const [playerVisible, setPlayerVisible] = useState(noThumbnail)
   const [playerReady, setPlayerReady] = useState(false)
@@ -79,6 +82,14 @@ export const YoutubePlayer = forwardRef(function YoutubePlayer(
     setPlayerReady(true)
     onReady?.()
   }
+
+  const handleLaunchPlayer = useCallback(() => {
+    if (!hasLaunched) {
+      setHasLaunched(true)
+      onPlayPress?.()
+    }
+    setPlayerVisible(true)
+  }, [hasLaunched, onPlayPress])
 
   if (!noThumbnail && !thumbnail) {
     return null
@@ -109,7 +120,7 @@ export const YoutubePlayer = forwardRef(function YoutubePlayer(
         <StyledAnimatedView height={playerProps.height} width={playerProps.width}>
           <Pressable
             accessibilityRole="imagebutton"
-            onPress={() => setPlayerVisible(true)}
+            onPress={handleLaunchPlayer}
             style={PRESSABLE_STYLE}>
             <ThumbnailOverlay>
               {playerVisible ? (

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -897,17 +897,6 @@ describe('<OfferContent />', () => {
         id: offerResponseSnap.id,
       })
     })
-
-    it('should trigger ConsultVideo log when pressing see video button', async () => {
-      setFeatureFlags([RemoteStoreFeatureFlags.WIP_OFFER_VIDEO_SECTION])
-      renderOfferContent({})
-
-      await screen.findByText('Réserver l’offre')
-
-      await user.press(screen.getByText('Voir la vidéo'))
-
-      expect(analytics.logConsultVideo).toHaveBeenCalledWith({ from: 'offer' })
-    })
   })
 })
 

--- a/src/features/offer/components/OfferContent/OfferContent.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.tsx
@@ -6,7 +6,6 @@ import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { OfferContentBase } from 'features/offer/components/OfferContent/OfferContentBase'
 import { OfferCTAProvider } from 'features/offer/components/OfferContent/OfferCTAProvider'
 import { OfferContentProps } from 'features/offer/types'
-import { analytics } from 'libs/analytics/provider'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -38,7 +37,6 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   }
 
   const handleVideoPress = () => {
-    analytics.logConsultVideo({ from: 'offer' })
     navigate('OfferVideoPreview', { id: offer.id })
   }
 

--- a/src/features/offer/components/OfferContent/OfferContent.web.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.tsx
@@ -6,7 +6,6 @@ import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { OfferContentBase } from 'features/offer/components/OfferContent/OfferContentBase'
 import { OfferCTAProvider } from 'features/offer/components/OfferContent/OfferCTAProvider'
 import { OfferContentProps } from 'features/offer/types'
-import { analytics } from 'libs/analytics/provider'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { getImagesUrlsWithCredit } from 'shared/getImagesUrlsWithCredit/getImagesUrlsWithCredit'
@@ -50,7 +49,6 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   }
 
   const handleVideoPress = () => {
-    analytics.logConsultVideo({ from: 'offer' })
     navigate('OfferVideoPreview', { id: offer.id })
   }
 

--- a/src/features/offer/components/OfferContent/VideoSection/VideoSection.native.test.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/VideoSection.native.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 
+import FastImage from '__mocks__/react-native-fast-image'
 import { SubcategoryIdEnum } from 'api/gen'
 import { VideoSection } from 'features/offer/components/OfferContent/VideoSection/VideoSection'
-import { render, screen } from 'tests/utils'
+import { analytics } from 'libs/analytics/provider'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
 
@@ -12,7 +14,11 @@ const defaultProps = {
   videoId: 'abc123',
   title: 'Peppa Pig',
   subtitle: 'le cochon rose',
+  videoThumbnail: <FastImage />,
 }
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<VideoSection />', () => {
   it('should display Vidéo section', () => {
@@ -31,5 +37,18 @@ describe('<VideoSection />', () => {
     render(<VideoSection {...defaultProps} />, { theme: { isDesktopViewport: false } })
 
     expect(screen.getByTestId('video-section-with-divider')).toBeOnTheScreen()
+  })
+
+  it('should send log ConsultVideo when user taps Play on the thumbnail', async () => {
+    render(<VideoSection {...defaultProps} />)
+
+    const playButton = screen.getByRole('imagebutton')
+
+    await user.press(playButton)
+
+    expect(analytics.logConsultVideo).toHaveBeenCalledWith({
+      from: 'offer',
+      offerId: '123',
+    })
   })
 })

--- a/src/features/offer/components/OfferContent/VideoSection/VideoSection.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/VideoSection.tsx
@@ -8,6 +8,7 @@ import { YoutubePlayer } from 'features/home/components/modules/video/YoutubePla
 import { FeedBackVideo } from 'features/offer/components/OfferContent/VideoSection/FeedBackVideo'
 import { MAX_WIDTH_VIDEO } from 'features/offer/constant'
 import { formatDuration } from 'features/offer/helpers/formatDuration/formatDuration'
+import { analytics } from 'libs/analytics/provider'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
@@ -57,6 +58,7 @@ export const VideoSection = ({
           width={viewportWidth < maxWidth ? undefined : maxWidth}
           initialPlayerParams={{ autoplay: true }}
           duration={duration ? formatDuration(duration, 'sec') : undefined}
+          onPlayPress={() => analytics.logConsultVideo({ from: 'offer', offerId: String(offerId) })}
         />
         <FeedBackVideo offerId={offerId} offerSubcategory={offerSubcategory} userId={userId} />
       </React.Fragment>

--- a/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.native.test.tsx
+++ b/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.native.test.tsx
@@ -4,6 +4,7 @@ import { OfferResponseV2 } from 'api/gen'
 import * as useGoBack from 'features/navigation/useGoBack'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { OfferVideoPreview } from 'features/offer/pages/OfferVideoPreview/OfferVideoPreview'
+import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { render, screen, userEvent } from 'tests/utils'
@@ -40,5 +41,18 @@ describe('<OfferPreview />', () => {
     await user.press(screen.getByLabelText('Revenir en arrière'))
 
     expect(mockGoBack).toHaveBeenCalledTimes(1)
+  })
+
+  it('should send log ConsultVideo when user taps Play on the thumbnail', async () => {
+    render(<OfferVideoPreview />)
+
+    const playButton = screen.getByRole('imagebutton')
+
+    await user.press(playButton)
+
+    expect(analytics.logConsultVideo).toHaveBeenCalledWith({
+      from: 'offer',
+      offerId: '116656',
+    })
   })
 })

--- a/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.tsx
+++ b/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.tsx
@@ -8,6 +8,7 @@ import { YoutubePlayer } from 'features/home/components/modules/video/YoutubePla
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { formatDuration } from 'features/offer/helpers/formatDuration/formatDuration'
+import { analytics } from 'libs/analytics/provider'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { FastImage } from 'libs/resizing-image-on-demand/FastImage'
@@ -51,6 +52,9 @@ export const OfferVideoPreview: FunctionComponent = () => {
             offer.video.durationSeconds
               ? formatDuration(offer.video.durationSeconds, 'sec')
               : undefined
+          }
+          onPlayPress={() =>
+            analytics.logConsultVideo({ from: 'offer', offerId: String(offer.id) })
           }
         />
       ) : null}

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -272,6 +272,7 @@ export const logEventAnalytics = {
     moduleId?: string
     homeEntryId?: string
     youtubeId?: string
+    offerId?: string
   }) => analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_VIDEO }, params),
   logConsultWholeOffer: (offerId: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_WHOLE_OFFER }, { offerId }),


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37971

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
