### PR TITLE
(PC-41213) chore(ci): use larger runners for E2E builds

### DIFF
--- a/.github/workflows/dev_on_workflow_call_e2e_android.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_android.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   maestro-cloud:
     name: 'Build & Test Android Staging'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 180
     steps:
       - name: Free up disk space

--- a/.github/workflows/dev_on_workflow_call_e2e_android.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_android.yml
@@ -25,9 +25,9 @@ permissions:
 
 jobs:
   maestro-cloud:
-    name: 'Build & Test Android Staging'
+    name: 'Build Android staging and upload to Maestro Cloud'
     runs-on: ubuntu-latest-8-cores
-    timeout-minutes: 180
+    timeout-minutes: 60
     steps:
       - name: Free up disk space
         run: |

--- a/.github/workflows/dev_on_workflow_call_e2e_android.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_android.yml
@@ -155,7 +155,7 @@ jobs:
           android-api-level: 34
           workspace: .maestro/tests/
           include-tags: ${{ inputs.test_tags }}
-          timeout: 180
+          async: true
           env: |
             MAESTRO_APP_ID=app.passculture.staging
             MAESTRO_PASSWORD=${{ steps.secrets.outputs.MAESTRO_PASSWORD }}

--- a/.github/workflows/dev_on_workflow_call_e2e_ios.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_ios.yml
@@ -142,7 +142,7 @@ jobs:
           device-os: iOS-17-5
           device-model: iPhone-11
           include-tags: ${{ inputs.test_tags }}
-          timeout: 180
+          async: true
           env: |
             MAESTRO_APP_ID=app.passculture.staging
             MAESTRO_PASSWORD=${{ steps.secrets.outputs.MAESTRO_PASSWORD }}

--- a/.github/workflows/dev_on_workflow_call_e2e_ios.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_ios.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   build_e2e:
     name: 'Build & Test iOS Staging'
-    runs-on: macos-26
+    runs-on: macos-26-xlarge
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dev_on_workflow_call_e2e_ios.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_ios.yml
@@ -26,9 +26,9 @@ permissions:
 
 jobs:
   build_e2e:
-    name: 'Build & Test iOS Staging'
+    name: 'Build iOS staging and upload to Maestro Cloud'
     runs-on: macos-26-xlarge
-    timeout-minutes: 180
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41213

## Context

Les builds dans les jobs de tests E2E étaient trop lent/long. 
Sur cet PR on :
- Remplace les anciens runners par des runners plus large pour faire les builds
- On rend le job de build async et on laisse la Maestro github app nous restituer les résultats dans la CI pour ne pas faire tourner un runner inutilement

## Résultats

| | Build avant | Build après | Gain |
|---|---|---|---|
| **Android** (8 cores) | 34min 25s | 22min 32s | **-11min 53s** (−35%) |
| **iOS** (M2 xlarge) | 37min 53s | 11min 16s | **-26min 37s** (−70%) |

## Comparaison des coûts (22 runs)

### Avant : Runners standards (sans larger runners)
| | Minutes totales | Coût |
|---|---|---|
| iOS | 1 818 min | $0 (forfait) |
| Android | 1 976 min | $0 (forfait) |
| **Total** | **3 794 min** | **$0** (mais consomme le forfait 50k min) |

### Maintenant : Larger runners + async ✅
| | Durée/run | Minutes totales | Coût |
|---|---|---|---|
| iOS (xlarge) | 20 min 39s | **454 min** | **$46.31** |
| Android (8-cores) | ~38 min | **~836 min** | **~$18.39** |
| **Total** | | **~1 290 min** | **~$64.70** |


### Résumé

| | Avant (standard) | Larger + sync | Larger + async |
|---|---|---|---|
| Coût | $0 (forfait) | $163.50 | **~$64.70** |
| Minutes consommées sur le forfait | 3 794 min | 0 | 0 |
| Coût par PR (iOS+Android) | - | $7.40 | **~$2.94** |

Le coût réel est ~$65/mois pour des builds **2 à 3× plus rapides**.
