### PR TITLE
(PC-39707) feat(SearchResults): remove search filters on focus

### DIFF
--- a/src/features/search/pages/SearchResults/v2/SearchResults.native.test.tsx
+++ b/src/features/search/pages/SearchResults/v2/SearchResults.native.test.tsx
@@ -31,7 +31,7 @@ const mockSearchState = {
 describe('Search Results V2', () => {
   beforeEach(jest.fn())
 
-  it('should display 3 search filter pastilles when `isFocusOnSuggestions` is false', () => {
+  it('should display search tabs when `isFocusOnSuggestions` is false', () => {
     getUseSearch()
 
     render(reactQueryProviderHOC(<SearchResultsV2 />))
@@ -41,7 +41,7 @@ describe('Search Results V2', () => {
     expect(screen.getByTestId('Lieux-search-filter')).toBeOnTheScreen()
   })
 
-  it('should not display search filter pastilles when `isFocusOnSuggestions` is true', () => {
+  it('should not display search tabs when `isFocusOnSuggestions` is true', () => {
     getUseSearch({ ...mockSearchState, isFocusOnSuggestions: true })
 
     render(reactQueryProviderHOC(<SearchResultsV2 />))

--- a/src/features/search/pages/SearchResults/v2/SearchResults.native.test.tsx
+++ b/src/features/search/pages/SearchResults/v2/SearchResults.native.test.tsx
@@ -1,0 +1,56 @@
+// eslint-disable-next-line no-restricted-imports
+import { NetInfoState } from '@react-native-community/netinfo'
+import React from 'react'
+
+import { initialSearchState } from 'features/search/context/reducer'
+import * as useSearch from 'features/search/context/SearchWrapper'
+import { ISearchContext } from 'features/search/context/SearchWrapper'
+import { SearchResults as SearchResultsV2 } from 'features/search/pages/SearchResults/v2/SearchResults'
+import * as useNetInfoContext from 'libs/network/NetInfoWrapper'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { render, screen } from 'tests/utils'
+
+jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
+jest.mock('libs/firebase/analytics/analytics')
+
+jest
+  .spyOn(useNetInfoContext, 'useNetInfoContext')
+  .mockReturnValue({ isConnected: true, isInternetReachable: true } as NetInfoState)
+
+const mockDispatch = jest.fn()
+const isFocusOnSuggestions = false
+const mockSearchState = {
+  searchState: initialSearchState,
+  dispatch: mockDispatch,
+  resetSearch: jest.fn(),
+  isFocusOnSuggestions,
+  showSuggestions: jest.fn(),
+  hideSuggestions: jest.fn(),
+}
+
+describe('Search Results V2', () => {
+  beforeEach(jest.fn())
+
+  it('should display 3 search filter pastilles when `isFocusOnSuggestions` is false', () => {
+    getUseSearch()
+
+    render(reactQueryProviderHOC(<SearchResultsV2 />))
+
+    expect(screen.getByTestId('Offres-search-filter')).toBeOnTheScreen()
+    expect(screen.getByTestId('Artistes-search-filter')).toBeOnTheScreen()
+    expect(screen.getByTestId('Lieux-search-filter')).toBeOnTheScreen()
+  })
+
+  it('should not display search filter pastilles when `isFocusOnSuggestions` is true', () => {
+    getUseSearch({ ...mockSearchState, isFocusOnSuggestions: true })
+
+    render(reactQueryProviderHOC(<SearchResultsV2 />))
+
+    expect(screen.queryByTestId('Offres-search-filter')).not.toBeOnTheScreen()
+    expect(screen.queryByTestId('Artistes-search-filter')).not.toBeOnTheScreen()
+    expect(screen.queryByTestId('Lieux-search-filter')).not.toBeOnTheScreen()
+  })
+})
+
+const getUseSearch = (searchState?: ISearchContext) =>
+  jest.spyOn(useSearch, 'useSearch').mockReturnValue(searchState ?? mockSearchState)

--- a/src/features/search/pages/SearchResults/v2/SearchResults.tsx
+++ b/src/features/search/pages/SearchResults/v2/SearchResults.tsx
@@ -12,6 +12,7 @@ import { SearchHeader } from 'features/search/components/SearchHeader/SearchHead
 import { SearchSuggestions } from 'features/search/components/SearchSuggestions/SearchSuggestions'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { getSearchClient } from 'features/search/helpers/getSearchClient'
+import { removeGeolocFromVenue } from 'features/search/helpers/searchList/removeGeolocFromVenue'
 import { useSearchHistory } from 'features/search/helpers/useSearchHistory/useSearchHistory'
 import { useSync } from 'features/search/helpers/useSync/useSync'
 import { SearchTab } from 'features/search/pages/SearchResults/v2/components/SearchTab'
@@ -94,15 +95,17 @@ export const SearchResults = () => {
   const transformHits = useTransformOfferHits()
 
   const {
-    data: artists,
+    data: artistsResponse = [],
     isLoading: isArtistsQueryLoading,
     isFetching: isArtistsQueryFetching,
     isSuccess: isArtistsQuerySuccess,
   } = useSearchArtistsQuery(queryParams, {
     select: (data) => selectSearchArtists(data, selectedFilter),
+    enabled: isArtistInSearchActive,
   })
+
   const {
-    data: offers,
+    data: offersResponse,
     hasNextPage,
     fetchNextPage,
     isFetching: isOffersQueryFetching,
@@ -114,7 +117,7 @@ export const SearchResults = () => {
     select: (data) => selectSearchOffers({ data, transformHits, selectedFilter }),
   })
   const {
-    data: venues,
+    data: venuesResponse,
     isLoading: isVenuesQueryLoading,
     isFetching: isVenuesQueryFetching,
     isSuccess: isVenuesQuerySuccess,
@@ -122,12 +125,19 @@ export const SearchResults = () => {
     select: (data) => selectSearchVenues(data, selectedFilter),
   })
 
+  const algoliaVenues = venuesResponse?.algoliaVenues ?? []
+  const venueNotOpenToPublic = venuesResponse?.venueNotOpenToPublic ?? []
+
+  const searchResultVenues = venueNotOpenToPublic[0]
+    ? [removeGeolocFromVenue(venueNotOpenToPublic[0]), ...algoliaVenues]
+    : algoliaVenues
+
   const hits: SearchOfferHits = {
-    artists: artists ?? [],
-    duplicatedOffers: offers?.duplicatedOffers ?? [],
-    offers: offers?.offers ?? [],
-    venues: venues?.algoliaVenues ?? [],
-    venueNotOpenToPublic: venues?.venueNotOpenToPublic ?? [],
+    artists: artistsResponse,
+    duplicatedOffers: offersResponse?.duplicatedOffers ?? [],
+    offers: offersResponse?.offers ?? [],
+    venues: searchResultVenues,
+    venueNotOpenToPublic,
   }
 
   const pageTracking = usePageTracking({
@@ -154,10 +164,10 @@ export const SearchResults = () => {
   }
 
   const handleEndReached = async () => {
-    if (!(offers && hasNextPage)) {
+    if (!(offersResponse && hasNextPage)) {
       return
     }
-    const page = offers.lastPage?.offersResponse.page ?? 0
+    const page = offersResponse.lastPage?.offersResponse.page ?? 0
 
     if (page > 0) {
       const currentSearchId = searchState.searchId ?? searchIdGenerated
@@ -180,12 +190,10 @@ export const SearchResults = () => {
       return prev === filter ? null : filter
     })
 
-  const searchResultHits = isArtistInSearchActive ? hits : { ...hits, artists: [] }
-
   const searchListContent = getSearchListContent({
     selectedFilter,
-    hits: searchResultHits,
-    nbHits: offers?.nbHits ?? hits.offers.length,
+    hits,
+    nbHits: offersResponse?.nbHits ?? hits.offers.length,
   })
 
   if (!netInfo.isConnected) {
@@ -207,7 +215,9 @@ export const SearchResults = () => {
             withFilterButton={!isFocusOnSuggestions}
             withArrow
             shouldDisplayHeader={!isFocusOnSuggestions}>
-            <SearchTab selectedFilter={selectedFilter} onFilterPress={handlePressFilter} />
+            {isFocusOnSuggestions ? null : (
+              <SearchTab selectedFilter={selectedFilter} onFilterPress={handlePressFilter} />
+            )}
           </SearchHeader>
         </Container>
         {isFocusOnSuggestions ? (
@@ -223,14 +233,13 @@ export const SearchResults = () => {
           <SearchResultsContent
             onEndReached={handleEndReached}
             onSearchResultsRefresh={() => refetch()}
-            nbHits={offers?.nbHits ?? hits.offers.length}
             searchListContent={searchListContent}
             isFetching={isArtistsQueryFetching && isOffersQueryFetching && isVenuesQueryFetching}
             isLoading={isArtistsQueryLoading && isOffersQueryLoading && isVenuesQueryLoading}
             isRefetching={isOffersQueryRefetching}
             isSuccess={isArtistsQuerySuccess && isOffersQuerySuccess && isVenuesQuerySuccess}
-            userData={offers?.userData}
-            venuesUserData={venues?.venuesUserData ?? undefined}
+            userData={offersResponse?.userData}
+            venuesUserData={venuesResponse?.venuesUserData ?? undefined}
             onViewableItemsChanged={handleViewableItemsChanged}
             enableAIFakeDoor={enableAIFakeDoor}
             onPressAIFakeDoorBanner={() => handleAIFakeDoorPress('search')}

--- a/src/features/search/pages/SearchResults/v2/SearchResults.tsx
+++ b/src/features/search/pages/SearchResults/v2/SearchResults.tsx
@@ -69,7 +69,9 @@ export const SearchResults = () => {
   const { userLocation, selectedLocationMode, aroundPlaceRadius, aroundMeRadius, geolocPosition } =
     useLocation()
 
-  const isArtistInSearchActive = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ARTIST_PAGE_IN_SEARCH)
+  const enableArtistInSearchActive = useFeatureFlag(
+    RemoteStoreFeatureFlags.WIP_ARTIST_PAGE_IN_SEARCH
+  )
   const enableAIFakeDoor = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_AI_FAKE_DOOR)
 
   const { disabilities } = useAccessibilityFiltersContext()
@@ -100,8 +102,9 @@ export const SearchResults = () => {
     isFetching: isArtistsQueryFetching,
     isSuccess: isArtistsQuerySuccess,
   } = useSearchArtistsQuery(queryParams, {
-    select: (data) => selectSearchArtists(data, selectedFilter),
-    enabled: isArtistInSearchActive,
+    select: (data) => selectSearchArtists(data),
+    enabled:
+      enableArtistInSearchActive && (selectedFilter === null || selectedFilter === 'Artistes'),
   })
 
   const {
@@ -114,7 +117,8 @@ export const SearchResults = () => {
     isLoading: isOffersQueryLoading,
     isSuccess: isOffersQuerySuccess,
   } = useSearchOffersQuery(queryParams, {
-    select: (data) => selectSearchOffers({ data, transformHits, selectedFilter }),
+    select: (data) => selectSearchOffers({ data, transformHits }),
+    enabled: selectedFilter === null || selectedFilter === 'Offres',
   })
   const {
     data: venuesResponse,
@@ -122,7 +126,8 @@ export const SearchResults = () => {
     isFetching: isVenuesQueryFetching,
     isSuccess: isVenuesQuerySuccess,
   } = useSearchVenuesQuery(queryParams, {
-    select: (data) => selectSearchVenues(data, selectedFilter),
+    select: (data) => selectSearchVenues(data),
+    enabled: selectedFilter === null || selectedFilter === 'Lieux',
   })
 
   const algoliaVenues = venuesResponse?.algoliaVenues ?? []

--- a/src/features/search/pages/SearchResults/v2/SearchResultsContent.tsx
+++ b/src/features/search/pages/SearchResults/v2/SearchResultsContent.tsx
@@ -13,10 +13,7 @@ import { NoSearchResult } from 'features/search/components/NoSearchResult/NoSear
 import { ArtistSection } from 'features/search/components/SearchListHeader/ArtistSection'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { getGridTileRatio } from 'features/search/helpers/getGridTileRatio'
-import {
-  convertAlgoliaVenue2AlgoliaVenueOfferListItem,
-  getReconciledVenues,
-} from 'features/search/helpers/searchList/getReconciledVenues'
+import { convertAlgoliaVenue2AlgoliaVenueOfferListItem } from 'features/search/helpers/searchList/getReconciledVenues'
 import { useNavigateToSearchFilter } from 'features/search/helpers/useNavigateToSearchFilter/useNavigateToSearchFilter'
 import { SearchArtistItemWrapper } from 'features/search/pages/SearchResults/v2/components/SearchArtistItemWrapper'
 import { SearchOfferItemWrapper } from 'features/search/pages/SearchResults/v2/components/SearchOfferItemWrapper'
@@ -50,7 +47,6 @@ import { Helmet } from 'ui/web/global/Helmet'
 type Props = {
   venuesUserData: VenuesUserData
   onViewableItemsChanged?: SearchListProps['onViewableVenuePlaylistItemsChanged']
-  nbHits: number
   isLoading: boolean
   isFetching: boolean
   isRefetching: boolean
@@ -82,7 +78,6 @@ const keyExtractor = (item: SearchResultItem) => {
 export const SearchResultsContent: FC<Props> = ({
   venuesUserData,
   onViewableItemsChanged,
-  nbHits,
   isLoading,
   isFetching,
   isRefetching,
@@ -96,6 +91,13 @@ export const SearchResultsContent: FC<Props> = ({
   disabilities,
   selectedFilter,
 }) => {
+  const {
+    hits: { artists, venues },
+    title,
+    nbHits,
+    items,
+  } = searchListContent
+
   const [autoScrollEnabled, setAutoScrollEnabled] = useState(true)
 
   const isFocused = useIsFocused()
@@ -143,10 +145,6 @@ export const SearchResultsContent: FC<Props> = ({
   const shouldDisplayGridList = enableGridList && !isWeb && isOffersContent
   const isGridLayout = shouldDisplayGridList && gridListLayout === GridListLayout.GRID
 
-  const isEnabledVenuesFromOfferIndex = useFeatureFlag(
-    RemoteStoreFeatureFlags.ENABLE_VENUES_FROM_OFFER_INDEX
-  )
-
   useEffect(() => {
     if (isSuccess && !isFetching) {
       void analytics.logPerformSearch(
@@ -165,16 +163,11 @@ export const SearchResultsContent: FC<Props> = ({
   const shouldDisplayVenueSection =
     !selectedFilter && !searchState.venue && previousRouteName !== SearchView.Thematic
 
-  const shouldDisplayArtistSection = !selectedFilter && searchListContent?.hits?.artists?.length
+  const shouldDisplayArtistSection = !selectedFilter && artists?.length
 
-  const venues = isEnabledVenuesFromOfferIndex
-    ? getReconciledVenues(searchListContent.hits?.offers, searchListContent.hits?.venues)
-    : searchListContent.hits?.venues.map(convertAlgoliaVenue2AlgoliaVenueOfferListItem)
+  const totalHitsToDisplay = items.length + artists.length + venues.length
 
-  const totalHitsToDisplay =
-    searchListContent.items.length + searchListContent.hits?.artists.length + venues.length
-
-  if (!totalHitsToDisplay || (selectedFilter && !searchListContent.items.length)) {
+  if (!totalHitsToDisplay || (selectedFilter && !items.length)) {
     return (
       <NoSearchResult
         setSelectedLocationMode={setSelectedLocationMode}
@@ -200,18 +193,18 @@ export const SearchResultsContent: FC<Props> = ({
           ref={searchListRef}
           key={`${isGridLayout ? 'grid_search_results' : 'list_search_results'}_${selectedFilter || 'all'}`}
           testID="searchResultsFlashlist"
-          data={searchListContent.items}
+          data={items}
           keyExtractor={keyExtractor}
           getItemType={(item: SearchResultItem) => item.type}
           ListHeaderComponent={
             <SearchResultsListHeader
-              nbHits={searchListContent.nbHits}
-              title={searchListContent.title}
+              nbHits={nbHits}
+              title={title}
               userData={userData}
               venuesSection={
                 shouldDisplayVenueSection ? (
                   <VenueSection
-                    venues={venues}
+                    venues={venues.map(convertAlgoliaVenue2AlgoliaVenueOfferListItem)}
                     onViewableVenuePlaylistItemsChanged={onViewableItemsChanged}
                     withMargins={false}
                   />
@@ -220,7 +213,7 @@ export const SearchResultsContent: FC<Props> = ({
               artistSection={
                 shouldDisplayArtistSection ? (
                   <StyledArtistSection
-                    artists={searchListContent.hits?.artists}
+                    artists={artists}
                     searchId={searchState.searchId}
                     withMargins={false}
                   />

--- a/src/features/search/pages/SearchResults/v2/components/SearchArtistItemWrapper.tsx
+++ b/src/features/search/pages/SearchResults/v2/components/SearchArtistItemWrapper.tsx
@@ -4,7 +4,7 @@ import { useSearch } from 'features/search/context/SearchWrapper'
 import { SearchResultArtist } from 'features/search/types'
 import { analytics } from 'libs/analytics/provider'
 import { AvatarListItem } from 'ui/components/Avatar/AvatarListItem'
-import { AVATAR_MEDIUM } from 'ui/theme/constants'
+import { AVATAR_SMALL } from 'ui/theme/constants'
 
 type SearchArtistItemWrapperProps = {
   item: SearchResultArtist
@@ -29,7 +29,7 @@ export const SearchArtistItemWrapper: FC<SearchArtistItemWrapperProps> = ({ item
       image={item.data.image}
       name={item.data.name}
       onItemPress={handleOnArtistPlaylistItemPress}
-      size={AVATAR_MEDIUM}
+      size={AVATAR_SMALL}
       isFullWidth
     />
   )

--- a/src/features/search/pages/SearchResults/v2/components/SearchTab.tsx
+++ b/src/features/search/pages/SearchResults/v2/components/SearchTab.tsx
@@ -24,6 +24,7 @@ export const SearchTab: FC<Props> = ({ selectedFilter, onFilterPress }) => {
 
         return (
           <StyledSearchFilterTab
+            testID={`${searchFilter}-search-filter`}
             key={searchFilter}
             isSelected={isCurrentSelected}
             onPress={() => onFilterPress(searchFilter)}>

--- a/src/features/search/pages/SearchResults/v2/utils.ts
+++ b/src/features/search/pages/SearchResults/v2/utils.ts
@@ -1,4 +1,3 @@
-import { removeGeolocFromVenue } from 'features/search/helpers/searchList/removeGeolocFromVenue'
 import { SelectSearchOffersParams } from 'features/search/queries/useSearchOffersQuery/types'
 import { SearchListContent, SearchOfferHits, SearchResultItem } from 'features/search/types'
 import { plural } from 'libs/plural'
@@ -20,10 +19,6 @@ type Args = {
   nbHits: number
 }
 export const getSearchListContent = ({ selectedFilter, hits, nbHits }: Args): SearchListContent => {
-  const venues = hits.venueNotOpenToPublic[0]
-    ? [removeGeolocFromVenue(hits.venueNotOpenToPublic[0]), ...hits.venues]
-    : hits.venues
-
   let items: SearchResultItem[] = []
   let title = ''
   let hitsNumber = 0
@@ -31,8 +26,8 @@ export const getSearchListContent = ({ selectedFilter, hits, nbHits }: Args): Se
   switch (selectedFilter) {
     case 'Lieux':
       title = 'Les lieux culturels'
-      items = venues.map((venue) => ({ type: 'venue', data: venue }))
-      hitsNumber = venues.length
+      items = hits.venues.map((venue) => ({ type: 'venue', data: venue }))
+      hitsNumber = hits.venues.length
       break
     case 'Artistes':
       title = 'Les artistes'
@@ -50,6 +45,6 @@ export const getSearchListContent = ({ selectedFilter, hits, nbHits }: Args): Se
     items,
     title,
     nbHits: hitsNumber,
-    hits: { ...hits, venues },
+    hits,
   }
 }

--- a/src/features/search/queries/useSearchArtists/selectors/selectSearchArtists.native.test.ts
+++ b/src/features/search/queries/useSearchArtists/selectors/selectSearchArtists.native.test.ts
@@ -29,31 +29,15 @@ const mockData = {
 } as unknown as FetchSearchArtistsResponse
 
 describe('selectSearchArtists', () => {
-  describe('selectedFilter', () => {
-    it('should return artists when selectedFilter is null', () => {
-      const result = selectSearchArtists(mockData, null)
+  it('should return artists', () => {
+    const result = selectSearchArtists(mockData)
 
-      expect(result).toHaveLength(2)
-    })
-
-    it('should return artists when selectedFilter is "Artistes"', () => {
-      const result = selectSearchArtists(mockData, 'Artistes')
-
-      expect(result).toHaveLength(2)
-    })
-
-    it('should return empty array when selectedFilter is "Offres"', () => {
-      expect(selectSearchArtists(mockData, 'Offres')).toEqual([])
-    })
-
-    it('should return empty array when selectedFilter is "Lieux"', () => {
-      expect(selectSearchArtists(mockData, 'Lieux')).toEqual([])
-    })
+    expect(result).toHaveLength(2)
   })
 
   describe('artists extraction', () => {
     it('should flatten and deduplicate artists across hits', () => {
-      const result = selectSearchArtists(mockData, null)
+      const result = selectSearchArtists(mockData)
 
       expect(result).toEqual([
         { id: 'artist-a', name: 'Artist A' },
@@ -71,7 +55,7 @@ describe('selectSearchArtists', () => {
         },
       } as unknown as FetchSearchArtistsResponse
 
-      expect(selectSearchArtists(emptyData, null)).toEqual([])
+      expect(selectSearchArtists(emptyData)).toEqual([])
     })
   })
 })

--- a/src/features/search/queries/useSearchArtists/selectors/selectSearchArtists.ts
+++ b/src/features/search/queries/useSearchArtists/selectors/selectSearchArtists.ts
@@ -1,16 +1,9 @@
 import { uniqBy } from 'lodash'
 
 import { FetchSearchArtistsResponse } from 'features/search/queries/useSearchArtists/types'
-import { SelectSearchOffersParams } from 'features/search/queries/useSearchOffersQuery/types'
 import { Artist } from 'features/venue/types'
 
-export const selectSearchArtists = (
-  data: FetchSearchArtistsResponse,
-  selectedFilter: SelectSearchOffersParams['selectedFilter']
-): Artist[] => {
-  const isArtistsFilterActive = selectedFilter === null || selectedFilter === 'Artistes'
-  if (!isArtistsFilterActive) return []
-
+export const selectSearchArtists = (data: FetchSearchArtistsResponse): Artist[] => {
   return uniqBy(
     data.offerArtistsResponse.hits
       .filter((offer) => offer.artists?.length)

--- a/src/features/search/queries/useSearchOffersQuery/selectors/selectSearchOffers.native.test.ts
+++ b/src/features/search/queries/useSearchOffersQuery/selectors/selectSearchOffers.native.test.ts
@@ -32,7 +32,7 @@ const makeData = (pages: FetchSearchOffersResponse[]): InfiniteData<FetchSearchO
 describe('selectSearchOffers', () => {
   it('should return all expected keys', () => {
     const data = makeData([makePage()])
-    const result = selectSearchOffers({ data, transformHits, selectedFilter: null })
+    const result = selectSearchOffers({ data, transformHits })
 
     expect(result).toEqual(
       expect.objectContaining({
@@ -58,54 +58,34 @@ describe('selectSearchOffers', () => {
     )
   })
 
-  describe('selectedFilter', () => {
-    const mockOffer: AlgoliaOffer<HitOffer> = {
-      objectID: '1',
-      offer: {
-        dates: [],
-        isDuo: false,
-        isDigital: false,
-        name: 'Bellatrix Tome 1',
-        prices: [14.95],
-        subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
-        thumbUrl: '',
-      },
-      venue: {
-        id: 1,
-        name: 'Lieu 1',
-        publicName: 'Lieu 1',
-        address: '1 rue de la paix',
-        postalCode: '75000',
-        city: 'Paris',
-        activity: 'BOOKSTORE',
-        isPermanent: true,
-      },
-      _geoloc: { lat: 48.94374, lng: 2.48171 },
-    }
-    const data = makeData([makePage({ hits: [mockOffer], nbHits: 1 }, { hits: [mockOffer] })])
+  const mockOffer: AlgoliaOffer<HitOffer> = {
+    objectID: '1',
+    offer: {
+      dates: [],
+      isDuo: false,
+      isDigital: false,
+      name: 'Bellatrix Tome 1',
+      prices: [14.95],
+      subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
+      thumbUrl: '',
+    },
+    venue: {
+      id: 1,
+      name: 'Lieu 1',
+      publicName: 'Lieu 1',
+      address: '1 rue de la paix',
+      postalCode: '75000',
+      city: 'Paris',
+      activity: 'BOOKSTORE',
+      isPermanent: true,
+    },
+    _geoloc: { lat: 48.94374, lng: 2.48171 },
+  }
+  const data = makeData([makePage({ hits: [mockOffer], nbHits: 1 }, { hits: [mockOffer] })])
 
-    it('should return offers when selectedFilter is null', () => {
-      const result = selectSearchOffers({ data, transformHits, selectedFilter: null })
+  it('should return offers', () => {
+    const result = selectSearchOffers({ data, transformHits })
 
-      expect(result.offers).toHaveLength(1)
-    })
-
-    it('should return offers when selectedFilter is "Offres"', () => {
-      const result = selectSearchOffers({ data, transformHits, selectedFilter: 'Offres' })
-
-      expect(result.offers).toHaveLength(1)
-    })
-
-    it('should return empty offers when selectedFilter is "Lieux"', () => {
-      const result = selectSearchOffers({ data, transformHits, selectedFilter: 'Lieux' })
-
-      expect(result.offers).toHaveLength(0)
-    })
-
-    it('should return empty offers when selectedFilter is "Artistes"', () => {
-      const result = selectSearchOffers({ data, transformHits, selectedFilter: 'Artistes' })
-
-      expect(result.offers).toHaveLength(0)
-    })
+    expect(result.offers).toHaveLength(1)
   })
 })

--- a/src/features/search/queries/useSearchOffersQuery/selectors/selectSearchOffers.ts
+++ b/src/features/search/queries/useSearchOffersQuery/selectors/selectSearchOffers.ts
@@ -13,17 +13,12 @@ import {
 export const selectSearchOffers = ({
   data,
   transformHits,
-  selectedFilter,
 }: SelectSearchOffersParams): SelectedSearchOffers => {
-  const isOffersFilterActive = selectedFilter === null || selectedFilter === 'Offres'
-
   const { pages } = data
   const [firstPage] = pages
 
-  const offers = isOffersFilterActive ? getFlattenHits(pages, transformHits, 'offersResponse') : []
-  const duplicatedOffers = isOffersFilterActive
-    ? getFlattenHits(pages, transformHits, 'duplicatedOffersResponse')
-    : []
+  const offers = getFlattenHits(pages, transformHits, 'offersResponse')
+  const duplicatedOffers = getFlattenHits(pages, transformHits, 'duplicatedOffersResponse')
 
   return {
     offers,

--- a/src/features/search/queries/useSearchOffersQuery/types.ts
+++ b/src/features/search/queries/useSearchOffersQuery/types.ts
@@ -33,5 +33,5 @@ export type SelectedSearchOffers = {
 export type SelectSearchOffersParams = {
   data: InfiniteData<FetchSearchOffersResponse>
   transformHits: ReturnType<typeof useTransformOfferHits>
-  selectedFilter: SearchFilter | null
+  selectedFilter?: SearchFilter | null
 }

--- a/src/features/search/queries/useSearchVenuesQuery/selectors/selectSearchVenues.native.test.ts
+++ b/src/features/search/queries/useSearchVenuesQuery/selectors/selectSearchVenues.native.test.ts
@@ -25,60 +25,29 @@ const emptyResponse: FetchSearchVenuesResponse = {
 }
 
 describe('selectSearchVenues', () => {
-  describe('selectedFilter', () => {
-    it('should return venues when selectedFilter is null', () => {
-      const result = selectSearchVenues(mockResponse, null)
+  it('should return venues', () => {
+    const result = selectSearchVenues(mockResponse)
 
-      expect(result.algoliaVenues).toEqual([mockVenueOpen])
-      expect(result.venues).toEqual([
-        expect.objectContaining({ objectID: 'v1', name: 'Venue Open' }),
-      ])
-    })
+    expect(result.algoliaVenues).toEqual([mockVenueOpen])
+    expect(result.venues).toEqual([expect.objectContaining({ objectID: 'v1', name: 'Venue Open' })])
+  })
 
-    it('should return venues when selectedFilter is "Lieux"', () => {
-      const result = selectSearchVenues(mockResponse, 'Lieux')
+  it('should always return venuesUserData', () => {
+    const result = selectSearchVenues(mockResponse)
 
-      expect(result.algoliaVenues).toEqual([mockVenueOpen])
-      expect(result.venues).toEqual([
-        expect.objectContaining({ objectID: 'v1', name: 'Venue Open' }),
-      ])
-    })
-
-    it('should return empty venues when selectedFilter is "Offres"', () => {
-      const result = selectSearchVenues(mockResponse, 'Offres')
-
-      expect(result.algoliaVenues).toEqual([])
-      expect(result.venues).toEqual([])
-    })
-
-    it('should return empty venues when selectedFilter is "Artistes"', () => {
-      const result = selectSearchVenues(mockResponse, 'Artistes')
-
-      expect(result.algoliaVenues).toEqual([])
-      expect(result.venues).toEqual([])
-    })
-
-    it('should always return venuesUserData regardless of selectedFilter', () => {
-      const filters = ['Offres', 'Lieux', 'Artistes', null] as const
-
-      filters.forEach((selectedFilter) => {
-        const result = selectSearchVenues(mockResponse, selectedFilter)
-
-        expect(result.venuesUserData).toEqual([{ venue_playlist_title: 'venue playlist title' }])
-      })
-    })
+    expect(result.venuesUserData).toEqual([{ venue_playlist_title: 'venue playlist title' }])
   })
 
   describe('data mapping', () => {
     it('should map venue data correctly', () => {
-      const result = selectSearchVenues(mockResponse, null)
+      const result = selectSearchVenues(mockResponse)
 
       expect(result.venuesUserData).toEqual([{ venue_playlist_title: 'venue playlist title' }])
       expect(result.venueNotOpenToPublic).toEqual([mockVenueNotOpenToPublic])
     })
 
     it('should handle undefined or empty responses', () => {
-      const result = selectSearchVenues(emptyResponse, null)
+      const result = selectSearchVenues(emptyResponse)
 
       expect(result.algoliaVenues).toEqual([])
       expect(result.venues).toEqual([])

--- a/src/features/search/queries/useSearchVenuesQuery/selectors/selectSearchVenues.ts
+++ b/src/features/search/queries/useSearchVenuesQuery/selectors/selectSearchVenues.ts
@@ -1,22 +1,16 @@
 import { flatten } from 'lodash'
 
-import { SelectSearchOffersParams } from 'features/search/queries/useSearchOffersQuery/types'
 import { mapAlgoliaVenueToAlgoliaVenueOfferListItem } from 'features/search/queries/useSearchVenuesQuery/helpers.ts/mapAlgoliaVenueToAlgoliaVenueOfferListItem'
 import { FetchSearchVenuesResponse } from 'features/search/queries/useSearchVenuesQuery/types'
 
-export const selectSearchVenues = (
-  venues: FetchSearchVenuesResponse,
-  selectedFilter: SelectSearchOffersParams['selectedFilter']
-) => {
-  const isVenuesFilterActive = selectedFilter === null || selectedFilter === 'Lieux'
+export const selectSearchVenues = (venues: FetchSearchVenuesResponse) => {
   const flattenVenues = flatten(venues.venuesResponse?.hits)
 
   return {
-    algoliaVenues: isVenuesFilterActive ? flattenVenues : [],
-    venues: isVenuesFilterActive
-      ? flattenVenues.map((venue) => mapAlgoliaVenueToAlgoliaVenueOfferListItem(venue))
-      : [],
+    algoliaVenues: flattenVenues,
+    venues: flattenVenues.map((venue) => mapAlgoliaVenueToAlgoliaVenueOfferListItem(venue)),
+
     venuesUserData: venues.venuesResponse?.userData,
-    venueNotOpenToPublic: isVenuesFilterActive ? flatten(venues.venueNotOpenToPublic?.hits) : [],
+    venueNotOpenToPublic: flatten(venues.venueNotOpenToPublic?.hits),
   }
 }

--- a/src/shared/verticalPlaylist/helpers/useGetArtistsFromPlaylist.ts
+++ b/src/shared/verticalPlaylist/helpers/useGetArtistsFromPlaylist.ts
@@ -64,7 +64,7 @@ export const useGetArtistsFromPlaylist = ({ params }): VerticalPlaylistArtistsDa
 
   const query = useSearchArtistsQuery(queryParams, {
     enabled: !venueId,
-    select: (data) => selectSearchArtists(data, null),
+    select: (data) => selectSearchArtists(data),
   })
 
   const artistsFromVenue = venueArtists?.artists

--- a/src/ui/components/Avatar/AvatarListItem.tsx
+++ b/src/ui/components/Avatar/AvatarListItem.tsx
@@ -49,12 +49,12 @@ const ArtistName = styled(Typo.BodyAccentS)<{ maxWidth: number; isFullWidth: boo
   ({ maxWidth, isFullWidth }) => ({
     textAlign: 'center',
     maxWidth: isFullWidth ? '100%' : maxWidth,
+    alignSelf: isFullWidth ? 'center' : 'self-start',
   })
 )
 
-const StyledView = styled(ViewGap)<{ isFullWidth: boolean }>(({ theme, isFullWidth }) => ({
+const StyledView = styled(ViewGap)<{ isFullWidth: boolean }>(({ isFullWidth }) => ({
   flexDirection: isFullWidth ? 'row' : 'column',
-  paddingVertical: theme.designSystem.size.spacing.s,
 }))
 
 const StyledImage = styled(FastImage)({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-39707

## Context

L'objectif de cette PR est de : 
- ne plus afficher les pastilles de filtre quand l'user clique sur l'input de recherche (état isFocusOnSuggestions)
- n'afficher dans la playlist de lieux que les résultats remontés par algolia (donc ne plus afficher le lieu rattaché à l'offre)


## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome | <img width="429" height="933" alt="image (4)" src="https://github.com/user-attachments/assets/45424c5e-de8d-4717-96f4-41ee4a6990af" /> | <img width="641" height="354" alt="Capture d’écran 2026-04-27 à 11 24 11" src="https://github.com/user-attachments/assets/0e1ce78d-fb97-4e65-acff-645e405d1fca" /> |


