### PR TITLE
(PC-39939) fix(sso): update error wording and unify SSO error codes

### DIFF
--- a/src/features/auth/helpers/getSSOErrorMessage.ts
+++ b/src/features/auth/helpers/getSSOErrorMessage.ts
@@ -1,0 +1,10 @@
+type SSOErrorContext = 'signup' | 'login'
+
+export const getSSOErrorMessage = (
+  provider: 'google' | 'apple' | undefined,
+  context: SSOErrorContext
+): string => {
+  const providerName = provider === 'apple' ? 'Apple' : 'Google'
+  const action = context === 'signup' ? 'L\u2019inscription avec ce' : 'La connexion avec ton'
+  return `${action} compte ${providerName} est refusée. Contacte le support pour plus d\u2019informations depuis le Profil.`
+}

--- a/src/features/auth/pages/AppleSSOCallback.web.tsx
+++ b/src/features/auth/pages/AppleSSOCallback.web.tsx
@@ -2,6 +2,7 @@ import { useRoute } from '@react-navigation/native'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { AccountState } from 'api/gen'
+import { getSSOErrorMessage } from 'features/auth/helpers/getSSOErrorMessage'
 import { useSignInMutation } from 'features/auth/queries/useSignInMutation'
 import { SignInResponseFailure } from 'features/auth/types'
 import { resetFromRef } from 'features/navigation/navigationRef'
@@ -63,17 +64,9 @@ export const AppleSSOCallback = () => {
           from: context?.type === 'signup' ? StepperOrigin.SIGNUP : StepperOrigin.LOGIN,
           ssoProvider: 'apple',
         })
-      } else if (
-        failureCode &&
-        [
-          'DUPLICATE_GOOGLE_ACCOUNT',
-          'SSO_ACCOUNT_DELETED',
-          'SSO_ACCOUNT_ANONYMIZED',
-          'SSO_EMAIL_NOT_VALIDATED',
-        ].includes(failureCode)
-      ) {
+      } else if (failureCode === 'SSO_ERROR') {
         showErrorSnackBar(
-          'Ton compte Apple semble ne pas être valide. Pour pouvoir te connecter, confirme d\u2019abord ton adresse e-mail Apple.'
+          getSSOErrorMessage('apple', context?.type === 'signup' ? 'signup' : 'login')
         )
         navigateBack()
       } else if (failureCode === 'NETWORK_REQUEST_FAILED') {

--- a/src/features/auth/pages/login/Login.native.test.tsx
+++ b/src/features/auth/pages/login/Login.native.test.tsx
@@ -154,7 +154,7 @@ describe('<Login/>', () => {
       responseOptions: {
         statusCode: 400,
         data: {
-          code: 'SSO_ACCOUNT_DELETED',
+          code: 'SSO_ERROR',
           general: [],
         },
       },
@@ -166,7 +166,30 @@ describe('<Login/>', () => {
 
     expect(
       screen.getByText(
-        'Ton compte Google semble ne pas être valide. Pour pouvoir te connecter, confirme d’abord ton adresse e-mail Google.'
+        'La connexion avec ton compte Google est refusée. Contacte le support pour plus d’informations depuis le Profil.'
+      )
+    ).toBeOnTheScreen()
+  })
+
+  it('should show snackbar when Apple SSO login fails because account is invalid', async () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_APPLE_SSO])
+    mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/apple/authorize', {
+      responseOptions: {
+        statusCode: 400,
+        data: {
+          code: 'SSO_ERROR',
+          general: [],
+        },
+      },
+    })
+
+    renderLogin()
+
+    await user.press(await screen.findByText('Se connecter avec Apple'))
+
+    expect(
+      screen.getByText(
+        'La connexion avec ton compte Apple est refusée. Contacte le support pour plus d’informations depuis le Profil.'
       )
     ).toBeOnTheScreen()
   })

--- a/src/features/auth/pages/login/Login.tsx
+++ b/src/features/auth/pages/login/Login.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components/native'
 import { AuthenticationButton } from 'features/auth/components/AuthenticationButton/AuthenticationButton'
 import { SSOButtonApple } from 'features/auth/components/SSOButton/SSOButtonApple'
 import { SSOButtonGoogleBase } from 'features/auth/components/SSOButton/SSOButtonGoogleBase'
+import { getSSOErrorMessage } from 'features/auth/helpers/getSSOErrorMessage'
 import { loginSchema } from 'features/auth/pages/login/schema/loginSchema'
 import { useSignInMutation } from 'features/auth/queries/useSignInMutation'
 import { SignInResponseFailure } from 'features/auth/types'
@@ -100,19 +101,8 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
           from: StepperOrigin.LOGIN,
           ssoProvider: response.provider,
         })
