### PR TITLE
(PC-40948) feat(PersonalData): fix goBack to Profile polluted by changement screens

### DIFF
--- a/src/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx
+++ b/src/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx
@@ -1,7 +1,7 @@
 import { FeatureCollection, Point } from 'geojson'
 import React from 'react'
 
-import { navigate, useRoute } from '__mocks__/@react-navigation/native'
+import { navigate, useRoute, replace } from '__mocks__/@react-navigation/native'
 import * as API from 'api/api'
 import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
 import { ChangeAddress } from 'features/profile/pages/ChangeAddress/ChangeAddress'
@@ -95,7 +95,7 @@ describe('<SetAddress/>', () => {
       await user.press(await screen.findByText(mockedSuggestedPlaces.features[1].properties.name))
       await user.press(screen.getByText('Valider mon adresse'))
 
-      expect(navigate).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
+      expect(replace).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
         params: undefined,
         screen: 'PersonalData',
       })

--- a/src/features/profile/pages/ChangeAddress/useSubmitChangeAddress.ts
+++ b/src/features/profile/pages/ChangeAddress/useSubmitChangeAddress.ts
@@ -42,7 +42,7 @@ export const useSubmitChangeAddress = () => {
   const storedAddress = useAddress()
   const initialCity = storedAddress === null ? '' : (storedAddress ?? user?.street ?? '')
 
-  const { navigate } = useNavigation<UseNavigationType>()
+  const { navigate, replace } = useNavigation<UseNavigationType>()
 
   const {
     control,
@@ -108,7 +108,7 @@ export const useSubmitChangeAddress = () => {
       if (isMandatoryUpdatePersonalData) {
         navigate(...getProfileHookConfig('ChangeStatus', { type }))
       } else {
-        navigate(...getProfileHookConfig('PersonalData'))
+        replace(...getProfileHookConfig('PersonalData'))
         showSuccessSnackBar('Ton adresse de résidence a bien été modifiée\u00a0!')
       }
       await analytics.logUpdateAddress({

--- a/src/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx
+++ b/src/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { navigate, useRoute } from '__mocks__/@react-navigation/native'
+import { navigate, replace, useRoute } from '__mocks__/@react-navigation/native'
 import * as API from 'api/api'
 import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
 import { ChangeCity } from 'features/profile/pages/ChangeCity/ChangeCity'
@@ -74,7 +74,7 @@ describe('ChangeCity', () => {
       await user.press(await screen.findByText(city.nom))
       await user.press(await screen.findByText('Valider ma ville de résidence'))
 
-      expect(navigate).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
+      expect(replace).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
         params: undefined,
         screen: 'PersonalData',
       })

--- a/src/features/profile/pages/ChangeCity/useSubmitChangeCity.ts
+++ b/src/features/profile/pages/ChangeCity/useSubmitChangeCity.ts
@@ -25,7 +25,7 @@ export const useSubmitChangeCity = () => {
   const { setCity } = cityActions
   const { resetAddress } = addressActions
 
-  const { navigate } = useNavigation<UseNavigationType>()
+  const { navigate, replace } = useNavigation<UseNavigationType>()
   const { params } = useRoute<UseRouteType<'ChangeCity'>>()
   const type = params?.type
 
@@ -44,15 +44,15 @@ export const useSubmitChangeCity = () => {
   })
 
   const { mutate: patchProfile, isPending } = usePatchProfileMutation({
-    onSuccess: (_, variables) => {
+    onSuccess: async (_, variables) => {
       if (isFromProfileUpdateFlow) {
         navigate(...getProfileHookConfig('ChangeAddress', { type }))
       } else {
-        navigate(...getProfileHookConfig('PersonalData'))
+        replace(...getProfileHookConfig('PersonalData'))
         showSuccessSnackBar('Ta ville de résidence a bien été modifiée\u00a0!')
       }
 
-      analytics.logUpdatePostalCode({
+      await analytics.logUpdatePostalCode({
         newCity: variables.city ?? '',
         oldCity: user?.city ?? '',
         newPostalCode: variables.postalCode ?? '',

--- a/src/features/profile/pages/ChangePhoneNumber/ChangePhoneNumber.native.test.tsx
+++ b/src/features/profile/pages/ChangePhoneNumber/ChangePhoneNumber.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { replace } from '__mocks__/@react-navigation/native'
 import { ChangePhoneNumber } from 'features/profile/pages/ChangePhoneNumber/ChangePhoneNumber'
 import { beneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics/provider'
@@ -112,7 +112,7 @@ describe('ChangePhoneNumber', () => {
     })
     await user.press(screen.getByTestId('Continuer'))
 
-    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', { screen: 'PersonalData' })
+    expect(replace).toHaveBeenCalledWith('ProfileStackNavigator', { screen: 'PersonalData' })
   })
 
   it('should call analytics when the phone number is updated', async () => {

--- a/src/features/profile/pages/ChangePhoneNumber/useSubmitChangePhoneNumber.ts
+++ b/src/features/profile/pages/ChangePhoneNumber/useSubmitChangePhoneNumber.ts
@@ -30,7 +30,7 @@ const getCountryIdFromPhoneNumber = (phoneNumber: string): string => {
 
 export const useSubmitChangePhoneNumber = () => {
   const { user } = useAuthContext()
-  const { navigate } = useNavigation<UseNavigationType>()
+  const { replace } = useNavigation<UseNavigationType>()
   const phoneNumber = user?.phoneNumber ? getLastNineDigits(user.phoneNumber) : ''
   const countryId = user?.phoneNumber
     ? getCountryIdFromPhoneNumber(user.phoneNumber)
@@ -49,9 +49,9 @@ export const useSubmitChangePhoneNumber = () => {
   })
   const { mutate: patchProfile, isPending } = usePatchProfileMutation({
     onSuccess: () => {
-      navigate(...getProfileHookConfig('PersonalData'))
+      replace(...getProfileHookConfig('PersonalData'))
       showSuccessSnackBar('Ton numéro de téléphone a bien été modifié\u00a0!')
-      analytics.logHasChangedPhoneNumber()
+      void analytics.logHasChangedPhoneNumber()
     },
     onError: () => {
       showErrorSnackBar('Une erreur est survenue')

--- a/src/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx
+++ b/src/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useRoute, reset, navigate } from '__mocks__/@react-navigation/native'
+import { useRoute, reset, replace } from '__mocks__/@react-navigation/native'
 import { ActivityIdEnum } from 'api/gen'
 import { initialSubscriptionState as mockState } from 'features/identityCheck/context/reducer'
 import { ActivityTypesSnap } from 'features/identityCheck/pages/profile/fixtures/mockedActivityTypes'
@@ -126,7 +126,7 @@ describe('<ChangeStatus/>', () => {
       await user.press(screen.getByText('Employé'))
       await user.press(screen.getByText('Valider mes informations'))
 
-      expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+      expect(replace).toHaveBeenCalledWith('ProfileStackNavigator', {
         screen: 'PersonalData',
         params: undefined,
       })

--- a/src/features/profile/pages/ChangeStatus/useSubmitChangeStatus.tsx
+++ b/src/features/profile/pages/ChangeStatus/useSubmitChangeStatus.tsx
@@ -28,7 +28,7 @@ export const useSubmitChangeStatus = () => {
     : 'Ton statut a bien été modifié\u00a0!'
 
   const { user } = useAuthContext()
-  const { navigate, reset } = useNavigation<UseNavigationType>()
+  const { replace, reset } = useNavigation<UseNavigationType>()
   const storedStatus = useStatus()
   const [navigatorName, screenConfig] = getProfileHookConfig('UpdatePersonalDataConfirmation')
 
@@ -43,7 +43,7 @@ export const useSubmitChangeStatus = () => {
           ],
         })
       } else {
-        navigate(...getProfileHookConfig('PersonalData'))
+        replace(...getProfileHookConfig('PersonalData'))
         showSuccessSnackBar(successSnackBarMessage)
       }
       await analytics.logUpdateStatus({

--- a/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { navigate, popTo } from '__mocks__/@react-navigation/native'
 import { UpdateEmailTokenExpiration } from 'api/gen'
 import * as Auth from 'features/auth/context/AuthContext'
 import * as OpenUrlAPI from 'features/navigation/helpers/openUrl'
@@ -213,6 +213,17 @@ describe('PersonalData', () => {
     render(reactQueryProviderHOC(<PersonalData />))
 
     expect(await screen.findByText('Numéro de téléphone')).toBeOnTheScreen()
+  })
+
+  it('should go to profile tab when pressing back arrow', async () => {
+    render(reactQueryProviderHOC(<PersonalData />))
+
+    await user.press(screen.getByTestId('Revenir en arrière'))
+
+    expect(popTo).toHaveBeenCalledWith('TabNavigator', {
+      screen: 'Profile',
+      params: undefined,
+    })
   })
 
   it('should  not display phone number section when user has none', async () => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-40948

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              | https://github.com/user-attachments/assets/de825369-4fff-46bb-b195-2af2e2822059 |   https://github.com/user-attachments/assets/55032096-9fb2-4d1a-acca-39c13fc95191 |
| Web - go back navigateur   |               | https://github.com/user-attachments/assets/cb5e807b-8752-4156-bd10-55e73efb5895|
| Web - go back app |               |  https://github.com/user-attachments/assets/656bcc49-1a04-49f7-be98-87822a3fe8d3 |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
