### PR TITLE
(BSR) chore(gitignore): add ssl certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,5 @@ storybook-static
 # hot-updater
 .hot-updater/output
 
+# ssl certificates
+proxy_cacert


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Context

Android emulator requires the proxy certificate in a specific in-project location. I am tired of not being able to `git add -A` so I added the file to `.gitignore`