-      } else if (
-        failureCode &&
-        [
-          'DUPLICATE_GOOGLE_ACCOUNT',
-          'SSO_ACCOUNT_DELETED',
-          'SSO_ACCOUNT_ANONYMIZED',
-          'SSO_EMAIL_NOT_VALIDATED',
-        ].includes(failureCode)
-      ) {
-        const providerName = response.provider === 'apple' ? 'Apple' : 'Google'
-        showErrorSnackBar(
-          `Ton compte ${providerName} semble ne pas être valide. Pour pouvoir te connecter, confirme d\u2019abord ton adresse e-mail ${providerName}.`
-        )
+      } else if (failureCode === 'SSO_ERROR') {
+        showErrorSnackBar(getSSOErrorMessage(response.provider, 'login'))
       } else if (failureCode === 'EMAIL_NOT_VALIDATED') {
         const email = getValues('email')?.trim()
         if (!email) {

--- a/src/features/auth/pages/signup/SetEmail/SetEmail.native.test.tsx
+++ b/src/features/auth/pages/signup/SetEmail/SetEmail.native.test.tsx
@@ -299,7 +299,7 @@ describe('<SetEmail />', () => {
         responseOptions: {
           statusCode: 400,
           data: {
-            code: 'SSO_ACCOUNT_DELETED',
+            code: 'SSO_ERROR',
             general: [],
           },
         },
@@ -314,7 +314,33 @@ describe('<SetEmail />', () => {
       expect(screen.getByTestId('snackbar-error')).toBeOnTheScreen()
       expect(
         screen.getByText(
-          'Ton compte Google semble ne pas être valide. Pour pouvoir t’inscrire, confirme d’abord ton adresse e-mail Google.'
+          'L’inscription avec ce compte Google est refusée. Contacte le support pour plus d’informations depuis le Profil.'
+        )
+      ).toBeOnTheScreen()
+    })
+
+    it('should display snackbar when Apple SSO account is invalid', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_APPLE_SSO])
+      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/apple/authorize', {
+        responseOptions: {
+          statusCode: 400,
+          data: {
+            code: 'SSO_ERROR',
+            general: [],
+          },
+        },
+      })
+
+      renderSetEmail()
+
+      await screen.findByText('Crée-toi un compte')
+
+      await user.press(screen.getByText('S’inscrire avec Apple'))
+
+      expect(screen.getByTestId('snackbar-error')).toBeOnTheScreen()
+      expect(
+        screen.getByText(
+          'L’inscription avec ce compte Apple est refusée. Contacte le support pour plus d’informations depuis le Profil.'
         )
       ).toBeOnTheScreen()
     })

--- a/src/features/auth/pages/signup/SetEmail/SetEmail.tsx
+++ b/src/features/auth/pages/signup/SetEmail/SetEmail.tsx
@@ -29,6 +29,11 @@ type FormValues = {
   marketingEmailSubscription: boolean
 }
 
