### PR TITLE
(PC-41375) feat(app): trigger log when pressing pro advice card header

### DIFF
--- a/src/features/advices/components/AdviceCard/AdviceCard.tsx
+++ b/src/features/advices/components/AdviceCard/AdviceCard.tsx
@@ -37,6 +37,7 @@ export const AdviceCard: FunctionComponent<AdviceCardProps> = ({
   headerNavigateTo,
   headerAccessibilityLabel,
   thumbnailHeight,
+  onCardHeaderPress,
 }) => {
   const theme = useTheme()
 
@@ -67,7 +68,8 @@ export const AdviceCard: FunctionComponent<AdviceCardProps> = ({
         <InternalTouchableLink
           navigateTo={headerNavigateTo}
           accessibilityLabel={headerAccessibilityLabel}
-          accessibilityRole={accessibilityRoleInternalNavigation()}>
+          accessibilityRole={accessibilityRoleInternalNavigation()}
+          onBeforeNavigate={() => onCardHeaderPress?.()}>
           {renderHeader()}
         </InternalTouchableLink>
       ) : (

--- a/src/features/advices/components/AdviceCardList/AdviceCardListBase.tsx
+++ b/src/features/advices/components/AdviceCardList/AdviceCardListBase.tsx
@@ -83,7 +83,8 @@ export const AdviceCardListBase = forwardRef<
           image={item.image}
           headerNavigateTo={item.headerNavigateTo}
           headerAccessibilityLabel={item.headerAccessibilityLabel}
-          thumbnailHeight={thumbnailHeight}>
+          thumbnailHeight={thumbnailHeight}
+          onCardHeaderPress={item.onCardHeaderPress}>
           {onSeeMoreButtonPress ? (
             <View>
               <Button

--- a/src/features/advices/types.ts
+++ b/src/features/advices/types.ts
@@ -14,6 +14,7 @@ export type AdviceCardData = {
   image?: string | null
   headerNavigateTo?: InternalNavigationProps['navigateTo']
   headerAccessibilityLabel?: string
+  onCardHeaderPress?: () => void
 }
 
 export type AdviceVariantInfo = {

--- a/src/features/offer/pages/Offer/Offer.native.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.native.test.tsx
@@ -275,6 +275,26 @@ describe('<Offer />', () => {
       expect(await screen.findByText('Les avis des pros')).toBeOnTheScreen()
     })
 
+    it('should trigger ConsultVenue log when pressing pro advice card header', async () => {
+      renderOfferPage({ mockOffer: offerResponseSnap })
+
+      await screen.findByText('Les avis des pros')
+
+      const cardHeader = screen.getByLabelText('Voir le lieu The Best Place')
+
+      if (cardHeader) {
+        await user.press(cardHeader)
+      }
+
+      expect(analytics.logConsultVenue).toHaveBeenCalledWith({
+        adviceType: 'pro',
+        from: 'offer',
+        offerId: '116656',
+        originDetail: 'Les avis des pros',
+        venueId: '1',
+      })
+    })
+
     describe('when AB testing segment is B', () => {
       beforeEach(() => {
         useABSegmentSpy.mockReturnValue('B')

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -145,7 +145,7 @@ export function Offer() {
     latitude: userLocation?.latitude,
     longitude: userLocation?.longitude,
     select: ({ proAdvices, nbResults }) => ({
-      list: offerProAdvicesToAdviceCardData(proAdvices.slice(0, 5)),
+      list: offerProAdvicesToAdviceCardData(proAdvices.slice(0, 5), offerId),
       nbResults,
     }),
   })

--- a/src/features/offerRefacto/pages/Offer.tsx
+++ b/src/features/offerRefacto/pages/Offer.tsx
@@ -138,7 +138,7 @@ export function Offer() {
     latitude: userLocation?.latitude,
     longitude: userLocation?.longitude,
     select: ({ proAdvices, nbResults }) => ({
-      list: offerProAdvicesToAdviceCardData(proAdvices),
+      list: offerProAdvicesToAdviceCardData(proAdvices, offerId),
       nbResults,
     }),
   })

--- a/src/features/offerRefacto/pages/OfferPage.native.test.tsx
+++ b/src/features/offerRefacto/pages/OfferPage.native.test.tsx
@@ -274,6 +274,26 @@ describe('<Offer />', () => {
       expect(await screen.findByText('Les avis des pros')).toBeOnTheScreen()
     })
 
+    it('should trigger ConsultVenue log when pressing pro advice card header', async () => {
+      renderOfferPage({ mockOffer: offerResponseSnap })
+
+      await screen.findByText('Les avis des pros')
+
+      const cardHeader = screen.getByLabelText('Voir le lieu The Best Place')
+
+      if (cardHeader) {
+        await user.press(cardHeader)
+      }
+
+      expect(analytics.logConsultVenue).toHaveBeenCalledWith({
+        adviceType: 'pro',
+        from: 'offer',
+        offerId: '116656',
+        originDetail: 'Les avis des pros',
+        venueId: '1',
+      })
+    })
+
     describe('when AB testing segment is B', () => {
       beforeEach(() => {
         useABSegmentSpy.mockReturnValue('B')

--- a/src/features/proAdvices/adapters/offerProAdvicesToAdviceCardData/offerProAdvicesToAdviceCardData.native.test.ts
+++ b/src/features/proAdvices/adapters/offerProAdvicesToAdviceCardData/offerProAdvicesToAdviceCardData.native.test.ts
@@ -5,7 +5,7 @@ import { TagVariant } from 'ui/designSystem/Tag/types'
 describe('offerProAdvicesToAdviceCardData', () => {
   it('should transform pro advices to advice card data', () => {
     const proAdvices = [...proAdvicesFixture]
-    const result = offerProAdvicesToAdviceCardData(proAdvices)
+    const result = offerProAdvicesToAdviceCardData(proAdvices, 1)
 
     expect(result).toEqual([
       {
@@ -19,6 +19,7 @@ describe('offerProAdvicesToAdviceCardData', () => {
         tagProps: { label: 'par Arthur', variant: TagVariant.PROEDITO },
         headerAccessibilityLabel: 'Voir le lieu The Best Place',
         headerNavigateTo: { screen: 'Venue', params: { id: 1 } },
+        onCardHeaderPress: expect.any(Function),
       },
       {
         date: 'Septembre 2026',
@@ -30,13 +31,14 @@ describe('offerProAdvicesToAdviceCardData', () => {
         tagProps: { label: 'par Bérangère', variant: TagVariant.PROEDITO },
         headerAccessibilityLabel: 'Voir le lieu The Amazing Place',
         headerNavigateTo: { screen: 'Venue', params: { id: 2 } },
+        onCardHeaderPress: expect.any(Function),
       },
     ])
   })
 
   it('should return "avis du pro" as tag label when author undefined', () => {
     const proAdvices = [{ ...proAdvicesFixture[0], author: undefined }]
-    const result = offerProAdvicesToAdviceCardData(proAdvices)
+    const result = offerProAdvicesToAdviceCardData(proAdvices, 1)
 
     expect(result).toEqual([
       {
@@ -50,6 +52,7 @@ describe('offerProAdvicesToAdviceCardData', () => {
         tagProps: { label: 'avis du pro', variant: TagVariant.PROEDITO },
         headerAccessibilityLabel: 'Voir le lieu The Best Place',
         headerNavigateTo: { screen: 'Venue', params: { id: 1 } },
+        onCardHeaderPress: expect.any(Function),
       },
     ])
   })

--- a/src/features/proAdvices/adapters/offerProAdvicesToAdviceCardData/offerProAdvicesToAdviceCardData.ts
+++ b/src/features/proAdvices/adapters/offerProAdvicesToAdviceCardData/offerProAdvicesToAdviceCardData.ts
@@ -1,10 +1,14 @@
 import { OfferProAdvice } from 'api/gen'
 import { getFormattedAdviceDate } from 'features/advices/helpers/getFormattedAdviceDate'
 import { AdviceCardData } from 'features/advices/types'
+import { analytics } from 'libs/analytics/provider'
 import { humanizeDistance } from 'libs/parsers/formatDistance'
 import { TagVariant } from 'ui/designSystem/Tag/types'
 
-export function offerProAdvicesToAdviceCardData(advices: OfferProAdvice[]): AdviceCardData[] {
+export function offerProAdvicesToAdviceCardData(
+  advices: OfferProAdvice[],
+  offerId: number
+): AdviceCardData[] {
   return advices.map(
     ({ venueId, content, venueName, distance, publicationDatetime, author, venueThumbUrl }) => ({
       id: venueId,
@@ -16,6 +20,15 @@ export function offerProAdvicesToAdviceCardData(advices: OfferProAdvice[]): Advi
       image: venueThumbUrl,
       headerNavigateTo: { screen: 'Venue', params: { id: venueId } },
       headerAccessibilityLabel: `Voir le lieu ${venueName}`,
+      onCardHeaderPress: () => {
+        void analytics.logConsultVenue({
+          from: 'offer',
+          originDetail: 'Les avis des pros',
+          adviceType: 'pro',
+          offerId: offerId.toString(),
+          venueId: venueId.toString(),
+        })
+      },
     })
   )
 }

--- a/src/features/proAdvices/adapters/venueProAdvicesToAdviceCardData/venueProAdvicesToAdviceCardData.native.test.ts
+++ b/src/features/proAdvices/adapters/venueProAdvicesToAdviceCardData/venueProAdvicesToAdviceCardData.native.test.ts
@@ -5,7 +5,7 @@ import { TagVariant } from 'ui/designSystem/Tag/types'
 describe('venueProAdvicesToAdviceCardData', () => {
   it('should transform pro advices to advice card data', () => {
     const proAdvices = [...proAdvicesFixture]
-    const result = venueProAdvicesToAdviceCardData(proAdvices)
+    const result = venueProAdvicesToAdviceCardData(proAdvices, 1)
 
     expect(result).toEqual([
       {
@@ -19,6 +19,7 @@ describe('venueProAdvicesToAdviceCardData', () => {
         tagProps: { label: 'par Arthur', variant: TagVariant.PROEDITO },
         headerAccessibilityLabel: 'Voir l‘offre American dream',
         headerNavigateTo: { screen: 'Offer', params: { id: 1 } },
+        onCardHeaderPress: expect.any(Function),
       },
       {
         date: 'Septembre 2026',
@@ -30,13 +31,14 @@ describe('venueProAdvicesToAdviceCardData', () => {
         tagProps: { label: 'par Bérangère', variant: TagVariant.PROEDITO },
         headerAccessibilityLabel: 'Voir l‘offre American dream',
         headerNavigateTo: { screen: 'Offer', params: { id: 1 } },
+        onCardHeaderPress: expect.any(Function),
       },
     ])
   })
 
   it('should return "avis du pro" as tag label when author undefined', () => {
     const proAdvices = [{ ...proAdvicesFixture[0], author: undefined }]
-    const result = venueProAdvicesToAdviceCardData(proAdvices)
+    const result = venueProAdvicesToAdviceCardData(proAdvices, 1)
 
     expect(result).toEqual([
       {
@@ -50,6 +52,7 @@ describe('venueProAdvicesToAdviceCardData', () => {
         tagProps: { label: 'avis du pro', variant: TagVariant.PROEDITO },
         headerAccessibilityLabel: 'Voir l‘offre American dream',
         headerNavigateTo: { screen: 'Offer', params: { id: 1 } },
+        onCardHeaderPress: expect.any(Function),
       },
     ])
   })

--- a/src/features/proAdvices/adapters/venueProAdvicesToAdviceCardData/venueProAdvicesToAdviceCardData.ts
+++ b/src/features/proAdvices/adapters/venueProAdvicesToAdviceCardData/venueProAdvicesToAdviceCardData.ts
@@ -1,9 +1,13 @@
 import { VenueProAdvice } from 'api/gen'
 import { getFormattedAdviceDate } from 'features/advices/helpers/getFormattedAdviceDate'
 import { AdviceCardData } from 'features/advices/types'
+import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog'
 import { TagVariant } from 'ui/designSystem/Tag/types'
 
-export function venueProAdvicesToAdviceCardData(advices: VenueProAdvice[]): AdviceCardData[] {
+export function venueProAdvicesToAdviceCardData(
+  advices: VenueProAdvice[],
+  venueId: number
+): AdviceCardData[] {
   return advices.map(
     ({
       offerId,
@@ -23,6 +27,15 @@ export function venueProAdvicesToAdviceCardData(advices: VenueProAdvice[]): Advi
       image: offerThumbUrl,
       headerNavigateTo: { screen: 'Offer', params: { id: offerId } },
       headerAccessibilityLabel: `Voir l‘offre ${offerName}`,
+      onCardHeaderPress: () => {
+        triggerConsultOfferLog({
+          from: 'venue',
+          originDetail: 'Les avis des pros',
+          adviceType: 'pro',
+          offerId,
+          venueId,
+        })
+      },
     })
   )
 }

--- a/src/features/proAdvices/pages/ProAdvicesOffer.native.test.tsx
+++ b/src/features/proAdvices/pages/ProAdvicesOffer.native.test.tsx
@@ -7,6 +7,7 @@ import { offerProAdvicesFixture } from 'features/advices/fixtures/offerProAdvice
 import * as useGoBack from 'features/navigation/useGoBack'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { ProAdvicesOffer } from 'features/proAdvices/pages/ProAdvicesOffer'
+import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { mockServer } from 'tests/mswServer'
@@ -84,6 +85,26 @@ describe('ProAdvicesOffer', () => {
     await user.press(await screen.findByText('Voir tous les avis des pros'))
 
     expect(mockHideModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('should trigger ConsultVenue log when pressing pro advice card header', async () => {
+    render(reactQueryProviderHOC(<ProAdvicesOffer />))
+
+    await screen.findByText('2 avis des pros')
+
+    const cardHeader = screen.getByLabelText('Voir le lieu The Best Place')
+
+    if (cardHeader) {
+      await user.press(cardHeader)
+    }
+
+    expect(analytics.logConsultVenue).toHaveBeenCalledWith({
+      adviceType: 'pro',
+      from: 'offer',
+      offerId: '116656',
+      originDetail: 'Les avis des pros',
+      venueId: '1',
+    })
   })
 
   describe('When venue id defined', () => {

--- a/src/features/proAdvices/pages/ProAdvicesOffer.tsx
+++ b/src/features/proAdvices/pages/ProAdvicesOffer.tsx
@@ -23,7 +23,7 @@ export const ProAdvicesOffer: FunctionComponent = () => {
     enableProAdvices,
     latitude: userLocation?.latitude,
     longitude: userLocation?.longitude,
-    select: ({ proAdvices }) => offerProAdvicesToAdviceCardData(proAdvices),
+    select: ({ proAdvices }) => offerProAdvicesToAdviceCardData(proAdvices, offerId),
   })
 
   const { goBack } = useGoBack('Offer')

--- a/src/features/proAdvices/pages/ProAdvicesOffer.web.tsx
+++ b/src/features/proAdvices/pages/ProAdvicesOffer.web.tsx
@@ -30,7 +30,7 @@ export const ProAdvicesOffer: FunctionComponent = () => {
     enableProAdvices,
     latitude: userLocation?.latitude,
     longitude: userLocation?.longitude,
-    select: ({ proAdvices }) => offerProAdvicesToAdviceCardData(proAdvices),
+    select: ({ proAdvices }) => offerProAdvicesToAdviceCardData(proAdvices, offerId),
   })
 
   const { goBack } = useGoBack('Offer')

--- a/src/features/proAdvices/pages/ProAdvicesVenue.native.test.tsx
+++ b/src/features/proAdvices/pages/ProAdvicesVenue.native.test.tsx
@@ -7,6 +7,7 @@ import * as useGoBack from 'features/navigation/useGoBack'
 import { ProAdvicesVenue } from 'features/proAdvices/pages/ProAdvicesVenue'
 import { venueDataTest } from 'features/venue/fixtures/venueDataTest'
 import { venueProAdvicesFixture } from 'features/venue/fixtures/venueProAdvices.fixture'
+import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { mockServer } from 'tests/mswServer'
@@ -32,6 +33,10 @@ jest.spyOn(useGoBack, 'useGoBack').mockReturnValue({
   goBack: mockGoBack,
   canGoBack: jest.fn(() => true),
 })
+
+jest.mock('libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog', () => ({
+  triggerConsultOfferLog: jest.fn(),
+}))
 
 const user = userEvent.setup()
 jest.useFakeTimers()
@@ -87,6 +92,26 @@ describe('ProAdvicesVenue', () => {
     await user.press(await screen.findByText('Voir tous les avis des pros'))
 
     expect(mockHideModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('should trigger ConsultOffer log when pressing pro advice card header', async () => {
+    render(reactQueryProviderHOC(<ProAdvicesVenue />))
+
+    await screen.findByText('2 avis des pros')
+
+    const cardHeader = await screen.getAllByLabelText('Voir l‘offre American dream')[0]
+
+    if (cardHeader) {
+      await user.press(cardHeader)
+    }
+
+    expect(triggerConsultOfferLog).toHaveBeenCalledWith({
+      adviceType: 'pro',
+      from: 'venue',
+      offerId: 1,
+      originDetail: 'Les avis des pros',
+      venueId: 5543,
+    })
   })
 
   describe('When offer id defined', () => {

--- a/src/features/proAdvices/pages/ProAdvicesVenue.tsx
+++ b/src/features/proAdvices/pages/ProAdvicesVenue.tsx
@@ -20,7 +20,7 @@ export const ProAdvicesVenue: FunctionComponent = () => {
   const { data: advices } = useVenueProAdvicesQuery({
     venueId,
     enableProAdvices,
-    select: ({ proAdvices }) => venueProAdvicesToAdviceCardData(proAdvices),
+    select: ({ proAdvices }) => venueProAdvicesToAdviceCardData(proAdvices, venueId),
   })
   const nbAdvices = advices?.length ?? 0
 

--- a/src/features/venue/pages/Venue/Venue.native.test.tsx
+++ b/src/features/venue/pages/Venue/Venue.native.test.tsx
@@ -23,6 +23,7 @@ import {
 } from 'features/venue/fixtures/venueOffersResponseSnap'
 import { venueProAdvicesFixture } from 'features/venue/fixtures/venueProAdvices.fixture'
 import { Venue } from 'features/venue/pages/Venue/Venue'
+import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
@@ -104,6 +105,10 @@ const mockUseDeviceInfo = jest.fn().mockReturnValue({
 })
 jest.mock('features/trustedDevice/helpers/useDeviceInfo', () => ({
   useDeviceInfo: () => mockUseDeviceInfo(),
+}))
+
+jest.mock('libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog', () => ({
+  triggerConsultOfferLog: jest.fn(),
 }))
 
 const user = userEvent.setup()
@@ -197,6 +202,27 @@ describe('<Venue />', () => {
       await screen.findByText('À la une')
 
       expect(screen.queryByText(`Les avis par “${venueDataTest.name}”`)).not.toBeOnTheScreen()
+    })
+
+    it('should trigger ConsultOffer log when pressing pro advice card header', async () => {
+      useABSegmentSpy.mockReturnValueOnce('A')
+      renderVenue(venueId)
+
+      await screen.findByText(`Les avis par “${venueDataTest.name}”`)
+
+      const cardHeader = await screen.getAllByLabelText('Voir l‘offre American dream')[0]
+
+      if (cardHeader) {
+        await user.press(cardHeader)
+      }
+
+      expect(triggerConsultOfferLog).toHaveBeenCalledWith({
+        adviceType: 'pro',
+        from: 'venue',
+        offerId: 1,
+        originDetail: 'Les avis des pros',
+        venueId: 5543,
+      })
     })
   })
 

--- a/src/features/venue/pages/Venue/Venue.tsx
+++ b/src/features/venue/pages/Venue/Venue.tsx
@@ -198,7 +198,8 @@ export const Venue: FunctionComponent = () => {
                     getAdvicesWithoutHeadline(
                       advices?.proAdvices.slice(0, 5),
                       headlineOfferData?.id
-                    )
+                    ),
+                    venue.id
                   )
                 : undefined
             }

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -299,6 +299,8 @@ export const logEventAnalytics = {
     homeEntryId?: string
     searchId?: string
     originDetail?: string
+    adviceType?: 'book_club' | 'cine_club' | 'pro'
+    offerId?: string
   }) => analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_VENUE }, params),
   logConsultVenueMap: ({ from, searchId }: { from: Referrals; searchId?: string }) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_VENUE_MAP }, { from, searchId }),


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41375

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
