### PR TITLE
(PC-40890) fix(Snackbar): add animation exit treshold to avoid animation on unmount

### DIFF
--- a/src/ui/designSystem/Snackbar/snackBar.store.native.test.ts
+++ b/src/ui/designSystem/Snackbar/snackBar.store.native.test.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  EXIT_THRESHOLD_IN_MS,
   LONG_TEXT_ANIMATION_DURATION_IN_MS,
   LONG_TEXT_CHARACTER_LENGTH,
   SHORT_TEXT_ANIMATION_DURATION_IN_MS,
@@ -54,7 +55,7 @@ describe('SnackBarStore', () => {
 
       expect(snackbars).toHaveLength(1)
 
-      jest.advanceTimersByTime(SHORT_TEXT_ANIMATION_DURATION_IN_MS)
+      jest.advanceTimersByTime(SHORT_TEXT_ANIMATION_DURATION_IN_MS + EXIT_THRESHOLD_IN_MS)
 
       expect(getSnackbars()).toHaveLength(0)
     })

--- a/src/ui/designSystem/Snackbar/snackBar.store.ts
+++ b/src/ui/designSystem/Snackbar/snackBar.store.ts
@@ -21,6 +21,7 @@ const defaultState: State = { snackbars: {} }
 export const SHORT_TEXT_ANIMATION_DURATION_IN_MS = 5000
 export const LONG_TEXT_ANIMATION_DURATION_IN_MS = 10000
 export const LONG_TEXT_CHARACTER_LENGTH = 120
+export const EXIT_THRESHOLD_IN_MS = 100 // keep snackbar a bit longer than the progress bar to avoid the progress bar animation after unmount
 
 const getAnimationDuration = (label: string) =>
   label.length < LONG_TEXT_CHARACTER_LENGTH
@@ -50,7 +51,7 @@ export const snackBarStore = createStore({
       const timeout = setTimeout(() => {
         snackBarStore.actions.close(id)
         clearTimeout(timeout)
-      }, animationDuration)
+      }, animationDuration + EXIT_THRESHOLD_IN_MS)
     },
     close: (id: string) => {
       set((state) => {


### PR DESCRIPTION
…ion after unmount

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-40890

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
