### PR TITLE
(PC-37573) feat(SearchList): add and dedupe venues from algolia indexes

### DIFF
--- a/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -1315,6 +1315,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                         "name": "Lieu 1",
                         "postalCode": "75000",
                         "publicName": "Lieu 1",
+                        "venue_type": "BOOKSTORE",
                       },
                     }
                   }
@@ -1361,6 +1362,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                         "name": "Lieu 2",
                         "postalCode": "75000",
                         "publicName": "Lieu 2",
+                        "venue_type": "CONCERT_HALL",
                       },
                     }
                   }
@@ -1648,6 +1650,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                         "name": "Lieu 2",
                         "postalCode": "75000",
                         "publicName": "Lieu 2",
+                        "venue_type": "CONCERT_HALL",
                       },
                     }
                   }
@@ -1686,6 +1689,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                         "name": "Lieu 3",
                         "postalCode": "75000",
                         "publicName": "Lieu 3",
+                        "venue_type": "CONCERT_HALL",
                       },
                     }
                   }
@@ -1965,6 +1969,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                         "name": "Lieu 3",
                         "postalCode": "75000",
                         "publicName": "Lieu 3",
+                        "venue_type": "CONCERT_HALL",
                       },
                     }
                   }

--- a/src/features/search/components/SearchList/SearchList.tsx
+++ b/src/features/search/components/SearchList/SearchList.tsx
@@ -3,7 +3,13 @@ import React from 'react'
 import { useTheme } from 'styled-components/native'
 
 import { SearchListHeader } from 'features/search/components/SearchListHeader/SearchListHeader'
+import {
+  convertAlgoliaVenue2AlgoliaVenueOfferListItem,
+  getReconciledVenues,
+} from 'features/search/helpers/searchList/getReconciledVenues'
 import { SearchListProps } from 'features/search/types'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { Offer } from 'shared/offer/types'
 import { LineSeparator } from 'ui/components/LineSeparator'
 import { getSpacing } from 'ui/theme'
@@ -31,6 +37,10 @@ export const SearchList = React.forwardRef<FlashListRef<Offer>, SearchListProps>
     ref
   ) => {
     const { tabBar } = useTheme()
+    const isEnabledVenuesFromOfferIndex = useFeatureFlag(
+      RemoteStoreFeatureFlags.ENABLE_VENUES_FROM_OFFER_INDEX
+    )
+
     return (
       <FlashList
         ref={ref}
@@ -42,7 +52,11 @@ export const SearchList = React.forwardRef<FlashListRef<Offer>, SearchListProps>
           <SearchListHeader
             nbHits={nbHits}
             userData={userData}
-            venues={hits.venues}
+            venues={
+              isEnabledVenuesFromOfferIndex
+                ? getReconciledVenues(hits.offers, hits.venues)
+                : hits.venues.map(convertAlgoliaVenue2AlgoliaVenueOfferListItem)
+            }
             artistSection={artistSection}
             venuesUserData={venuesUserData}
             shouldDisplayGridList={shouldDisplayGridList}

--- a/src/features/search/components/SearchList/SearchList.web.test.tsx
+++ b/src/features/search/components/SearchList/SearchList.web.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { SearchList } from 'features/search/components/SearchList/SearchList'
 import { getHeaderSize } from 'features/search/components/SearchList/SearchList.web'
 import { initialSearchState } from 'features/search/context/reducer'
+import * as getReconciledVenuesAPI from 'features/search/helpers/searchList/getReconciledVenues'
 import { SearchListProps } from 'features/search/types'
 import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
@@ -56,6 +57,8 @@ jest.mock('react-native/Libraries/Utilities/useWindowDimensions', () => ({
   default: mockUseWindowDimensions,
 }))
 
+const spiedGetReconciledVenue = jest.spyOn(getReconciledVenuesAPI, 'getReconciledVenues')
+
 describe('<SearchList />', () => {
   beforeEach(() => {
     setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_PACIFIC_FRANC_CURRENCY])
@@ -75,6 +78,16 @@ describe('<SearchList />', () => {
 
       expect(screen.queryByTestId('grid-list-menu')).not.toBeOnTheScreen()
     })
+  })
+})
+
+describe('with ENABLE_VENUES_FROM_OFFER_INDEX FF enabled', () => {
+  beforeEach(() => setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_VENUES_FROM_OFFER_INDEX]))
+
+  it('should call getReconciledVenues with offers and venues from algolia indexes', () => {
+    render(reactQueryProviderHOC(<SearchList {...props} isGridLayout={false} />))
+
+    expect(spiedGetReconciledVenue).toHaveBeenCalledWith(mockHits, [])
   })
 })
 

--- a/src/features/search/components/SearchListHeader/SearchListHeader.native.test.tsx
+++ b/src/features/search/components/SearchListHeader/SearchListHeader.native.test.tsx
@@ -9,6 +9,7 @@ import { usePreviousRoute } from 'features/navigation/helpers/__mocks__/usePrevi
 import { initialSearchState } from 'features/search/context/reducer'
 import { mockAlgoliaVenues } from 'features/search/fixtures/mockAlgoliaVenues'
 import { MAX_RADIUS } from 'features/search/helpers/reducer.helpers'
+import { convertAlgoliaVenue2AlgoliaVenueOfferListItem } from 'features/search/helpers/searchList/getReconciledVenues'
 import { SearchState } from 'features/search/types'
 import { Venue } from 'features/venue/types'
 import { analytics } from 'libs/analytics/provider'
