### PR TITLE
(PC-41325) build(nix): use good node version with nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       in {
         devShells.default = pkgs.mkShellNoCC {
           packages = [
-            pkgs_nodejs.nodejs # needed to install NodeJS dependencies, run scripts...
+            pkgs_nodejs.nodejs_20 # needed to install NodeJS dependencies, run scripts...
             pkgs_ruby.ruby # needed to run FastLane and to install iOS dependencies
             pkgs.jdk17 # needed by Android
             pkgs.jq # needed by some scripts run in the pipeline


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41325

J'ai pas creusé assé pour être sûr à 100 mais à priori l'url de nix qu'on utilise pour node contiendrait plusieurs version de node et si on ne précise pas la version il va prendre la plus récente, qui dans notre cas est node 22 et pas node 20.19
