### PR TITLE
(PC-40230) feat(interactiontag): add pro advices count support in off…

### DIFF
--- a/src/features/offer/components/InteractionTag/InteractionTag.native.test.tsx
+++ b/src/features/offer/components/InteractionTag/InteractionTag.native.test.tsx
@@ -14,7 +14,7 @@ describe('getTagProps', () => {
     expect(
       getTagProps({
         theme: computedTheme,
-        advicesCount: 1,
+        clubAdvicesCount: 1,
         likesCount: 10,
         subcategoryId,
       })
@@ -24,9 +24,18 @@ describe('getTagProps', () => {
     })
   })
 
-  it('should return "j’aime" tag when only likesCount > 0', () => {
+  it('should return "X avis des pros" tag when proAdvicesCount > 0 and no club advices', () => {
+    expect(
+      getTagProps({ theme: computedTheme, proAdvicesCount: 1, likesCount: 10, subcategoryId })
+    ).toEqual({
+      label: '1 avis des pros',
+      variant: TagVariant.PROEDITO,
+    })
+  })
+
+  it('should return "j\u2019aime" tag when only likesCount > 0', () => {
     expect(getTagProps({ theme: computedTheme, likesCount: 1, subcategoryId })).toEqual({
-      label: '1 j’aime',
+      label: '1 j\u2019aime',
       variant: TagVariant.LIKE,
     })
   })
@@ -35,18 +44,32 @@ describe('getTagProps', () => {
     expect(getTagProps({ theme: computedTheme, subcategoryId })).toBeNull()
   })
 
-  it('should use short label when hasSmallLayout is true — "X avis"', () => {
+  it('should use short label when hasSmallLayout is true \u2014 "X avis" when proAdvicesCount > 0 and no club advices', () => {
     expect(
-      getTagProps({ theme: computedTheme, advicesCount: 1, hasSmallLayout: true, subcategoryId })
+      getTagProps({ theme: computedTheme, proAdvicesCount: 1, hasSmallLayout: true, subcategoryId })
+    ).toEqual({
+      label: '1 avis',
+      variant: TagVariant.PROEDITO,
+    })
+  })
+
+  it('should use short label when hasSmallLayout is true \u2014 "X avis" when club advices > 0', () => {
+    expect(
+      getTagProps({
+        theme: computedTheme,
+        clubAdvicesCount: 1,
+        hasSmallLayout: true,
+        subcategoryId,
+      })
     ).toEqual({
       label: '1 avis',
       variant: TagVariant.BOOKCLUB,
     })
   })
 
-  it('should return "Bientôt dispo" tag when isComingSoonOffer is true', () => {
+  it('should return "Bient\u00f4t dispo" tag when isComingSoonOffer is true', () => {
     expect(getTagProps({ theme: computedTheme, isComingSoonOffer: true, subcategoryId })).toEqual({
-      label: 'Bientôt dispo',
+      label: 'Bient\u00f4t dispo',
       variant: TagVariant.WARNING,
       Icon: expect.anything(),
     })
@@ -61,21 +84,21 @@ describe('getTagProps', () => {
         subcategoryId,
       })
     ).toEqual({
-      label: 'Bientôt',
+      label: 'Bient\u00f4t',
       variant: TagVariant.WARNING,
       Icon: expect.anything(),
     })
   })
 
-  it('should return "X avis ciné club" tag when advicesCount > 0 and subcategory is not a book club', () => {
+  it('should return "X avis cin\u00e9 club" tag when advicesCount > 0 and subcategory is not a book club', () => {
     expect(
       getTagProps({
         theme: computedTheme,
-        advicesCount: 1,
+        clubAdvicesCount: 1,
         subcategoryId: SubcategoryIdEnum.CINE_PLEIN_AIR,
       })
     ).toEqual({
-      label: '1 avis ciné club',
+      label: '1 avis cin\u00e9 club',
       variant: TagVariant.CINECLUB,
     })
   })
@@ -84,7 +107,7 @@ describe('getTagProps', () => {
     expect(
       getTagProps({
         theme: computedTheme,
-        advicesCount: 1,
+        clubAdvicesCount: 1,
         hasSmallLayout: true,
         subcategoryId: SubcategoryIdEnum.CINE_PLEIN_AIR,
       })

--- a/src/features/offer/components/InteractionTag/InteractionTag.tsx
+++ b/src/features/offer/components/InteractionTag/InteractionTag.tsx
@@ -12,7 +12,8 @@ type InteractionTagParams = {
   theme: DefaultTheme
   subcategoryId: SubcategoryIdEnum
   likesCount?: number
-  advicesCount?: number
+  clubAdvicesCount?: number
+  proAdvicesCount?: number
   hasSmallLayout?: boolean
   isComingSoonOffer?: boolean
 }
@@ -26,7 +27,8 @@ export const renderInteractionTag = (params: InteractionTagParams): ReactNode | 
 
 export const getTagProps = ({
   likesCount = 0,
-  advicesCount = 0,
+  clubAdvicesCount = 0,
+  proAdvicesCount = 0,
   hasSmallLayout,
   isComingSoonOffer,
   subcategoryId,
@@ -39,16 +41,23 @@ export const getTagProps = ({
     }
   }
 
-  if (advicesCount > 0) {
+  if (clubAdvicesCount > 0) {
     if (isBookClubSubcategory(subcategoryId)) {
       return {
-        label: hasSmallLayout ? `${advicesCount} avis` : `${advicesCount} avis book club`,
+        label: hasSmallLayout ? `${clubAdvicesCount} avis` : `${clubAdvicesCount} avis book club`,
         variant: TagVariant.BOOKCLUB,
       }
     }
     return {
-      label: hasSmallLayout ? `${advicesCount} avis` : `${advicesCount} avis ciné club`,
+      label: hasSmallLayout ? `${clubAdvicesCount} avis` : `${clubAdvicesCount} avis ciné club`,
       variant: TagVariant.CINECLUB,
+    }
+  }
+
+  if (proAdvicesCount > 0) {
+    return {
+      label: hasSmallLayout ? `${proAdvicesCount} avis` : `${proAdvicesCount} avis des pros`,
+      variant: TagVariant.PROEDITO,
     }
   }
 

--- a/src/features/offer/components/OfferPlaylistItem/OfferPlaylistItem.tsx
+++ b/src/features/offer/components/OfferPlaylistItem/OfferPlaylistItem.tsx
@@ -58,10 +58,11 @@ export const OfferPlaylistItem = ({
     const tag = renderInteractionTag({
       theme,
       likesCount: item.offer.likes,
-      advicesCount: item.offer.chroniclesCount,
+      clubAdvicesCount: item.offer.chroniclesCount,
       hasSmallLayout,
       isComingSoonOffer: getIsAComingSoonOffer(item.offer.bookingAllowedDatetime),
       subcategoryId: item.offer.subcategoryId,
+      proAdvicesCount: item.offer.proAdvicesCount,
     })
     return (
       <OfferTile

--- a/src/features/offer/components/OfferTile/OfferTileWrapper.tsx
+++ b/src/features/offer/components/OfferTile/OfferTileWrapper.tsx
@@ -51,10 +51,11 @@ export const OfferTileWrapper = React.memo(function OfferTileWrapper(props: Prop
   const tag = renderInteractionTag({
     theme,
     likesCount: likes,
-    advicesCount: chroniclesCount,
+    clubAdvicesCount: chroniclesCount,
     hasSmallLayout,
     isComingSoonOffer: getIsAComingSoonOffer(item.offer.bookingAllowedDatetime),
     subcategoryId: item.offer.subcategoryId,
+    proAdvicesCount: item.offer.proAdvicesCount,
   })
 
   return (

--- a/src/features/venue/components/VenueOffers/VenueOffersList.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffersList.tsx
@@ -110,9 +110,10 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
     const tag = renderInteractionTag({
       theme,
       likesCount: item.offer.likes,
-      advicesCount: item.offer.chroniclesCount,
+      clubAdvicesCount: item.offer.chroniclesCount,
       isComingSoonOffer: getIsAComingSoonOffer(item.offer.bookingAllowedDatetime),
       subcategoryId: item.offer.subcategoryId,
+      proAdvicesCount: item.offer.proAdvicesCount,
     })
 
     return (

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueMapOfferPlaylist.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueMapOfferPlaylist.tsx
@@ -54,10 +54,11 @@ export const VenueMapOfferPlaylist = ({
       const tag = renderInteractionTag({
         theme,
         likesCount: item.offer.likes,
-        advicesCount: item.offer.chroniclesCount,
+        clubAdvicesCount: item.offer.chroniclesCount,
         hasSmallLayout: true,
         isComingSoonOffer: getIsAComingSoonOffer(item.offer.bookingAllowedDatetime),
         subcategoryId: item.offer.subcategoryId,
+        proAdvicesCount: item.offer.proAdvicesCount,
       })
       return (
         <OfferTile

--- a/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/fetchMultipleOffers.test.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/fetchMultipleOffers.test.ts
@@ -65,7 +65,12 @@ describe('fetchMultipleOffers', () => {
         ...buildHitsPerPage(10),
         ...buildOfferSearchParameters(mockParams1.offerParams, mockParams1.locationParams, false),
         attributesToHighlight: [],
-        attributesToRetrieve: [...offerAttributesToRetrieve, 'offer.isHeadline', 'artists'],
+        attributesToRetrieve: [
+          ...offerAttributesToRetrieve,
+          'offer.isHeadline',
+          'artists',
+          'offer.proAdvicesCount',
+        ],
       },
       {
         indexName: 'customIndex',
@@ -73,7 +78,12 @@ describe('fetchMultipleOffers', () => {
         ...buildHitsPerPage(10),
         ...buildOfferSearchParameters(mockParams2.offerParams, mockParams2.locationParams, false),
         attributesToHighlight: [],
-        attributesToRetrieve: [...offerAttributesToRetrieve, 'offer.isHeadline', 'artists'],
+        attributesToRetrieve: [
+          ...offerAttributesToRetrieve,
+          'offer.isHeadline',
+          'artists',
+          'offer.proAdvicesCount',
+        ],
       },
     ])
   })

--- a/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/fetchMultipleOffers.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/fetchMultipleOffers.ts
@@ -24,7 +24,12 @@ export const fetchMultipleOffers = async ({
     ...buildHitsPerPage(params.offerParams.hitsPerPage),
     ...buildOfferSearchParameters(params.offerParams, params.locationParams, isUserUnderage),
     attributesToHighlight: [], // We disable highlighting because we don't need it
-    attributesToRetrieve: [...offerAttributesToRetrieve, 'offer.isHeadline', 'artists'],
+    attributesToRetrieve: [
+      ...offerAttributesToRetrieve,
+      'offer.isHeadline',
+      'artists',
+      'offer.proAdvicesCount',
+    ],
   }))
 
   try {

--- a/src/libs/algolia/types.ts
+++ b/src/libs/algolia/types.ts
@@ -39,6 +39,7 @@ export type HitOffer = {
   chroniclesCount?: number
   headlineCount?: number
   tags?: string[]
+  proAdvicesCount?: number
 }
 
 export type AlgoliaOfferWithArtistAndEan = AlgoliaOffer<


### PR DESCRIPTION
## Lien vers le ticket                                                                                                                                                                                                                          
                                            
  https://passculture.atlassian.net/browse/PC-40230                                                                                                                                                                                               
                                                                   
  ## Description                                                                                                                                                                                                                                  
                                                                   
  Ajout du support des **avis des pros** (`proAdvicesCount`) dans les tags d'interaction affichés sur les tuiles d'offres.                                                                                                                        
                                            
  ### Changements principaux                                                                                                                                                                                                                      
                                                                   
  - **Renommage** de `advicesCount` en `clubAdvicesCount` dans `InteractionTag` pour distinguer clairement les avis club (book club / ciné club) des avis des pros                                                                                
  - **Ajout** du champ `proAdvicesCount` dans le type `HitOffer` (Algolia) et récupération de `offer.proAdvicesCount` via `fetchMultipleOffers`
  - **Nouveau tag** avec le variant `PROEDITO` : affiche "X avis des pros" (ou "X avis" en layout compact)                                                                                                                                        
  - **Ordre de priorité** des tags : Bientôt dispo > Avis club > Avis des pros > J'aime                                                                                                                                                           
                                                                                                                                                                                                                                                  
  ### Fichiers impactés                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                  
  - `src/libs/algolia/types.ts`                                                                                                                                                                                                                   
  - `src/libs/algolia/fetchAlgolia/fetchMultipleOffers/`                                                                                                                                                                                        
  - `src/features/offer/components/InteractionTag/`                                                                                                                                                                                               
  - `src/features/offer/components/OfferPlaylistItem/`
  - `src/features/offer/components/OfferTile/OfferTileWrapper.tsx`                                                                                                                                                                                
  - `src/features/venueMap/components/VenueMapBottomSheet/VenueMapOfferPlaylist.tsx`                                                                                                                                                              
  - `src/features/venue/components/VenueOffers/VenueOffersList.tsx`
                                                                                                                                                                                                                                                  
  ## Screenshots

<img width="1080" height="2400" alt="Screenshot_1776265623" src="https://github.com/user-attachments/assets/a89e226c-09a9-4bfe-ac77-0c553e56e810" />
<img width="1080" height="2400" alt="Screenshot_1776265557" src="https://github.com/user-attachments/assets/ca615788-ca8e-47ce-a6ce-21440fdea1c1" />
<img width="1724" height="898" alt="Capture d’écran 2026-04-15 à 16 48 55" src="https://github.com/user-attachments/assets/e8b84645-afea-4f3f-9818-afb3f738b011" />
<img width="395" height="689" alt="Capture d’écran 2026-04-15 à 16 49 17" src="https://github.com/user-attachments/assets/8ad8ab67-72b1-429e-9ff7-dc569cee87c0" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-04-15 at 17 07 29" src="https://github.com/user-attachments/assets/97b7d7ed-9e78-4e9e-88c5-8dfbda9fc3dc" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-04-15 at 16 49 43" src="https://github.com/user-attachments/assets/166b4d1f-ae55-472d-a16e-31ee5c55058c" />
