### PR TITLE
(PC-41623) fix(query): fix maintenance and force update screen

### DIFF
--- a/src/cheatcodes/queries/useCheatcodesFeatureFlagQuery.ts
+++ b/src/cheatcodes/queries/useCheatcodesFeatureFlagQuery.ts
@@ -1,4 +1,4 @@
-import { onlineManager, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { getAllFeatureFlags } from 'libs/firebase/firestore/featureFlags/getAllFeatureFlags'
 import { FeatureFlagConfig, squads } from 'libs/firebase/firestore/featureFlags/types'
@@ -33,7 +33,6 @@ export const useCheatcodesFeatureFlagQuery = () => {
     queryKey: ['FEATURE_FLAGS'],
     queryFn: getAllFeatureFlags,
     staleTime: 1000 * 30,
-    enabled: onlineManager.isOnline(),
   })
 
   if (!docSnapshot || isLoading || error) {

--- a/src/features/forceUpdate/queries/useMinimalBuildNumberQuery.ts
+++ b/src/features/forceUpdate/queries/useMinimalBuildNumberQuery.ts
@@ -1,4 +1,4 @@
-import { onlineManager, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { getMinimalBuildNumber } from 'libs/firebase/firestore/getMinimalBuildNumber/getMinimalBuildNumber'
 import { QueryKeys } from 'libs/queryKeys'
@@ -13,7 +13,6 @@ export const useMinimalBuildNumberQuery = () => {
     queryFn: getMinimalBuildNumber,
     staleTime: 1000 * 30,
     gcTime: 1000 * 30,
-    enabled: onlineManager.isOnline(),
   })
 
   return { minimalBuildNumber, isLoading, error }

--- a/src/features/maintenance/queries/useMaintenanceQuery.ts
+++ b/src/features/maintenance/queries/useMaintenanceQuery.ts
@@ -1,4 +1,4 @@
-import { onlineManager, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { getMaintenance } from 'libs/firebase/firestore/getMaintenance/getMaintenance'
 import { MAINTENANCE, Maintenance, RemoteStoreMaintenance } from 'libs/firebase/firestore/types'
@@ -13,7 +13,6 @@ export const useMaintenanceQuery = (): Maintenance => {
     queryFn: getMaintenance,
     staleTime: 1000 * 30,
     gcTime: 1000 * 30,
-    enabled: onlineManager.isOnline(),
     select: (data: DocumentData) => {
       const maintenanceIsOn = data?.[RemoteStoreMaintenance.MAINTENANCE_IS_ON]
       const rawMessage = data?.[RemoteStoreMaintenance.MAINTENANCE_MESSAGE]

--- a/src/features/search/api/useSearchResults/useSearchResults.ts
+++ b/src/features/search/api/useSearchResults/useSearchResults.ts
@@ -1,4 +1,4 @@
-import { onlineManager, useInfiniteQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import { SearchResponse } from 'algoliasearch/lite'
 import { uniqBy } from 'lodash'
 import flatten from 'lodash/flatten'
@@ -90,7 +90,6 @@ export const useSearchInfiniteQuery = (searchState: SearchState) => {
     // first page is 0
     initialPageParam: 0,
     getNextPageParam: ({ offers }) => getNextPageParam(offers),
-    enabled: onlineManager.isOnline(),
   })
 
   const hits: SearchOfferHits = useMemo(() => {

--- a/src/libs/firebase/firestore/featureFlags/queries/useFeatureFlagOptionsQuery.ts
+++ b/src/libs/firebase/firestore/featureFlags/queries/useFeatureFlagOptionsQuery.ts
@@ -1,4 +1,4 @@
-import { onlineManager, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import { getAllFeatureFlags } from 'libs/firebase/firestore/featureFlags/getAllFeatureFlags'
 import { FeatureFlagConfig, squads } from 'libs/firebase/firestore/featureFlags/types'
@@ -26,7 +26,6 @@ export const useFeatureFlagOptionsQuery = (
     queryKey: [QueryKeys.FEATURE_FLAGS],
     queryFn: getAllFeatureFlags,
     staleTime: 1000 * 60 * 60 * 24, // 24h (re-renders whole app because of usage of feature flag in the ThemeWrapper)
-    enabled: onlineManager.isOnline(),
   })
   const { logType } = useLogTypeFromRemoteConfig()
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41623

Les condition `enabled: onlineManager.isOnline(),` n'étaient évaluées qu'au lancement de l'app mais étaient tout le temps en false à cause de [cette ligne](https://github.com/pass-culture/pass-culture-app-native/blob/1f37dfe65b1581200d2f9a4f5b08878b35bb14f5/src/libs/react-query/ReactQueryClientProvider.tsx#L34). Cette ligne à pour but de partir du principe qu'il n'y a pas de réseau afin d'éviter que des calls se lancent s'il n'y a effectivement pas de réseau. Ensuite [ce code](https://github.com/pass-culture/pass-culture-app-native/blob/ba6f6fa54c6d5c2926086b7a8d2497fbe88b8525/src/libs/network/NetInfoWrapper.tsx) permet de définir correctement s'il y a du réseau ou non. Par défaut toutes les requetes react-query écoutent déjà le réseau ([voir NetworkMode](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery)) donc s'il y a effectivement du réseau les call vont se relancer tout seul. 
Le check pour la page de maintenance et de maj forcée ne se fait qu'au lancement de l'app donc ça reste pas idéal mais ça permet au moins que ça fonctionne à ce moment là alors qu'ajd ça ne fonctionne pas du tout. 
On pourra réfléchir pour faire mieux mais je pense que c'est un premier quick win rapide

