### PR TITLE
(BSR) feat(HotUpdater): improve ota workflow

### DIFF
--- a/.github/workflows/dev_on_workflow_environment_soft_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_soft_deploy.yml
@@ -131,7 +131,7 @@ jobs:
                       "author_icon": "https://github.com/${{github.actor}}.png",
                       "title": "PCAPPNATIVE Deployment",
                       "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                      "text": "Le déploiement codePush Android/iOS sur `${{ inputs.ENV }}` a ${{ fromJSON('["réussi :rocket:", "échoué :boom:"]')[needs.sentry_and_deploy.result == 'failure'] }}"
+                      "text": "Le déploiement en OTA Android/iOS sur `${{ inputs.ENV }}` a ${{ fromJSON('["réussi :rocket:", "échoué :boom:"]')[needs.sentry_and_deploy.result == 'failure'] }}"
                   }
               ],
               "unfurl_links": false,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,8 +58,8 @@ platform :ios do
       escaped_release_notes = release_notes.gsub("\"", "\\\"")
       sh "cd .. && \
       yarn hotupdater:deploy:ios:#{ENV['ENV']} \
-          --target-app-version #{version} \
-          --message \"#{escaped_release_notes}\" "
+          -m \"#{escaped_release_notes}\" \
+          -t #{version} "
       
     else
       match(
@@ -124,8 +124,8 @@ platform :android do
       escaped_release_notes = release_notes.gsub("\"", "\\\"")
       sh "cd .. && \
       yarn hotupdater:deploy:android:#{ENV['ENV']} \
-          --target-app-version #{version} \
-          --message \"#{escaped_release_notes}\" "
+          -m \"#{escaped_release_notes}\" \
+          -t #{version} "
       
     else
       build

--- a/hot-updater.config.ts
+++ b/hot-updater.config.ts
@@ -6,7 +6,7 @@ import { config } from 'dotenv'
 import * as admin from 'firebase-admin'
 import { defineConfig } from 'hot-updater'
 
-const ENV = process.env.NODE_ENV || 'testing'
+const ENV = process.env.NODE_ENV || 'local'
 
 config({ path: `.env.${ENV}` })
 config()

--- a/src/ui/hooks/useVersion.native.test.ts
+++ b/src/ui/hooks/useVersion.native.test.ts
@@ -1,4 +1,4 @@
-import CodePush, { LocalPackage } from 'react-native-code-push'
+import { HotUpdater } from '@hot-updater/react-native'
 
 import { eventMonitoring } from 'libs/monitoring/services'
 import * as PackageJson from 'libs/packageJson'
@@ -6,31 +6,41 @@ import { act, renderHook, waitFor } from 'tests/utils'
 
 import { useVersion } from './useVersion'
 
-const appVersion = '1.10.5'
+const appVersion = '1.360.2'
 jest.spyOn(PackageJson, 'getAppVersion').mockReturnValue(appVersion)
 
-describe('useVersion', () => {
-  it('should return only the version when there are not CodePush information', async () => {
-    CodePush.getUpdateMetadata = jest.fn(() => Promise.resolve(null))
+jest.mock('@hot-updater/react-native', () => ({
+  HotUpdater: {
+    getBundleId: jest.fn(() => '0199a453-9467-7933-b6d7-6b1020cb5b25'),
+  },
+}))
 
+describe('useVersion', () => {
+  it('should return only the version when there are no HotUpdater information', async () => {
+    ;(HotUpdater.getBundleId as jest.Mock).mockReturnValueOnce(undefined)
     const { result } = renderHook(() => useVersion())
+
+    await act(async () => {})
 
     expect(result.current).toEqual('Version\u00A0' + appVersion)
   })
 
-  it('should return version and CodePush label when there are CodePush information', async () => {
-    CodePush.getUpdateMetadata = jest.fn(() => Promise.resolve({ label: 'V4' } as LocalPackage))
-
+  it('should return version and HotUpdater label when there are HotUpdater information', async () => {
+    ;(HotUpdater.getBundleId as jest.Mock).mockReturnValueOnce(
+      '0199a453-9467-7933-b6d7-6b1020cb5b25'
+    )
     const { result } = renderHook(useVersion)
 
     await act(async () => {})
 
-    expect(result.current).toEqual('Version\u00A0' + appVersion + '-4')
+    expect(result.current).toEqual('Version\u00A0' + appVersion + '-5b25')
   })
 
   it('should capture a Sentry issue when there is an error', async () => {
-    const error = new Error('CodePush error')
-    CodePush.getUpdateMetadata = jest.fn(() => Promise.reject(error))
+    const error = new Error('HotUpdater failure')
+    ;(HotUpdater.getBundleId as jest.Mock).mockImplementationOnce(() => {
+      throw error
+    })
     renderHook(() => useVersion())
 
     await waitFor(() => {

--- a/src/ui/hooks/useVersion.ts
+++ b/src/ui/hooks/useVersion.ts
@@ -1,33 +1,33 @@
+import { HotUpdater } from '@hot-updater/react-native'
 import { useState, useEffect } from 'react'
-import CodePush from 'react-native-code-push'
 
 import { eventMonitoring } from 'libs/monitoring/services'
 import { getAppVersion } from 'libs/packageJson'
 
 export function useVersion() {
-  const [codePushLabel, setCodePushLabel] = useState('')
+  const [hotUpdaterLabel, setHotUpdaterLabel] = useState('')
 
   useEffect(() => {
-    async function getcodePushLabel() {
+    async function getHotUpdaterLabel() {
       try {
-        const metadata = await CodePush.getUpdateMetadata()
+        const metadata = await HotUpdater.getBundleId()
 
         if (!metadata) {
           return
         }
-        setCodePushLabel(metadata.label)
+        setHotUpdaterLabel(metadata)
       } catch (error) {
         eventMonitoring.captureException(error)
       }
     }
-    getcodePushLabel()
+    getHotUpdaterLabel()
   }, [])
 
-  // exemple Code Push format : 'v3875' => '3875'
-  const shortCodePushLabel = codePushLabel.slice(1)
+  // for Hot Updater we take the last 4 digits of the bundle id
+  const shortHotUpdaterLabel = hotUpdaterLabel.slice(-4)
 
   let version = `Version\u00A0${getAppVersion()}`
-  if (codePushLabel) version += `-${shortCodePushLabel}`
+  if (hotUpdaterLabel && shortHotUpdaterLabel !== '0000') version += `-${shortHotUpdaterLabel}`
 
   return version
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
