### PR TITLE
(PC-37578) fix(CineOffer): remove blink

### DIFF
--- a/src/features/offer/components/MovieCalendar/MovieCalendar.native.test.tsx
+++ b/src/features/offer/components/MovieCalendar/MovieCalendar.native.test.tsx
@@ -1,6 +1,6 @@
+import { FlashListRef } from '@shopify/flash-list'
 import mockDate from 'mockdate'
 import React from 'react'
-import { FlatList } from 'react-native'
 
 import { MovieCalendar } from 'features/offer/components/MovieCalendar/MovieCalendar'
 import { toMutable } from 'shared/types/toMutable'
@@ -145,7 +145,11 @@ describe('<MovieCalendar/>', () => {
 
     it('should scroll to the middle element when an item is clicked', async () => {
       const itemIndex = 5
-      renderMovieCalendar(dummyDates, { isDesktopViewport: false }, mockFlatListRef)
+      renderMovieCalendar(
+        dummyDates,
+        { isDesktopViewport: false },
+        mockFlatListRef as unknown as React.RefObject<FlashListRef<Date>>
+      )
       mockFlatListRef.current.scrollToOffset = jest.fn()
 
       const firstDateItem = await screen.findByLabelText('Mardi 23 Juillet')
@@ -160,7 +164,11 @@ describe('<MovieCalendar/>', () => {
 
     it('should scroll to the start when the offset is less than 0', async () => {
       const itemIndex = 1
-      renderMovieCalendar(dummyDates, { isDesktopViewport: false }, mockFlatListRef)
+      renderMovieCalendar(
+        dummyDates,
+        { isDesktopViewport: false },
+        mockFlatListRef as unknown as React.RefObject<FlashListRef<Date>>
+      )
       mockFlatListRef.current.scrollToOffset = jest.fn()
 
       const firstDateItem = await screen.findByLabelText('Vendredi 19 Juillet')
@@ -178,7 +186,7 @@ describe('<MovieCalendar/>', () => {
 const renderMovieCalendar = (
   dates: Date[],
   theme?: CustomRenderOptions['theme'],
-  ref = React.createRef<FlatList | null>()
+  ref = React.createRef<FlashListRef<Date> | null>()
 ) => {
   const MovieCalendarWrapper = () => {
     return (
@@ -186,8 +194,8 @@ const renderMovieCalendar = (
         dates={dates}
         selectedDate={dates[0]}
         onTabChange={mockOnTabChange}
-        flatListRef={ref}
-        flatListWidth={DEFAULT_FLATLIST_WIDTH}
+        listRef={ref}
+        listWidth={DEFAULT_FLATLIST_WIDTH}
         onFlatListLayout={jest.fn()}
         itemWidth={DEFAULT_ITEM_WIDTH}
         onItemLayout={jest.fn()}

--- a/src/features/offer/components/MovieCalendar/MovieCalendar.tsx
+++ b/src/features/offer/components/MovieCalendar/MovieCalendar.tsx
@@ -1,6 +1,7 @@
+import { FlashList, FlashListRef } from '@shopify/flash-list'
 import { differenceInCalendarDays } from 'date-fns'
-import React, { useCallback } from 'react'
-import { FlatList, LayoutChangeEvent, View } from 'react-native'
+import React, { Ref, useCallback } from 'react'
+import { LayoutChangeEvent, View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -19,9 +20,9 @@ type Props = {
   dates: Date[]
   selectedDate: Date | undefined
   onTabChange: (date: Date) => void
-  flatListRef: React.MutableRefObject<FlatList | null>
+  listRef: Ref<FlashListRef<Date>> | null
   disabledDates?: Date[]
-  flatListWidth?: number
+  listWidth?: number
   onFlatListLayout?: (event: LayoutChangeEvent) => void
   itemWidth?: number
   onItemLayout?: (event: LayoutChangeEvent) => void
@@ -31,8 +32,8 @@ export const MovieCalendar: React.FC<Props> = ({
   dates,
   selectedDate,
   onTabChange,
-  flatListRef,
-  flatListWidth,
+  listRef,
+  listWidth,
   onFlatListLayout,
   itemWidth,
   onItemLayout,
@@ -47,19 +48,24 @@ export const MovieCalendar: React.FC<Props> = ({
     onContainerLayout,
     isEnd,
     isStart,
-  } = useHorizontalFlatListScroll({ ref: flatListRef, isActive: isDesktopViewport })
+  } = useHorizontalFlatListScroll({
+    ref: listRef,
+    isActive: isDesktopViewport,
+  })
 
   const scrollToMiddleElement = useCallback(
     (currentIndex: number) => {
-      if (!flatListWidth || !itemWidth) return
-      const { offset } = handleMovieCalendarScroll(currentIndex, flatListWidth, itemWidth)
+      if (!listWidth || !itemWidth) return
+      const { offset } = handleMovieCalendarScroll(currentIndex, listWidth, itemWidth)
 
-      flatListRef.current?.scrollToOffset({
-        animated: true,
-        offset,
-      })
+      if (listRef && 'current' in listRef) {
+        listRef.current?.scrollToOffset({
+          animated: true,
+          offset,
+        })
+      }
     },
-    [flatListRef, flatListWidth, itemWidth]
+    [listRef, listWidth, itemWidth]
   )
 
   const onInternalTabChange = useCallback(
@@ -82,9 +88,9 @@ export const MovieCalendar: React.FC<Props> = ({
         />
       ) : null}
       <View>
-        <FlatList
+        <FlashList
           onLayout={onFlatListLayout}
-          ref={flatListRef}
+          ref={listRef}
           data={dates}
           horizontal
           contentContainerStyle={contentContainerStyle}

--- a/src/features/offer/components/MovieScreeningCalendar/MovieScreeningCalendar.tsx
+++ b/src/features/offer/components/MovieScreeningCalendar/MovieScreeningCalendar.tsx
@@ -1,5 +1,6 @@
+import { FlashListRef } from '@shopify/flash-list'
 import React, { FunctionComponent, useEffect, useMemo, useRef } from 'react'
-import { FlatList, View } from 'react-native'
+import { View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { OfferResponseV2 } from 'api/gen'
@@ -34,7 +35,7 @@ export const MovieScreeningCalendar: FunctionComponent<Props> = ({ offer, subcat
     movieScreeningUserData,
   } = useOfferCTAButton(offer, subcategory, bookingData)
 
-  const flatListRef = useRef<FlatList | null>(null)
+  const flatListRef = useRef<FlashListRef<Date> | null>(null)
 
   const eventCardData = useMemo(
     () => selectedDateScreenings(offerVenueId, onPressOfferCTA, movieScreeningUserData),
@@ -56,7 +57,7 @@ export const MovieScreeningCalendar: FunctionComponent<Props> = ({ offer, subcat
         dates={movieScreeningDates}
         selectedDate={selectedDate}
         onTabChange={setSelectedDate}
-        flatListRef={flatListRef}
+        listRef={flatListRef}
       />
       {eventCardData ? (
         <EventCardListContainer>

--- a/src/features/offer/components/MoviesScreeningCalendar/MovieCalendarContext.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendar/MovieCalendarContext.tsx
@@ -1,3 +1,4 @@
+import { FlashListRef } from '@shopify/flash-list'
 import React, {
   createContext,
   useCallback,
@@ -6,12 +7,8 @@ import React, {
   useRef,
   useEffect,
   useState,
-  PropsWithChildren,
 } from 'react'
-import { Animated, View, ViewStyle } from 'react-native'
-import { FlatList } from 'react-native-gesture-handler'
-import { Easing } from 'react-native-reanimated'
-import styled from 'styled-components/native'
+import { View, ViewStyle } from 'react-native'
 
 import { MovieCalendar } from 'features/offer/components/MovieCalendar/MovieCalendar'
 import { useDaysSelector } from 'features/offer/helpers/useDaysSelector/useDaysSelector'
@@ -32,49 +29,6 @@ type MovieCalendarContextType = {
 
 const MovieCalendarContext = createContext<MovieCalendarContextType | undefined>(undefined)
 
-const AnimatedCalendarView: React.FC<PropsWithChildren<{ selectedDate: Date }>> = ({
-  selectedDate,
-  children,
-}) => {
-  const fadeAnim = useRef(new Animated.Value(0)).current
-  const translateAnim = useRef(new Animated.Value(0)).current
-  const [width, setWidth] = useState<number>(0)
-
-  useEffect(() => {
-    translateAnim.setValue(0)
-    fadeAnim.setValue(0)
-    Animated.timing(translateAnim, {
-      toValue: 1,
-      duration: 200,
-      useNativeDriver: true,
-      easing: Easing.out(Easing.ease),
-    }).start()
-    Animated.timing(fadeAnim, {
-      toValue: 1,
-      duration: 300,
-      easing: Easing.in(Easing.ease),
-      useNativeDriver: true,
-    }).start()
-  }, [fadeAnim, translateAnim, selectedDate])
-
-  return (
-    <AnimationContainer>
-      <Animated.View
-        onLayout={({ nativeEvent }) => {
-          setWidth(nativeEvent.layout.width)
-        }}
-        style={{
-          opacity: fadeAnim,
-          transform: [
-            { translateX: Animated.subtract(Animated.multiply(translateAnim, width), width) },
-          ],
-        }}>
-        {children}
-      </Animated.View>
-    </AnimationContainer>
-  )
-}
-
 export const MovieCalendarProvider: React.FC<{
   children: React.ReactNode
   containerStyle?: ViewStyle
@@ -82,7 +36,7 @@ export const MovieCalendarProvider: React.FC<{
 }> = ({ containerStyle, children, initialDates = [] }) => {
   const { dates, selectedDate, setSelectedDate, setDates } = useDaysSelector(initialDates)
   const [disabledDates, setDisabledDates] = useState<Date[]>([])
-  const flatListRef = useRef<FlatList | null>(null)
+  const flatListRef = useRef<FlashListRef<Date> | null>(null)
   const { width: flatListWidth, onLayout: onFlatListLayout } = useLayout()
   const { width: itemWidth, onLayout: onItemLayout } = useLayout()
   const scrollToAnchor = useScrollToAnchor()
@@ -151,8 +105,8 @@ export const MovieCalendarProvider: React.FC<{
               selectedDate={selectedDate}
               disabledDates={disabledDates}
               onTabChange={setSelectedDate}
-              flatListRef={flatListRef}
-              flatListWidth={flatListWidth}
+              listRef={flatListRef}
+              listWidth={flatListWidth}
               onFlatListLayout={onFlatListLayout}
               itemWidth={itemWidth}
               onItemLayout={onItemLayout}
@@ -160,13 +114,10 @@ export const MovieCalendarProvider: React.FC<{
           </Anchor>
         </View>
       ) : null}
-
-      <AnimatedCalendarView selectedDate={selectedDate}>{children}</AnimatedCalendarView>
+      {children}
     </MovieCalendarContext.Provider>
   )
 }
-
-const AnimationContainer = styled.View({ overflow: 'hidden' })
 
 export const useMovieCalendar = (): MovieCalendarContextType => {
   const context = useContext(MovieCalendarContext)

--- a/src/ui/hooks/useHorizontalFlatListScroll.ts
+++ b/src/ui/hooks/useHorizontalFlatListScroll.ts
@@ -2,16 +2,16 @@ import { FlashListRef } from '@shopify/flash-list'
 import React, { useCallback, useEffect, useState } from 'react'
 import { FlatList, LayoutChangeEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native'
 
-type UseFlatListScrollArgs = {
-  ref: React.RefObject<FlatList | FlashListRef<unknown> | null>
+type UseFlatListScrollArgs<T = unknown> = {
+  ref: React.Ref<FlatList<T> | FlashListRef<T>> | null
   scrollRatio?: number
   isActive?: boolean
 }
-export const useHorizontalFlatListScroll = ({
+export const useHorizontalFlatListScroll = <T = unknown>({
   ref,
   scrollRatio = 1,
   isActive = true,
-}: UseFlatListScrollArgs) => {
+}: UseFlatListScrollArgs<T>) => {
   const [containerWidth, setContainerWidth] = useState<number>(0)
   const [contentWidth, setContentWidth] = useState<number>(0)
   const [scrollPosition, setScrollPosition] = useState<number>(0)
@@ -56,12 +56,16 @@ export const useHorizontalFlatListScroll = ({
 
   const handleScrollNext = useCallback(() => {
     const nextOffset = scrollPosition + containerWidth * scrollRatio
-    ref.current?.scrollToOffset({ offset: nextOffset, animated: true })
+    if (ref && 'current' in ref) {
+      ref.current?.scrollToOffset({ offset: nextOffset, animated: true })
+    }
   }, [containerWidth, ref, scrollPosition, scrollRatio])
 
   const handleScrollPrevious = useCallback(() => {
     const prevOffset = Math.max(scrollPosition - containerWidth * scrollRatio, 0)
-    ref.current?.scrollToOffset({ offset: prevOffset, animated: true })
+    if (ref && 'current' in ref) {
+      ref.current?.scrollToOffset({ offset: prevOffset, animated: true })
+    }
   }, [containerWidth, ref, scrollPosition, scrollRatio])
 
   return {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37578

La `FlatList` provoque un problème de rendu, qui sépare le rendu des sous composants de sa liste, la liste change donc de taille à plusieurs reprise (plus visible quand l'animation est retirée), je l'ai modifié pour utiliser `FlashList` qui corrige ce problème

Le problème du blink est dû aux animations qui ne sont pas fluides sur le device, j'ai tenté d'utiliser `react-native-reanimated`, et `react-native-reanimatable` sans succès, j'ai donc décidé de supprimer ces animations afin de privilégier une expérience d'utilisation plus fluide au dépit d'un UI plus agréable

Les performances de cette page ne nous laissent malheureusement pas le luxe d'avoir des animations pour l'instant.

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<video src="https://github.com/user-attachments/assets/9fba936e-bfe6-4d1c-9690-4b16d7db9969"/>|<video src="https://github.com/user-attachments/assets/20002425-d68c-41fa-8fe2-713282903ad7"/>|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
