### PR TITLE
(PC-41219) fix(offer): handle missing club advice variant

### DIFF
--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -41,7 +41,7 @@ type Props = {
   offer: OfferResponse
   subcategory: Subcategory
   children: ReactNode
-  adviceVariantInfo: AdviceVariantInfo
+  adviceVariantInfo?: AdviceVariantInfo
   onVideoConsentPress: () => void
   onShowOfferArtistsModal: (artists: OfferArtist[]) => void
   likesCount?: number

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -358,7 +358,7 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
             </OfferBody>
           </BodyWrapper>
 
-          {clubAdvices?.length ? (
+          {clubAdvices?.length && adviceVariantInfo ? (
             <AdviceSectionWithAnchor
               anchorName={AnchorNames.CLUB_ADVICE_SECTION}
               sectionId="club-advice-section"

--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.native.test.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.native.test.tsx
@@ -121,6 +121,17 @@ describe('<OfferReactionSection />', () => {
 
       expect(screen.queryByText('Nouveau')).not.toBeOnTheScreen()
     })
+
+    it('should display pro advices without crashing when no club advice variant exists', async () => {
+      renderOfferReactionSection({
+        adviceVariantInfo: undefined,
+        proAdvices: [...offerProAdvicesCardDataFixture],
+        proAdvicesCount: 2,
+      })
+
+      expect(await screen.findByText('2 avis des pros')).toBeOnTheScreen()
+      expect(screen.queryByTestId('clubAdvicesCounter')).not.toBeOnTheScreen()
+    })
   })
 
   describe('Headline offers information', () => {

--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
@@ -21,7 +21,7 @@ type Props = {
   likesCount?: number
   clubAdvicesCount?: number | null
   headlineOffersCount?: number
-  adviceVariantInfo: AdviceVariantInfo
+  adviceVariantInfo?: AdviceVariantInfo
   clubAdvices?: AdviceCardData[]
   proAdvicesCount?: number
   proAdvices?: AdviceCardData[]
@@ -42,23 +42,29 @@ export const OfferReactionSection: FunctionComponent<Props> = ({
 
   const clubAdvicesStatus: AdvicesStatus = getAdvicesStatus(clubAdvicesCount, clubAdvices?.length)
   const proAdvicesStatus: AdvicesStatus = getAdvicesStatus(proAdvicesCount, proAdvices?.length)
+  const hasClubAdvices =
+    !!adviceVariantInfo && (clubAdvicesStatus.hasPublished || clubAdvicesStatus.hasUnpublished)
+  const hasProAdvices = proAdvicesStatus.hasPublished || proAdvicesStatus.hasUnpublished
+  const hasLikes = !!likesCount
+  const hasHeadlineOffers = !!headlineOffersCount
 
-  const likesCounterElement = likesCount ? (
+  const likesCounterElement = hasLikes ? (
     <LikesInfoCounter text={formatLikesCounter(likesCount)} />
   ) : null
 
-  const clubAdvicesCounterElement = (
-    <OfferAdvicesCounter
-      testID="clubAdvicesCounter"
-      publishedText={`${clubAdvicesStatus.total} avis ${adviceVariantInfo.labelReaction}`}
-      unpublishedText={`Recommandé par le ${adviceVariantInfo.labelReaction}`}
-      icon={adviceVariantInfo.SmallIcon}
-      advicesStatus={clubAdvicesStatus}
-      onPress={() => scrollToAnchor(AnchorNames.CLUB_ADVICE_SECTION)}
-    />
-  )
+  const clubAdvicesCounterElement =
+    hasClubAdvices && adviceVariantInfo ? (
+      <OfferAdvicesCounter
+        testID="clubAdvicesCounter"
+        publishedText={`${clubAdvicesStatus.total} avis ${adviceVariantInfo.labelReaction}`}
+        unpublishedText={`Recommandé par le ${adviceVariantInfo.labelReaction}`}
+        icon={adviceVariantInfo.SmallIcon}
+        advicesStatus={clubAdvicesStatus}
+        onPress={() => scrollToAnchor(AnchorNames.CLUB_ADVICE_SECTION)}
+      />
+    ) : null
 
-  const proAdvicesCounterElement = (
+  const proAdvicesCounterElement = hasProAdvices ? (
     <ProAdvicesCounterContainer gap={2}>
       <OfferAdvicesCounter
         testID="proAdvicesCounter"
@@ -74,25 +80,17 @@ export const OfferReactionSection: FunctionComponent<Props> = ({
         </TagContainer>
       ) : null}
     </ProAdvicesCounterContainer>
-  )
+  ) : null
 
-  const headlineOffersCounterElement = headlineOffersCount ? (
+  const headlineOffersCounterElement = hasHeadlineOffers ? (
     <HeadlineOffersCount text={getRecommendationText(headlineOffersCount)} />
   ) : null
 
-  if (
-    !(
-      likesCounterElement ||
-      clubAdvicesCounterElement ||
-      headlineOffersCounterElement ||
-      proAdvicesCounterElement
-    )
-  )
-    return null
+  if (!(hasLikes || hasClubAdvices || hasHeadlineOffers || hasProAdvices)) return null
 
   return (
     <ViewGap gap={4}>
-      {likesCounterElement || clubAdvicesCounterElement || proAdvicesCounterElement ? (
+      {hasLikes || hasClubAdvices || hasProAdvices ? (
         <InfosCounterContainer gap={2}>
           {likesCounterElement}
           {clubAdvicesCounterElement}

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -151,10 +151,13 @@ export function Offer() {
 
   const subcategory = subcategoriesMapping[offer?.subcategoryId]
   const adviceVariantInfo = clubAdviceVariant[subcategory.id]
+  const hasClubAdviceVariant = !!adviceVariantInfo
 
-  const clubAdvices = offer?.chronicles?.map((value) =>
-    advicePreviewToAdviceCardData(value, adviceVariantInfo.subtitleItem)
-  )
+  const clubAdvices = hasClubAdviceVariant
+    ? offer?.chronicles?.map((value) =>
+        advicePreviewToAdviceCardData(value, adviceVariantInfo.subtitleItem)
+      )
+    : undefined
 
   const shouldFetchSearchVenueOffers = isMultiVenueCompatibleOffer(offer)
   const headlineOffersCount = shouldFetchSearchVenueOffers ? data?.headlineOffersCount : undefined
@@ -178,7 +181,7 @@ export function Offer() {
           bodyType={ReactionChoiceModalBodyEnum.VALIDATION}
         />
 
-        {adviceVariantInfo ? (
+        {hasClubAdviceVariant ? (
           <AdvicesWritersModal
             closeModal={hideChroniclesWritersModal}
             isVisible={chroniclesWritersModalVisible}

--- a/src/features/offer/types.ts
+++ b/src/features/offer/types.ts
@@ -89,7 +89,7 @@ type OfferCTAsComponentProps = {
 export type OfferContentProps = {
   offer: OfferResponse
   searchGroupList: SearchGroupResponseModelv2[]
-  adviceVariantInfo: AdviceVariantInfo
+  adviceVariantInfo?: AdviceVariantInfo
   subcategory: Subcategory
   onShowClubAdviceWritersModal: () => void
   onShowOfferArtistsModal: (artists: OfferArtist[]) => void

--- a/src/features/offerRefacto/pages/Offer.tsx
+++ b/src/features/offerRefacto/pages/Offer.tsx
@@ -144,10 +144,13 @@ export function Offer() {
 
   const subcategory = subcategoriesMapping[offer?.subcategoryId]
   const adviceVariantInfo = clubAdviceVariant[subcategory.id]
+  const hasClubAdviceVariant = !!adviceVariantInfo
 
-  const clubAdvices = offer?.chronicles?.map((value) =>
-    advicePreviewToAdviceCardData(value, adviceVariantInfo.subtitleItem)
-  )
+  const clubAdvices = hasClubAdviceVariant
+    ? offer?.chronicles?.map((value) =>
+        advicePreviewToAdviceCardData(value, adviceVariantInfo.subtitleItem)
+      )
+    : undefined
 
   const shouldFetchSearchVenueOffers = isMultiVenueCompatibleOffer(offer)
   const headlineOffersCount = shouldFetchSearchVenueOffers ? data?.headlineOffersCount : undefined
@@ -171,7 +174,7 @@ export function Offer() {
           bodyType={ReactionChoiceModalBodyEnum.VALIDATION}
         />
 
-        {adviceVariantInfo ? (
+        {hasClubAdviceVariant ? (
           <AdvicesWritersModal
             closeModal={hideChroniclesWritersModal}
             isVisible={chroniclesWritersModalVisible}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41219

## Context

Cette PR corrige un bug sur la page offre quand `adviceVariantInfo` est undefined.
Certaines offres peuvent afficher des avis des pros sans appartenir à un club (`book club` / `ciné club`).

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Video


https://github.com/user-attachments/assets/7e9f969c-5492-4122-bba4-c7abd0aa5309



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
