### PR TITLE
(PC-40823) feat(onboarding): add trackers to monitore onbording exit

### DIFF
--- a/src/features/auth/pages/signup/SignupForm.tsx
+++ b/src/features/auth/pages/signup/SignupForm.tsx
@@ -15,7 +15,7 @@ import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { getTabHookConfig } from 'features/navigation/TabBar/getTabHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
-import { getSSOLoginMethod } from 'libs/analytics/logEventAnalytics'
+import { getSSOLoginMethod, CTAexitActivationFlow } from 'libs/analytics/logEventAnalytics'
 import { analytics } from 'libs/analytics/provider'
 import { firebaseAnalytics } from 'libs/firebase/analytics/analytics'
 import { eventMonitoring } from 'libs/monitoring/services'
@@ -187,10 +187,25 @@ export const SignupForm: FunctionComponent<{ currentStep?: number }> = ({ curren
     }
   }
 
+  const onExitPress = (origin_detail: CTAexitActivationFlow) =>
+    analytics.logHasExitedActivationFlow({
+      from: 'signupform',
+      origin_detail,
+    })
+
+  const closeSignup = () => {
+    onExitPress('Close')
+    navigateToHome()
+  }
+  const exitSignup = () => {
+    onExitPress('Exit')
+    showQuitSignupModal()
+  }
+
   const RightButton = isConfirmationEmailSentStep ? (
-    <RightButtonText onClose={navigateToHome} wording="Fermer" />
+    <RightButtonText onClose={closeSignup} wording="Fermer" />
   ) : (
-    <RightButtonText onClose={showQuitSignupModal} wording="Quitter" />
+    <RightButtonText onClose={exitSignup} wording="Quitter" />
   )
 
   return (

--- a/src/features/identityCheck/pages/Stepper.tsx
+++ b/src/features/identityCheck/pages/Stepper.tsx
@@ -88,6 +88,13 @@ export const Stepper = () => {
     }
   }, [params?.from, stepToComplete?.name])
 
