### PR TITLE
(PC-38107) fix(sonaralerte): replace Math.random by Date.now to force cache and remove weak crypto…

### DIFF
--- a/src/features/forceUpdate/helpers/onPressStoreLink.ts
+++ b/src/features/forceUpdate/helpers/onPressStoreLink.ts
@@ -13,7 +13,8 @@ const clearStorageAndReload = (): void => {
 
   const location = globalThis.window.location
   const url = new URL(location.href)
-  url.searchParams.set(QUERY_PARAMETER_THAT_CLEAR_STUFF, Math.random().toString()) // force to bypass HTML cache
+  const rand = Date.now()
+  url.searchParams.set(QUERY_PARAMETER_THAT_CLEAR_STUFF, rand.toString()) // force to bypass HTML cache
   location.assign(url)
 }
 

--- a/src/features/forceUpdate/helpers/onPressStoreLink.web.test.ts
+++ b/src/features/forceUpdate/helpers/onPressStoreLink.web.test.ts
@@ -21,7 +21,7 @@ describe('onPressStoreLink', () => {
       writable: true,
     })
 
-    jest.spyOn(global.Math, 'random').mockReturnValue(0.123456)
+    jest.spyOn(global.Date, 'now').mockReturnValue(123456)
   })
 
   it('should clear session storage', () => {
@@ -40,6 +40,6 @@ describe('onPressStoreLink', () => {
     onPressStoreLink()
     const assignedUrlCall = mockAssign.mock.calls[0][0].toString()
 
-    expect(assignedUrlCall).toBe('https://example.com/?force=0.123456')
+    expect(assignedUrlCall).toBe('https://example.com/?force=123456')
   })
 })


### PR DESCRIPTION
Sonar remonte une alerte sur le danger d'utiliser Math.random() : https://sonarcloud.io/project/security_hotspots?id=pass-culture_pass-culture-app-native&tab=how_to_fix

Je propose d'utiliser Date.now() car il n'est pas considéré comme sensible