### PR TITLE
(PC-39550) feat(analytics): refine login event params for sso and ema…

### DIFF
--- a/src/features/auth/components/SSOButton/SSOButtonApple.native.test.tsx
+++ b/src/features/auth/components/SSOButton/SSOButtonApple.native.test.tsx
@@ -140,7 +140,10 @@ describe('<SSOButtonApple />', () => {
 
     await user.press(await screen.findByTestId('S\u2019inscrire avec Apple'))
 
-    expect(analytics.logLogin).toHaveBeenCalledWith({ method: 'fromSignup', type: 'SSO_signup' })
+    expect(analytics.logLogin).toHaveBeenCalledWith({
+      method: 'fromSignupApple',
+      type: 'SSO_signup',
+    })
   })
 
   it('should log analytics when logging in with sso from login', async () => {
@@ -157,7 +160,10 @@ describe('<SSOButtonApple />', () => {
 
     await user.press(await screen.findByTestId('Se connecter avec Apple'))
 
-    expect(analytics.logLogin).toHaveBeenCalledWith({ method: 'fromLogin', type: 'SSO_login' })
+    expect(analytics.logLogin).toHaveBeenCalledWith({
+      method: 'fromLoginApple',
+      type: 'SSO_login',
+    })
   })
 
   describe('When shouldLogInfo remote config is false', () => {

--- a/src/features/auth/components/SSOButton/SSOButtonGoogle.native.test.tsx
+++ b/src/features/auth/components/SSOButton/SSOButtonGoogle.native.test.tsx
@@ -138,7 +138,10 @@ describe('<SSOButton />', () => {
 
     await user.press(await screen.findByTestId('S’inscrire avec Google'))
 
-    expect(analytics.logLogin).toHaveBeenCalledWith({ method: 'fromSignup', type: 'SSO_signup' })
+    expect(analytics.logLogin).toHaveBeenCalledWith({
+      method: 'fromSignupGoogle',
+      type: 'SSO_signup',
+    })
   })
 
   it('should log analytics when logging in with sso from login', async () => {
@@ -153,7 +156,10 @@ describe('<SSOButton />', () => {
 
     await user.press(await screen.findByTestId('Se connecter avec Google'))
 
-    expect(analytics.logLogin).toHaveBeenCalledWith({ method: 'fromLogin', type: 'SSO_login' })
+    expect(analytics.logLogin).toHaveBeenCalledWith({
+      method: 'fromLoginGoogle',
+      type: 'SSO_login',
+    })
   })
 
   describe('When shouldLogInfo remote config is false', () => {

--- a/src/features/auth/helpers/useLoginRoutine.native.test.ts
+++ b/src/features/auth/helpers/useLoginRoutine.native.test.ts
@@ -5,7 +5,7 @@ import { LoginRoutine, useLoginRoutine } from 'features/auth/helpers/useLoginRou
 import { ALL_OPTIONAL_COOKIES, COOKIES_BY_CATEGORY } from 'features/cookies/CookiesPolicy'
 import { CookiesConsent } from 'features/cookies/types'
 import { FAKE_USER_ID } from 'fixtures/fakeUserId'
-import { SSOType } from 'libs/analytics/logEventAnalytics'
+import { LoginType } from 'libs/analytics/logEventAnalytics'
 import { analytics } from 'libs/analytics/provider'
 // eslint-disable-next-line no-restricted-imports
 import { firebaseAnalytics } from 'libs/firebase/analytics/analytics'
@@ -153,7 +153,7 @@ const renderUseLoginRoutine = () => {
   })
 }
 
-function loginFunction(login: LoginRoutine, analyticsType?: SSOType): () => Promise<void> {
+function loginFunction(login: LoginRoutine, analyticsType?: LoginType): () => Promise<void> {
   return async () => {
     await login(
       {

--- a/src/features/auth/helpers/useLoginRoutine.ts
+++ b/src/features/auth/helpers/useLoginRoutine.ts
@@ -3,7 +3,7 @@ import { scheduleAccessTokenRemoval } from 'api/refreshAccessToken'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useResetContexts } from 'features/auth/context/useResetContexts'
 import { useConnectServicesRequiringUserId } from 'features/auth/helpers/useConnectServicesRequiringUserId'
-import { LoginRoutineMethod, SSOType } from 'libs/analytics/logEventAnalytics'
+import { LoginRoutineMethod, LoginType } from 'libs/analytics/logEventAnalytics'
 import { analytics } from 'libs/analytics/provider'
 import { saveRefreshToken } from 'libs/keychain/keychain'
 import { storage } from 'libs/storage'
@@ -11,7 +11,7 @@ import { storage } from 'libs/storage'
 export type LoginRoutine = (
   response: SigninResponse,
   method: LoginRoutineMethod,
-  analyticsType?: SSOType
+  analyticsType?: LoginType
 ) => Promise<void>
 
 export function useLoginRoutine(): LoginRoutine {

--- a/src/features/auth/pages/login/Login.native.test.tsx
+++ b/src/features/auth/pages/login/Login.native.test.tsx
@@ -477,7 +477,7 @@ describe('<Login/>', () => {
     await fillInputs()
     await user.press(screen.getByText('Se connecter'))
 
-    expect(analytics.logLogin).toHaveBeenCalledWith({ method: 'fromLogin', type: undefined })
+    expect(analytics.logLogin).toHaveBeenCalledWith({ method: 'fromLogin', type: 'email_login' })
   })
 
   it('should log analytics when signing in with SSO', async () => {
@@ -491,7 +491,10 @@ describe('<Login/>', () => {
 
     await user.press(await screen.findByTestId('Se connecter avec Google'))
 
-    expect(analytics.logLogin).toHaveBeenCalledWith({ method: 'fromLogin', type: 'SSO_login' })
+    expect(analytics.logLogin).toHaveBeenCalledWith({
+      method: 'fromLoginGoogle',
+      type: 'SSO_login',
+    })
   })
 
   it('should display forced login help message when the query param is given', async () => {

--- a/src/features/auth/pages/signup/SignupForm.native.test.tsx
+++ b/src/features/auth/pages/signup/SignupForm.native.test.tsx
@@ -689,7 +689,7 @@ describe('Signup Form', () => {
           accessToken: 'accessToken',
           refreshToken: 'refreshToken',
         },
-        'SSO_signup'
+        { method: 'fromSignupGoogle', analyticsType: 'SSO_signup' }
       )
     })
 
@@ -734,7 +734,7 @@ describe('Signup Form', () => {
           accessToken: 'accessToken',
           refreshToken: 'refreshToken',
         },
-        'SSO_login'
+        { method: 'fromLoginGoogle', analyticsType: 'SSO_login' }
       )
     })
 

--- a/src/features/auth/pages/signup/SignupForm.tsx
+++ b/src/features/auth/pages/signup/SignupForm.tsx
@@ -16,6 +16,7 @@ import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigat
 import { getTabHookConfig } from 'features/navigation/TabBar/getTabHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { useDeviceInfo } from 'features/trustedDevice/helpers/useDeviceInfo'
+import { getSSOLoginMethod } from 'libs/analytics/logEventAnalytics'
 import { analytics } from 'libs/analytics/provider'
 import { firebaseAnalytics } from 'libs/firebase/analytics/analytics'
 import { eventMonitoring } from 'libs/monitoring/services'
@@ -161,7 +162,24 @@ export const SignupForm: FunctionComponent<{ currentStep?: number }> = ({ curren
           ...rest,
           accountCreationToken,
         })
-        await loginAndRedirect({ accessToken, refreshToken }, stepperAnalyticsType)
+        const ssoProvider = signupData.ssoProvider
+        if (!ssoProvider) {
+          eventMonitoring.captureException(
+            new Error('SSO signup finalization without ssoProvider'),
+            { extra: { stepperAnalyticsType } }
+          )
+          return
+        }
+        await loginAndRedirect(
+          { accessToken, refreshToken },
+          {
+            method: getSSOLoginMethod(
+              ssoProvider,
+              stepperAnalyticsType === 'SSO_login' ? 'login' : 'signup'
+            ),
+            analyticsType: stepperAnalyticsType,
+          }
+        )
       } else {
         await appSignup(commonParams)
         syncStepIndexWithNavigation(numberOfSteps - 1)

--- a/src/features/auth/pages/signup/helpers/useLoginAndRedirect.native.test.ts
+++ b/src/features/auth/pages/signup/helpers/useLoginAndRedirect.native.test.ts
@@ -39,6 +39,36 @@ describe('useLoginAndRedirect', () => {
     expect(loginRoutine).toHaveBeenCalledTimes(1)
   })
 
+  it('should call loginRoutine with fromSignup method and email_signup type by default (email signup)', async () => {
+    mockUseLoginRoutine.mockReturnValueOnce(loginRoutine)
+    mockServer.getApi<UserProfile>('/v1/me', nonBeneficiaryUser)
+
+    await loginAndRedirect()
+
+    expect(loginRoutine).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: 'accessToken', refreshToken: 'refreshToken' }),
+      'fromSignup',
+      'email_signup'
+    )
+  })
+
+  it('should forward custom method and analyticsType when provided (SSO signup finalization)', async () => {
+    mockUseLoginRoutine.mockReturnValueOnce(loginRoutine)
+    mockServer.getApi<UserProfile>('/v1/me', nonBeneficiaryUser)
+
+    const { result } = renderUseLoginAndRedirect()
+    await result.current(
+      { accessToken: 'accessToken', refreshToken: 'refreshToken' },
+      { method: 'fromSignupGoogle', analyticsType: 'SSO_signup' }
+    )
+
+    expect(loginRoutine).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: 'accessToken', refreshToken: 'refreshToken' }),
+      'fromSignupGoogle',
+      'SSO_signup'
+    )
+  })
+
   it('should redirect to DisableActivation when disableActivation is true', async () => {
     setFeatureFlags([RemoteStoreFeatureFlags.DISABLE_ACTIVATION])
     mockServer.getApi<UserProfile>('/v1/me', nonBeneficiaryUser)

--- a/src/features/auth/pages/signup/helpers/useLoginAndRedirect.ts
+++ b/src/features/auth/pages/signup/helpers/useLoginAndRedirect.ts
@@ -6,7 +6,7 @@ import { AccountState, EligibilityType } from 'api/gen'
 import { useLoginRoutine } from 'features/auth/helpers/useLoginRoutine'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getSubscriptionHookConfig } from 'features/navigation/SubscriptionStackNavigator/getSubscriptionHookConfig'
-import { SSOType } from 'libs/analytics/logEventAnalytics'
+import { LoginRoutineMethod, LoginType } from 'libs/analytics/logEventAnalytics'
 // eslint-disable-next-line no-restricted-imports
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
@@ -24,11 +24,14 @@ export const useLoginAndRedirect = () => {
   const loginRoutine = useLoginRoutine()
 
   return useCallback(
-    async (props: { accessToken: string; refreshToken: string }, analyticsType?: SSOType) => {
+    async (
+      props: { accessToken: string; refreshToken: string },
+      options?: { method?: LoginRoutineMethod; analyticsType?: LoginType }
+    ) => {
       await loginRoutine(
         { ...props, accountState: AccountState.ACTIVE },
-        'fromSignup',
-        analyticsType
+        options?.method ?? 'fromSignup',
+        options?.analyticsType ?? 'email_signup'
       )
 
       try {

--- a/src/features/auth/queries/useSignInMutation.ts
+++ b/src/features/auth/queries/useSignInMutation.ts
@@ -14,7 +14,7 @@ import {
   UseNavigationType,
 } from 'features/navigation/RootNavigator/types'
 import { useDeviceInfo } from 'features/trustedDevice/helpers/useDeviceInfo'
-import { LoginRoutineMethod, SSOType } from 'libs/analytics/logEventAnalytics'
+import { getSSOLoginMethod, LoginRoutineMethod, LoginType } from 'libs/analytics/logEventAnalytics'
 import { analytics } from 'libs/analytics/provider'
 import { storage } from 'libs/storage'
 import { useAddFavoriteMutation } from 'queries/favorites/useAddFavoriteMutation'
@@ -30,7 +30,7 @@ export const useSignInMutation = ({
   params: RootStackParamList['Login' | 'SignupForm']
   doNotNavigateOnSigninSuccess?: boolean
   analyticsMethod?: LoginRoutineMethod
-  analyticsType?: SSOType
+  analyticsType?: LoginType
   onFailure: (error: SignInResponseFailure) => void
   setErrorMessage?: (message: string) => void
 }) => {
@@ -50,8 +50,13 @@ export const useSignInMutation = ({
     },
 
     onSuccess: async (response, body) => {
-      const loginAnalyticsType = isOAuthLoginRequest(body) ? 'SSO_login' : undefined
-      await loginRoutine(response, analyticsMethod, analyticsType || loginAnalyticsType)
+      const isOAuth = isOAuthLoginRequest(body)
+      const loginAnalyticsType: LoginType = isOAuth ? 'SSO_login' : 'email_login'
+      const ssoKind = analyticsMethod === 'fromSignup' ? 'signup' : 'login'
+      const resolvedMethod: LoginRoutineMethod = isOAuth
+        ? getSSOLoginMethod(body.provider, ssoKind)
+        : analyticsMethod
+      await loginRoutine(response, resolvedMethod, analyticsType || loginAnalyticsType)
       onSuccess(response.accountState)
     },
 

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -72,10 +72,26 @@ type OfferIdOrVenueId = { offerId: number; venueId?: never } | { venueId: number
 export type LoginRoutineMethod =
   | 'fromLogin'
   | 'fromSignup'
+  | 'fromLoginApple'
+  | 'fromSignupApple'
+  | 'fromLoginGoogle'
+  | 'fromSignupGoogle'
   | 'fromReinitializePassword'
   | 'fromConfirmChangeEmail'
 
-export type SSOType = 'SSO_login' | 'SSO_signup'
+type SSOType = 'SSO_login' | 'SSO_signup'
+type EmailType = 'email_login' | 'email_signup'
+export type LoginType = SSOType | EmailType
+
+type SSOProvider = 'apple' | 'google'
+
+export function getSSOLoginMethod(
+  provider: SSOProvider,
+  kind: 'login' | 'signup'
+): LoginRoutineMethod {
+  const suffix = provider === 'apple' ? 'Apple' : 'Google'
+  return `${kind === 'login' ? 'fromLogin' : 'fromSignup'}${suffix}` as LoginRoutineMethod
+}
 
 /* eslint sort-keys-fix/sort-keys-fix: "error" */
 export const logEventAnalytics = {
@@ -475,7 +491,7 @@ export const logEventAnalytics = {
     analytics.logEvent({ firebase: AnalyticsEvent.IDENTITY_CHECK_SUCCESS }, params),
   logLocationToggle: (enabled: boolean) =>
     analytics.logEvent({ firebase: AnalyticsEvent.LOCATION_TOGGLE }, { enabled }),
-  logLogin: (params: { method: string; type?: SSOType }) =>
+  logLogin: (params: { method: LoginRoutineMethod; type?: LoginType }) =>
     analytics.logEvent({ firebase: AnalyticsEvent.LOGIN }, params),
   logLoginClicked: (params: { from: string }) =>
     analytics.logEvent({ firebase: AnalyticsEvent.LOGIN_CLICKED }, params),


### PR DESCRIPTION
…il distinction

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-39550

## Contexte

L'event `LOGIN` envoyé à Firebase Analytics mélangeait contexte d'action (login/signup) et provider SSO sur `method`, et `type` ne distinguait que `SSO_login` vs `SSO_signup` sans préciser le provider ni le canal email. Impossible d'analyser finement l'adoption comparative Apple / Google / Email.

Ticket : [PC-39550](https://passculture.atlassian.net/browse/PC-39550)

## Changements

### Nouveaux paramètres de l'event `LOGIN`

| Flux | `method` | `type` |
|------|----------|--------|
| Apple login | `fromLoginApple` | `SSO_login` |
| Apple signup | `fromSignupApple` | `SSO_signup` |
| Google login | `fromLoginGoogle` *(au lieu de `fromLogin`)* | `SSO_login` |
| Google signup | `fromSignupGoogle` *(au lieu de `fromSignup`)* | `SSO_signup` |
| Email login | `fromLogin` *(inchangé)* | `email_login` *(nouveau)* |
| Email signup | `fromSignup` *(inchangé)* | `email_signup` *(nouveau)* |
| Reset password | `fromReinitializePassword` *(inchangé)* | `undefined` *(inchangé)* |
| Confirm change email | `fromConfirmChangeEmail` *(inchangé)* | `undefined` *(inchangé)* |

### Implémentation

- **`logEventAnalytics.ts`** : extension de `LoginRoutineMethod` avec les variantes `Apple`/`Google`, ajout des types `EmailType` et `LoginType = SSOType | EmailType`, et helper `getSSOLoginMethod(provider, kind)` pour factoriser la construction du method SSO.
- **`useSignInMutation.ts`** : résolution centralisée du method lorsque le body est OAuth — les callers (`SSOButtonApple/Google`, `AppleSSOCallback.web`) continuent de passer `fromLogin`/`fromSignup` génériques, la mutation dérive le provider depuis `body.provider`. Le fallback email passe de `undefined` à `email_login`.
- **`useLoginAndRedirect.ts`** : signature en objet d'options (`{ method, analyticsType }`) avec défauts `fromSignup` + `email_signup` pour couvrir le flux email signup (`AfterSignupEmailValidationBuffer`).
- **`SignupForm.tsx`** : passe method + type explicites à `loginAndRedirect` lors de la finalisation SSO, avec garde-fou `captureException` si `signupData.ssoProvider` est absent.

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md


[PC-39550]: https://passculture.atlassian.net/browse/PC-39550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