### PR TITLE
(PC-38131) feat(bonification): create screens in cheatcodes

### DIFF
--- a/src/cheatcodes/pages/CheatcodesMenu.tsx
+++ b/src/cheatcodes/pages/CheatcodesMenu.tsx
@@ -6,6 +6,7 @@ import { CheatcodesButtonList } from 'cheatcodes/components/CheatcodesButtonList
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { cheatcodesNavigationAchievementsButtons } from 'cheatcodes/pages/features/achievements/CheatcodesNavigationAchievements'
 import { cheatcodesNavigationBirthdayNotificationsButtons } from 'cheatcodes/pages/features/birthdayNotifications/CheatcodesNavigationBirthdayNotifications'
+import { cheatcodesNavigationBonificationButtons } from 'cheatcodes/pages/features/bonification/CheatcodesNavigationBonification'
 import { cheatcodesNavigationBookingsButtons } from 'cheatcodes/pages/features/bookings/CheatcodesNavigationBookings'
 import { cheatcodesNavigationBookOfferButtons } from 'cheatcodes/pages/features/bookOffer/CheatcodesNavigationBookOffer'
 import { cheatcodesNavigationCulturalSurveyButtons } from 'cheatcodes/pages/features/culturalSurvey/CheatcodesNavigationCulturalSurvey'
