### PR TITLE
(PC-41580) refactor(home): improve video module page accessibility

### DIFF
--- a/src/features/home/components/modules/video/VideoModuleDesktop.tsx
+++ b/src/features/home/components/modules/video/VideoModuleDesktop.tsx
@@ -87,7 +87,8 @@ export const VideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) =
           <StyledTouchableHighlight
             onPress={props.onVideoPlaceholderPress}
             testID="video-thumbnail"
-            accessibilityRole={AccessibilityRole.BUTTON}>
+            accessibilityRole={AccessibilityRole.BUTTON}
+            accessibilityLabel={`Ouvrir la page et lire la vidéo ${props.videoTitle}. Transcription disponible.`}>
             <Thumbnail source={{ uri: props.videoThumbnail }}>
               <BlackView />
               <TextContainer>

--- a/src/features/home/components/modules/video/VideoModuleHeader.tsx
+++ b/src/features/home/components/modules/video/VideoModuleHeader.tsx
@@ -10,6 +10,7 @@ import { Offer } from 'shared/offer/types'
 import { Tag } from 'ui/designSystem/Tag/Tag'
 import { TagVariant } from 'ui/designSystem/Tag/types'
 import { Typo } from 'ui/theme'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type Props = {
   analyticsParams: OfferAnalyticsParams
@@ -39,7 +40,7 @@ export const VideoModuleHeader: FunctionComponent<Props> = ({
         <Tag label={videoTag} variant={TagVariant.DEFAULT} />
       </StyledTagContainer>
 
-      <Typo.Title3>{moduleName}</Typo.Title3>
+      <Typo.Title3 {...getHeadingAttrs(1)}>{moduleName}</Typo.Title3>
 
       <StyledCaptionDate>{`Publiée le ${formatToFrenchDate(
         new Date(videoPublicationDate)
@@ -52,7 +53,7 @@ export const VideoModuleHeader: FunctionComponent<Props> = ({
       ) : null}
 
       <OfferTitleContainer>
-        <Typo.Title4>{offerTitle}</Typo.Title4>
+        <Typo.Title4 {...getHeadingAttrs(2)}>{offerTitle}</Typo.Title4>
       </OfferTitleContainer>
 
       {!isMultiOffer && offers[0] ? (

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -51,7 +51,8 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
         <StyledTouchableHighlight
           onPress={props.onVideoPlaceholderPress}
           testID="video-thumbnail"
-          accessibilityRole={AccessibilityRole.BUTTON}>
+          accessibilityRole={AccessibilityRole.BUTTON}
+          accessibilityLabel={`Ouvrir la page et lire la vidéo ${props.videoTitle}. Transcription disponible.`}>
           <Thumbnail source={{ uri: props.videoThumbnail }}>
             <BlackView />
             <TextContainer>

--- a/src/features/home/components/modules/video/VideoPlayer.tsx
+++ b/src/features/home/components/modules/video/VideoPlayer.tsx
@@ -89,23 +89,21 @@ export const VideoPlayer: React.FC<VideoPlayerNativeProps> = ({
   )
 
   return (
-    <React.Fragment>
-      <StyledVideoPlayerContainer marginTop={headerHeight}>
-        <StyledYoutubePlayer
-          ref={playerRef}
-          initialPlayerParams={{ modestbranding: true, rel: false }}
-          height={playerHeight}
-          width={playerWidth}
-          play={isPlaying}
-          noThumbnail
-          onReady={playVideo}
-          videoId={youtubeVideoId}
-          onChangeState={onChangeState}
-          onError={() => {
-            setShowErrorView(true)
-          }}
-        />
-      </StyledVideoPlayerContainer>
+    <StyledVideoPlayerContainer marginTop={headerHeight}>
+      <StyledYoutubePlayer
+        ref={playerRef}
+        initialPlayerParams={{ controls: false, rel: false, iv_load_policy: 3 }}
+        height={playerHeight}
+        width={playerWidth}
+        play={isPlaying}
+        noThumbnail
+        onReady={playVideo}
+        videoId={youtubeVideoId}
+        onChangeState={onChangeState}
+        onError={() => {
+          setShowErrorView(true)
+        }}
+      />
       {hasFinishPlaying ? (
         <VideoEndView
           onPressReplay={replayVideo}
@@ -120,7 +118,7 @@ export const VideoPlayer: React.FC<VideoPlayerNativeProps> = ({
       {showErrorView ? (
         <VideoErrorView style={{ height: playerHeight, width: playerWidth }} />
       ) : null}
-    </React.Fragment>
+    </StyledVideoPlayerContainer>
   )
 }
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41580

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