@@ -88,6 +89,10 @@ jest.mock('libs/subcategories/useSubcategories', () => ({
   }),
 }))
 
+const mockedAlgoliaVenuesItems = mockAlgoliaVenues.map(
+  convertAlgoliaVenue2AlgoliaVenueOfferListItem
+)
+
 describe('<SearchListHeader />', () => {
   beforeEach(() => {
     mockUseAccessibilityFiltersContext.mockReturnValue(defaultValuesAccessibilityContext)
@@ -109,7 +114,7 @@ describe('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
         />
       )
 
@@ -155,7 +160,7 @@ describe('<SearchListHeader />', () => {
               nbHits={10}
               userData={[]}
               venuesUserData={mockVenuesUserData}
-              venues={mockAlgoliaVenues}
+              venues={mockedAlgoliaVenuesItems}
             />
           )
 
@@ -170,7 +175,7 @@ describe('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
         />
       )
 
@@ -187,7 +192,7 @@ describe('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
         />
       )
 
@@ -224,7 +229,7 @@ describe('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
         />
       )
 
@@ -237,7 +242,7 @@ describe('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
         />
       )
 
@@ -265,7 +270,7 @@ describe('<SearchListHeader />', () => {
             nbHits={10}
             userData={[]}
             venuesUserData={[]}
-            venues={mockAlgoliaVenues}
+            venues={mockedAlgoliaVenuesItems}
           />
         )
 
@@ -291,7 +296,7 @@ describe('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
         />
       )
 
@@ -315,7 +320,7 @@ describe('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
         />
       )
 
@@ -331,7 +336,7 @@ describe('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
         />
       )
 
@@ -395,7 +400,7 @@ describe('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
         />
       )
 
@@ -420,7 +425,7 @@ describe('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
         />
       )
 
@@ -439,7 +444,7 @@ describe('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
         />
       )
 
@@ -453,7 +458,12 @@ describe('<SearchListHeader />', () => {
       selectedLocationMode: LocationMode.EVERYWHERE,
     })
     render(
-      <SearchListHeader nbHits={10} userData={[]} venuesUserData={[]} venues={mockAlgoliaVenues} />
+      <SearchListHeader
+        nbHits={10}
+        userData={[]}
+        venuesUserData={[]}
+        venues={mockedAlgoliaVenuesItems}
+      />
     )
 
     expect(screen.getByTestId('systemBanner')).toBeOnTheScreen()
@@ -466,7 +476,7 @@ describe('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
           shouldDisplayGridList
         />
       )

--- a/src/features/search/components/SearchListHeader/SearchListHeader.tsx
+++ b/src/features/search/components/SearchListHeader/SearchListHeader.tsx
@@ -6,7 +6,6 @@ import styled from 'styled-components/native'
 import { SearchGroupNameEnumv2 } from 'api/gen'
 import { useAccessibilityFiltersContext } from 'features/accessibility/context/AccessibilityFiltersWrapper'
 import { usePreviousRoute } from 'features/navigation/helpers/usePreviousRoute'
-import { SearchOfferHits } from 'features/search/api/useSearchResults/useSearchResults'
 import { NumberOfResults } from 'features/search/components/NumberOfResults/NumberOfResults'
 import { VenuePlaylist } from 'features/search/components/VenuePlaylist/VenuePlaylist'
 import { useSearch } from 'features/search/context/SearchWrapper'
@@ -14,6 +13,7 @@ import { getSearchVenuePlaylistTitle } from 'features/search/helpers/getSearchVe
 import { gridListLayoutActions, useGridListLayout } from 'features/search/store/gridListLayoutStore'
 import { GridListLayout, SearchView, VenuesUserData } from 'features/search/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import { AlgoliaVenueOfferListItem } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics/provider'
 import { useLocation } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
@@ -28,7 +28,7 @@ import { Typo } from 'ui/theme'
 interface SearchListHeaderProps extends ScrollViewProps {
   nbHits: number
   userData: SearchResponse<Offer[]>['userData']
-  venues?: SearchOfferHits['venues']
+  venues?: AlgoliaVenueOfferListItem[]
   venuesUserData: VenuesUserData
   artistSection?: React.ReactNode
   shouldDisplayGridList?: boolean

--- a/src/features/search/components/SearchListHeader/SearchListHeader.web.test.tsx
+++ b/src/features/search/components/SearchListHeader/SearchListHeader.web.test.tsx
@@ -5,6 +5,7 @@ import { SearchListHeader } from 'features/search/components/SearchListHeader/Se
 import { initialSearchState } from 'features/search/context/reducer'
 import { mockAlgoliaVenues } from 'features/search/fixtures/mockAlgoliaVenues'
 import { MAX_RADIUS } from 'features/search/helpers/reducer.helpers'
+import { convertAlgoliaVenue2AlgoliaVenueOfferListItem } from 'features/search/helpers/searchList/getReconciledVenues'
 import { SearchState } from 'features/search/types'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
@@ -85,7 +86,7 @@ describe.skip('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockAlgoliaVenues.map(convertAlgoliaVenue2AlgoliaVenueOfferListItem)}
         />
       )
 
@@ -116,7 +117,7 @@ describe.skip('<SearchListHeader />', () => {
           nbHits={10}
           userData={[]}
           venuesUserData={[]}
-          venues={mockAlgoliaVenues}
+          venues={mockAlgoliaVenues.map(convertAlgoliaVenue2AlgoliaVenueOfferListItem)}
         />
       )
 

--- a/src/features/search/components/SearchListItem.web.tsx
+++ b/src/features/search/components/SearchListItem.web.tsx
@@ -6,7 +6,7 @@ import { SearchListFooter } from 'features/search/components/SearchListFooter/Se
 import { SearchListHeader } from 'features/search/components/SearchListHeader/SearchListHeader'
 import { SearchListProps, SearchState } from 'features/search/types'
 import { Artist } from 'features/venue/types'
-import { AlgoliaVenue } from 'libs/algolia/types'
+import { AlgoliaVenueOfferListItem } from 'libs/algolia/types'
 import { Offer } from 'shared/offer/types'
 import { LineSeparator } from 'ui/components/LineSeparator'
 import { HorizontalOfferTile } from 'ui/components/tiles/HorizontalOfferTile'
@@ -21,7 +21,7 @@ export type RowData = {
   nbHits: SearchListProps['nbHits']
   artists?: Artist[]
   offers: Offer[]
-  venues: AlgoliaVenue[]
+  venues: AlgoliaVenueOfferListItem[]
   isFetchingNextPage: SearchListProps['isFetchingNextPage']
   autoScrollEnabled: SearchListProps['autoScrollEnabled']
   onPress: SearchListProps['onPress']

--- a/src/features/search/components/VenuePlaylist/VenuePlaylist.native.test.tsx
+++ b/src/features/search/components/VenuePlaylist/VenuePlaylist.native.test.tsx
@@ -6,6 +6,7 @@ import { SearchGroupNameEnumv2, VenueTypeCodeKey } from 'api/gen'
 import { VenuePlaylist } from 'features/search/components/VenuePlaylist/VenuePlaylist'
 import { initialSearchState } from 'features/search/context/reducer'
 import { mockAlgoliaVenues } from 'features/search/fixtures/mockAlgoliaVenues'
+import { convertAlgoliaVenue2AlgoliaVenueOfferListItem } from 'features/search/helpers/searchList/getReconciledVenues'
 import { venuesFilterActions } from 'features/venueMap/store/venuesFilterStore'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
@@ -31,6 +32,10 @@ jest.mock('libs/subcategories/useSubcategories', () => ({
   }),
 }))
 
+const mockedAlgoliaVenuesItems = mockAlgoliaVenues.map(
+  convertAlgoliaVenue2AlgoliaVenueOfferListItem
+)
+
 const user = userEvent.setup()
 
 jest.useFakeTimers()
@@ -41,7 +46,7 @@ describe('<VenuePlaylist />', () => {
   })
 
   it('should render the title and venues playlist', () => {
-    render(<VenuePlaylist venuePlaylistTitle="Test Playlist" venues={mockAlgoliaVenues} />)
+    render(<VenuePlaylist venuePlaylistTitle="Test Playlist" venues={mockedAlgoliaVenuesItems} />)
 
     expect(screen.getByText('Test Playlist')).toBeOnTheScreen()
     expect(screen.getByTestId('search-venue-list')).toBeOnTheScreen()
@@ -51,7 +56,7 @@ describe('<VenuePlaylist />', () => {
     render(
       <VenuePlaylist
         venuePlaylistTitle="Test Playlist"
-        venues={mockAlgoliaVenues}
+        venues={mockedAlgoliaVenuesItems}
         currentView="SearchResults"
       />
     )
@@ -68,7 +73,7 @@ describe('<VenuePlaylist />', () => {
       render(
         <VenuePlaylist
           venuePlaylistTitle="Test Playlist"
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
           currentView="ThematicSearch"
         />
       )
@@ -80,7 +85,7 @@ describe('<VenuePlaylist />', () => {
       render(
         <VenuePlaylist
           venuePlaylistTitle="Test Playlist"
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
           currentView="SearchResults"
         />
       )
@@ -92,7 +97,7 @@ describe('<VenuePlaylist />', () => {
       render(
         <VenuePlaylist
           venuePlaylistTitle="Test Playlist"
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
           currentView="ThematicSearch"
           offerCategory={SearchGroupNameEnumv2.LIVRES}
         />
@@ -111,7 +116,7 @@ describe('<VenuePlaylist />', () => {
       render(
         <VenuePlaylist
           venuePlaylistTitle="Test Playlist"
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
           currentView="ThematicSearch"
           offerCategory={SearchGroupNameEnumv2.ARTS_LOISIRS_CREATIFS}
         />
@@ -126,7 +131,7 @@ describe('<VenuePlaylist />', () => {
       render(
         <VenuePlaylist
           venuePlaylistTitle="Test Playlist"
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
           currentView="ThematicSearch"
         />
       )
@@ -147,7 +152,7 @@ describe('<VenuePlaylist />', () => {
       render(
         <VenuePlaylist
           venuePlaylistTitle="Test Playlist"
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
           currentView="ThematicSearch"
           offerCategory={SearchGroupNameEnumv2.CINEMA}
           isLocated={false}
@@ -163,7 +168,7 @@ describe('<VenuePlaylist />', () => {
       render(
         <VenuePlaylist
           venuePlaylistTitle="Test Playlist"
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
           currentView="ThematicSearch"
           offerCategory={SearchGroupNameEnumv2.CINEMA}
           isLocated
@@ -179,7 +184,7 @@ describe('<VenuePlaylist />', () => {
       render(
         <VenuePlaylist
           venuePlaylistTitle="Test Playlist"
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
           currentView="ThematicSearch"
           offerCategory={SearchGroupNameEnumv2.CINEMA}
           isLocated
@@ -195,7 +200,7 @@ describe('<VenuePlaylist />', () => {
       render(
         <VenuePlaylist
           venuePlaylistTitle="Test Playlist"
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
           currentView="ThematicSearch"
           offerCategory={SearchGroupNameEnumv2.CINEMA}
           isLocated={false}
@@ -213,7 +218,7 @@ describe('<VenuePlaylist />', () => {
       render(
         <VenuePlaylist
           venuePlaylistTitle="Test Playlist"
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
           currentView="ThematicSearch"
           offerCategory={SearchGroupNameEnumv2.CINEMA}
           isLocated={false}
@@ -228,7 +233,7 @@ describe('<VenuePlaylist />', () => {
       render(
         <VenuePlaylist
           venuePlaylistTitle="Test Playlist"
-          venues={mockAlgoliaVenues}
+          venues={mockedAlgoliaVenuesItems}
           currentView="ThematicSearch"
           offerCategory={SearchGroupNameEnumv2.CINEMA}
           isLocated={false}

--- a/src/features/search/components/VenuePlaylist/VenuePlaylist.tsx
+++ b/src/features/search/components/VenuePlaylist/VenuePlaylist.tsx
@@ -12,7 +12,7 @@ import { SearchVenueItem } from 'features/search/components/SearchVenueItems/Sea
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { getVenueTypesFromSearchGroup } from 'features/search/helpers/getVenueTypesFromSearchGroup/getVenueTypesFromSearchGroup'
 import { venuesFilterActions } from 'features/venueMap/store/venuesFilterStore'
-import { AlgoliaVenue } from 'libs/algolia/types'
+import { AlgoliaVenue, AlgoliaVenueOfferListItem } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics/provider'
 import { ContentfulLabelCategories } from 'libs/contentful/types'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
@@ -32,7 +32,7 @@ const keyExtractor = (item: AlgoliaVenue) => item.objectID
 
 type Props = {
   venuePlaylistTitle: string
-  venues: AlgoliaVenue[]
+  venues: AlgoliaVenueOfferListItem[]
   isLocated?: boolean
   shouldDisplaySeparator?: boolean
   currentView?: keyof SearchStackParamList

--- a/src/features/search/components/VenuePlaylist/VenuePlaylist.web.test.tsx
+++ b/src/features/search/components/VenuePlaylist/VenuePlaylist.web.test.tsx
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { VenuePlaylist } from 'features/search/components/VenuePlaylist/VenuePlaylist'
 import { initialSearchState } from 'features/search/context/reducer'
 import { mockAlgoliaVenues } from 'features/search/fixtures/mockAlgoliaVenues'
+import { convertAlgoliaVenue2AlgoliaVenueOfferListItem } from 'features/search/helpers/searchList/getReconciledVenues'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
@@ -47,7 +48,7 @@ describe('<VenuePlaylist />', () => {
       render(
         <VenuePlaylist
           venuePlaylistTitle="Test Playlist"
-          venues={mockAlgoliaVenues}
+          venues={mockAlgoliaVenues.map(convertAlgoliaVenue2AlgoliaVenueOfferListItem)}
           currentView="ThematicSearch"
         />
       )

--- a/src/features/search/helpers/searchList/getReconciledVenues.test.ts
+++ b/src/features/search/helpers/searchList/getReconciledVenues.test.ts
@@ -1,0 +1,342 @@
+import { VenueTypeCodeKey } from 'api/gen'
+import { mockAlgoliaVenues } from 'features/search/fixtures/mockAlgoliaVenues'
+import {
+  getReconciledVenues,
+  convertAlgoliaVenue2AlgoliaVenueOfferListItem,
+  convertAlgoliaVenueOffer2AlgoliaVenueOfferListItem,
+  AlgoliaVenueOfferWithGeoloc,
+} from 'features/search/helpers/searchList/getReconciledVenues'
+import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
+import { AlgoliaVenue, AlgoliaVenueOfferListItem } from 'libs/algolia/types'
+
+const expectedVenues = [
+  {
+    objectID: '1',
+    name: 'Lieu 1',
+    postalCode: '75000',
+    city: 'Paris',
+    banner_url: '',
+    venue_type: VenueTypeCodeKey.BOOKSTORE,
+    _geoloc: { lat: 48.94374, lng: 2.48171 },
+  },
+  {
+    objectID: '2',
+    name: 'Lieu 2',
+    postalCode: '75000',
+    city: 'Paris',
+    banner_url: '',
+    venue_type: VenueTypeCodeKey.CONCERT_HALL,
+    _geoloc: { lat: 48.91265, lng: 2.4513 },
+  },
+  {
+    objectID: '3',
+    name: 'Lieu 3',
+    postalCode: '75000',
+    city: 'Paris',
+    banner_url: '',
+    venue_type: VenueTypeCodeKey.CONCERT_HALL,
+    _geoloc: { lat: 4.90339, lng: -52.31663 },
+  },
+  {
+    objectID: '4',
+    name: 'Lieu 4',
+    postalCode: '75000',
+    city: 'Paris',
+    banner_url: '',
+    venue_type: VenueTypeCodeKey.OTHER,
+    _geoloc: { lat: 4.90339, lng: -52.31663 },
+  },
+]
+const expectedAlgoliaVenues = [
+  {
+    _geoloc: {
+      lat: 44.82186,
+      lng: -0.56366,
+    },
+    banner_url:
+      'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/krists-luhaers-AtPWnYNDJnM-unsplash.png',
+    city: 'Bordeaux',
+    name: 'EMS 0063 (ne fonctionne pas)',
+    objectID: '7931',
+    postalCode: '75000',
+    venue_type: 'MOVIE',
+  },
+  {
+    _geoloc: {
+      lat: 48.85959,
+      lng: 2.33561,
+    },
+    banner_url:
+      'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/darya-tryfanava-UCNaGWn4EfU-unsplash.jpg',
+    city: 'Paris',
+    name: 'ETABLISSEMENT PUBLIC DU MUSEE DU LOUVRE',
+    objectID: '7929',
+    postalCode: '75000',
+    venue_type: 'VISUAL_ARTS',
+  },
+  {
+    _geoloc: {
+      lat: 44.85597,
+      lng: -0.63444,
+    },
+    banner_url:
+      'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/uxuipc_High_angle_avec_un_Canon_R5_50_mm_DSLR_planetarium_with__f16e10f2-eb38-4314-b5f2-784819f04c05%20(1).png',
+    city: 'Bordeaux',
+    name: 'culture scientifique 2',
+    objectID: '7927',
+    postalCode: '75000',
+    venue_type: 'SCIENTIFIC_CULTURE',
+  },
+  {
+    _geoloc: {
+      lat: 43.3112,
+      lng: 5.3832,
+    },
+    banner_url:
+      'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/edd_Medium-Shot_avec_un_Canon_R5_50_mm_DSLR_Science_class_with__0251a3c2-c494-4b61-8116-a22c61848947%20(1).png',
+    city: 'Marseille',
+    name: 'culture scientifique 1',
+    objectID: '7926',
+    postalCode: '75000',
+    venue_type: 'SCIENTIFIC_CULTURE',
+  },
+  {
+    _geoloc: {
+      lat: 48.84303,
+      lng: 2.30445,
+    },
+    banner_url:
+      'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/amy-leigh-barnard-H3APOiYLyzk-unsplashed.png',
+    city: 'Paris',
+    name: 'musee test2',
+    objectID: '7924',
+    postalCode: '75000',
+    venue_type: 'MUSEUM',
+  },
+  {
+    _geoloc: {
+      lat: 50.63111,
+      lng: 3.0716,
+    },
+    banner_url:
+      'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/erik-mclean-PFfA3xlHFbQ-unsplash_(1).png',
+    city: 'Paris',
+    name: 'Le Sous-sol DATA',
+    objectID: '7922',
+    postalCode: '75000',
+    venue_type: 'PERFORMING_ARTS',
+  },
+]
+
+describe('getReconciledVenues', () => {
+  it('should return empty array when both venues from offers and algoliavenues are empty', () => {
+    const result = getReconciledVenues([], [])
+
+    expect(result).toEqual([])
+  })
+
+  it('should return venues from offer when algoliavenues is empty', () => {
+    const result = getReconciledVenues(
+      [
+        ...mockedAlgoliaResponse.hits,
+        {
+          ...mockedAlgoliaResponse.hits[0],
+          venue: { ...mockedAlgoliaResponse.hits[0].venue, id: 1 },
+        },
+        {
+          ...mockedAlgoliaResponse.hits[1],
+          venue: { ...mockedAlgoliaResponse.hits[1].venue, id: 5 },
+        },
+      ],
+      []
+    )
+
+    expect(result).toEqual([
+      ...expectedVenues,
+      {
+        ...expectedVenues[1],
+        objectID: '5',
+      },
+    ])
+  })
+
+  it('should return algoliavenues when venues from offer is empty', () => {
+    const result = getReconciledVenues([], mockAlgoliaVenues)
+
+    expect(result).toEqual(expectedAlgoliaVenues)
+  })
+
+  it('should return algoliavenues and venues from offer formatted when present and venues disjoint', () => {
+    const result = getReconciledVenues(mockedAlgoliaResponse.hits, mockAlgoliaVenues)
+
+    expect(result).toEqual([...expectedAlgoliaVenues, ...expectedVenues])
+  })
+
+  it('should return deduped algoliavenues and venues from offer formatted when present and venues ids duplicated', () => {
+    const _mockAlgoliaVenues = [
+      {
+        audio_disability: false,
+        banner_url:
+          'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/krists-luhaers-AtPWnYNDJnM-unsplash.png',
+        city: 'Bordeaux',
+        description: '',
+        email: null,
+        facebook: null,
+
+        instagram: null,
+        mental_disability: false,
+        motor_disability: false,
+        name: 'EMS 0063 (ne fonctionne pas)',
+        objectID: '1',
+        offerer_name: 'Structure du cinéma EMS',
+        phone_number: null,
+        snapchat: null,
+        twitter: null,
+        venue_type: VenueTypeCodeKey.MOVIE,
+        visual_disability: false,
+        isPermanent: true,
+        isOpenToPublic: true,
+        website: null,
+        _geoloc: { lat: 44.82186, lng: -0.56366 },
+        postalCode: '75000',
+      },
+
+      {
+        audio_disability: false,
+        banner_url:
+          'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/darya-tryfanava-UCNaGWn4EfU-unsplash.jpg',
+        city: 'Paris',
+        description: '',
+        email: null,
+        facebook: null,
+        instagram: null,
+        mental_disability: false,
+        motor_disability: false,
+        name: 'ETABLISSEMENT PUBLIC DU MUSEE DU LOUVRE',
+        objectID: '3',
+        offerer_name: 'ETABLISSEMENT PUBLIC DU MUSEE DU LOUVRE',
+        phone_number: null,
+        snapchat: null,
+        twitter: null,
+        venue_type: VenueTypeCodeKey.VISUAL_ARTS,
+        visual_disability: false,
+        website: null,
+        isPermanent: true,
+        isOpenToPublic: true,
+        _geoloc: { lat: 48.85959, lng: 2.33561 },
+        postalCode: '75000',
+      },
+    ]
+
+    const expectedAlgoliaVenuesDedup = [
+      {
+        _geoloc: {
+          lat: 44.82186,
+          lng: -0.56366,
+        },
+        banner_url:
+          'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/krists-luhaers-AtPWnYNDJnM-unsplash.png',
+        city: 'Bordeaux',
+        name: 'EMS 0063 (ne fonctionne pas)',
+        objectID: '1',
+        postalCode: '75000',
+        venue_type: 'MOVIE',
+      },
+      {
+        _geoloc: {
+          lat: 48.85959,
+          lng: 2.33561,
+        },
+        banner_url:
+          'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/darya-tryfanava-UCNaGWn4EfU-unsplash.jpg',
+        city: 'Paris',
+        name: 'ETABLISSEMENT PUBLIC DU MUSEE DU LOUVRE',
+        objectID: '3',
+        postalCode: '75000',
+        venue_type: 'VISUAL_ARTS',
+      },
+    ]
+
+    const result = getReconciledVenues(mockedAlgoliaResponse.hits, _mockAlgoliaVenues)
+
+    expect(result).toEqual([...expectedAlgoliaVenuesDedup, expectedVenues[1], expectedVenues[3]])
+  })
+})
+
+describe('convertAlgoliaVenue2AlgoliaVenueOfferListItem', () => {
+  it('should return formatted venue when venue exists', () => {
+    const expectedAlgoliaVenueOffer: AlgoliaVenueOfferListItem = {
+      objectID: '7931',
+      banner_url:
+        'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/krists-luhaers-AtPWnYNDJnM-unsplash.png',
+      city: 'Bordeaux',
+      name: 'EMS 0063 (ne fonctionne pas)',
+      postalCode: '75000',
+      venue_type: VenueTypeCodeKey.MOVIE,
+      _geoloc: { lat: 44.82186, lng: -0.56366 },
+    }
+
+    const result = convertAlgoliaVenue2AlgoliaVenueOfferListItem(
+      mockAlgoliaVenues[0] ?? <AlgoliaVenue>{}
+    )
+
+    expect(result).toEqual(expectedAlgoliaVenueOffer)
+  })
+
+  it('should return default when fields are missing', () => {
+    const expectedAlgoliaVenueOffer: AlgoliaVenueOfferListItem = {
+      objectID: '7931',
+      banner_url:
+        'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/krists-luhaers-AtPWnYNDJnM-unsplash.png',
+      city: 'Bordeaux',
+      name: 'EMS 0063 (ne fonctionne pas)',
+      postalCode: '75000',
+      venue_type: VenueTypeCodeKey.MOVIE,
+      _geoloc: { lat: 44.82186, lng: -0.56366 },
+    }
+
+    const result = convertAlgoliaVenue2AlgoliaVenueOfferListItem(
+      mockAlgoliaVenues[0] ?? <AlgoliaVenue>{}
+    )
+
+    expect(result).toEqual(expectedAlgoliaVenueOffer)
+  })
+})
+
+describe('convertAlgoliaVenueOffer2AlgoliaVenueOfferListItem', () => {
+  it('should return formatted venue when venue exists', () => {
+    const expectedAlgoliaVenueOffer: AlgoliaVenueOfferListItem = {
+      objectID: '1',
+      banner_url: '',
+      city: 'Paris',
+      name: 'Lieu 1',
+      postalCode: '75000',
+      venue_type: VenueTypeCodeKey.BOOKSTORE,
+      _geoloc: { lat: 48.94374, lng: 2.48171 },
+    }
+    const result = convertAlgoliaVenueOffer2AlgoliaVenueOfferListItem({
+      ...mockedAlgoliaResponse.hits[0].venue,
+      geoloc: mockedAlgoliaResponse.hits[0]._geoloc,
+    })
+
+    expect(result).toEqual(expectedAlgoliaVenueOffer)
+  })
+
+  it('should return default when fields are missing', () => {
+    const mockedAlgoliaVenueOffer: AlgoliaVenueOfferWithGeoloc = {
+      geoloc: { lat: 48.94374, lng: 2.48171 },
+    }
+    const expectedAlgoliaVenueOffer: AlgoliaVenueOfferListItem = {
+      objectID: '',
+      banner_url: '',
+      city: '',
+      name: '',
+      postalCode: '',
+      venue_type: VenueTypeCodeKey.OTHER,
+      _geoloc: { lat: 48.94374, lng: 2.48171 },
+    }
+    const result = convertAlgoliaVenueOffer2AlgoliaVenueOfferListItem(mockedAlgoliaVenueOffer)
+
+    expect(result).toEqual(expectedAlgoliaVenueOffer)
+  })
+})

--- a/src/features/search/helpers/searchList/getReconciledVenues.ts
+++ b/src/features/search/helpers/searchList/getReconciledVenues.ts
@@ -1,0 +1,65 @@
+import { uniqBy } from 'lodash'
+
+import { VenueTypeCodeKey } from 'api/gen'
+import {
+  AlgoliaOffer,
+  AlgoliaVenue,
+  AlgoliaVenueOffer,
+  AlgoliaVenueOfferListItem,
+  Geoloc,
+} from 'libs/algolia/types'
+
+export type AlgoliaVenueOfferWithGeoloc = AlgoliaVenueOffer & {
+  geoloc: Geoloc
+}
+
+export const getReconciledVenues = (
+  offers: AlgoliaOffer[],
+  venues: AlgoliaVenue[]
+): Array<AlgoliaVenueOfferListItem> => {
+  const venueIds = venues.map((venue) => venue.objectID)
+  // dedupe venues from algolia offers
+  const reconciledVenues: Array<AlgoliaVenueOfferWithGeoloc> = uniqBy(offers, 'venue.id').map(
+    (offer: AlgoliaOffer) => ({
+      ...offer.venue,
+      geoloc: offer._geoloc,
+    })
+  )
+  // dedupe algolia venues with venues from algolia offers
+  return venueIds.length
+    ? venues
+        .map(convertAlgoliaVenue2AlgoliaVenueOfferListItem)
+        .concat(
+          reconciledVenues
+            .filter(
+              (venueWGeoloc: AlgoliaVenueOfferWithGeoloc) =>
+                !!venueWGeoloc.id && !venueIds.includes(venueWGeoloc.id.toString())
+            )
+            .map(convertAlgoliaVenueOffer2AlgoliaVenueOfferListItem)
+        )
+    : reconciledVenues.map(convertAlgoliaVenueOffer2AlgoliaVenueOfferListItem)
+}
+
+export const convertAlgoliaVenue2AlgoliaVenueOfferListItem = (
+  venue: AlgoliaVenue
+): AlgoliaVenueOfferListItem => ({
+  objectID: venue.objectID,
+  banner_url: venue.banner_url ?? '',
+  venue_type: venue.venue_type,
+  name: venue.name,
+  city: venue.city,
+  postalCode: venue.postalCode ?? '',
+  _geoloc: venue._geoloc,
+})
+
+export const convertAlgoliaVenueOffer2AlgoliaVenueOfferListItem = (
+  venue: AlgoliaVenueOfferWithGeoloc
+): AlgoliaVenueOfferListItem => ({
+  objectID: venue.id?.toString() ?? '',
+  banner_url: venue.banner_url ?? '',
+  venue_type: venue.venue_type ?? VenueTypeCodeKey.OTHER,
+  name: venue.name ?? '',
+  city: venue.city ?? '',
+  postalCode: venue.postalCode ?? '',
+  _geoloc: venue.geoloc,
+})

--- a/src/features/search/pages/ThematicSearch/ThematicSearch.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearch.tsx
@@ -12,6 +12,7 @@ import { useSearchResults } from 'features/search/api/useSearchResults/useSearch
 import { VenuePlaylist } from 'features/search/components/VenuePlaylist/VenuePlaylist'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { getSearchVenuePlaylistTitle } from 'features/search/helpers/getSearchVenuePlaylistTitle/getSearchVenuePlaylistTitle'
+import { convertAlgoliaVenue2AlgoliaVenueOfferListItem } from 'features/search/helpers/searchList/getReconciledVenues'
 import { BookPlaylists } from 'features/search/pages/ThematicSearch/Book/BookPlaylists'
 import { CinemaPlaylists } from 'features/search/pages/ThematicSearch/Cinema/CinemaPlaylists'
 import { ConcertsAndFestivalsPlaylists } from 'features/search/pages/ThematicSearch/ConcertsAndFestivals/ConcertsAndFestivalsPlaylists'
@@ -106,7 +107,7 @@ export const ThematicSearch: React.FC = () => {
           {shouldDisplayVenuesPlaylist ? (
             <VenuePlaylist
               venuePlaylistTitle={venuePlaylistTitle}
-              venues={venues}
+              venues={venues.map(convertAlgoliaVenue2AlgoliaVenueOfferListItem)}
               isLocated={isLocated}
               currentView={currentView}
               offerCategory={offerCategory}

--- a/src/libs/algolia/fetchAlgolia/utils.ts
+++ b/src/libs/algolia/fetchAlgolia/utils.ts
@@ -1,8 +1,8 @@
 export const buildHitsPerPage = (hitsPerPage: number | null) =>
   hitsPerPage ? { hitsPerPage } : null
 
-export function parseAndCleanStringsToNumbers(allocineIdList: string[]) {
-  return allocineIdList
+export const parseAndCleanStringsToNumbers = (allocineIdList: string[]) =>
+  allocineIdList
     .map(Number)
     .filter(
       (allocineId) =>
@@ -11,4 +11,3 @@ export function parseAndCleanStringsToNumbers(allocineIdList: string[]) {
         allocineId !== Infinity &&
         allocineId !== -Infinity
     )
-}

--- a/src/libs/algolia/fixtures/algoliaFixtures.ts
+++ b/src/libs/algolia/fixtures/algoliaFixtures.ts
@@ -28,6 +28,7 @@ export const mockedAlgoliaResponse = toMutable({
         address: '1 rue de la paix',
         postalCode: '75000',
         city: 'Paris',
+        venue_type: VenueTypeCodeKey.BOOKSTORE,
       },
       artists: [{ id: '1', name: 'Artist 1' }],
     },
@@ -51,6 +52,7 @@ export const mockedAlgoliaResponse = toMutable({
         address: '2 rue de la paix',
         postalCode: '75000',
         city: 'Paris',
+        venue_type: VenueTypeCodeKey.CONCERT_HALL,
       },
       artists: [
         { id: '2', name: 'Artist 2' },
@@ -77,6 +79,7 @@ export const mockedAlgoliaResponse = toMutable({
         address: '3 rue de la paix',
         postalCode: '75000',
         city: 'Paris',
+        venue_type: VenueTypeCodeKey.CONCERT_HALL,
       },
     },
     {

--- a/src/libs/algolia/types.ts
+++ b/src/libs/algolia/types.ts
@@ -61,19 +61,38 @@ export interface AlgoliaGeoloc {
   lng?: number | null
 }
 
-export interface AlgoliaOffer<T = HitOffer> {
+export type AlgoliaVenueOffer = {
+  id?: number
+  name?: string
+  publicName?: string
+  address?: string
+  city?: string
+  postalCode?: string
+  departmentCode?: string
+  banner_url?: string
+  isAudioDisabilityCompliant?: boolean
+  isMentalDisabilityCompliant?: boolean
+  isMotorDisabilityCompliant?: boolean
+  isVisualDisabilityCompliant?: boolean
+  isPermanent?: boolean
+  venue_type?: string
+}
+
+export type AlgoliaVenueOfferListItem = {
+  objectID: string
+  _geoloc: Geoloc
+  banner_url: string
+  venue_type: string
+  name: string
+  city: string
+  postalCode: string
+}
+
+export type AlgoliaOffer<T = HitOffer> = {
   offer: T
   _geoloc: Geoloc
   objectID: string
-  venue: {
-    departmentCode?: string
-    id?: number
-    name?: string
-    publicName?: string
-    address?: string
-    postalCode?: string
-    city?: string
-  }
+  venue: AlgoliaVenueOffer
   artists?: Artist[]
   _tags?: string[]
 }

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -53,6 +53,7 @@ export enum RemoteStoreFeatureFlags {
   ENABLE_PACIFIC_FRANC_CURRENCY = 'enablePacificFrancCurrency',
   ENABLE_PASS_FOR_ALL = 'enablePassForAll',
   ENABLE_REPLICA_ALGOLIA_INDEX = 'enableReplicaAlgoliaIndex',
+  ENABLE_VENUES_FROM_OFFER_INDEX = 'enableVenuesFromOfferIndex',
   SHOW_REMOTE_GENERIC_BANNER = 'showRemoteBanner',
   TARGET_XP_CINE_FROM_OFFER = 'targetXpCineFromOffer',
   WIP_ARTIST_PAGE = 'wipArtistPage',

--- a/src/queries/venue/useVenueOffersQuery.ts
+++ b/src/queries/venue/useVenueOffersQuery.ts
@@ -68,18 +68,16 @@ export const useVenueOffersQuery = ({
     indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
   }
 
-  const venueOffersQueriesParamsList = [
-    venueSearchedOffersQueryParams,
-    venueTopOffersQueryParams,
-    headlineOfferQueryParams,
-  ]
-
   return useQuery({
     queryKey: [QueryKeys.VENUE_OFFERS, venue?.id, userLocation, selectedLocationMode],
 
     queryFn: () =>
       fetchMultipleOffers({
-        paramsList: venueOffersQueriesParamsList,
+        paramsList: [
+          venueSearchedOffersQueryParams,
+          venueTopOffersQueryParams,
+          headlineOfferQueryParams,
+        ],
         isUserUnderage,
       }),
 

--- a/src/shared/offer/offer.fixture.ts
+++ b/src/shared/offer/offer.fixture.ts
@@ -1,6 +1,6 @@
 import type { ReadonlyDeep } from 'type-fest'
 
-import { SubcategoryIdEnum } from 'api/gen'
+import { SubcategoryIdEnum, VenueTypeCodeKey } from 'api/gen'
 import { Offer } from 'shared/offer/types'
 import { toMutable } from 'shared/types/toMutable'
 
@@ -25,6 +25,7 @@ export const offersFixture = toMutable([
       address: '1 rue de la paix',
       postalCode: '75000',
       city: 'Paris',
+      venue_type: VenueTypeCodeKey.BOOKSTORE,
     },
     artists: [{ id: '1', name: 'Artist 1' }],
   },
@@ -48,6 +49,7 @@ export const offersFixture = toMutable([
       address: '2 rue de la paix',
       postalCode: '75000',
       city: 'Paris',
+      venue_type: VenueTypeCodeKey.CONCERT_HALL,
     },
     artists: [
       { id: '2', name: 'Artist 2' },
@@ -74,6 +76,7 @@ export const offersFixture = toMutable([
       address: '3 rue de la paix',
       postalCode: '75000',
       city: 'Paris',
+      venue_type: VenueTypeCodeKey.CONCERT_HALL,
     },
   },
   {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37573

## Context

In order to increase the number of venues displayed in the playlist of venues from the search results we want to use the venues coming from the offers results and add them to the venues coming from the venues results.

## Tasks
 - added a function that reconcile venues from two sources: dedupes results from offers source, dedupes results between two sources
 - added new target type for venue playlist (with only required data)
 - added functions to convert format of results from venues and offers source to target type of playlist
