### PR TITLE
(PC-38204) fix(TalkBack): remove click sound between elements of site map

### DIFF
--- a/__snapshots__/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx.native-snap
@@ -230,16 +230,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -319,7 +315,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -358,16 +354,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -447,7 +439,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -486,16 +478,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -575,7 +563,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -614,16 +602,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -703,7 +687,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -742,16 +726,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -831,7 +811,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -870,16 +850,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -959,7 +935,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -998,16 +974,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -1087,7 +1059,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -1126,16 +1098,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -1215,7 +1183,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -1254,16 +1222,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -1343,7 +1307,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -1382,16 +1346,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -1471,7 +1431,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -1510,16 +1470,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -1599,7 +1555,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -1638,16 +1594,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -1727,7 +1679,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -1766,16 +1718,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -1855,7 +1803,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -1894,16 +1842,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -1983,7 +1927,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -2022,16 +1966,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -2111,7 +2051,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -2150,16 +2090,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -2239,7 +2175,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -2278,16 +2214,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -2367,7 +2299,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -2406,16 +2338,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -2495,7 +2423,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -2534,16 +2462,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -2623,7 +2547,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -2662,16 +2586,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -2751,7 +2671,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -2790,16 +2710,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -2879,7 +2795,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -2918,16 +2834,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -3007,7 +2919,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -3046,16 +2958,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -3135,7 +3043,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -3174,16 +3082,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -3263,7 +3167,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -3302,16 +3206,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -3391,7 +3291,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -3430,16 +3330,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -3519,7 +3415,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -3558,16 +3454,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -3647,7 +3539,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -3686,16 +3578,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -3775,7 +3663,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -3814,16 +3702,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -3903,7 +3787,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -3942,16 +3826,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -4031,7 +3911,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
         <View
@@ -4070,16 +3950,12 @@ exports[`SiteMapScreen should render correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <Text
+            <View
               style={
                 {
-                  "color": "#161617",
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Medium",
-                  "fontSize": 16,
-                  "lineHeight": 25.6,
                   "marginLeft": 12,
                 }
               }
@@ -4159,7 +4035,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
                   </Text>
                 </View>
               </View>
-            </Text>
+            </View>
           </View>
         </View>
       </View>

--- a/doc/decision-records/DR009 - accessibility-audit.md
+++ b/doc/decision-records/DR009 - accessibility-audit.md
@@ -250,12 +250,14 @@ On ignore les textes/éléments ajoutés dans `accessibilityHint` pour éviter u
 **Ticket** : [PC-38205](https://passculture.atlassian.net/browse/PC-38205)  
 **PR** : [#8740](https://github.com/pass-culture/pass-culture-app-native/pull/8740)
 
-**Problème** 😱  
+**Problème** 😱
+
 - **(E04)** Les sous titres ne sont pas identifié comme des titres mais simplement comme des textes, car n'utilisent pas `getHeadingAttrs()`.
 - **(E09)** Le titre dans le header d'un lieu n'est pas identifié comme un titre mais simplement comme un texte, car n'utilise pas `getHeadingAttrs()`.
-- **(E14)** Le titre "Rechercher" de la page de recherche n'est pas identifié comme un titre mais simplement comme un texte, car utilise `getHeadingAttrs()` mais sur une `View`. 
+- **(E14)** Le titre "Rechercher" de la page de recherche n'est pas identifié comme un titre mais simplement comme un texte, car utilise `getHeadingAttrs()` mais sur une `View`.
 
-**Correction** 💡  
+**Correction** 💡
+
 - **(E04)** Utilisation de `getHeadingAttrs(3)` pour les sous titres de type `Typo.BodyAccent`
 - **(E09)** Utilisation de `getHeadingAttrs(3)` pour les sous titres de type `Typo.BodyAccent`
 - **(E14)** Utilisation de `getHeadingAttrs(1)` sur le texte et non sur le container qui était une `View`
@@ -425,7 +427,9 @@ Lors d'une lecture manuelle des éléments de la home, les emojis ne sont pas lu
 Si je supprime ce `accessibilityLabel`, les emojis dans le titre sont lus, même en lecture manuelle, ce qui me permet de conclure que ce code fonctionne correctement.
 
 **Correction** 💡  
-Texte
+En réalité, nous n'avions pas testé correctement le plan du site avec le TalkBack. En plus de la restitution de toute la page lors de l'activation du TalkBack, de la restitution en appuyant un élément, on peut utiliser le swipe pour "naviguer" à travers les éléments. En swipant, on arrive bien a reproduire le problème qu'avait constaté l'auditeur. On endend bien un "click" entre les éléments. Mais ce n'était pas la restitution du svg "point" comme le pensait l'auditeur.
+
+Le son que nous entendions entre les éléments du plan du site était la restitution d'un texte vide. Ce texte vide était dû à la mauvaise utilisation d'un composant texte, utilisé comme conteneur, alors qu'il fallait utilisé une simple `View`. Une fois le composant texte remplacé par une `View`, nous n'avions plus le bruit parasite entre chaque element.
 
 </details>
 

--- a/src/features/profile/pages/Accessibility/SiteMapScreen.tsx
+++ b/src/features/profile/pages/Accessibility/SiteMapScreen.tsx
@@ -108,7 +108,7 @@ const BulletContainer = styled.View(({ theme }) => ({
   alignSelf: 'center',
 }))
 
-const ListText = styled(Typo.Body)({
+const ListText = styled.View({
   marginLeft: getSpacing(3),
   flex: 1,
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-38204

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
