### PR TITLE
(PC-41237) fix(SetAddress): input should update when suggestion is chosen and api suggestion are valid even when containing unvalid characters

### DIFF
--- a/src/features/identityCheck/pages/profile/SetAddress.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.native.test.tsx
@@ -97,6 +97,18 @@ describe('<SetAddress/>', () => {
     })
   })
 
+  it('should display selected suggestion in input', async () => {
+    renderSetAddress()
+
+    const input = screen.getByTestId('Entrée pour l’adresse')
+    fireEvent.changeText(input, QUERY_ADDRESS)
+
+    const selectedSuggestion = mockedSuggestedPlaces.features[1].properties.name
+    await user.press(await screen.findByText(selectedSuggestion))
+
+    expect(screen.getByTestId('Entrée pour l’adresse').props.value).toBe(selectedSuggestion)
+  })
+
   it('should save address in local storage when clicking on "Continuer"', async () => {
     renderSetAddress()
 

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -85,6 +85,8 @@ export const SetAddress = () => {
 
   const onAddressSelection = (address: string) => {
     setSelectedAddress(address)
+    setQuery(address)
+    debouncedSetQuery(address)
     Keyboard.dismiss()
   }
 
@@ -94,7 +96,7 @@ export const SetAddress = () => {
     debouncedSetQuery('')
   }
 
-  const isValidAddress = isAddressValid(query)
+  const isValidAddress = selectedAddress !== null || isAddressValid(query)
 
   const enabled = query.trim().length > 0
 


### PR DESCRIPTION

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41237

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               | https://github.com/user-attachments/assets/1033798a-a781-42b9-8fee-ff301a2707dd|


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
