### PR TITLE
(PC-40895) refactor(reactions): use v2 routes

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -3691,7 +3691,18 @@ export interface ReactionCount {
   likes: number
 }
 /**
- * An enumeration.
+ * @export
+ * @interface ReactionCountV2
+ */
+export interface ReactionCountV2 {
+  /**
+   * @type {number}
+   * @memberof ReactionCountV2
+   */
+  likes: number
+}
+/**
+ * 
  * @export
  * @enum {string}
  */
@@ -5925,6 +5936,7 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
     },
     /**
      * @summary get_available_reactions <GET>
+     * @deprecated
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -6254,6 +6266,24 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
      */
     async getNativeV2ProfileEmailUpdateStatus(options: any = {}): Promise<FetchArgs> {
       let pathname = `/native/v2/profile/email_update/status`
+      let secureOptions = Object.assign(options, { credentials: 'omit' })
+      // authentication JWTAuth required
+      secureOptions = Object.assign(secureOptions, { credentials: 'include' })
+      const localVarRequestOptions = Object.assign({ method: 'GET' }, secureOptions)
+      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
+      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
+      return {
+        url: pathname,
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     * @summary get_available_reactions <GET>
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getNativeV2ReactionAvailable(options: any = {}): Promise<FetchArgs> {
+      let pathname = `/native/v2/reaction/available`
       let secureOptions = Object.assign(options, { credentials: 'omit' })
       // authentication JWTAuth required
       secureOptions = Object.assign(secureOptions, { credentials: 'include' })
@@ -6943,6 +6973,7 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
     },
     /**
      * @summary post_reaction <POST>
+     * @deprecated
      * @param {PostReactionRequest} body 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -7481,6 +7512,35 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
       }
     },
     /**
+     * @summary post_reaction <POST>
+     * @param {PostReactionRequest} body 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async postNativeV2Reaction(body: PostReactionRequest, options: any = {}): Promise<FetchArgs> {
+      // verify required parameter 'body' is not null or undefined
+      if (body === null || body === undefined) {
+        throw new RequiredError(
+          'body',
+          'Required parameter body was null or undefined when calling postNativeV2Reaction.'
+        )
+      }
+      let pathname = `/native/v2/reaction`
+      let secureOptions = Object.assign(options, { credentials: 'omit' })
+      // authentication JWTAuth required
+      secureOptions = Object.assign(secureOptions, { credentials: 'include' })
+      const localVarRequestOptions = Object.assign({ method: 'POST' }, secureOptions)
+      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
+      localVarHeaderParameter['Content-Type'] = 'application/json'
+      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
+      const needsSerialization = (<any>"PostReactionRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json'
+      localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "")
+      return {
+        url: pathname,
+        options: localVarRequestOptions,
+      }
+    },
+    /**
      * @summary refresh <POST>
      * @param {RefreshRequestV2} body 
      * @param {*} [options] Override http request option.
@@ -7808,6 +7868,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     /**
      * 
      * @summary get_available_reactions <GET>
+     * @deprecated
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -7957,6 +8018,17 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
      */
     async getNativeV2ProfileEmailUpdateStatus(options?: any): Promise<EmailUpdateStatusResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV2ProfileEmailUpdateStatus(options)
+      const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
+      return handleGeneratedApiResponse(response)
+    },
+    /**
+     * 
+     * @summary get_available_reactions <GET>
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getNativeV2ReactionAvailable(options?: any): Promise<GetAvailableReactionsResponse> {
+      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV2ReactionAvailable(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
       return handleGeneratedApiResponse(response)
     },
@@ -8260,6 +8332,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     /**
      * 
      * @summary post_reaction <POST>
+     * @deprecated
      * @param {PostReactionRequest} body 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -8493,6 +8566,18 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
      */
     async postNativeV2ProfileUpdateEmail(options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV2ProfileUpdateEmail(options)
+      const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
+      return handleGeneratedApiResponse(response)
+    },
+    /**
+     * 
+     * @summary post_reaction <POST>
+     * @param {PostReactionRequest} body 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async postNativeV2Reaction(body: PostReactionRequest, options?: any): Promise<EmptyResponse> {
+      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV2Reaction(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
       return handleGeneratedApiResponse(response)
     },
@@ -8781,6 +8866,7 @@ export class DefaultApi extends BaseAPI {
   /**
     * 
     * @summary get_available_reactions <GET>
+    * @deprecated
     * @param {*} [options] Override http request option.
     * @throws {RequiredError}
     * @memberof DefaultApi
@@ -8923,6 +9009,17 @@ export class DefaultApi extends BaseAPI {
   public async getNativeV2ProfileEmailUpdateStatus(options?: any) {
     const configuration = this.getConfiguration()
     return DefaultApiFp(this, configuration).getNativeV2ProfileEmailUpdateStatus(options)
+  }
+  /**
+    * 
+    * @summary get_available_reactions <GET>
+    * @param {*} [options] Override http request option.
+    * @throws {RequiredError}
+    * @memberof DefaultApi
+    */
+  public async getNativeV2ReactionAvailable(options?: any) {
+    const configuration = this.getConfiguration()
+    return DefaultApiFp(this, configuration).getNativeV2ReactionAvailable(options)
   }
   /**
     * 
@@ -9224,6 +9321,7 @@ export class DefaultApi extends BaseAPI {
   /**
     * 
     * @summary post_reaction <POST>
+    * @deprecated
     * @param {PostReactionRequest} body 
     * @param {*} [options] Override http request option.
     * @throws {RequiredError}
@@ -9459,6 +9557,18 @@ export class DefaultApi extends BaseAPI {
   public async postNativeV2ProfileUpdateEmail(options?: any) {
     const configuration = this.getConfiguration()
     return DefaultApiFp(this, configuration).postNativeV2ProfileUpdateEmail(options)
+  }
+  /**
+    * 
+    * @summary post_reaction <POST>
+    * @param {PostReactionRequest} body 
+    * @param {*} [options] Override http request option.
+    * @throws {RequiredError}
+    * @memberof DefaultApi
+    */
+  public async postNativeV2Reaction(body: PostReactionRequest, options?: any) {
+    const configuration = this.getConfiguration()
+    return DefaultApiFp(this, configuration).postNativeV2Reaction(body, options)
   }
   /**
     * 

--- a/src/features/bookings/pages/Bookings/Bookings.native.test.tsx
+++ b/src/features/bookings/pages/Bookings/Bookings.native.test.tsx
@@ -69,7 +69,7 @@ describe('Bookings', () => {
     mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', subcategoriesDataTest)
     setFeatureFlags()
     mockServer.getApi<GetAvailableReactionsResponse>(
-      '/v1/reaction/available',
+      '/v2/reaction/available',
       availableReactionsSnap
     )
   })

--- a/src/features/reactions/queries/useAvailableReactionQuery.test.ts
+++ b/src/features/reactions/queries/useAvailableReactionQuery.test.ts
@@ -12,7 +12,7 @@ jest.mock('features/auth/context/AuthContext', () => ({
 
 describe('useAvailableReaction', () => {
   beforeEach(() => {
-    mockServer.getApi('/v1/reaction/available', availableReactionsSnap)
+    mockServer.getApi('/v2/reaction/available', availableReactionsSnap)
   })
 
   it('should fetch available reactions correctly', async () => {
@@ -22,7 +22,7 @@ describe('useAvailableReaction', () => {
   })
 
   it('should return an empty object if API response is empty', async () => {
-    mockServer.getApi('/v1/reaction/available', {})
+    mockServer.getApi('/v2/reaction/available', {})
 
     const { result } = renderUseAvailableReaction()
 
@@ -30,7 +30,7 @@ describe('useAvailableReaction', () => {
   })
 
   it('should handle errors correctly', async () => {
-    mockServer.getApi('/v1/reaction/available', { responseOptions: { statusCode: 400, data: {} } })
+    mockServer.getApi('/v2/reaction/available', { responseOptions: { statusCode: 400, data: {} } })
 
     const { result } = renderUseAvailableReaction()
 

--- a/src/features/reactions/queries/useAvailableReactionQuery.ts
+++ b/src/features/reactions/queries/useAvailableReactionQuery.ts
@@ -9,7 +9,7 @@ export const useAvailableReactionQuery = () => {
 
   return useQuery({
     queryKey: [QueryKeys.AVAILABLE_REACTION],
-    queryFn: () => api.getNativeV1ReactionAvailable(),
+    queryFn: () => api.getNativeV2ReactionAvailable(),
     enabled: isLoggedIn,
   })
 }

--- a/src/features/reactions/queries/useReactionMutation.test.ts
+++ b/src/features/reactions/queries/useReactionMutation.test.ts
@@ -19,7 +19,7 @@ const setup = (queryClient: QueryClient) => {
 
 describe('useReactionMutation', () => {
   it('should call reaction mutation function', async () => {
-    mockServer.postApi('/v1/reaction', { offerId: 1, reactionType: ReactionTypeEnum.LIKE })
+    mockServer.postApi('/v2/reaction', { offerId: 1, reactionType: ReactionTypeEnum.LIKE })
 
     const { result } = renderUseReactionMutation()
 
@@ -29,7 +29,7 @@ describe('useReactionMutation', () => {
   })
 
   it('should call reaction mutate function with error', async () => {
-    mockServer.postApi('/v1/reaction', { responseOptions: { statusCode: 400, data: {} } })
+    mockServer.postApi('/v2/reaction', { responseOptions: { statusCode: 400, data: {} } })
 
     const { result } = renderUseReactionMutation()
 
@@ -42,7 +42,7 @@ describe('useReactionMutation', () => {
   })
 
   it('should invalidate bookings queries on success', async () => {
-    mockServer.postApi('/v1/reaction', { offerId: 1, reactionType: ReactionTypeEnum.LIKE })
+    mockServer.postApi('/v2/reaction', { offerId: 1, reactionType: ReactionTypeEnum.LIKE })
     const { result } = renderUseReactionMutation()
 
     result.current.mutate({ reactions: [{ offerId: 1, reactionType: ReactionTypeEnum.LIKE }] })
@@ -56,7 +56,7 @@ describe('useReactionMutation', () => {
   })
 
   it('should invalidate bookings queries on error', async () => {
-    mockServer.postApi('/v1/reaction', { responseOptions: { statusCode: 400, data: {} } })
+    mockServer.postApi('/v2/reaction', { responseOptions: { statusCode: 400, data: {} } })
     const { result } = renderUseReactionMutation()
 
     result.current.mutate({ reactions: [{ offerId: 1, reactionType: ReactionTypeEnum.LIKE }] })

--- a/src/features/reactions/queries/useReactionMutation.ts
+++ b/src/features/reactions/queries/useReactionMutation.ts
@@ -22,7 +22,7 @@ export const useReactionMutation = () => {
   const BOOKING_KEYS = [QueryKeys.BOOKINGSV2, QueryKeys.BOOKINGSLIST]
 
   return useMutation({
-    mutationFn: (reactionRequest: PostReactionRequest) => api.postNativeV1Reaction(reactionRequest),
+    mutationFn: (reactionRequest: PostReactionRequest) => api.postNativeV2Reaction(reactionRequest),
 
     onMutate: async (reactionRequest: PostReactionRequest) => {
       const offerId = reactionRequest.reactions[0]?.offerId


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-40895

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