+  const onExitPress = () => {
+    void analytics.logHasExitedActivationFlow({
+      from: 'stepper',
+      origin_detail: 'Quit',
+    })
+    showQuitIdentityCheckModal()
+  }
   const stepList = (
     <StepList currentStepIndex={currentStepIndex}>
       {steps.map((step, index) => (
@@ -128,7 +135,7 @@ export const Stepper = () => {
             color="neutral"
             icon={Invalidate}
             wording="Abandonner"
-            onPress={showQuitIdentityCheckModal}
+            onPress={onExitPress}
             accessibilityRole={AccessibilityRole.BUTTON}
           />
         </QuitButtonContainer>

--- a/src/features/identityCheck/pages/identification/ubble/ComeBackLater.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/ComeBackLater.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, useEffect } from 'react'
 import styled from 'styled-components/native'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
+import { analytics } from 'libs/analytics/provider'
 import { BatchEvent, BatchProfile } from 'libs/react-native-batch'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { IdCardInvalid } from 'ui/svg/icons/IdCardInvalid'
@@ -9,8 +10,15 @@ import { Typo } from 'ui/theme'
 
 export const ComeBackLater: FunctionComponent = () => {
   useEffect(() => {
-    BatchProfile.trackEvent(BatchEvent.screenViewComeBackLater)
+    void BatchProfile.trackEvent(BatchEvent.screenViewComeBackLater)
   }, [])
+
+  const onExitPress = () => {
+    void analytics.logHasExitedActivationFlow({
+      from: 'comebacklater',
+      origin_detail: 'IdentifyLater',
+    })
+  }
 
   return (
     <GenericInfoPage
@@ -20,6 +28,7 @@ export const ComeBackLater: FunctionComponent = () => {
       buttonPrimary={{
         wording: 'M’identifier plus tard',
         navigateTo: navigateToHomeConfig,
+        onBeforeNavigate: onExitPress,
       }}>
       <StyledText>
         <Typo.Body>Pour profiter du pass Culture, tu dois avoir </Typo.Body>

--- a/src/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import styled from 'styled-components/native'
 
+import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
 import { BatchEvent, BatchProfile } from 'libs/react-native-batch'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -10,8 +11,15 @@ import { Typo } from 'ui/theme'
 
 export const ExpiredOrLostID = (): React.JSX.Element => {
   useEffect(() => {
-    BatchProfile.trackEvent(BatchEvent.screenViewExpiredOrLostId)
+    void BatchProfile.trackEvent(BatchEvent.screenViewExpiredOrLostId)
   }, [])
+
+  const onExitPress = () => {
+    void analytics.logHasExitedActivationFlow({
+      from: 'expiredorlostid',
+      origin_detail: 'GoToDemarcheNumerique',
+    })
+  }
 
   return (
     <GenericInfoPage
@@ -21,6 +29,7 @@ export const ExpiredOrLostID = (): React.JSX.Element => {
       buttonPrimary={{
         wording: 'Aller sur demarche.numerique.gouv.fr',
         externalNav: { url: env.DMS_FRENCH_CITIZEN_URL },
+        onBeforeNavigate: onExitPress,
       }}>
       <ViewGap gap={6}>
         <StyledBody>

--- a/src/features/onboarding/pages/onboarding/OnboardingAgeInformation.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingAgeInformation.tsx
@@ -34,6 +34,10 @@ export const OnboardingAgeInformation = ({ route }: Props): React.JSX.Element | 
   }
 
   const onLaterPress = () => {
+    void analytics.logHasExitedActivationFlow({
+      from: 'onboardingageinformation',
+      origin_detail: 'FinishLater',
+    })
     navigateToHomeWithReset()
   }
 

--- a/src/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.tsx
@@ -3,15 +3,28 @@ import React from 'react'
 import { useNavigateToHomeWithReset } from 'features/navigation/helpers/useNavigateToHomeWithReset'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
 import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
+import { analytics } from 'libs/analytics/__mocks__/provider'
+import { CTAexitActivationFlow } from 'libs/analytics/logEventAnalytics'
 import QpiThanks from 'ui/animations/qpi_thanks.json'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 
 export const OnboardingGeneralPublicWelcome = () => {
   const { navigateToHomeWithReset } = useNavigateToHomeWithReset()
 
+  const onExitPress = (origin_detail: CTAexitActivationFlow) =>
+    analytics.logHasExitedActivationFlow({
+      from: 'onboardinggeneralpublicwelcome',
+      origin_detail,
+    })
+
+  const skipAction = () => {
+    void onExitPress('Skip')
+    navigateToHomeWithReset()
+  }
+
   return (
     <GenericInfoPage
-      withSkipAction={navigateToHomeWithReset}
+      withSkipAction={skipAction}
       animation={QpiThanks}
       animationColoringMode="targeted"
       animationTargetShapeNames={['Fond 1', 'Gradient Fill 1']}
@@ -26,6 +39,7 @@ export const OnboardingGeneralPublicWelcome = () => {
         },
       }}
       buttonSecondary={{
+        onBeforeNavigate: () => onExitPress('AccessCatalog'),
         wording: 'Accéder au catalogue',
         navigateTo: {
           screen: homeNavigationConfig[0],

--- a/src/features/onboarding/pages/onboarding/OnboardingNotEligible.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingNotEligible.tsx
@@ -3,12 +3,18 @@ import React from 'react'
 import { useNavigateToHomeWithReset } from 'features/navigation/helpers/useNavigateToHomeWithReset'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
 import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
+import { analytics } from 'libs/analytics/__mocks__/provider'
 import BirthdayCake from 'ui/animations/onboarding_birthday_cake.json'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 
 export const OnboardingNotEligible = () => {
   const { navigateToHomeWithReset } = useNavigateToHomeWithReset()
 
+  const onExitPress = () =>
+    analytics.logHasExitedActivationFlow({
+      from: 'onboardingnoteligible',
+      origin_detail: 'AccessCatalog',
+    })
   return (
     <GenericInfoPage
       withSkipAction={navigateToHomeWithReset}
@@ -25,6 +31,7 @@ export const OnboardingNotEligible = () => {
         },
       }}
       buttonSecondary={{
+        onBeforeNavigate: onExitPress,
         wording: 'Accéder au catalogue',
         navigateTo: {
           screen: homeNavigationConfig[0],

--- a/src/features/onboarding/pages/onboarding/OnboardingWelcome.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingWelcome.tsx
@@ -20,12 +20,16 @@ import { getSpacing, Spacer, Typo } from 'ui/theme'
 const setHasSeenTutorials = () => storage.saveObject('has_seen_tutorials', true)
 
 const onStartPress = () => {
-  analytics.logOnboardingStarted({ type: 'start' })
+  void analytics.logOnboardingStarted({ type: 'start' })
   setHasSeenTutorials()
 }
 
 const onLoginPress = () => {
-  analytics.logOnboardingStarted({ type: 'login' })
+  void analytics.logOnboardingStarted({ type: 'login' })
+  void analytics.logHasExitedActivationFlow({
+    from: 'onboardingwelcome',
+    origin_detail: 'Login',
+  })
   setHasSeenTutorials()
 }
 

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -108,6 +108,7 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logHasCorrectedEmail: jest.fn(),
   logHasDismissedAppSharingModal: jest.fn(),
   logHasDismissedModal: jest.fn(),
+  logHasExitedActivationFlow: jest.fn(),
   logHasMadeAChoiceForCookies: jest.fn(),
   logHasOpenedAccessibilityAccordion: jest.fn(),
   logHasOpenedCookiesAccordion: jest.fn(),

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -93,6 +93,17 @@ export function getSSOLoginMethod(
   return `${kind === 'login' ? 'fromLogin' : 'fromSignup'}${suffix}` as LoginRoutineMethod
 }
 
+export type CTAexitActivationFlow =
+  | 'Skip'
+  | 'Exit'
+  | 'AccessCatalog'
+  | 'FinishLater'
+  | 'Quit'
+  | 'IdentifyLater'
+  | 'Login'
+  | 'Close'
+  | 'GoToDemarcheNumerique'
+
 /* eslint sort-keys-fix/sort-keys-fix: "error" */
 export const logEventAnalytics = {
   logAcceptNotifications: () =>
@@ -449,6 +460,17 @@ export const logEventAnalytics = {
     seenDuration: number
     videoDuration: number
   }) => analytics.logEvent({ firebase: AnalyticsEvent.HAS_DISMISSED_MODAL }, params),
+  logHasExitedActivationFlow: ({
+    from,
+    origin_detail,
+  }: {
+    from: Referrals
+    origin_detail: CTAexitActivationFlow
+  }) =>
+    analytics.logEvent(
+      { firebase: AnalyticsEvent.HAS_EXITED_ACTIVATION_FLOW },
+      { from, origin_detail }
+    ),
   logHasMadeAChoiceForCookies: ({ from, type }: { from: string; type: CookiesChoiceByCategory }) =>
     analytics.logEvent(
       { firebase: AnalyticsEvent.HAS_MADE_A_CHOICE_FOR_COOKIES },

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -112,6 +112,7 @@ export enum AnalyticsEvent {
   HAS_CORRECTED_EMAIL = 'HasCorrectedEmail',
   HAS_DISMISSED_APP_SHARING_MODAL = 'HasDismissedAppSharingModal',
   HAS_DISMISSED_MODAL = 'HasDismissedModal',
+  HAS_EXITED_ACTIVATION_FLOW = 'HasExitedActivationFlow',
   HAS_MADE_A_CHOICE_FOR_COOKIES = 'HasMadeAChoiceForCookies',
   HAS_OPENED_ACCESSIBILITY_ACCORDION = 'HasOpenedAccessibilityAccordion',
   HAS_OPENED_COOKIES_ACCORDION = 'HasOpenedCookiesAccordion',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-40823

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_
<img width="416" height="110" alt="Capture d’écran 2026-05-05 à 15 51 50" src="https://github.com/user-attachments/assets/381c9434-37fb-4f39-a634-ad3f4a2ad6bf" />

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