@@ -73,6 +74,7 @@ export function CheatcodesMenu(): React.JSX.Element {
 
   const featuresButtons: CheatcodeCategory[] = [
     ...cheatcodesNavigationAchievementsButtons,
+    ...cheatcodesNavigationBonificationButtons,
     ...cheatcodesNavigationBirthdayNotificationsButtons,
     ...cheatcodesNavigationBookOfferButtons,
     ...cheatcodesNavigationBookingsButtons,

--- a/src/cheatcodes/pages/features/bonification/CheatcodesNavigationBonification.tsx
+++ b/src/cheatcodes/pages/features/bonification/CheatcodesNavigationBonification.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { v4 as uuidv4 } from 'uuid'
+
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
+import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
+import { CheatcodeCategory } from 'cheatcodes/types'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
+import { getSubscriptionPropConfig } from 'features/navigation/SubscriptionStackNavigator/getSubscriptionPropConfig'
+import { useGoBack } from 'features/navigation/useGoBack'
+
+const bonificationCheatcodeCategory: CheatcodeCategory = {
+  id: uuidv4(),
+  title: 'Bonification 💸',
+  navigationTarget: {
+    screen: 'CheatcodesStackNavigator',
+    params: { screen: 'CheatcodesNavigationBonification' },
+  },
+  subscreens: [
+    {
+      id: uuidv4(),
+      title: 'BonificationIntroduction',
+      navigationTarget: getSubscriptionPropConfig('BonificationIntroduction'),
+    },
+    {
+      id: uuidv4(),
+      title: 'BonificationNames',
+      navigationTarget: getSubscriptionPropConfig('BonificationNames'),
+    },
+    {
+      id: uuidv4(),
+      title: 'BonificationTitle',
+      navigationTarget: getSubscriptionPropConfig('BonificationTitle'),
+    },
+    {
+      id: uuidv4(),
+      title: 'BonificationBirthDate',
+      navigationTarget: getSubscriptionPropConfig('BonificationBirthDate'),
+    },
+    {
+      id: uuidv4(),
+      title: 'BonificationBirthPlace',
+      navigationTarget: getSubscriptionPropConfig('BonificationBirthPlace'),
+    },
+    {
+      id: uuidv4(),
+      title: 'BonificationRecap',
+      navigationTarget: getSubscriptionPropConfig('BonificationRecap'),
+    },
+    {
+      id: uuidv4(),
+      title: 'BonificationError',
+      navigationTarget: getSubscriptionPropConfig('BonificationError'),
+    },
+  ],
+}
+
+export const cheatcodesNavigationBonificationButtons: CheatcodeCategory[] = [
+  bonificationCheatcodeCategory,
+]
+
+export function CheatcodesNavigationBonification(): React.JSX.Element {
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
+
+  const visibleSubscreens = bonificationCheatcodeCategory.subscreens.filter(
+    (subscreen) => !subscreen.showOnlyInSearch
+  )
+
+  return (
+    <CheatcodesTemplateScreen title={bonificationCheatcodeCategory.title} onGoBack={goBack}>
+      <CheatcodesSubscreensButtonList buttons={visibleSubscreens} />
+    </CheatcodesTemplateScreen>
+  )
+}

--- a/src/features/bonification/pages/BonificationBirthDate.native.test.tsx
+++ b/src/features/bonification/pages/BonificationBirthDate.native.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+import { goBack, navigate } from '__mocks__/@react-navigation/native'
+import { ELIGIBLE_AGE_DATE } from 'features/auth/fixtures/fixtures'
+import { BonificationBirthDate } from 'features/bonification/pages/BonificationBirthDate'
+import { act, fireEvent, render, screen, userEvent } from 'tests/utils'
+
+jest.mock('libs/firebase/analytics/analytics')
+
+describe('BonificationBirthDate', () => {
+  it('Should navigate to next form when pressing "Continuer" when forms are filled', async () => {
+    render(<BonificationBirthDate />)
+
+    const datePicker = screen.getByTestId('date-picker-spinner-native')
+    await act(() =>
+      fireEvent(datePicker, 'onChange', { nativeEvent: { timestamp: ELIGIBLE_AGE_DATE } })
+    )
+
+    const button = screen.getByText('Continuer')
+    await userEvent.press(button)
+
+    expect(navigate).toHaveBeenCalledWith('BonificationBirthPlace')
+  })
+
+  it('Should go back when pressing go back button', async () => {
+    render(<BonificationBirthDate />)
+
+    const button = screen.getByLabelText('Revenir en arrière')
+    await userEvent.press(button)
+
+    expect(goBack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/bonification/pages/BonificationBirthDate.tsx
+++ b/src/features/bonification/pages/BonificationBirthDate.tsx
@@ -1,10 +1,91 @@
-import React from 'react'
-import { View, Text } from 'react-native'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { useNavigation } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
+import React, { useCallback } from 'react'
+import { Controller, useForm } from 'react-hook-form'
+
+import { MINIMUM_DATE } from 'features/auth/constants'
+import { setBirthdaySchema } from 'features/auth/pages/signup/SetBirthday/schema/setBirthdaySchema'
+import { SubscriptionStackParamList } from 'features/navigation/SubscriptionStackNavigator/SubscriptionStackTypes'
+import { formatDateToISOStringWithoutTime } from 'libs/parsers/formatDates'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { Form } from 'ui/components/Form'
+import { DateInput } from 'ui/components/inputs/DateInput/DateInput'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { PageWithHeader } from 'ui/pages/PageWithHeader'
+import { Typo } from 'ui/theme'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+
+type BirthdayForm = {
+  birthdate: Date
+}
 
 export const BonificationBirthDate = () => {
+  const { navigate } = useNavigation<StackNavigationProp<SubscriptionStackParamList>>()
+
+  const currentYear = new Date().getFullYear()
+  const maximumSpinnerDate = new Date(currentYear - 17, 11, 31)
+  const defaultDate = new Date(new Date().setFullYear(currentYear - 17))
+
+  const {
+    control,
+    formState: { isValid },
+    handleSubmit,
+  } = useForm<BirthdayForm>({
+    resolver: yupResolver(setBirthdaySchema),
+    defaultValues: { birthdate: defaultDate },
+    mode: 'onChange',
+  })
+
+  const onGoToNextStep = useCallback(
+    ({ birthdate }: BirthdayForm) => {
+      if (birthdate) {
+        navigate('BonificationBirthPlace')
+      }
+    },
+    [navigate]
+  )
+
   return (
-    <View>
-      <Text>BonificationBirthDate</Text>
-    </View>
+    <PageWithHeader
+      title="Informations Personnelles"
+      scrollChildren={
+        <Form.MaxWidth>
+          <ViewGap gap={4}>
+            <Typo.Title3 {...getHeadingAttrs(2)}>
+              Quelle est sa date de naissance&nbsp;?
+            </Typo.Title3>
+
+            <Controller
+              control={control}
+              name="birthdate"
+              render={({ field: { value, onChange }, formState: { errors } }) => (
+                <DateInput
+                  onChange={onChange}
+                  date={value}
+                  errorMessage={
+                    formatDateToISOStringWithoutTime(value) ===
+                    formatDateToISOStringWithoutTime(defaultDate)
+                      ? undefined
+                      : errors.birthdate?.message
+                  }
+                  maximumDate={maximumSpinnerDate}
+                  minimumDate={MINIMUM_DATE}
+                />
+              )}
+            />
+          </ViewGap>
+        </Form.MaxWidth>
+      }
+      fixedBottomChildren={
+        <ButtonPrimary
+          type="submit"
+          wording="Continuer"
+          accessibilityLabel="Continuer vers le lieu de naissance"
+          onPress={handleSubmit(onGoToNextStep)}
+          disabled={!isValid}
+        />
+      }
+    />
   )
 }

--- a/src/features/bonification/pages/BonificationBirthDate.tsx
+++ b/src/features/bonification/pages/BonificationBirthDate.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { View, Text } from 'react-native'
+
+export const BonificationBirthDate = () => {
+  return (
+    <View>
+      <Text>BonificationBirthDate</Text>
+    </View>
+  )
+}

--- a/src/features/bonification/pages/BonificationBirthPlace.native.test.tsx
+++ b/src/features/bonification/pages/BonificationBirthPlace.native.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import { goBack, navigate } from '__mocks__/@react-navigation/native'
+import { BonificationBirthPlace } from 'features/bonification/pages/BonificationBirthPlace'
+import { render, screen, userEvent } from 'tests/utils'
+
+jest.mock('libs/firebase/analytics/analytics')
+
+describe('BonificationBirthPlace', () => {
+  it('Should navigate to next form when pressing "Continuer" when forms are filled', async () => {
+    render(<BonificationBirthPlace />)
+
+    const countryOfBirthField = screen.getByPlaceholderText('Son pays de naissance')
+    await userEvent.type(countryOfBirthField, 'France')
+    const cityOfBirthField = screen.getByPlaceholderText('Sa ville de naissance')
+    await userEvent.type(cityOfBirthField, 'Toulouse')
+
+    const button = screen.getByText('Continuer')
+    await userEvent.press(button)
+
+    expect(navigate).toHaveBeenCalledWith('BonificationRecap')
+  })
+
+  it('Should go back when pressing go back button', async () => {
+    render(<BonificationBirthPlace />)
+
+    const button = screen.getByLabelText('Revenir en arrière')
+    await userEvent.press(button)
+
+    expect(goBack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/bonification/pages/BonificationBirthPlace.tsx
+++ b/src/features/bonification/pages/BonificationBirthPlace.tsx
@@ -1,10 +1,106 @@
+import { yupResolver } from '@hookform/resolvers/yup'
+import { useNavigation } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
 import React from 'react'
-import { View, Text } from 'react-native'
+import { Controller, useForm } from 'react-hook-form'
+
+import { BonificationBirthPlaceSchema } from 'features/bonification/schemas/BonificationBirthPlaceSchema'
+import { SubscriptionStackParamList } from 'features/navigation/SubscriptionStackNavigator/SubscriptionStackTypes'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { Form } from 'ui/components/Form'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { InputText } from 'ui/designSystem/InputText/InputText'
+import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
+import { PageWithHeader } from 'ui/pages/PageWithHeader'
+import { Typo } from 'ui/theme'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+
+type FormValues = {
+  country: string
+  city?: string
+}
 
 export const BonificationBirthPlace = () => {
+  const { navigate } = useNavigation<StackNavigationProp<SubscriptionStackParamList>>()
+
+  const { control, formState, handleSubmit } = useForm<FormValues>({
+    defaultValues: {
+      country: '',
+      city: '',
+    },
+    resolver: yupResolver(BonificationBirthPlaceSchema),
+    mode: 'all',
+  })
+
+  const disabled = !formState.isValid
+
+  async function saveBirthPlaceAndNavigate({ country, city }: FormValues) {
+    if (disabled) return
+    // eslint-disable-next-line no-console
+    console.log({ country, city })
+    navigate('BonificationRecap')
+  }
+
+  useEnterKeyAction(disabled ? undefined : () => handleSubmit(saveBirthPlaceAndNavigate))
+
   return (
-    <View>
-      <Text>BonificationBirthPlace</Text>
-    </View>
+    <PageWithHeader
+      title="Informations Personnelles"
+      scrollChildren={
+        <Form.MaxWidth>
+          <ViewGap gap={4}>
+            <Typo.Title3 {...getHeadingAttrs(2)}>
+              {'Quel est son lieu de naissance\u00a0?'}
+            </Typo.Title3>
+            <Controller
+              control={control}
+              name="country"
+              render={({ field: { onChange, value }, fieldState: { error } }) => (
+                <InputText
+                  label="Pays de naissance"
+                  value={value}
+                  autoFocus
+                  onChangeText={onChange}
+                  placeholder="Son pays de naissance"
+                  isRequiredField
+                  accessibilityHint={error?.message}
+                  testID="Entrée pour le pays de naissance"
+                  textContentType="countryName"
+                  autoComplete="country"
+                  errorMessage={error?.message}
+                />
+              )}
+            />
+            <Controller
+              control={control}
+              name="city"
+              render={({ field: { onChange, value }, fieldState: { error } }) => (
+                <InputText
+                  label="Ville de naissance"
+                  value={value}
+                  onChangeText={onChange}
+                  placeholder="Sa ville de naissance"
+                  isRequiredField
+                  accessibilityHint={error?.message}
+                  testID="Entrée pour la ville de naissance"
+                  textContentType="addressCity"
+                  autoComplete="postal-address-locality"
+                  errorMessage={error?.message}
+                />
+              )}
+            />
+          </ViewGap>
+        </Form.MaxWidth>
+      }
+      fixedBottomChildren={
+        <ButtonPrimary
+          type="submit"
+          wording="Continuer"
+          accessibilityLabel="Continuer vers le résumé"
+          onPress={handleSubmit(saveBirthPlaceAndNavigate)}
+          disabled={disabled}
+        />
+      }
+    />
   )
 }

--- a/src/features/bonification/pages/BonificationBirthPlace.tsx
+++ b/src/features/bonification/pages/BonificationBirthPlace.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { View, Text } from 'react-native'
+
+export const BonificationBirthPlace = () => {
+  return (
+    <View>
+      <Text>BonificationBirthPlace</Text>
+    </View>
+  )
+}

--- a/src/features/bonification/pages/BonificationError.native.test.tsx
+++ b/src/features/bonification/pages/BonificationError.native.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+import { navigate } from '__mocks__/@react-navigation/native'
+import { BonificationError } from 'features/bonification/pages/BonificationError'
+import { render, screen, userEvent } from 'tests/utils'
+
+jest.mock('libs/firebase/analytics/analytics')
+
+describe('BonificationError', () => {
+  it('Should navigate to next form when pressing "Retourner vers le formulaire" when checkbox is checked', async () => {
+    render(<BonificationError />)
+
+    const button = screen.getByText('Retourner vers le formulaire')
+    await userEvent.press(button)
+
+    expect(navigate).toHaveBeenCalledWith('SubscriptionStackNavigator', {
+      params: undefined,
+      screen: 'BonificationNames',
+    })
+  })
+
+  it('Should go navigate to home when pressing "Retourner à l’accueil"', async () => {
+    render(<BonificationError />)
+
+    const button = screen.getByText('Retourner à l’accueil')
+    await userEvent.press(button)
+
+    expect(navigate).toHaveBeenCalledWith('TabNavigator', { params: undefined, screen: 'Home' })
+  })
+})

--- a/src/features/bonification/pages/BonificationError.tsx
+++ b/src/features/bonification/pages/BonificationError.tsx
@@ -1,10 +1,36 @@
 import React from 'react'
-import { View, Text } from 'react-native'
+import styled from 'styled-components/native'
 
-export const BonificationError = () => {
+import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
+import { getSubscriptionPropConfig } from 'features/navigation/SubscriptionStackNavigator/getSubscriptionPropConfig'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
+import { HappyFaceWithTear } from 'ui/svg/icons/HappyFaceWithTear'
+import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
+import { Typo } from 'ui/theme'
+
+export function BonificationError() {
   return (
-    <View>
-      <Text>BonificationError</Text>
-    </View>
+    <GenericInfoPage
+      illustration={HappyFaceWithTear}
+      title="Oups... Un problème est survenu&nbsp;!"
+      buttonPrimary={{
+        wording: 'Retourner vers le formulaire',
+        navigateTo: getSubscriptionPropConfig('BonificationNames'),
+      }}
+      buttonSecondary={{
+        wording: 'Retourner à l’accueil',
+        navigateTo: navigateToHomeConfig,
+        icon: PlainArrowPrevious,
+      }}>
+      <ViewGap gap={4}>
+        <StyledBody>BLA BLA</StyledBody>
+        <StyledBody>BLA BLA</StyledBody>
+      </ViewGap>
+    </GenericInfoPage>
   )
 }
+
+const StyledBody = styled(Typo.Body)({
+  textAlign: 'center',
+})

--- a/src/features/bonification/pages/BonificationError.tsx
+++ b/src/features/bonification/pages/BonificationError.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { View, Text } from 'react-native'
+
+export const BonificationError = () => {
+  return (
+    <View>
+      <Text>BonificationError</Text>
+    </View>
+  )
+}

--- a/src/features/bonification/pages/BonificationIntroduction.native.test.tsx
+++ b/src/features/bonification/pages/BonificationIntroduction.native.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import { goBack, navigate } from '__mocks__/@react-navigation/native'
+import { BonificationIntroduction } from 'features/bonification/pages/BonificationIntroduction'
+import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
+import { render, screen, userEvent } from 'tests/utils'
+
+jest.mock('libs/firebase/analytics/analytics')
+const openUrl = jest.spyOn(NavigationHelpers, 'openUrl')
+
+describe('BonificationIntroduction', () => {
+  it('Should navigate to form when pressing "Commencer"', async () => {
+    render(<BonificationIntroduction />)
+
+    const button = screen.getByText('Commencer')
+    await userEvent.press(button)
+
+    expect(navigate).toHaveBeenCalledWith('BonificationNames')
+  })
+
+  it('Should navigate to FAQ when pressing "Consulter l’article d’aide"', async () => {
+    render(<BonificationIntroduction />)
+
+    const button = screen.getByText('Consulter l’article d’aide')
+    await userEvent.press(button)
+
+    expect(openUrl).toHaveBeenCalledWith('https://passculture.faq', undefined, true)
+  })
+
+  it('Should go back when pressing go back button', async () => {
+    render(<BonificationIntroduction />)
+
+    const button = screen.getByLabelText('Revenir en arrière')
+    await userEvent.press(button)
+
+    expect(goBack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/bonification/pages/BonificationIntroduction.tsx
+++ b/src/features/bonification/pages/BonificationIntroduction.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { View, Text } from 'react-native'
+
+export const BonificationIntroduction = () => {
+  return (
+    <View>
+      <Text>BonificationIntroduction</Text>
+    </View>
+  )
+}

--- a/src/features/bonification/pages/BonificationIntroduction.tsx
+++ b/src/features/bonification/pages/BonificationIntroduction.tsx
@@ -1,10 +1,103 @@
+/* eslint-disable no-console */
+import { useNavigation } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
 import React from 'react'
-import { View, Text } from 'react-native'
+import { styled } from 'styled-components/native'
+
+import { SubscriptionStackParamList } from 'features/navigation/SubscriptionStackNavigator/SubscriptionStackTypes'
+import { env } from 'libs/environment/env'
+import { InfoBanner } from 'ui/components/banners/InfoBanner'
+import { BulletListItem } from 'ui/components/BulletListItem'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
+import { Form } from 'ui/components/Form'
+import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
+import { VerticalUl } from 'ui/components/Ul'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { PageWithHeader } from 'ui/pages/PageWithHeader'
+import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
+import { IdCardWithMagnifyingGlass as InitialIdCardWithMagnifyingGlass } from 'ui/svg/icons/IdCardWithMagnifyingGlass'
+import { Info } from 'ui/svg/icons/Info'
+import { Typo } from 'ui/theme'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const BonificationIntroduction = () => {
+  const { navigate } = useNavigation<StackNavigationProp<SubscriptionStackParamList>>()
+
   return (
-    <View>
-      <Text>BonificationIntroduction</Text>
-    </View>
+    <PageWithHeader
+      title="Informations Personnelles"
+      scrollChildren={
+        <Form.MaxWidth>
+          <ViewGap gap={4}>
+            <Container>
+              <IdCardWithMagnifyingGlass />
+            </Container>
+            <Typo.Title3 {...getHeadingAttrs(2)}>
+              On a besoin d’infos sur ton parent ou tuteur
+            </Typo.Title3>
+            <Typo.Body>
+              Pour demander ton allocation, tu dois remplir quelques infos sur ton parent, ton
+              tuteur légal ou l’organisme qui te prend en charge.
+            </Typo.Body>
+            <Typo.Body>On va te demander&nbsp;:</Typo.Body>
+            <VerticalUl>
+              <BulletListItem>
+                <Typo.BodyAccent>Nom de naissance (avant mariage)</Typo.BodyAccent>
+              </BulletListItem>
+              <BulletListItem>
+                <Typo.BodyAccent>Prénom complet</Typo.BodyAccent>
+              </BulletListItem>
+              <BulletListItem>
+                <Typo.BodyAccent>Nom d’usage</Typo.BodyAccent>
+              </BulletListItem>
+              <BulletListItem>
+                <Typo.BodyAccent>Date de naissance</Typo.BodyAccent>
+              </BulletListItem>
+              <BulletListItem>
+                <Typo.BodyAccent>Ville de naissance</Typo.BodyAccent>
+              </BulletListItem>
+            </VerticalUl>
+            <Typo.Body>
+              Ces infos nous servirons à vérifier si tu es éligible à l’allocation.
+            </Typo.Body>
+            <InfoBanner
+              icon={Info}
+              message="Il se peut que tu ne sois pas éligible et que ta demande soit refusée."
+            />
+          </ViewGap>
+        </Form.MaxWidth>
+      }
+      fixedBottomChildren={
+        <React.Fragment>
+          <ButtonPrimary
+            wording="Commencer"
+            isLoading={false}
+            type="submit"
+            accessibilityLabel="Commencer la demande"
+            onPress={() => {
+              navigate('BonificationNames')
+            }}
+          />
+          <ExternalTouchableLink
+            as={ButtonTertiaryBlack}
+            wording="Consulter l’article d’aide"
+            externalNav={{ url: env.FAQ_LINK }}
+            onBeforeNavigate={() => {
+              // ANALYTICS?
+              console.log('KO')
+            }}
+            icon={ExternalSiteFilled}
+          />
+        </React.Fragment>
+      }
+    />
   )
 }
+
+const IdCardWithMagnifyingGlass = styled(InitialIdCardWithMagnifyingGlass).attrs(({ theme }) => ({
+  color: theme.designSystem.color.icon.brandPrimary,
+  size: theme.illustrations.sizes.fullPage,
+}))``
+
+const Container = styled.View({ alignItems: 'center' })

--- a/src/features/bonification/pages/BonificationNames.native.test.tsx
+++ b/src/features/bonification/pages/BonificationNames.native.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import { goBack, navigate } from '__mocks__/@react-navigation/native'
+import { BonificationNames } from 'features/bonification/pages/BonificationNames'
+import { render, screen, userEvent } from 'tests/utils'
+
+jest.mock('libs/firebase/analytics/analytics')
+
+describe('BonificationNames', () => {
+  it('Should navigate to next form when pressing "Continuer" when forms are filled', async () => {
+    render(<BonificationNames />)
+
+    const firstNameField = screen.getByPlaceholderText('Son prénom')
+    await userEvent.type(firstNameField, 'Jaques')
+    const birthNameField = screen.getByPlaceholderText('Son nom de naissance')
+    await userEvent.type(birthNameField, 'Dupont')
+
+    const button = screen.getByText('Continuer')
+    await userEvent.press(button)
+
+    expect(navigate).toHaveBeenCalledWith('BonificationTitle')
+  })
+
+  it('Should go back when pressing go back button', async () => {
+    render(<BonificationNames />)
+
+    const button = screen.getByLabelText('Revenir en arrière')
+    await userEvent.press(button)
+
+    expect(goBack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/bonification/pages/BonificationNames.tsx
+++ b/src/features/bonification/pages/BonificationNames.tsx
@@ -1,10 +1,129 @@
+import { yupResolver } from '@hookform/resolvers/yup'
+import { useNavigation } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
 import React from 'react'
-import { View, Text } from 'react-native'
+import { Controller, useForm } from 'react-hook-form'
+
+import { BonificationNamesSchema } from 'features/bonification/schemas/BonificationNamesSchema'
+import { SubscriptionStackParamList } from 'features/navigation/SubscriptionStackNavigator/SubscriptionStackTypes'
+import { InfoBanner } from 'ui/components/banners/InfoBanner'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { Form } from 'ui/components/Form'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { InputText } from 'ui/designSystem/InputText/InputText'
+import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
+import { PageWithHeader } from 'ui/pages/PageWithHeader'
+import { IdCard } from 'ui/svg/icons/IdCard'
+import { Typo } from 'ui/theme'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+
+type FormValues = {
+  firstName: string
+  givenName: string
+  commonName?: string
+}
 
 export const BonificationNames = () => {
+  const { navigate } = useNavigation<StackNavigationProp<SubscriptionStackParamList>>()
+
+  const { control, formState, handleSubmit } = useForm<FormValues>({
+    defaultValues: {
+      firstName: '',
+      givenName: '',
+      commonName: '',
+    },
+    resolver: yupResolver(BonificationNamesSchema),
+    mode: 'all',
+  })
+
+  const disabled = !formState.isValid
+
+  async function saveNameAndNavigate({ firstName, givenName, commonName }: FormValues) {
+    if (disabled) return
+    // eslint-disable-next-line no-console
+    console.log({ firstName, givenName, commonName })
+    navigate('BonificationTitle')
+  }
+
+  useEnterKeyAction(disabled ? undefined : () => handleSubmit(saveNameAndNavigate))
+
   return (
-    <View>
-      <Text>BonificationNames</Text>
-    </View>
+    <PageWithHeader
+      title="Informations Personnelles"
+      scrollChildren={
+        <Form.MaxWidth>
+          <ViewGap gap={4}>
+            <Typo.Title3 {...getHeadingAttrs(2)}>{'Quel est son nom et prénom\u00a0?'}</Typo.Title3>
+            <InfoBanner
+              icon={IdCard}
+              message="Plus tu seras précis sur ces informations, plus on aura de chances de trouver la personne en question."
+            />
+            <Controller
+              control={control}
+              name="firstName"
+              render={({ field: { onChange, value }, fieldState: { error } }) => (
+                <InputText
+                  label="Prénom"
+                  value={value}
+                  autoFocus
+                  onChangeText={onChange}
+                  placeholder="Son prénom"
+                  isRequiredField
+                  accessibilityHint={error?.message}
+                  testID="Entrée pour le prénom"
+                  textContentType="givenName"
+                  autoComplete="given-name"
+                  errorMessage={error?.message}
+                />
+              )}
+            />
+            <Controller
+              control={control}
+              name="givenName"
+              render={({ field: { onChange, value }, fieldState: { error } }) => (
+                <InputText
+                  label="Nom de naissance"
+                  value={value}
+                  onChangeText={onChange}
+                  placeholder="Son nom de naissance"
+                  isRequiredField
+                  accessibilityHint={error?.message}
+                  testID="Entrée pour le nom"
+                  textContentType="familyName"
+                  autoComplete="family-name"
+                  errorMessage={error?.message}
+                />
+              )}
+            />
+            <Controller
+              control={control}
+              name="commonName"
+              render={({ field: { onChange, value }, fieldState: { error } }) => (
+                <InputText
+                  label="Nom d’usage"
+                  value={value}
+                  onChangeText={onChange}
+                  placeholder="Son nom d’usage"
+                  accessibilityHint={error?.message}
+                  testID="Entrée pour le nom d’usage"
+                  textContentType="familyName"
+                  autoComplete="family-name"
+                  errorMessage={error?.message}
+                />
+              )}
+            />
+          </ViewGap>
+        </Form.MaxWidth>
+      }
+      fixedBottomChildren={
+        <ButtonPrimary
+          type="submit"
+          wording="Continuer"
+          accessibilityLabel="Continuer vers la civilité"
+          onPress={handleSubmit(saveNameAndNavigate)}
+          disabled={disabled}
+        />
+      }
+    />
   )
 }

--- a/src/features/bonification/pages/BonificationNames.tsx
+++ b/src/features/bonification/pages/BonificationNames.tsx
@@ -53,7 +53,7 @@ export const BonificationNames = () => {
       scrollChildren={
         <Form.MaxWidth>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getHeadingAttrs(2)}>{'Quel est son nom et prénom\u00a0?'}</Typo.Title3>
+            <Typo.Title3 {...getHeadingAttrs(2)}>Quel est son nom et prénom&nbsp;?</Typo.Title3>
             <InfoBanner
               icon={IdCard}
               message="Plus tu seras précis sur ces informations, plus on aura de chances de trouver la personne en question."

--- a/src/features/bonification/pages/BonificationNames.tsx
+++ b/src/features/bonification/pages/BonificationNames.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { View, Text } from 'react-native'
+
+export const BonificationNames = () => {
+  return (
+    <View>
+      <Text>BonificationNames</Text>
+    </View>
+  )
+}

--- a/src/features/bonification/pages/BonificationRecap.native.test.tsx
+++ b/src/features/bonification/pages/BonificationRecap.native.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+
+import { navigate } from '__mocks__/@react-navigation/native'
+import { BonificationRecap } from 'features/bonification/pages/BonificationRecap'
+import { render, screen, userEvent } from 'tests/utils'
+
+jest.mock('libs/firebase/analytics/analytics')
+
+jest.useFakeTimers()
+
+describe('BonificationRecap', () => {
+  it('Should navigate to next form when pressing "Envoyer" when checkbox is checked', async () => {
+    render(<BonificationRecap />)
+
+    const checkbox = screen.getByText(
+      'Je déclare que l’ensemble des informations que j’ai renseignées sont correctes.'
+    )
+    await userEvent.press(checkbox)
+
+    const button = screen.getByText('Envoyer')
+    await userEvent.press(button)
+
+    await jest.runAllTimers() // to account for the setTimout (will be removed when real API is called)
+
+    expect(navigate).toHaveBeenCalledWith('BonificationError')
+  })
+
+  it('Should go navigate to first screen when pressing "Modifier les informations"', async () => {
+    render(<BonificationRecap />)
+
+    const button = screen.getByText('Modifier les informations')
+    await userEvent.press(button)
+
+    expect(navigate).toHaveBeenCalledWith('BonificationNames')
+  })
+})

--- a/src/features/bonification/pages/BonificationRecap.tsx
+++ b/src/features/bonification/pages/BonificationRecap.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { View, Text } from 'react-native'
+
+export const BonificationRecap = () => {
+  return (
+    <View>
+      <Text>BonificationRecap</Text>
+    </View>
+  )
+}

--- a/src/features/bonification/pages/BonificationRecap.tsx
+++ b/src/features/bonification/pages/BonificationRecap.tsx
@@ -1,10 +1,71 @@
-import React from 'react'
-import { View, Text } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
+import React, { useState } from 'react'
+
+import { Summary } from 'features/identityCheck/components/Summary'
+import { SubscriptionStackParamList } from 'features/navigation/SubscriptionStackNavigator/SubscriptionStackTypes'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { ButtonSecondary } from 'ui/components/buttons/ButtonSecondary'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { Checkbox } from 'ui/designSystem/Checkbox/Checkbox'
+import { PageWithHeader } from 'ui/pages/PageWithHeader'
 
 export const BonificationRecap = () => {
+  const { navigate } = useNavigation<StackNavigationProp<SubscriptionStackParamList>>()
+  const [accepted, setAccepted] = useState(false)
+
+  const [loading, setLoading] = useState(false)
+  const submit = () => {
+    setLoading(true)
+
+    setTimeout(() => {
+      setLoading(false)
+      navigate('BonificationError')
+    }, 4000)
+  }
   return (
-    <View>
-      <Text>BonificationRecap</Text>
-    </View>
+    <PageWithHeader
+      title="Informations personnelles"
+      scrollChildren={
+        <ViewGap gap={4}>
+          <Summary
+            title="Ces informations sont-elles exactes&nbsp;?"
+            data={[
+              { title: 'Nom', value: 'Mr Jean Dupont' },
+              { title: 'Date de naissance', value: '12/12/79' },
+              { title: 'Lieu de naissance', value: 'Toulouse, France' },
+            ]}
+          />
+          <Checkbox
+            label="Je déclare que l’ensemble des informations que j’ai renseignées sont correctes."
+            variant="default"
+            isChecked={accepted}
+            onPress={() => {
+              setAccepted((prev) => !prev)
+            }}
+          />
+        </ViewGap>
+      }
+      fixedBottomChildren={
+        <ViewGap gap={4}>
+          <ButtonPrimary
+            isLoading={loading}
+            type="submit"
+            wording="Envoyer"
+            accessibilityLabel="Envoyer les informations"
+            onPress={submit}
+            disabled={!accepted}
+          />
+          <ButtonSecondary
+            type="button"
+            wording="Modifier les informations"
+            onPress={() => {
+              navigate('BonificationNames')
+            }}
+          />
+        </ViewGap>
+      }
+      shouldDisplayBackButton={false}
+    />
   )
 }

--- a/src/features/bonification/pages/BonificationRecap.tsx
+++ b/src/features/bonification/pages/BonificationRecap.tsx
@@ -65,7 +65,6 @@ export const BonificationRecap = () => {
           />
         </ViewGap>
       }
-      shouldDisplayBackButton={false}
     />
   )
 }

--- a/src/features/bonification/pages/BonificationTitle.native.test.tsx
+++ b/src/features/bonification/pages/BonificationTitle.native.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+import { goBack, navigate } from '__mocks__/@react-navigation/native'
+import { BonificationTitle } from 'features/bonification/pages/BonificationTitle'
+import { render, screen, userEvent } from 'tests/utils'
+
+jest.mock('libs/firebase/analytics/analytics')
+
+describe('BonificationTitle', () => {
+  it('Should navigate to next form when pressing "Continuer" when forms are filled', async () => {
+    render(<BonificationTitle />)
+
+    const titleField = screen.getByTestId('Civilité - Monsieur - non sélectionné')
+    await userEvent.press(titleField)
+
+    const button = screen.getByText('Continuer')
+    await userEvent.press(button)
+
+    expect(navigate).toHaveBeenCalledWith('BonificationBirthDate')
+  })
+
+  it('Should go back when pressing go back button', async () => {
+    render(<BonificationTitle />)
+
+    const button = screen.getByLabelText('Revenir en arrière')
+    await userEvent.press(button)
+
+    expect(goBack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/bonification/pages/BonificationTitle.tsx
+++ b/src/features/bonification/pages/BonificationTitle.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { View, Text } from 'react-native'
+
+export const BonificationTitle = () => {
+  return (
+    <View>
+      <Text>BonificationTitle</Text>
+    </View>
+  )
+}

--- a/src/features/bonification/pages/BonificationTitle.tsx
+++ b/src/features/bonification/pages/BonificationTitle.tsx
@@ -1,10 +1,72 @@
-import React from 'react'
-import { View, Text } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
+import React, { useState } from 'react'
+import { styled } from 'styled-components/native'
+import { v4 as uuidv4 } from 'uuid'
+
+import { SubscriptionStackParamList } from 'features/navigation/SubscriptionStackNavigator/SubscriptionStackTypes'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { RadioSelector } from 'ui/components/radioSelector/RadioSelector'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { PageWithHeader } from 'ui/pages/PageWithHeader'
+import { Typo } from 'ui/theme'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+
+enum FormValues {
+  MADAM = 'Madame',
+  MISTER = 'Monsieur',
+}
 
 export const BonificationTitle = () => {
+  const { navigate } = useNavigation<StackNavigationProp<SubscriptionStackParamList>>()
+
+  const titleID = uuidv4()
+  const titleLabel = 'Civilité'
+  const [title, setTitle] = useState<FormValues | null>(null)
+  const disabled = !title
+
+  const saveTitleAndNavigate = () => {
+    navigate('BonificationBirthDate')
+  }
   return (
-    <View>
-      <Text>BonificationTitle</Text>
-    </View>
+    <PageWithHeader
+      title="Informations Personnelles"
+      scrollChildren={
+        <React.Fragment>
+          <Typo.Title3 {...getHeadingAttrs(2)}>{'Quelle est sa civilité\u00a0?'}</Typo.Title3>
+          <SelectorContainer
+            gap={5}
+            accessibilityRole={AccessibilityRole.RADIOGROUP}
+            accessibilityLabelledBy={titleID}>
+            <RadioSelector
+              radioGroupLabel={titleLabel}
+              label="Madame"
+              checked={title === FormValues.MADAM}
+              onPress={() => setTitle(FormValues.MADAM)}
+            />
+            <RadioSelector
+              radioGroupLabel={titleLabel}
+              label="Monsieur"
+              checked={title === FormValues.MISTER}
+              onPress={() => setTitle(FormValues.MISTER)}
+            />
+          </SelectorContainer>
+        </React.Fragment>
+      }
+      fixedBottomChildren={
+        <ButtonPrimary
+          type="submit"
+          wording="Continuer"
+          accessibilityLabel="Continuer vers la date de naissance"
+          onPress={saveTitleAndNavigate}
+          disabled={disabled}
+        />
+      }
+    />
   )
 }
+
+const SelectorContainer = styled(ViewGap)(({ theme }) => ({
+  marginVertical: theme.designSystem.size.spacing.xl,
+}))

--- a/src/features/bonification/schemas/BonificationBirthPlaceSchema.ts
+++ b/src/features/bonification/schemas/BonificationBirthPlaceSchema.ts
@@ -1,0 +1,20 @@
+import { object, string } from 'yup'
+
+import { isNameValid } from 'ui/components/inputs/nameCheck'
+
+export const BonificationBirthPlaceSchema = object().shape({
+  country: string()
+    .required('Le pays de naissance est obligatoire')
+    .test(
+      'isCountryValid',
+      'Le pays ne doit pas contenir de chiffres ou de caractères spéciaux.',
+      (name) => !!name && isNameValid(name)
+    ),
+  city: string()
+    .required('La ville de naissance est obligatoire pour les personnes nées en France')
+    .test(
+      'isCityValid',
+      'La ville ne doit pas contenir de chiffres ou de caractères spéciaux.',
+      (name) => !!name && isNameValid(name)
+    ),
+})

--- a/src/features/bonification/schemas/BonificationNamesSchema.ts
+++ b/src/features/bonification/schemas/BonificationNamesSchema.ts
@@ -1,0 +1,21 @@
+import { object, string } from 'yup'
+
+import { isNameValid } from 'ui/components/inputs/nameCheck'
+
+export const BonificationNamesSchema = object().shape({
+  firstName: string()
+    .required('Le prénom est obligatoire')
+    .test(
+      'isFirstNameValid',
+      'Ton prénom ne doit pas contenir de chiffres ou de caractères spéciaux.',
+      (name) => !!name && isNameValid(name)
+    ),
+  givenName: string()
+    .required('Le nom de naissance est obligatoire')
+    .test(
+      'isGivenNameValid',
+      'Ton nom ne doit pas contenir de chiffres ou de caractères spéciaux.',
+      (name) => !!name && isNameValid(name)
+    ),
+  commonName: string().optional(),
+})

--- a/src/features/navigation/CheatcodesStackNavigator/CheatcodesStackNavigator.tsx
+++ b/src/features/navigation/CheatcodesStackNavigator/CheatcodesStackNavigator.tsx
@@ -3,6 +3,7 @@ import React, { ComponentType } from 'react'
 import { CheatcodesMenu } from 'cheatcodes/pages/CheatcodesMenu'
 import { CheatcodesNavigationAchievements } from 'cheatcodes/pages/features/achievements/CheatcodesNavigationAchievements'
 import { CheatcodesNavigationBirthdayNotifications } from 'cheatcodes/pages/features/birthdayNotifications/CheatcodesNavigationBirthdayNotifications'
+import { CheatcodesNavigationBonification } from 'cheatcodes/pages/features/bonification/CheatcodesNavigationBonification'
 import { CheatcodesNavigationBookings } from 'cheatcodes/pages/features/bookings/CheatcodesNavigationBookings'
 import { CheatcodesScreenBookingNotFound } from 'cheatcodes/pages/features/bookings/CheatcodesScreenBookingNotFound'
 import { CheatcodesNavigationBookOffer } from 'cheatcodes/pages/features/bookOffer/CheatcodesNavigationBookOffer'
@@ -89,6 +90,10 @@ const routes: CheatcodesStackRoute[] = [
   {
     name: 'CheatcodesNavigationAchievements',
     component: CheatcodesNavigationAchievements,
+  },
+  {
+    name: 'CheatcodesNavigationBonification',
+    component: CheatcodesNavigationBonification,
   },
   {
     name: 'CheatcodesNavigationShare',

--- a/src/features/navigation/CheatcodesStackNavigator/CheatcodesStackTypes.ts
+++ b/src/features/navigation/CheatcodesStackNavigator/CheatcodesStackTypes.ts
@@ -6,6 +6,7 @@ export type CheatcodesStackParamList = {
   CheatcodesNavigationBirthdayNotifications: undefined
   CheatcodesNavigationBookings: undefined
   CheatcodesNavigationBookOffer: undefined
+  CheatcodesNavigationBonification: undefined
   CheatcodesNavigationCulturalSurvey: undefined
   CheatcodesNavigationForceUpdate: undefined
   CheatcodesNavigationHome: undefined

--- a/src/features/navigation/CheatcodesStackNavigator/cheatcodesStackNavigatorPathConfig.tsx
+++ b/src/features/navigation/CheatcodesStackNavigator/cheatcodesStackNavigatorPathConfig.tsx
@@ -7,6 +7,7 @@ export const cheatcodesStackNavigatorPathConfig = {
       CheatcodesNavigationBirthdayNotifications: 'cheatcodes/birthday-notifications',
       CheatcodesNavigationBookings: 'cheatcodes/bookings',
       CheatcodesNavigationBookOffer: 'cheatcodes/book-offer',
+      CheatcodesNavigationBonification: 'cheatcodes/bonification',
       CheatcodesNavigationCulturalSurvey: 'cheatcodes/cultural-survey',
       CheatcodesNavigationErrors: 'cheatcodes/other/errors',
       CheatcodesNavigationForceUpdate: 'cheatcodes/other/force-update',

--- a/src/features/navigation/RootNavigator/linking/rootStackNavigatorPathConfig.ts
+++ b/src/features/navigation/RootNavigator/linking/rootStackNavigatorPathConfig.ts
@@ -158,6 +158,27 @@ export const rootStackNavigatorPathConfig = {
       ComeBackLater: {
         path: 'identification/reviens-plus-tard',
       },
+      BonificationIntroduction: {
+        path: 'bonification/introduction',
+      },
+      BonificationNames: {
+        path: 'bonification/noms',
+      },
+      BonificationTitle: {
+        path: 'bonification/civilite',
+      },
+      BonificationBirthDate: {
+        path: 'bonification/date-de-naissance',
+      },
+      BonificationBirthPlace: {
+        path: 'bonification/lieux-de-naissance',
+      },
+      BonificationRecap: {
+        path: 'bonification/resume',
+      },
+      BonificationError: {
+        path: 'bonification/erreur',
+      },
     },
   },
   AccountSecurityBuffer: {

--- a/src/features/navigation/RootNavigator/linking/rootStackNavigatorPathConfig.ts
+++ b/src/features/navigation/RootNavigator/linking/rootStackNavigatorPathConfig.ts
@@ -171,7 +171,7 @@ export const rootStackNavigatorPathConfig = {
         path: 'bonification/date-de-naissance',
       },
       BonificationBirthPlace: {
-        path: 'bonification/lieux-de-naissance',
+        path: 'bonification/lieu-de-naissance',
       },
       BonificationRecap: {
         path: 'bonification/resume',

--- a/src/features/navigation/SubscriptionStackNavigator/SubscriptionStackNavigator.tsx
+++ b/src/features/navigation/SubscriptionStackNavigator/SubscriptionStackNavigator.tsx
@@ -1,6 +1,13 @@
 import { StackNavigationOptions } from '@react-navigation/stack'
 import React from 'react'
 
+import { BonificationBirthDate } from 'features/bonification/pages/BonificationBirthDate'
+import { BonificationBirthPlace } from 'features/bonification/pages/BonificationBirthPlace'
+import { BonificationError } from 'features/bonification/pages/BonificationError'
+import { BonificationIntroduction } from 'features/bonification/pages/BonificationIntroduction'
+import { BonificationNames } from 'features/bonification/pages/BonificationNames'
+import { BonificationRecap } from 'features/bonification/pages/BonificationRecap'
+import { BonificationTitle } from 'features/bonification/pages/BonificationTitle'
 import { CulturalSurveyIntro } from 'features/culturalSurvey/pages/CulturalSurveyIntro'
 import { CulturalSurveyQuestions } from 'features/culturalSurvey/pages/CulturalSurveyQuestions'
 import { CulturalSurveyThanks } from 'features/culturalSurvey/pages/CulturalSurveyThanks'
@@ -197,6 +204,35 @@ const subscriptionScreens: SubscriptionRouteConfig[] = [
     component: withAuthProtection(CulturalSurveyThanks),
   },
   { name: 'FAQWebview', component: FAQWebview },
+  // Bonification
+  {
+    name: 'BonificationIntroduction',
+    component: withAuthProtection(BonificationIntroduction),
+  },
+  {
+    name: 'BonificationNames',
+    component: withAuthProtection(BonificationNames),
+  },
+  {
+    name: 'BonificationTitle',
+    component: withAuthProtection(BonificationTitle),
+  },
+  {
+    name: 'BonificationBirthDate',
+    component: withAuthProtection(BonificationBirthDate),
+  },
+  {
+    name: 'BonificationBirthPlace',
+    component: withAuthProtection(BonificationBirthPlace),
+  },
+  {
+    name: 'BonificationRecap',
+    component: withAuthProtection(BonificationRecap),
+  },
+  {
+    name: 'BonificationError',
+    component: withAuthProtection(BonificationError),
+  },
 ]
 
 export const SubscriptionStackNavigator = () => (

--- a/src/features/navigation/SubscriptionStackNavigator/SubscriptionStackTypes.ts
+++ b/src/features/navigation/SubscriptionStackNavigator/SubscriptionStackTypes.ts
@@ -59,6 +59,14 @@ export type SubscriptionStackParamList = {
   // Errors
   EduConnectErrors: { code?: string; logoutUrl?: string }
   EduConnectErrorsPage: { code?: string; logoutUrl?: string }
+  // Bonification
+  BonificationIntroduction: undefined
+  BonificationTitle: undefined
+  BonificationNames: undefined
+  BonificationBirthDate: undefined
+  BonificationBirthPlace: undefined
+  BonificationRecap: undefined
+  BonificationError: undefined
 } & CulturalSurveyRootStackParamList
 
 export type SubscriptionStackRouteName = keyof SubscriptionStackParamList


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-38131

Questions soulevés par le ticket:
- Revoir tous les wordings! Notamment pour les headers "informations personnelles" est trop générique
- Pour tous les écrans avec formulaires, il reste à ajouter la barre de progression, et une mention "n écran sur 5".
- Pour tous les formulaires, il faut ajouter l'enregistrement des infos dans un store, puis l'affichage de ces infos à partir du store dans l'écran de recap
- Existe t-il un template sans header? Pour l'instant je n'ai trouvé que `PageWithHeader` pour l'écran `BonificationIntroduction`
- Si on retire le header, quel exit pour la page d'intro?
- `BonificationNames`: il faudra ajouter un champ "prénoms"
- `BonificationTitle`: il faut trouver un moyen de ne montrer le champ "ville de naissance" que si le pays de naissance est "France". Il n'y a pas de manière de le faire nativement avec `react-hook-form`. Si on utilise `watch` ça ne retrigger pas de rendu car la valeur des champs est muté (pas de nouvelle ref), donc aucun changement n'est detecté.
- Ou alors dans une v1, on demandera  la ville de naissance pour tout le monde?
- Il faut trouver une lib pour la liste des pays.
- Pour l'instant on a qu'une variante de l'écran d'erreur. On pourra passer le code d'erreur fourni par le back en paramètre de navigation.
- Il faut évidement créer l'écran de succès et s'occuper des appels backend quand la route sera prête.
- Quels analytics pour la feature Qu'est ce qu'on veut savoir sur la feature?

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