+const SSO_ERROR_MESSAGES: Partial<Record<string, string>> = {
+  NETWORK_REQUEST_FAILED: 'Erreur réseau. Tu peux réessayer une fois la connexion réétablie.',
+  TOO_MANY_ATTEMPTS: 'Nombre de tentatives dépassé. Réessaye dans 1 minute.',
+}
+
 export const SetEmail: FunctionComponent<PreValidationSignupNormalStepProps> = ({
   goToNextStep,
   accessibilityLabelForNextStep,
@@ -67,22 +72,19 @@ export const SetEmail: FunctionComponent<PreValidationSignupNormalStepProps> = (
   const onSSOSignInFailure = useCallback(
     (errorResponse: SignInResponseFailure) => {
       const { content, provider, statusCode } = errorResponse
-      const failureCode = content?.code
       if (content?.code === 'SSO_EMAIL_NOT_FOUND') {
         onSSOEmailNotFoundError()
         goToNextStep({
           accountCreationToken: content.accountCreationToken,
           ssoProvider: provider,
         })
-      } else if (failureCode === 'SSO_ERROR') {
-        showErrorSnackBar(getSSOErrorMessage(provider, 'signup'))
-      } else if (failureCode === 'NETWORK_REQUEST_FAILED') {
-        showErrorSnackBar('Erreur réseau. Tu peux réessayer une fois la connexion réétablie.')
-      } else if (statusCode === 429 || failureCode === 'TOO_MANY_ATTEMPTS') {
-        showErrorSnackBar('Nombre de tentatives dépassé. Réessaye dans 1 minute.')
-      } else {
-        showErrorSnackBar(getSSOErrorMessage(provider, 'signup'))
+        return
       }
+      const failureCode = content?.code
+      const isRateLimited = statusCode === 429 || failureCode === 'TOO_MANY_ATTEMPTS'
+      const key = isRateLimited ? 'TOO_MANY_ATTEMPTS' : failureCode
+      const message = (key && SSO_ERROR_MESSAGES[key]) ?? getSSOErrorMessage(provider, 'signup')
+      showErrorSnackBar(message)
     },
     [goToNextStep, onSSOEmailNotFoundError]
   )

--- a/src/features/auth/pages/signup/SetEmail/SetEmail.tsx
+++ b/src/features/auth/pages/signup/SetEmail/SetEmail.tsx
@@ -7,6 +7,7 @@ import styled, { useTheme } from 'styled-components/native'
 import { AuthenticationButton } from 'features/auth/components/AuthenticationButton/AuthenticationButton'
 import { SSOButtonApple } from 'features/auth/components/SSOButton/SSOButtonApple'
 import { SSOButtonGoogle } from 'features/auth/components/SSOButton/SSOButtonGoogle'
+import { getSSOErrorMessage } from 'features/auth/helpers/getSSOErrorMessage'
 import { setEmailSchema } from 'features/auth/pages/signup/SetEmail/schema/setEmailSchema'
 import { PreValidationSignupNormalStepProps, SignInResponseFailure } from 'features/auth/types'
 import { StepperOrigin, UseRouteType } from 'features/navigation/RootNavigator/types'
@@ -65,17 +66,22 @@ export const SetEmail: FunctionComponent<PreValidationSignupNormalStepProps> = (
 
   const onSSOSignInFailure = useCallback(
     (errorResponse: SignInResponseFailure) => {
-      if (errorResponse.content?.code === 'SSO_EMAIL_NOT_FOUND') {
+      const { content, provider, statusCode } = errorResponse
+      const failureCode = content?.code
+      if (content?.code === 'SSO_EMAIL_NOT_FOUND') {
         onSSOEmailNotFoundError()
         goToNextStep({
-          accountCreationToken: errorResponse.content.accountCreationToken,
-          ssoProvider: errorResponse.provider,
+          accountCreationToken: content.accountCreationToken,
+          ssoProvider: provider,
         })
+      } else if (failureCode === 'SSO_ERROR') {
+        showErrorSnackBar(getSSOErrorMessage(provider, 'signup'))
+      } else if (failureCode === 'NETWORK_REQUEST_FAILED') {
+        showErrorSnackBar('Erreur réseau. Tu peux réessayer une fois la connexion réétablie.')
+      } else if (statusCode === 429 || failureCode === 'TOO_MANY_ATTEMPTS') {
+        showErrorSnackBar('Nombre de tentatives dépassé. Réessaye dans 1 minute.')
       } else {
-        const providerName = errorResponse.provider === 'apple' ? 'Apple' : 'Google'
-        showErrorSnackBar(
-          `Ton compte ${providerName} semble ne pas être valide. Pour pouvoir t\u2019inscrire, confirme d\u2019abord ton adresse e-mail ${providerName}.`
-        )
+        showErrorSnackBar(getSSOErrorMessage(provider, 'signup'))
       }
     },
     [goToNextStep, onSSOEmailNotFoundError]

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -11,10 +11,7 @@ export type SignInResponseFailure = {
           | 'EMAIL_NOT_VALIDATED'
           | 'NETWORK_REQUEST_FAILED'
           | 'TOO_MANY_ATTEMPTS'
-          | 'DUPLICATE_GOOGLE_ACCOUNT'
-          | 'SSO_ACCOUNT_DELETED'
-          | 'SSO_ACCOUNT_ANONYMIZED'
-          | 'SSO_EMAIL_NOT_VALIDATED'
+          | 'SSO_ERROR'
         general: string[]
       }
     | {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-39939

## Context

Les codes d'erreur SSO côté backend ont été consolidés en un seul code `SSO_ERROR` (à la place de `DUPLICATE_GOOGLE_ACCOUNT`, `SSO_ACCOUNT_DELETED`, `SSO_ACCOUNT_ANONYMIZED`, `SSO_EMAIL_NOT_VALIDATED`). 
Ce fix adapte le front-end à cette nouvelle convention et améliore le message d'erreur affiché à l'utilisateur.

## Changements

- Remplacement des multiples codes d'erreur SSO par le code unifié `SSO_ERROR` dans le type `SignInResponseFailure`
- Création d'un helper `getSSOErrorMessage` qui génère un message contextuel selon le provider (Apple/Google) et le contexte (login/inscription)
- Mise à jour de `Login.tsx`, `SetEmail.tsx` et `AppleSSOCallback.web.tsx` pour utiliser ce nouveau helper
- Nouveau message d'erreur : **"La connexion avec ton compte Google est refusée. Contacte le support pour plus d'informations depuis le Profil."**
- Ajout de tests pour les cas d'erreur SSO Apple dans `Login` et `SetEmail`
- Gestion supplémentaire dans `SetEmail.tsx` des erreurs `NETWORK_REQUEST_FAILED` et `TOO_MANY_ATTEMPTS`

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
