### PR TITLE
(PC-41283) fix(Navigation): stack order in Personal Data screens

### DIFF
--- a/src/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx
+++ b/src/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx
@@ -1,7 +1,7 @@
 import { FeatureCollection, Point } from 'geojson'
 import React from 'react'
 
-import { navigate, useRoute, replace } from '__mocks__/@react-navigation/native'
+import { navigate, useRoute } from '__mocks__/@react-navigation/native'
 import * as API from 'api/api'
 import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
 import { ChangeAddress } from 'features/profile/pages/ChangeAddress/ChangeAddress'
@@ -95,7 +95,7 @@ describe('<SetAddress/>', () => {
       await user.press(await screen.findByText(mockedSuggestedPlaces.features[1].properties.name))
       await user.press(screen.getByText('Valider mon adresse'))
 
-      expect(replace).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
+      expect(navigate).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
         params: undefined,
         screen: 'PersonalData',
       })

--- a/src/features/profile/pages/ChangeAddress/useSubmitChangeAddress.ts
+++ b/src/features/profile/pages/ChangeAddress/useSubmitChangeAddress.ts
@@ -131,8 +131,8 @@ export const useSubmitChangeAddress = () => {
 
   const hasNonEmptyQuery = query.trim().length > 0
   const isValidAndNotEmpty = isValid && hasNonEmptyQuery
-
-  const isValidAddress = selectedAddress !== null || isAddressValid(query)
+  const hasSameAddress = storedAddress === query
+  const isValidAddress = selectedAddress !== null || isAddressValid(query) || hasSameAddress
   const label = idCheckAddressAutocompletion
     ? 'Recherche et sélectionne ton adresse'
     : 'Entre ton adresse'

--- a/src/features/profile/pages/ChangeAddress/useSubmitChangeAddress.ts
+++ b/src/features/profile/pages/ChangeAddress/useSubmitChangeAddress.ts
@@ -1,4 +1,4 @@
-import { useNavigation, useRoute } from '@react-navigation/native'
+import { CommonActions, useNavigation, useRoute } from '@react-navigation/native'
 import { debounce } from 'lodash'
 import { useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -42,7 +42,7 @@ export const useSubmitChangeAddress = () => {
   const storedAddress = useAddress()
   const initialCity = storedAddress === null ? '' : (storedAddress ?? user?.street ?? '')
 
-  const { navigate, replace } = useNavigation<UseNavigationType>()
+  const { navigate, dispatch } = useNavigation<UseNavigationType>()
 
   const {
     control,
@@ -103,12 +103,26 @@ export const useSubmitChangeAddress = () => {
     debouncedSetQuery('')
   }
 
+  const removePrecedentScreen = () => {
+    dispatch((state) => {
+      const routesToDelete = new Set(['ChangeAddress', 'ChangeCity'])
+      const routes = state.routes.filter((r) => !routesToDelete.has(r.name))
+
+      return CommonActions.reset({
+        ...state,
+        routes,
+        index: routes.length - 1,
+      })
+    })
+  }
+
   const { mutate: patchProfile } = usePatchProfileMutation({
     onSuccess: async (_, variables) => {
       if (isMandatoryUpdatePersonalData) {
         navigate(...getProfileHookConfig('ChangeStatus', { type }))
       } else {
-        replace(...getProfileHookConfig('PersonalData'))
+        navigate(...getProfileHookConfig('PersonalData'))
+        removePrecedentScreen()
         showSuccessSnackBar('Ton adresse de résidence a bien été modifiée\u00a0!')
       }
       await analytics.logUpdateAddress({

--- a/src/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx
+++ b/src/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { navigate, replace, useRoute } from '__mocks__/@react-navigation/native'
+import { navigate, useRoute } from '__mocks__/@react-navigation/native'
 import * as API from 'api/api'
 import { PersonalDataTypes } from 'features/navigation/ProfileStackNavigator/enums'
 import { ChangeCity } from 'features/profile/pages/ChangeCity/ChangeCity'
@@ -74,7 +74,7 @@ describe('ChangeCity', () => {
       await user.press(await screen.findByText(city.nom))
       await user.press(await screen.findByText('Valider ma ville de résidence'))
 
-      expect(replace).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
+      expect(navigate).toHaveBeenNthCalledWith(1, 'ProfileStackNavigator', {
         params: undefined,
         screen: 'PersonalData',
       })

--- a/src/features/profile/pages/ChangeCity/useSubmitChangeCity.ts
+++ b/src/features/profile/pages/ChangeCity/useSubmitChangeCity.ts
@@ -25,7 +25,7 @@ export const useSubmitChangeCity = () => {
   const { setCity } = cityActions
   const { resetAddress } = addressActions
 
-  const { navigate, replace } = useNavigation<UseNavigationType>()
+  const { navigate } = useNavigation<UseNavigationType>()
   const { params } = useRoute<UseRouteType<'ChangeCity'>>()
   const type = params?.type
 
@@ -48,7 +48,7 @@ export const useSubmitChangeCity = () => {
       if (isFromProfileUpdateFlow) {
         navigate(...getProfileHookConfig('ChangeAddress', { type }))
       } else {
-        replace(...getProfileHookConfig('PersonalData'))
+        navigate(...getProfileHookConfig('PersonalData'))
         showSuccessSnackBar('Ta ville de résidence a bien été modifiée\u00a0!')
       }
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41283

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
