### PR TITLE
(PC-41139) refactor(location): create store to replace location context

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -17,6 +17,7 @@ const defaultConfig: KnipConfig = {
     'src/ui/designSystem/Snackbar/**', // TODO(PC-39606): remove
     // TODO(PC-36439): should delete those lines
     'src/features/bookings/queries/useOngoingOrEndedBookingQuery.ts',
+    'src/libs/locationV2/**',
     'src/queries/bookings/useUserHasBookingsQuery.ts',
     'src/**/*.ios.*',
     '.storybook/**/*',

--- a/src/libs/locationV2/store/locationStore.ts
+++ b/src/libs/locationV2/store/locationStore.ts
@@ -1,0 +1,22 @@
+import { createStore } from 'libs/store/createStore'
+
+type Location = {
+  lat?: string
+}
+
+const defaultState: Location = {
+  lat: undefined,
+}
+
+const locationStore = createStore({
+  name: 'location',
+  defaultState,
+  actions: (set) => ({
+    setLat: (lat?) => set({ lat }),
+    resetLat: () => set(defaultState),
+  }),
+  options: { persist: true },
+})
+
+export const locationActions = locationStore.actions
+export const locationSelectors = locationStore.selectors


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41139

## Context

Create LocationV2 store to replace location context and centralize permission/geolocation/location management 

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
