### PR TITLE
(PC-40382) feat(DefaultAvatar): set the default color to subtle

### DIFF
--- a/src/features/artist/components/ArtistHeader/ArtistHeader.tsx
+++ b/src/features/artist/components/ArtistHeader/ArtistHeader.tsx
@@ -20,7 +20,7 @@ export const ArtistHeader = ({ avatarImage, name }: ArtistHeaderProps) => {
         {avatarImage ? (
           <StyledImage url={avatarImage} testID="artistAvatar" />
         ) : (
-          <DefaultAvatar testID="defaultArtistAvatar" />
+          <DefaultAvatar testID="defaultArtistAvatar" size={50} />
         )}
       </Avatar>
       <Typo.Title1>{name}</Typo.Title1>

--- a/src/shared/verticalPlaylist/components/HorizontalArtistTile.tsx
+++ b/src/shared/verticalPlaylist/components/HorizontalArtistTile.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components/native'
 import { Artist } from 'features/venue/types'
 import { FastImage } from 'libs/resizing-image-on-demand/FastImage'
 import { Avatar } from 'ui/components/Avatar/Avatar'
+import { DefaultAvatar } from 'ui/components/Avatar/DefaultAvatar'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
-import { Profile } from 'ui/svg/icons/Profile'
 import { Typo } from 'ui/theme'
 import { AVATAR_SMALL } from 'ui/theme/constants'
 
@@ -20,9 +20,7 @@ export const HorizontalArtistTile = ({ artist }: ArtistItemProps) => {
         {artist.image ? (
           <StyledImage url={artist.image} testID="artistAvatar" />
         ) : (
-          <DefaultAvatarContainer testID="defaultArtistAvatar">
-            <StyledProfile />
-          </DefaultAvatarContainer>
+          <DefaultAvatar testID="defaultArtistAvatar" />
         )}
       </Avatar>
       <TextContainer>
@@ -46,19 +44,3 @@ const StyledImage = styled(FastImage)({
   width: '100%',
   height: '100%',
 })
-
-const DefaultAvatarContainer = styled.View(({ theme }) => ({
-  backgroundColor: theme.designSystem.color.background.disabled,
-  width: '100%',
-  height: '100%',
-  alignItems: 'center',
-  justifyContent: 'center',
-  borderWidth: 1,
-  borderColor: theme.designSystem.color.border.subtle,
-  borderRadius: theme.designSystem.size.borderRadius.pill,
-}))
-
-const StyledProfile = styled(Profile).attrs(({ theme }) => ({
-  color: theme.designSystem.color.icon.subtle,
-  size: theme.icons.sizes.standard,
-}))``

--- a/src/ui/components/Avatar/Avatar.stories.tsx
+++ b/src/ui/components/Avatar/Avatar.stories.tsx
@@ -59,9 +59,9 @@ const variantConfig: Variants<typeof Avatar> = [
     },
   },
   {
-    label: 'Avatar with custom images',
+    label: 'Default Avatar',
     props: {
-      size: AVATAR_LARGE,
+      size: AVATAR_SMALL,
       children: <DefaultAvatar />,
     },
   },

--- a/src/ui/components/Avatar/DefaultAvatar.tsx
+++ b/src/ui/components/Avatar/DefaultAvatar.tsx
@@ -1,17 +1,20 @@
 import React from 'react'
-import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
 
 import { Profile } from 'ui/svg/icons/Profile'
 
-export const DefaultAvatar = styled(LinearGradient).attrs<{
+export const DefaultAvatar = styled.View.attrs<{
   colors?: string[]
-}>(({ theme, colors }) => ({
-  colors: colors || [
-    theme.designSystem.color.icon.brandPrimary,
-    theme.designSystem.color.icon.brandPrimary,
-  ],
-  useAngle: true,
-  angle: -30,
-  children: <Profile color={theme.designSystem.color.icon.lockedInverted} size={50} />,
-}))({ width: '100%', height: '100%', alignItems: 'center', justifyContent: 'center' })
+  size?: number
+}>(({ theme, size = theme.designSystem.size.icon.m }) => ({
+  children: <Profile color={theme.designSystem.color.icon.subtle} size={size} />,
+}))(({ theme }) => ({
+  width: '100%',
+  height: '100%',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: theme.designSystem.color.background.subtle,
+  borderWidth: 1,
+  borderColor: theme.designSystem.color.border.subtle,
+  borderRadius: theme.designSystem.size.borderRadius.pill,
+}))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-40382

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |<img width="555" height="693" alt="Capture d’écran 2026-04-28 à 15 36 51" src="https://github.com/user-attachments/assets/6f11723f-dcfa-4c45-bce6-af5c650cacc9" />|<img width="645" height="735" alt="Capture d’écran 2026-04-28 à 15 34 10" src="https://github.com/user-attachments/assets/395d8b0e-d140-41fb-88d2-06dd961f2b0b" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
