### PR TITLE
(BSR) feat(ESlint): a query hook should return a useQueryResult

### DIFF
--- a/eslint-custom-rules/query-hooks-must-return-use-query-result.js
+++ b/eslint-custom-rules/query-hooks-must-return-use-query-result.js
@@ -1,0 +1,164 @@
+const MESSAGES = {
+  mustReturnUseQuery:
+    'Le hook "{{ name }}" se termine par "Query" et doit retourner le résultat d\'un appel à useQuery ou usePersistQuery.',
+}
+
+const EXCLUDED_HOOKS = new Set(['usePersistQuery'])
+
+const isQueryHook = (name) => {
+  if (!name || typeof name !== 'string') return false
+  if (EXCLUDED_HOOKS.has(name)) return false
+
+  const startsWithUse = name.startsWith('use')
+  const endsWithQuery = name.endsWith('Query')
+  const hasEnoughCharacters = name.length > 8
+
+  return startsWithUse && endsWithQuery && hasEnoughCharacters
+}
+
+const isUseQueryCall = (node) => {
+  if (!node) return false
+  
+  if (node.type === 'CallExpression') {
+    const calleeName = node.callee?.name
+    return (
+      calleeName === 'useQuery' ||
+      calleeName === 'usePersistQuery' ||
+      isQueryHook(calleeName)
+    )
+  }
+  
+  return false
+}
+
+const returnsUseQuery = (functionBody) => {
+  if (!functionBody) return false
+
+  if (functionBody.type === 'CallExpression') {
+    return isUseQueryCall(functionBody)
+  }
+
+  if (functionBody.type === 'BlockStatement') {
+    const queryVariables = new Map()
+    let hasUseQueryCall = false
+    
+    functionBody.body.forEach((statement) => {
+      if (statement.type === 'VariableDeclaration') {
+        statement.declarations.forEach((declaration) => {
+          if (declaration.init && isUseQueryCall(declaration.init)) {
+            if (declaration.id.type === 'Identifier') {
+              queryVariables.set(declaration.id.name, true)
+            }
+            hasUseQueryCall = true
+          }
+        })
+      }
+      if (statement.type === 'ExpressionStatement' && isUseQueryCall(statement.expression)) {
+        hasUseQueryCall = true
+      }
+    })
+    
+    const isQueryVariable = (node) => {
+      if (!node) return false
+      if (node.type === 'Identifier' && queryVariables.has(node.name)) {
+        return true
+      }
+      return false
+    }
+
+    const isTernaryWithQueryVariables = (node) => {
+      if (!node || node.type !== 'ConditionalExpression') return false
+      return isQueryVariable(node.consequent) && isQueryVariable(node.alternate)
+    }
+
+    const hasAnyReturnWithValue = functionBody.body.some(
+      (statement) => statement.type === 'ReturnStatement' && statement.argument
+    )
+
+    if (!hasAnyReturnWithValue && !hasUseQueryCall) {
+      return true
+    }
+
+    if (!hasAnyReturnWithValue && hasUseQueryCall) {
+      return false
+    }
+
+    const hasValidReturn = functionBody.body.some((statement) => {
+      if (statement.type === 'ReturnStatement' && statement.argument) {
+        if (isUseQueryCall(statement.argument)) {
+          return true
+        }
+        
+        if (isQueryVariable(statement.argument)) {
+          return true
+        }
+
+        if (isTernaryWithQueryVariables(statement.argument)) {
+          return true
+        }
+      }
+      return false
+    })
+    
+    return hasValidReturn
+  }
+
+  return false
+}
+
+module.exports = {
+  name: 'query-hooks-must-return-use-query-result',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Les hooks se terminant par "Query" doivent avoir un type de retour explicite UseQueryResult',
+      recommended: true,
+    },
+    messages: MESSAGES,
+    schema: [],
+  },
+  defaultOptions: [],
+
+  create(context) {
+    let hasReactQueryImport = false
+
+    const checkFunction = (node, functionName) => {
+      if (!isQueryHook(functionName)) return
+      if (!hasReactQueryImport) return
+
+      const functionBody = node.body
+      
+      if (!returnsUseQuery(functionBody)) {
+        context.report({
+          node,
+          messageId: 'mustReturnUseQuery',
+          data: { name: functionName },
+        })
+      }
+    }
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === '@tanstack/react-query') {
+          hasReactQueryImport = true
+        }
+      },
+      FunctionDeclaration(node) {
+        if (node.id && node.id.name) {
+          checkFunction(node, node.id.name)
+        }
+      },
+      VariableDeclarator(node) {
+        if (
+          node.init &&
+          (node.init.type === 'ArrowFunctionExpression' || node.init.type === 'FunctionExpression') &&
+          node.id.name
+        ) {
+          checkFunction(node.init, node.id.name)
+        }
+      },
+    }
+  },
+}
+

