### PR TITLE
(PC-41627) fix(cheatcodes): AB test RadioButtonGroup in native

### DIFF
--- a/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
@@ -425,9 +425,9 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
                       />
                     </View>
                     <View
+                      sizing="hug"
                       style={
                         {
-                          "flexBasis": 0,
                           "flexGrow": 1,
                           "flexShrink": 1,
                         }
@@ -542,9 +542,9 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
                       variant="default"
                     />
                     <View
+                      sizing="hug"
                       style={
                         {
-                          "flexBasis": 0,
                           "flexGrow": 1,
                           "flexShrink": 1,
                         }
@@ -659,9 +659,9 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
                       variant="default"
                     />
                     <View
+                      sizing="hug"
                       style={
                         {
-                          "flexBasis": 0,
                           "flexGrow": 1,
                           "flexShrink": 1,
                         }

--- a/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
@@ -531,9 +531,9 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           variant="default"
                         />
                         <View
+                          sizing="hug"
                           style={
                             {
-                              "flexBasis": 0,
                               "flexGrow": 1,
                               "flexShrink": 1,
                             }
@@ -648,9 +648,9 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           variant="default"
                         />
                         <View
+                          sizing="hug"
                           style={
                             {
-                              "flexBasis": 0,
                               "flexGrow": 1,
                               "flexShrink": 1,
                             }
@@ -765,9 +765,9 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           variant="default"
                         />
                         <View
+                          sizing="hug"
                           style={
                             {
-                              "flexBasis": 0,
                               "flexGrow": 1,
                               "flexShrink": 1,
                             }
@@ -910,9 +910,9 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           />
                         </View>
                         <View
+                          sizing="hug"
                           style={
                             {
-                              "flexBasis": 0,
                               "flexGrow": 1,
                               "flexShrink": 1,
                             }
@@ -1027,9 +1027,9 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           variant="default"
                         />
                         <View
+                          sizing="hug"
                           style={
                             {
-                              "flexBasis": 0,
                               "flexGrow": 1,
                               "flexShrink": 1,
                             }
@@ -1144,9 +1144,9 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           variant="default"
                         />
                         <View
+                          sizing="hug"
                           style={
                             {
-                              "flexBasis": 0,
                               "flexGrow": 1,
                               "flexShrink": 1,
                             }
@@ -1261,9 +1261,9 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           variant="default"
                         />
                         <View
+                          sizing="hug"
                           style={
                             {
-                              "flexBasis": 0,
                               "flexGrow": 1,
                               "flexShrink": 1,
                             }
@@ -1378,9 +1378,9 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           variant="default"
                         />
                         <View
+                          sizing="hug"
                           style={
                             {
-                              "flexBasis": 0,
                               "flexGrow": 1,
                               "flexShrink": 1,
                             }
@@ -1495,9 +1495,9 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           variant="default"
                         />
                         <View
+                          sizing="hug"
                           style={
                             {
-                              "flexBasis": 0,
                               "flexGrow": 1,
                               "flexShrink": 1,
                             }
@@ -1612,9 +1612,9 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           variant="default"
                         />
                         <View
+                          sizing="hug"
                           style={
                             {
-                              "flexBasis": 0,
                               "flexGrow": 1,
                               "flexShrink": 1,
                             }

--- a/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
@@ -536,7 +536,6 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
                     <View
                       style={
                         {
-                          "flexBasis": 0,
                           "flexGrow": 1,
                           "flexShrink": 1,
                         }
@@ -692,7 +691,6 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
                     <View
                       style={
                         {
-                          "flexBasis": 0,
                           "flexGrow": 1,
                           "flexShrink": 1,
                         }
@@ -897,7 +895,6 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
                     <View
                       style={
                         {
-                          "flexBasis": 0,
                           "flexGrow": 1,
                           "flexShrink": 1,
                         }

--- a/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
@@ -545,7 +545,6 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
                       <View
                         style={
                           {
-                            "flexBasis": 0,
                             "flexGrow": 1,
                             "flexShrink": 1,
                           }
@@ -694,7 +693,6 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
                       <View
                         style={
                           {
-                            "flexBasis": 0,
                             "flexGrow": 1,
                             "flexShrink": 1,
                           }
@@ -892,7 +890,6 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
                       <View
                         style={
                           {
-                            "flexBasis": 0,
                             "flexGrow": 1,
                             "flexShrink": 1,
                           }

--- a/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
@@ -597,7 +597,6 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
                       <View
                         style={
                           {
-                            "flexBasis": 0,
                             "flexGrow": 1,
                             "flexShrink": 1,
                           }
@@ -753,7 +752,6 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
                       <View
                         style={
                           {
-                            "flexBasis": 0,
                             "flexGrow": 1,
                             "flexShrink": 1,
                           }

--- a/__snapshots__/features/profile/pages/Appearance/Appearance.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Appearance/Appearance.native.test.tsx.native-snap
@@ -584,7 +584,6 @@ exports[`Appearance should render correctly 1`] = `
                         <View
                           style={
                             {
-                              "flexBasis": 0,
                               "flexGrow": 1,
                               "flexShrink": 1,
                             }
@@ -754,7 +753,6 @@ exports[`Appearance should render correctly 1`] = `
                         <View
                           style={
                             {
-                              "flexBasis": 0,
                               "flexGrow": 1,
                               "flexShrink": 1,
                             }
@@ -952,7 +950,6 @@ exports[`Appearance should render correctly 1`] = `
                         <View
                           style={
                             {
-                              "flexBasis": 0,
                               "flexGrow": 1,
                               "flexShrink": 1,
                             }

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -491,9 +491,9 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                         />
                       </View>
                       <View
+                        sizing="hug"
                         style={
                           {
-                            "flexBasis": 0,
                             "flexGrow": 1,
                             "flexShrink": 1,
                           }
@@ -629,9 +629,9 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                         variant="default"
                       />
                       <View
+                        sizing="hug"
                         style={
                           {
-                            "flexBasis": 0,
                             "flexGrow": 1,
                             "flexShrink": 1,
                           }

--- a/src/cheatcodes/pages/others/CheatcodesABTest/CheatcodesHeaderABTest.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesABTest/CheatcodesHeaderABTest.tsx
@@ -15,17 +15,21 @@ export const CheatcodeHeaderABTest = ({
 }) => {
   return (
     <HeaderRow gap={16}>
-      <Typo.BodyItalicAccent>
-        {forcedCount > 0
-          ? `${forcedCount} test${forcedCount > 1 ? 's' : ''} forcé${forcedCount > 1 ? 's' : ''} — ${total} au total`
-          : `Aucun forçage — ${total} au total`}
-      </Typo.BodyItalicAccent>
+      <TextWrapper>
+        <Typo.BodyItalicAccent>
+          {forcedCount > 0
+            ? `${forcedCount} test${forcedCount > 1 ? 's' : ''} forcé${forcedCount > 1 ? 's' : ''} — ${total} au total`
+            : `Aucun forçage — ${total} au total`}
+        </Typo.BodyItalicAccent>
+      </TextWrapper>
       {forcedCount > 0 ? (
-        <Button
-          variant="tertiary"
-          wording="Tout réinitialiser"
-          onPress={abTestOverridesActions.resetAll}
-        />
+        <ButtonContainer>
+          <Button
+            variant="tertiary"
+            wording="Tout réinitialiser"
+            onPress={abTestOverridesActions.resetAll}
+          />
+        </ButtonContainer>
       ) : null}
     </HeaderRow>
   )
@@ -35,3 +39,11 @@ const HeaderRow = styled(ViewGap)(() => ({
   flexDirection: 'row',
   justifyContent: 'space-between',
 }))
+
+const TextWrapper = styled.View({
+  flex: 1,
+})
+
+const ButtonContainer = styled.View({
+  flexShrink: 0,
+})

--- a/src/cheatcodes/pages/others/CheatcodesABTest/CheatcodesScreenABTest.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesABTest/CheatcodesScreenABTest.tsx
@@ -17,7 +17,7 @@ export function CheatcodesScreenABTest(): React.JSX.Element {
   const total = AB_TESTS_REGISTRY.length
 
   return (
-    <CheatcodesTemplateScreen title="Cheatcodes AB Test" onGoBack={goBack}>
+    <CheatcodesTemplateScreen title="Cheatcodes AB Test" onGoBack={goBack} flexDirection="column">
       <CheatcodeHeaderABTest forcedCount={forcedCount} total={total} />
       <StyledSeparator />
       <FlatList

--- a/src/ui/designSystem/RadioButton/RadioButtonDefault.tsx
+++ b/src/ui/designSystem/RadioButton/RadioButtonDefault.tsx
@@ -52,7 +52,7 @@ export const RadioButtonDefault = ({
       {...accessibleRadioProps({ checked: selected, label, accessibilityLabel })}>
       <ContentContainer>
         <RadioCircle radioState={radioState} variant="default" hoverProps={hoverProps} />
-        <RightBox radioState={radioState} label={label} hoverProps={hoverProps} />
+        <RightBox radioState={radioState} label={label} hoverProps={hoverProps} sizing={sizing} />
       </ContentContainer>
     </RadioButtonDefaultContainer>
   )
@@ -82,13 +82,14 @@ type RightBoxProps = {
   hoverProps: HoverProps
   radioState: RadioStateObject
   label: string
+  sizing?: SelectableSizing
   children?: React.JSX.Element | null
 }
 
-export const RightBox = ({ radioState, label, hoverProps, children }: RightBoxProps) => {
+export const RightBox = ({ radioState, label, hoverProps, sizing, children }: RightBoxProps) => {
   const Label = radioState.selected ? RadioLabelTextSelected : RadioLabelText
   return (
-    <RightBoxContainer>
+    <RightBoxContainer sizing={sizing}>
       <Label radioState={radioState} {...hoverProps}>
         {label}
       </Label>
@@ -103,7 +104,11 @@ export const ContentContainer = styled.View(({ theme }) => ({
   columnGap: theme.designSystem.size.spacing.m,
 }))
 
-const RightBoxContainer = styled.View({ flex: 1 })
+const RightBoxContainer = styled.View<{ sizing?: SelectableSizing }>(({ sizing }) => ({
+  flex: sizing === 'fill' ? 1 : undefined,
+  flexShrink: 1,
+  flexGrow: 1,
+}))
 
 type ContainerProps = {
   radioState: RadioStateObject


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41627

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-04 at 16 59 08" src="https://github.com/user-attachments/assets/b49bb631-7e4f-4ffc-8580-1c441f59775c" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-04 at 17 00 51" src="https://github.com/user-attachments/assets/a30b8792-3e31-4fe7-88da-97642c7986ba" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-04 at 16 57 54" src="https://github.com/user-attachments/assets/0b83b572-bc4e-46ef-a238-3ab1e08e86fa" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-04 at 17 41 58" src="https://github.com/user-attachments/assets/43666c62-c888-4fff-89b2-1d95d67d22a1" />|
| Android          |<img width="1080" height="2400" alt="Screenshot_1777906744" src="https://github.com/user-attachments/assets/a113b4b3-d153-43d9-9a42-d455936726b9" /> <img width="1080" height="2400" alt="Screenshot_1777906844" src="https://github.com/user-attachments/assets/7871e414-6cbf-4255-85a7-011959b7eaf9" />|<img width="1080" height="2400" alt="Screenshot_1777906687" src="https://github.com/user-attachments/assets/08a3d905-3ed6-452a-bf60-0ec2b1e78aae" /> <img width="1080" height="2400" alt="Screenshot_1777906769" src="https://github.com/user-attachments/assets/b1bfb1b2-06d6-431f-8fe2-fc55b7edd705" />|
| Phone - Chrome   |<img width="406" height="689" alt="Capture d’écran 2026-05-04 à 16 58 59" src="https://github.com/user-attachments/assets/a2f57ccc-03f3-41b3-8c80-8bf5a442ad2e" /> <img width="406" height="695" alt="Capture d’écran 2026-05-04 à 17 00 04" src="https://github.com/user-attachments/assets/421f6843-9de5-40f4-8e3b-9755ba1b8a4b" />|<img width="420" height="718" alt="Capture d’écran 2026-05-04 à 16 58 21" src="https://github.com/user-attachments/assets/6b823772-d1bb-4cca-b68f-767555e8184c" /> <img width="406" height="695" alt="Capture d’écran 2026-05-04 à 17 00 04" src="https://github.com/user-attachments/assets/2d44f737-b03b-44df-8f2a-480ea7a3e1f3" />|
| Desktop - Chrome |<img width="1512" height="770" alt="Capture d’écran 2026-05-04 à 17 30 37" src="https://github.com/user-attachments/assets/ffa9035a-189b-44db-aada-208936951abf" /> <img width="1509" height="761" alt="Capture d’écran 2026-05-04 à 17 00 34" src="https://github.com/user-attachments/assets/a2a80b99-0cba-4e03-aa99-73014e68b519" />|<img width="1503" height="765" alt="Capture d’écran 2026-05-04 à 16 58 31" src="https://github.com/user-attachments/assets/c97dd2ab-8d4c-4c56-b242-18c79d2c19a6" /> <img width="1505" height="762" alt="Capture d’écran 2026-05-04 à 16 59 55" src="https://github.com/user-attachments/assets/6529dbbd-8513-4ea6-b509-1ff32eb254f2" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
