### PR TITLE
(BSR) test(eslint): add eslint rule to enforce naming

### DIFF
--- a/eslint-custom-rules/no-dotted-test-filename-without-render.js
+++ b/eslint-custom-rules/no-dotted-test-filename-without-render.js
@@ -1,0 +1,61 @@
+/**
+ * Enforce a simpler naming for non-UI unit tests.
+ *
+ * If a test file DOES NOT call `render()` nor `renderHook()`, it must be named:
+ *   `*.test.ts`
+ * and NOT:
+ *   `*.*.test.ts` (e.g. `foo.ios.test.ts`, `bar.native.test.ts`, ...)
+ */
+const path = require('path')
+ 
+module.exports = {
+  name: 'no-dotted-test-filename-without-render',
+  meta: {
+    docs: {
+      description:
+        'Non-UI tests (no render/renderHook) must be named *.test.ts and not *.*.test.ts',
+    },
+    messages: {
+      renameTestFile:
+        'Ce test ne contient ni `render()` ni `renderHook()`. Il doit être nommé `*.test.ts` (pas `*.*.test.ts`). Renomme `{{ from }}` en `{{ to }}`.',
+    },
+  },
+  create(context) {
+    const filename = context.getFilename()
+    const absoluteFilename = path.resolve(filename)
+    const basename = path.basename(absoluteFilename)
+ 
+    // Only target `.test.ts` files that have an extra dotted segment before `.test.ts`
+    // Example: `checkGeolocPermission.ios.test.ts`
+    const isDottedTestTs = /.+\.[^.]+\.test\.ts$/.test(basename)
+    const isTestTs = basename.endsWith('.test.ts')
+    const isIosOrAndroidTestTs = /.+\.(ios|android)\.test\.ts$/.test(basename)
+ 
+    if (!isTestTs || !isDottedTestTs || isIosOrAndroidTestTs) return {}
+ 
+    let hasRenderLikeCall = false
+ 
+    return {
+      CallExpression(node) {
+        if (hasRenderLikeCall) return
+        const callee = node.callee
+        if (callee?.type === 'Identifier' && (callee.name === 'render' || callee.name === 'renderHook')) {
+          hasRenderLikeCall = true
+        }
+      },
+      'Program:exit'(node) {
+        if (hasRenderLikeCall) return
+ 
+        const match = basename.match(/^(.+)\.[^.]+(\.test\.ts)$/)
+        if (!match) return
+        const suggestedBasename = `${match[1]}${match[2]}`
+ 
+        context.report({
+          node,
+          messageId: 'renameTestFile',
+          data: { from: basename, to: suggestedBasename },
+        })
+      },
+    }
+  },
+}

--- a/eslint-custom-rules/no-dotted-test-filename-without-render.test.js
+++ b/eslint-custom-rules/no-dotted-test-filename-without-render.test.js
@@ -1,0 +1,34 @@
+import { RuleTester } from 'eslint'
+import { config } from './config'
+
+import rule from './no-dotted-test-filename-without-render'
+
+const ruleTester = new RuleTester()
+
+const tests = {
+  valid: [
+    { code: `describe('x', () => {})`, filename: 'toto.test.ts' },
+    { code: `describe('x', () => {})`, filename: 'toto.ios.test.ts' },
+    { code: `describe('x', () => {})`, filename: 'toto.android.test.ts' },
+    { code: `renderHook(() => ({}))`, filename: 'toto.native.test.ts' },
+    { code: `describe('x', () => {})`, filename: 'toto.native.test.tsx' },
+    { code: `describe('x', () => {})`, filename: 'toto.web.test.tsx' },
+  ],
+  invalid: [
+    {
+      code: `it('x', () => { expect(1).toBe(1) })`,
+      filename: 'toto.native.test.ts',
+      errors: 1,
+    },
+    {
+      code: `it('x', () => { expect(1).toBe(1) })`,
+      filename: 'toto.web.test.ts',
+      errors: 1,
+    },
+  ],
+}
+
+tests.valid.forEach((t) => Object.assign(t, config))
+tests.invalid.forEach((t) => Object.assign(t, config))
+
+ruleTester.run('no-dotted-test-filename-without-render', rule, tests)

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -21,6 +21,7 @@ const noThemeFromTheme = require('./eslint-custom-rules/no-theme-from-theme')
 const noTsExpectError = require('./eslint-custom-rules/no-ts-expect-error')
 const noUselessHook = require('./eslint-custom-rules/no-useless-hook')
 const mockPathExists = require('./eslint-custom-rules/mock-path-exists')
+const noDottedTestFilenameWithoutRender = require('./eslint-custom-rules/no-dotted-test-filename-without-render')
 
 module.exports = {
   'apostrophe-in-text': apostropheInText,
@@ -46,4 +47,5 @@ module.exports = {
   'no-ts-expect-error': noTsExpectError,
   'no-useless-hook': noUselessHook,
   'mock-path-exists': mockPathExists,
+  'no-dotted-test-filename-without-render': noDottedTestFilenameWithoutRender,
 }

--- a/eslint-soft-rules.js
+++ b/eslint-soft-rules.js
@@ -3,6 +3,7 @@ const { boundariesRule } = require('./eslint-custom-rules/boundaries-rule')
 
 const softRules = {
   cleancode: {
+    'local-rules/no-dotted-test-filename-without-render': 'warn',
     'local-rules/no-ts-expect-error': 'warn',
     'local-rules/no-get-spacing': 'warn',
     'local-rules/no-theme-colors': 'warn',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
