### PR TITLE
(PC-41524) fix(BugReportButton): set BugReportButton as clickable instead of navigable

### DIFF
--- a/src/features/profile/components/Buttons/BugReportButton/BugReportButton.tsx
+++ b/src/features/profile/components/Buttons/BugReportButton/BugReportButton.tsx
@@ -18,7 +18,7 @@ export const BugReportButton: FC = () => {
     <StyledSectionRow
       key="BugReportButton"
       title="Signaler un bug"
-      type="navigable"
+      type="clickable"
       externalNav={{ url }}
       icon={ExternalSite}
     />


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41524

## Context

Updated the accessibility role of the BugReport button. It was previously announced as a link/navigable, it is now correctly identified as a clickable button.

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the [best practices][3] and respected them.

## Screenshots

<img width="386" height="212" alt="image" src="https://github.com/user-attachments/assets/77437abd-a868-4871-b9da-dcb2c8a7aaec" />

<img width="390" height="218" alt="image" src="https://github.com/user-attachments/assets/02d1b615-5c26-4139-9cf6-c80cfeae19b7" />