--- a/eslint-custom-rules/query-hooks-must-return-use-query-result.test.js
+++ b/eslint-custom-rules/query-hooks-must-return-use-query-result.test.js
@@ -1,0 +1,198 @@
+const { RuleTester } = require('eslint')
+
+const rule = require('./query-hooks-must-return-use-query-result')
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('query-hooks-must-return-use-query-result', rule, {
+  valid: [
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        function useUserQuery() {
+          return useQuery({ queryKey: ['user'], queryFn: fetchUser })
+        }
+      `,
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        const useUserQuery = () => {
+          return useQuery({ queryKey: ['user'], queryFn: fetchUser })
+        }
+      `,
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        const useUserQuery = () => useQuery({ queryKey: ['user'], queryFn: fetchUser })
+      `,
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        const useUserQuery = () => {
+          return usePersistQuery({ queryKey: ['user'], queryFn: fetchUser })
+        }
+      `,
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        const useUserQuery = (): UseQueryResult<User> => {
+          return useQuery({ queryKey: ['user'], queryFn: fetchUser })
+        }
+      `,
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        const useBannerQuery = (hasGeolocPosition: boolean) => {
+          return useQuery({
+            queryKey: ['HOME_BANNER', hasGeolocPosition],
+            queryFn: () => api.getNativeV1Banner(hasGeolocPosition),
+          })
+        }
+      `,
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        const useOfferQuery = ({ offerId, select }) => {
+          const queryClient = useQueryClient()
+          const query = useQuery({
+            queryKey: ['OFFER', offerId],
+            queryFn: async () => {
+              const offer = await getOfferById(offerId)
+              queryClient.setQueryData(['OFFER', 'PREVIEW', offerId], false)
+              return offer
+            },
+            select,
+          })
+          return query
+        }
+      `,
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        const useBookingsV2WithConvertedTimezoneQuery = (enabled: boolean) =>
+          useBookingsQuery(enabled, (data) => convertOffererDatesToTimezone(data))
+      `,
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        const useSpecialUserQuery = () => {
+          return useUserQuery({ userId: 123 })
+        }
+      `,
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        const useConditionalQuery = (condition) => {
+          const queryA = useQuery({ queryKey: ['a'], queryFn: fetchA })
+          const queryB = useQuery({ queryKey: ['b'], queryFn: fetchB })
+          return condition ? queryA : queryB
+        }
+      `,
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        function useSetPersistQuery(query, queryKey) {
+          useEffect(() => {
+            if (!query.isLoading && query.data) {
+              AsyncStorage.setItem(String(queryKey), JSON.stringify(query.data))
+            }
+          }, [query.data, query.isLoading, queryKey])
+        }
+      `,
+    },
+    {
+      code: `
+        const useUser = () => {
+          return { data: null }
+        }
+      `,
+    },
+    {
+      code: `
+        const useUserData = () => {
+          return { data: null }
+        }
+      `,
+    },
+    {
+      code: `
+        const fetchQuery = () => {
+          return { data: null }
+        }
+      `,
+    },
+    {
+      code: `
+        const useMediaQuery = ({ minWidth }) => {
+          const { width } = useWindowDimensions()
+          return width >= minWidth
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        function useUserQuery() {
+          return { data: null }
+        }
+      `,
+      errors: [{ messageId: 'mustReturnUseQuery', data: { name: 'useUserQuery' } }],
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        const useUserQuery = () => {
+          return { data: null }
+        }
+      `,
+      errors: [{ messageId: 'mustReturnUseQuery', data: { name: 'useUserQuery' } }],
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        const useUserQuery = () => {
+          const result = useQuery({ queryKey: ['user'], queryFn: fetchUser })
+          return result.data
+        }
+      `,
+      errors: [{ messageId: 'mustReturnUseQuery', data: { name: 'useUserQuery' } }],
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        const useUserQuery = () => {
+          return { user: null, loading: false }
+        }
+      `,
+      errors: [{ messageId: 'mustReturnUseQuery', data: { name: 'useUserQuery' } }],
+    },
+    {
+      code: `
+        import { useQuery } from '@tanstack/react-query'
+        const useUserQuery = () => {
+          useQuery({ queryKey: ['user'], queryFn: fetchUser })
+        }
+      `,
+      errors: [{ messageId: 'mustReturnUseQuery', data: { name: 'useUserQuery' } }],
+    },
+  ],
+})
+

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -22,6 +22,7 @@ const noThemeFromTheme = require('./eslint-custom-rules/no-theme-from-theme')
 const noTsExpectError = require('./eslint-custom-rules/no-ts-expect-error')
 const noUselessHook = require('./eslint-custom-rules/no-useless-hook')
 const mockPathExists = require('./eslint-custom-rules/mock-path-exists')
+const queryHooksMustReturnUseQueryResult = require('./eslint-custom-rules/query-hooks-must-return-use-query-result')
 
 module.exports = {
   'apostrophe-in-text': apostropheInText,
@@ -48,4 +49,5 @@ module.exports = {
   'no-ts-expect-error': noTsExpectError,
   'no-useless-hook': noUselessHook,
   'mock-path-exists': mockPathExists,
+  'query-hooks-must-return-use-query-result': queryHooksMustReturnUseQueryResult,
 }

--- a/eslint-soft-rules.js
+++ b/eslint-soft-rules.js
@@ -14,6 +14,7 @@ const softRules = {
     'local-rules/queries-only-in-use-query-functions': 'warn',
     'local-rules/queries-must-be-in-queries-folder': 'warn',
     'boundaries/element-types': ['warn', boundariesRule],
+    'local-rules/query-hooks-must-return-use-query-result': 'warn',
   },
   reactRules: {
     'react-hooks/rules-of-hooks': 'warn',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
