### PR TITLE
(PC-41190) fix(proAdvices): keep new tag only for pro advices

### DIFF
--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.native.test.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.native.test.tsx
@@ -109,6 +109,18 @@ describe('<OfferReactionSection />', () => {
 
       expect(screen.queryByText('Nouveau')).not.toBeOnTheScreen()
     })
+
+    it('should not display new tag when wipProReviewsNewTag FF activated but no pro advices', async () => {
+      renderOfferReactionSection({
+        clubAdvices: [advicesFixture[0]],
+        clubAdvicesCount: 1,
+        enableProReviewNewTag: true,
+      })
+
+      await screen.findByText('1 avis book club')
+
+      expect(screen.queryByText('Nouveau')).not.toBeOnTheScreen()
+    })
   })
 
   describe('Headline offers information', () => {

--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
@@ -68,7 +68,7 @@ export const OfferReactionSection: FunctionComponent<Props> = ({
         advicesStatus={proAdvicesStatus}
         onPress={() => scrollToAnchor(AnchorNames.PRO_ADVICE_SECTION)}
       />
-      {enableProReviewNewTag ? (
+      {enableProReviewNewTag && proAdvicesStatus.total > 0 ? (
         <TagContainer>
           <Tag variant={TagVariant.NEW} label="Nouveau" />
         </TagContainer>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41190

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome - Club  |<img width="562" height="736" alt="Capture d’écran 2026-04-09 à 14 31 58" src="https://github.com/user-attachments/assets/b1291c8a-7f54-4a31-8ee8-eace5f0d352a" />|<img width="561" height="737" alt="Capture d’écran 2026-04-09 à 14 32 27" src="https://github.com/user-attachments/assets/bddbdb0d-869f-4404-ad30-30a5b992cc66" />|
| Desktop - Chrome - Pro |<img width="561" height="735" alt="Capture d’écran 2026-04-09 à 14 31 27" src="https://github.com/user-attachments/assets/d2382513-a00e-43c3-ade4-1ae7ff578a4e" />|<img width="561" height="736" alt="Capture d’écran 2026-04-09 à 14 32 57" src="https://github.com/user-attachments/assets/a6818ff5-faa4-4c8f-aad2-21cb7be5a06c" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
