### PR TITLE
(PC-41606) fix(home): use new RecommendationApiParams typing to send correctly call_id params in ModuleDisplayedOnHomePage log

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -3720,12 +3720,12 @@ export interface RecommendationApiParams {
    * @type {string | null}
    * @memberof RecommendationApiParams
    */
-  ab_test?: string | null
+  abTest?: string | null
   /**
    * @type {string | null}
    * @memberof RecommendationApiParams
    */
-  call_id?: string | null
+  callId?: string | null
   /**
    * @type {boolean | null}
    * @memberof RecommendationApiParams
@@ -3735,27 +3735,32 @@ export interface RecommendationApiParams {
    * @type {boolean | null}
    * @memberof RecommendationApiParams
    */
-  geo_located?: boolean | null
+  geoLocated?: boolean | null
   /**
    * @type {string | null}
    * @memberof RecommendationApiParams
    */
-  model_endpoint?: string | null
+  modelEndpoint?: string | null
   /**
    * @type {string | null}
    * @memberof RecommendationApiParams
    */
-  model_name?: string | null
+  modelName?: string | null
   /**
    * @type {string | null}
    * @memberof RecommendationApiParams
    */
-  model_version?: string | null
+  modelOrigin?: string | null
   /**
    * @type {string | null}
    * @memberof RecommendationApiParams
    */
-  reco_origin?: string | null
+  modelVersion?: string | null
+  /**
+   * @type {string | null}
+   * @memberof RecommendationApiParams
+   */
+  recoOrigin?: string | null
 }
 /**
  * An enumeration.

--- a/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
@@ -103,13 +103,13 @@ jest.mock('queries/searchVenuesOffer/useSearchVenueOffersInfiniteQuery', () => (
 }))
 
 const apiRecoParams: RecommendationApiParams = {
-  call_id: '1',
+  callId: '1',
   filtered: true,
-  geo_located: false,
-  model_endpoint: 'default',
-  model_name: 'similar_offers_default_prod',
-  model_version: 'similar_offers_clicks_v2_1_prod_v_20230317T173445',
-  reco_origin: 'default',
+  geoLocated: false,
+  modelEndpoint: 'default',
+  modelName: 'similar_offers_default_prod',
+  modelVersion: 'similar_offers_clicks_v2_1_prod_v_20230317T173445',
+  recoOrigin: 'default',
 }
 
 jest.mock('libs/firebase/analytics/analytics')

--- a/src/features/home/components/modules/HomeModule.native.test.tsx
+++ b/src/features/home/components/modules/HomeModule.native.test.tsx
@@ -208,13 +208,13 @@ describe('<HomeModule />', () => {
   it('should display RecommendationModule', async () => {
     const recommendedOffers: SimilarOffersResponse = {
       params: {
-        call_id: 'c2b19286-a4e9-4aef-9bab-3dcbbd631f0c',
+        callId: 'c2b19286-a4e9-4aef-9bab-3dcbbd631f0c',
         filtered: true,
-        geo_located: true,
-        model_endpoint: 'default',
-        model_name: 'similar_offers_default_prod',
-        model_version: 'similar_offers_clicks_v2_1_prod_v_20230428T220000',
-        reco_origin: 'default',
+        geoLocated: true,
+        modelEndpoint: 'default',
+        modelName: 'similar_offers_default_prod',
+        modelVersion: 'similar_offers_clicks_v2_1_prod_v_20230428T220000',
+        recoOrigin: 'default',
       },
       results: ['102280', '102272'],
     }

--- a/src/features/home/components/modules/HomeModule.web.test.tsx
+++ b/src/features/home/components/modules/HomeModule.web.test.tsx
@@ -117,13 +117,13 @@ describe('<HomeModule />', () => {
   it('Recommendation module should not have basic accessibility issues', async () => {
     const recommendedOffers: SimilarOffersResponse = {
       params: {
-        call_id: 'c2b19286-a4e9-4aef-9bab-3dcbbd631f0c',
+        callId: 'c2b19286-a4e9-4aef-9bab-3dcbbd631f0c',
         filtered: true,
-        geo_located: true,
-        model_endpoint: 'default',
-        model_name: 'similar_offers_default_prod',
-        model_version: 'similar_offers_clicks_v2_1_prod_v_20230428T220000',
-        reco_origin: 'default',
+        geoLocated: true,
+        modelEndpoint: 'default',
+        modelName: 'similar_offers_default_prod',
+        modelVersion: 'similar_offers_clicks_v2_1_prod_v_20230428T220000',
+        recoOrigin: 'default',
       },
       results: ['102280', '102272'],
     }

--- a/src/features/home/components/modules/OffersModule.tsx
+++ b/src/features/home/components/modules/OffersModule.tsx
@@ -134,7 +134,7 @@ export const OffersModule = (props: OffersModuleProps) => {
         hybridModuleOffsetIndex: props.recommendationParameters
           ? hybridModuleOffsetIndex
           : undefined,
-        call_id: props.recommendationParameters ? recommendationApiParams?.call_id : undefined,
+        call_id: props.recommendationParameters ? recommendationApiParams?.callId : undefined,
         offers: (offersToDisplay as Offer[]).map((item) => item.objectID),
       })
     }
@@ -147,7 +147,7 @@ export const OffersModule = (props: OffersModuleProps) => {
     offersToDisplay,
     playlistItems,
     props.recommendationParameters,
-    recommendationApiParams?.call_id,
+    recommendationApiParams?.callId,
     shouldModuleBeDisplayed,
   ])
 

--- a/src/features/home/components/modules/RecommendationModule.native.test.tsx
+++ b/src/features/home/components/modules/RecommendationModule.native.test.tsx
@@ -18,8 +18,8 @@ const displayParameters: DisplayParametersFields = {
 }
 
 const defaultRecommendationApiParams: RecommendationApiParams = {
-  call_id: '1',
-  reco_origin: 'unknown',
+  callId: '1',
+  recoOrigin: 'unknown',
 }
 
 const mockUseHomeRecommendedOffers = jest.fn().mockReturnValue({

--- a/src/features/home/components/modules/RecommendationModule.tsx
+++ b/src/features/home/components/modules/RecommendationModule.tsx
@@ -65,7 +65,7 @@ export const RecommendationModule = (props: RecommendationModuleProps) => {
   useEffect(() => {
     if (shouldModuleBeDisplayed) {
       void analytics.logModuleDisplayedOnHomepage({
-        call_id: recommendationApiParams?.call_id,
+        call_id: recommendationApiParams?.callId,
         moduleId,
         moduleType: ContentTypes.RECOMMENDATION,
         index,
@@ -93,7 +93,7 @@ export const RecommendationModule = (props: RecommendationModuleProps) => {
   )
 
   const handleOnViewableItemsChanged = (items: Pick<ViewToken, 'key' | 'index'>[]) => {
-    onViewableItemsChanged?.(items, recommendationApiParams?.call_id)
+    onViewableItemsChanged?.(items, recommendationApiParams?.callId)
   }
 
   const { itemWidth, itemHeight } = getPlaylistItemDimensionsFromLayout(displayParameters.layout)

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -120,13 +120,13 @@ const fetchOffersSpy = jest.spyOn(fetchAlgoliaOffer, 'fetchOffers')
 fetchOffersSpy.mockResolvedValue({} as fetchAlgoliaOffer.FetchOffersResponse)
 
 const apiRecoParams: RecommendationApiParams = {
-  call_id: '1',
+  callId: '1',
   filtered: true,
-  geo_located: false,
-  model_endpoint: 'default',
-  model_name: 'similar_offers_default_prod',
-  model_version: 'similar_offers_clicks_v2_1_prod_v_20230317T173445',
-  reco_origin: 'default',
+  geoLocated: false,
+  modelEndpoint: 'default',
+  modelName: 'similar_offers_default_prod',
+  modelVersion: 'similar_offers_clicks_v2_1_prod_v_20230317T173445',
+  recoOrigin: 'default',
 }
 
 const useSimilarOffersSpy = jest

--- a/src/features/offer/components/OfferTile/OfferTile.native.test.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.native.test.tsx
@@ -28,13 +28,13 @@ const OFFER_ID = 116656
 const searchId = uuidv4()
 
 const apiRecoParams: RecommendationApiParams = {
-  call_id: '1',
+  callId: '1',
   filtered: true,
-  geo_located: false,
-  model_endpoint: 'default',
-  model_name: 'similar_offers_default_prod',
-  model_version: 'similar_offers_clicks_v2_1_prod_v_20230317T173445',
-  reco_origin: 'default',
+  geoLocated: false,
+  modelEndpoint: 'default',
+  modelName: 'similar_offers_default_prod',
+  modelVersion: 'similar_offers_clicks_v2_1_prod_v_20230317T173445',
+  recoOrigin: 'default',
 }
 
 const props = {

--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
@@ -651,9 +651,9 @@ describe('getCtaWordingAndAction', () => {
 
   describe('CTA - Analytics', () => {
     const defaultApiRecoParams = {
-      call_id: '1',
-      reco_origin: 'unknown',
-      model_origin: 'default',
+      callId: '1',
+      recoOrigin: 'unknown',
+      modelOrigin: 'default',
     }
 
     const defaultPlaylistType = PlaylistType.OTHER_CATEGORIES_SIMILAR_OFFERS

--- a/src/features/offer/helpers/useLogPlaylistVertical/useLogPlaylistVertical.test.ts
+++ b/src/features/offer/helpers/useLogPlaylistVertical/useLogPlaylistVertical.test.ts
@@ -5,13 +5,13 @@ import { analytics } from 'libs/analytics/provider'
 import { renderHook } from 'tests/utils'
 
 const apiRecoParams: RecommendationApiParams = {
-  call_id: '1',
+  callId: '1',
   filtered: true,
-  geo_located: false,
-  model_endpoint: 'default',
-  model_name: 'similar_offers_default_prod',
-  model_version: 'similar_offers_clicks_v2_1_prod_v_20230317T173445',
-  reco_origin: 'default',
+  geoLocated: false,
+  modelEndpoint: 'default',
+  modelName: 'similar_offers_default_prod',
+  modelVersion: 'similar_offers_clicks_v2_1_prod_v_20230317T173445',
+  recoOrigin: 'default',
 }
 
 describe('useLogPlaylist', () => {

--- a/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.test.ts
+++ b/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.test.ts
@@ -8,13 +8,13 @@ import { searchGroupsDataTest } from 'libs/subcategories/fixtures/subcategoriesR
 import { renderHook } from 'tests/utils'
 
 const apiRecoParams: RecommendationApiParams = {
-  call_id: '1',
+  callId: '1',
   filtered: true,
-  geo_located: false,
-  model_endpoint: 'default',
-  model_name: 'similar_offers_default_prod',
-  model_version: 'similar_offers_clicks_v2_1_prod_v_20230317T173445',
-  reco_origin: 'default',
+  geoLocated: false,
+  modelEndpoint: 'default',
+  modelName: 'similar_offers_default_prod',
+  modelVersion: 'similar_offers_clicks_v2_1_prod_v_20230317T173445',
+  recoOrigin: 'default',
 }
 
 const offer = offerResponseSnap


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41606

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
