### PR TITLE
(PC-39019) chore(deps): use pressable instead of deprecated touchable opacity from RNGestureHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,7 +145,10 @@ scripts/dead_code_current.txt
 # Storybook
 storybook-static
 
+#environnment managers
 .direnv/
+.devbox/
 
 # hot-updater
 .hot-updater/output
+

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2063,7 +2063,7 @@ PODS:
     - Firebase/RemoteConfig (= 11.13.0)
     - React-Core
     - RNFBApp
-  - RNGestureHandler (2.26.0):
+  - RNGestureHandler (2.29.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2891,7 +2891,7 @@ SPEC CHECKSUMS:
   RNFBFirestore: fa1739cc4dc22aff2cc384808a963e809802d956
   RNFBPerf: c32ec64522c2e4d81d1562747809314e9050b75f
   RNFBRemoteConfig: 1bd86986a8372a52c95c00d83d73c44a3d61f31d
-  RNGestureHandler: 6bd728f386096ebb26670b4dd6a604a67b14f65d
+  RNGestureHandler: 02598e2ce3935830461bc7a69de5f0e7009d840c
   RNGoogleSignin: a6a612cce56a45ab701c5c5c6e36f5390522d100
   RNKeychain: 774184659ed098fd715a4976d44e2003c829934f
   RNPermissions: 57959c69d512e865639e7c312005ac7d610e0064

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-native-email-link": "^1.10.0",
     "react-native-fast-image": "^8.6.3",
     "react-native-geolocation-service": "5.3.1",
-    "react-native-gesture-handler": "^2.26.0",
+    "react-native-gesture-handler": "^2.29.1",
     "react-native-get-random-values": "^1.5.1",
     "react-native-in-app-review": "^4.3.1",
     "react-native-intersection-observer": "^0.2.1",

--- a/src/ui/components/TouchableOpacity.tsx
+++ b/src/ui/components/TouchableOpacity.tsx
@@ -7,8 +7,8 @@ import {
   TouchableOpacity as RNTouchableOpacity,
   TouchableOpacityProps,
 } from 'react-native'
-import { TouchableOpacity as GestureTouchableOpacity } from 'react-native-gesture-handler'
-import styled from 'styled-components/native'
+import { Pressable } from 'react-native-gesture-handler'
+import styled, { DefaultTheme } from 'styled-components/native'
 
 import { accessibilityAndTestId } from 'libs/accessibilityAndTestId'
 import { useHandleFocus } from 'libs/hooks/useHandleFocus'
@@ -61,15 +61,17 @@ export function TouchableOpacity({
   )
 }
 
-const addStyled = (Component: typeof RNTouchableOpacity | typeof GestureTouchableOpacity) =>
-  styled(Component).attrs(({ activeOpacity, theme }) => ({
-    activeOpacity: activeOpacity ?? theme.activeOpacity,
-  }))<StyledProps>(({ theme, unselectable, isFocus }) => ({
+const addStyled = (Component: typeof RNTouchableOpacity | typeof Pressable) =>
+  styled(Component).attrs(
+    ({ activeOpacity, theme }: { activeOpacity?: number; theme: DefaultTheme }) => ({
+      activeOpacity: activeOpacity ?? theme.activeOpacity,
+    })
+  )<StyledProps>(({ theme, unselectable, isFocus }) => ({
     userSelect: unselectable ? 'none' : 'auto',
     ...touchableFocusOutline({ theme, isFocus }),
   }))
 const StyledRNTouchableOpacity = addStyled(RNTouchableOpacity)
-const StyledGestureTouchableOpacity = addStyled(GestureTouchableOpacity)
+const StyledGestureTouchableOpacity = addStyled(Pressable)
 
 // eslint-disable-next-line no-restricted-imports
 export { TouchableOpacity as RNTouchableOpacity } from 'react-native'

--- a/yarn.lock
+++ b/yarn.lock
@@ -11203,7 +11203,7 @@ __metadata:
     react-native-email-link: ^1.10.0
     react-native-fast-image: ^8.6.3
     react-native-geolocation-service: 5.3.1
-    react-native-gesture-handler: ^2.26.0
+    react-native-gesture-handler: ^2.29.1
     react-native-get-random-values: ^1.5.1
     react-native-in-app-review: ^4.3.1
     react-native-intersection-observer: ^0.2.1
@@ -23707,9 +23707,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-gesture-handler@npm:^2.26.0":
-  version: 2.26.0
-  resolution: "react-native-gesture-handler@npm:2.26.0"
+"react-native-gesture-handler@npm:^2.29.1":
+  version: 2.29.1
+  resolution: "react-native-gesture-handler@npm:2.29.1"
   dependencies:
     "@egjs/hammerjs": ^2.0.17
     hoist-non-react-statics: ^3.3.0
@@ -23717,7 +23717,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: e01cc57598b1cd2b4bf2886906e0d3a03ef09a57ce7a8ab530ec7779853919bb8265dd9afc0f023a0418cf60f6762eb27d1d71f8e3e9416a78ab0ddd55c22bb9
+  checksum: dddabdb12ce31d68ef71796e8fcaa57acd4608cca14412f36ce36fee14911fb629f325f0ced86bea1336a64673a434e34cde32a63be8d33f29d9a7bed292c5b2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
