### PR TITLE
(PC-40851) feat(home): trigger ClickSeeVideoTranscription log when pressing see transcription button on video module page

### DIFF
--- a/src/features/home/pages/VideoModulePage.native.test.tsx
+++ b/src/features/home/pages/VideoModulePage.native.test.tsx
@@ -83,6 +83,17 @@ describe('VideoModulePage', () => {
       expect(await screen.findByText(mockTranscription)).toBeOnTheScreen()
     })
 
+    it('should trigger ClickSeeVideoTranscription log when pressing see transcription button', async () => {
+      render(reactQueryProviderHOC(<VideoModulePage />))
+
+      await user.press(await screen.findByText('Voir la transcription'))
+
+      expect(analytics.logClickSeeVideoTranscription).toHaveBeenCalledWith({
+        from: 'videoModal',
+        moduleId: 'module-123',
+      })
+    })
+
     describe('should trigger hasDismissedModal log', () => {
       it('When pressing header back button', async () => {
         render(reactQueryProviderHOC(<VideoModulePage />))

--- a/src/features/home/pages/VideoModulePage.tsx
+++ b/src/features/home/pages/VideoModulePage.tsx
@@ -55,7 +55,7 @@ export const VideoModulePage: FunctionComponent = () => {
     moduleId,
     moduleName,
     from: 'videoModal',
-    homeEntryId: homeEntryId,
+    homeEntryId,
   }
 
   const handleLogHasDismissedModal = async () => {
@@ -78,6 +78,11 @@ export const VideoModulePage: FunctionComponent = () => {
   const onGoBackPress = async () => {
     await handleLogHasDismissedModal()
     goBack()
+  }
+
+  const handleTranscriptionButtonPress = () => {
+    void analytics.logClickSeeVideoTranscription({ from: 'videoModal', moduleId, homeEntryId })
+    showModal()
   }
 
   return (
@@ -111,7 +116,7 @@ export const VideoModulePage: FunctionComponent = () => {
             color="neutral"
             fullWidth={false}
             icon={PressFilled}
-            onPress={showModal}
+            onPress={handleTranscriptionButtonPress}
           />
         </TranscriptionButtonContainer>
 

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -34,6 +34,7 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logClickInfoReview: jest.fn(),
   logClickMailDebugInfo: jest.fn(),
   logClickSeeAll: jest.fn(),
+  logClickSeeVideoTranscription: jest.fn(),
   logClickSocialNetwork: jest.fn(),
   logClickVolunteerCTA: jest.fn(),
   logClickWhatsClub: jest.fn(),

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -214,6 +214,11 @@ export const logEventAnalytics = {
     homeEntryId?: string
     from?: Referrals
   }) => analytics.logEvent({ firebase: AnalyticsEvent.SEE_ALL_CLICKED }, params),
+  logClickSeeVideoTranscription: (params: {
+    from: Referrals
+    moduleId?: string
+    homeEntryId?: string
+  }) => analytics.logEvent({ firebase: AnalyticsEvent.CLICK_SEE_VIDEO_TRANSCRIPTION }, params),
   logClickSocialNetwork: (network: string) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CLICK_SOCIAL_NETWORK }, { network }),
   logClickVolunteerCTA: (params: { from: Referrals; venueId: string }) =>

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -36,6 +36,7 @@ export enum AnalyticsEvent {
   CLICK_FORCE_UPDATE = 'ClickForceUpdate',
   CLICK_INFO_REVIEW = 'ClickInfoReview',
   CLICK_MAIL_DEBUG_INFO = 'ClickMailDebugInfo',
+  CLICK_SEE_VIDEO_TRANSCRIPTION = 'ClickSeeVideoTranscription',
   CLICK_SOCIAL_NETWORK = 'ClickSocialNetwork',
   CLICK_VOLUNTEER_CTA = 'ClickVolunteerCTA',
   CLICK_WHATS_CLUB = 'ClickWhatsClub',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-40851

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
