### PR TITLE
(PC-41384) chore(server): update proxy routes

### DIFF
--- a/server/.env.integration
+++ b/server/.env.integration
@@ -4,6 +4,5 @@ APP_BUCKET_URL=https://app-bucket.integration.passculture.app
 API_BASE_URL=https://backend.integration.passculture.app
 API_BASE_PATH_NATIVE_V1=native/v1
 DEEPLINK_PROTOCOL=passculture://
-REGION=europe-west1
 PROXY_CACHE_CONTROL=public,max-age=3600
 ORGANIZATION_PREFIX=pass Culture

--- a/server/.env.integration
+++ b/server/.env.integration
@@ -2,7 +2,6 @@ ENV=integration
 APP_PUBLIC_URL=https://integration.passculture.app
 APP_BUCKET_URL=https://app-bucket.integration.passculture.app
 API_BASE_URL=https://backend.integration.passculture.app
-API_BASE_PATH_NATIVE_V1=native/v1
 DEEPLINK_PROTOCOL=passculture://
 PROXY_CACHE_CONTROL=public,max-age=3600
 ORGANIZATION_PREFIX=pass Culture

--- a/server/.env.perf
+++ b/server/.env.perf
@@ -2,7 +2,6 @@ ENV=perf
 APP_PUBLIC_URL=https://app.perf.passculture.team
 APP_BUCKET_URL=https://app-bucket.perf.passculture.team
 API_BASE_URL=https://backend.perf.passculture.team
-API_BASE_PATH_NATIVE_V1=native/v1
 DEEPLINK_PROTOCOL=passculture://
 PROXY_CACHE_CONTROL=public,max-age=3600
 ORGANIZATION_PREFIX=pass Culture

--- a/server/.env.perf
+++ b/server/.env.perf
@@ -4,6 +4,5 @@ APP_BUCKET_URL=https://app-bucket.perf.passculture.team
 API_BASE_URL=https://backend.perf.passculture.team
 API_BASE_PATH_NATIVE_V1=native/v1
 DEEPLINK_PROTOCOL=passculture://
-REGION=europe-west1
 PROXY_CACHE_CONTROL=public,max-age=3600
 ORGANIZATION_PREFIX=pass Culture

--- a/server/.env.production
+++ b/server/.env.production
@@ -2,7 +2,6 @@ ENV=production
 APP_PUBLIC_URL=https://passculture.app
 APP_BUCKET_URL=https://app-bucket.passculture.app
 API_BASE_URL=https://backend.passculture.app
-API_BASE_PATH_NATIVE_V1=native/v1
 DEEPLINK_PROTOCOL=passculture://
 PROXY_CACHE_CONTROL=public,max-age=3600
 ORGANIZATION_PREFIX=pass Culture

--- a/server/.env.production
+++ b/server/.env.production
@@ -4,6 +4,5 @@ APP_BUCKET_URL=https://app-bucket.passculture.app
 API_BASE_URL=https://backend.passculture.app
 API_BASE_PATH_NATIVE_V1=native/v1
 DEEPLINK_PROTOCOL=passculture://
-REGION=europe-west1
 PROXY_CACHE_CONTROL=public,max-age=3600
 ORGANIZATION_PREFIX=pass Culture

--- a/server/.env.staging
+++ b/server/.env.staging
@@ -4,6 +4,5 @@ APP_BUCKET_URL=https://app-bucket.staging.passculture.team
 API_BASE_URL=https://backend.staging.passculture.team
 API_BASE_PATH_NATIVE_V1=native/v1
 DEEPLINK_PROTOCOL=passculture://
-REGION=europe-west1
 PROXY_CACHE_CONTROL=public,max-age=3600
 ORGANIZATION_PREFIX=pass Culture

--- a/server/.env.staging
+++ b/server/.env.staging
@@ -2,7 +2,6 @@ ENV=staging
 APP_PUBLIC_URL=https://app.staging.passculture.team
 APP_BUCKET_URL=https://app-bucket.staging.passculture.team
 API_BASE_URL=https://backend.staging.passculture.team
-API_BASE_PATH_NATIVE_V1=native/v1
 DEEPLINK_PROTOCOL=passculture://
 PROXY_CACHE_CONTROL=public,max-age=3600
 ORGANIZATION_PREFIX=pass Culture

--- a/server/.env.testing
+++ b/server/.env.testing
@@ -2,7 +2,6 @@ ENV=testing
 APP_PUBLIC_URL=https://app.testing.passculture.team
 APP_BUCKET_URL=https://app-bucket.testing.passculture.team
 API_BASE_URL=https://backend.testing.passculture.team
-API_BASE_PATH_NATIVE_V1=native/v1
 DEEPLINK_PROTOCOL=passculture://
 REGION=europe-west1
 PROXY_CACHE_CONTROL=public,max-age=3600

--- a/server/src/libs/environment/__mocks__/serverEnv.ts
+++ b/server/src/libs/environment/__mocks__/serverEnv.ts
@@ -6,7 +6,6 @@ export const env: Environment = {
   APP_PUBLIC_URL: 'http://localhost:8080',
   APP_BUCKET_URL: 'https://app-bucket.testing.passculture.team',
   API_BASE_URL: 'https://backend.testing.passculture.team',
-  API_BASE_PATH_NATIVE_V1: 'native/v1',
   DEEPLINK_PROTOCOL: 'passculture://',
   PROXY_CACHE_CONTROL: 'public,max-age=3600',
   ORGANIZATION_PREFIX: 'pass Culture',

--- a/server/src/libs/environment/__mocks__/serverEnv.ts
+++ b/server/src/libs/environment/__mocks__/serverEnv.ts
@@ -2,7 +2,6 @@ import { Environment } from '../types'
 
 export const env: Environment = {
   __DEV__: true,
-  REGION: 'europe-west1',
   ENV: 'test',
   APP_PUBLIC_URL: 'http://localhost:8080',
   APP_BUCKET_URL: 'https://app-bucket.testing.passculture.team',

--- a/server/src/libs/environment/types.ts
+++ b/server/src/libs/environment/types.ts
@@ -8,7 +8,6 @@ export interface Environment {
   APP_PUBLIC_URL: string
   APP_BUCKET_URL: string
   API_BASE_URL: string
-  API_BASE_PATH_NATIVE_V1: string
   DEEPLINK_PROTOCOL: string
   PROXY_CACHE_CONTROL: string
   ORGANIZATION_PREFIX: string

--- a/server/src/libs/environment/types.ts
+++ b/server/src/libs/environment/types.ts
@@ -5,7 +5,6 @@ export interface EnvConfig {
 export interface Environment {
   __DEV__: boolean
   ENV: string
-  REGION: string
   APP_PUBLIC_URL: string
   APP_BUCKET_URL: string
   API_BASE_URL: string

--- a/server/src/services/apiClient.ts
+++ b/server/src/services/apiClient.ts
@@ -5,7 +5,7 @@ import { env } from '../libs/environment/serverEnv'
 import { ENTITY_MAP, EntityKeys } from './entities/types'
 
 export async function apiClient(type: EntityKeys, id: number) {
-  const { API_BASE_URL, API_BASE_PATH_NATIVE_V1, PROXY_CACHE_CONTROL } = env
+  const { API_BASE_URL, PROXY_CACHE_CONTROL } = env
 
   const { href } = new URL(API_BASE_URL)
   const entityValue = ENTITY_MAP[type]
@@ -13,7 +13,7 @@ export async function apiClient(type: EntityKeys, id: number) {
     throw new Error(`Unknown entity: ${type}`)
   }
 
-  const url = `${href}${API_BASE_PATH_NATIVE_V1}/${entityValue.API_MODEL_NAME}/${id}`
+  const url = `${href}${entityValue.PATH}/${id}`
 
   const response = await fetch(url, {
     headers: new Headers({

--- a/server/src/services/entities/offer.ts
+++ b/server/src/services/entities/offer.ts
@@ -77,4 +77,5 @@ export const OFFER: EntityType<OfferData> = {
       return `${DEEPLINK_PROTOCOL}${href}${subPath}`
     },
   },
+  PATH: 'native/v3/offer',
 }

--- a/server/src/services/entities/types.ts
+++ b/server/src/services/entities/types.ts
@@ -72,6 +72,7 @@ export type EntityType<T> = {
     ['al:ios:url']: (entity: T, href: string, subPath: string) => string
     ['al:android:url']: (entity: T, href: string, subPath: string) => string
   }
+  PATH: string
 }
 
 export enum TwitterCard {

--- a/server/src/services/entities/venue.ts
+++ b/server/src/services/entities/venue.ts
@@ -68,4 +68,5 @@ export const VENUE: EntityType<VenueData> = {
       return `${DEEPLINK_PROTOCOL}${href}${subPath}`
     },
   },
+  PATH: 'native/v2/venue',
 }

--- a/server/tests/server.ts
+++ b/server/tests/server.ts
@@ -11,26 +11,23 @@ import {
 
 export const server = setupServer(
   // offer
-  rest.get(
-    `${env.API_BASE_URL}/${env.API_BASE_PATH_NATIVE_V1}/offer/${OFFER_RESPONSE_SNAPSHOT.id}`,
-    (req, res, ctx) => res(ctx.status(200), ctx.json(OFFER_RESPONSE_SNAPSHOT))
+  rest.get(`${env.API_BASE_URL}/native/v3/offer/${OFFER_RESPONSE_SNAPSHOT.id}`, (req, res, ctx) =>
+    res(ctx.status(200), ctx.json(OFFER_RESPONSE_SNAPSHOT))
   ),
   // 404 offer
-  rest.get(`${env.API_BASE_URL}/${env.API_BASE_PATH_NATIVE_V1}/offer/0`, (req, res, ctx) =>
+  rest.get(`${env.API_BASE_URL}/native/v3/offer/0`, (req, res, ctx) =>
     res(ctx.status(200), ctx.json({}))
   ),
   // 502 offer
-  rest.get(`${env.API_BASE_URL}/${env.API_BASE_PATH_NATIVE_V1}/offer/502`, (req, res, ctx) =>
-    res(ctx.status(502))
-  ),
+  rest.get(`${env.API_BASE_URL}/native/v3/offer/502`, (req, res, ctx) => res(ctx.status(502))),
   // venue
   rest.get(
-    `${env.API_BASE_URL}/${env.API_BASE_PATH_NATIVE_V1}/venue/${VENUE_WITH_BANNER_RESPONSE_SNAPSHOT.id}`,
+    `${env.API_BASE_URL}/native/v2/venue/${VENUE_WITH_BANNER_RESPONSE_SNAPSHOT.id}`,
     (req, res, ctx) => res(ctx.status(200), ctx.json(VENUE_WITH_BANNER_RESPONSE_SNAPSHOT))
   ),
   // venue alternative
   rest.get(
-    `${env.API_BASE_URL}/${env.API_BASE_PATH_NATIVE_V1}/venue/${VENUE_WITHOUT_BANNER_RESPONSE_SNAPSHOT.id}`,
+    `${env.API_BASE_URL}/native/v2/venue/${VENUE_WITHOUT_BANNER_RESPONSE_SNAPSHOT.id}`,
     (req, res, ctx) => res(ctx.status(200), ctx.json(VENUE_WITHOUT_BANNER_RESPONSE_SNAPSHOT))
   )
 )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41384

### Contexte

Les routes backend `/native/v1/offer/id`, `/native/v2/offer/id`, `/native/v1/venue/id` sont dépréciées, vont être supprimées et ne sont donc plus censées être utilisées pour remonter les metadata des objets.