### PR TITLE
(PC-41298) fix(Home): ensure home flatlist ids are unique and stable for modules

### DIFF
--- a/src/features/home/pages/GenericHome.tsx
+++ b/src/features/home/pages/GenericHome.tsx
@@ -44,7 +44,7 @@ import { ScreenPerformance } from 'performance/ScreenPerformance'
 import { useMarkScreenInteractive } from 'performance/useMarkScreenInteractive'
 import { useMeasureScreenPerformanceWhenVisible } from 'performance/useMeasureScreenPerformanceWhenVisible'
 import { AccessibilityFooter } from 'shared/AccessibilityFooter/AccessibilityFooter'
-import { usePageTracking, createViewableItemsHandler } from 'shared/tracking/usePageTracking'
+import { createViewableItemsHandler, usePageTracking } from 'shared/tracking/usePageTracking'
 import { useIsLandscape } from 'shared/useIsLandscape/useIsLandscape'
 import { ScrollToTopButton } from 'ui/components/ScrollToTopButton'
 import { Spinner } from 'ui/components/Spinner'
@@ -66,7 +66,7 @@ type GenericHomeProps = {
   statusBar?: React.JSX.Element
 }
 
-const keyExtractor = (item: HomepageModule) => item.id
+const keyExtractor = (item: HomepageModule, index: number) => item.id + index
 
 const renderModule = (
   { item, index }: { item: HomepageModule; index: number },


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41298

Corriger l'erreur
```
Encountered two children with the same key, `.$6rFJvIiOgrdwaOvZilDwaI`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```
