### PR TITLE
(PC-41649) refactor(app): replace Omit<VenueResponse, 'isVirtual'>  by VenueResponse (isVirtual deleted)

### DIFF
--- a/src/features/gtlPlaylist/components/GtlPlaylist.native.test.tsx
+++ b/src/features/gtlPlaylist/components/GtlPlaylist.native.test.tsx
@@ -15,7 +15,7 @@ import { act, render, screen, userEvent } from 'tests/utils'
 
 jest.mock('queries/subcategories/useSubcategoriesQuery')
 
-const venue: Omit<VenueResponse, 'isVirtual'> = venueDataTest
+const venue: VenueResponse = venueDataTest
 
 const playlist = gtlPlaylistAlgoliaSnapshot[0] as GtlPlaylistData
 
@@ -195,7 +195,7 @@ function renderGtlPlaylist(
   gtlPlaylist: GtlPlaylistData,
   analyticsFrom: Referrals,
   route: Extract<ScreenNames, 'Venue' | 'ThematicSearch'>,
-  venue?: Omit<VenueResponse, 'isVirtual'>
+  venue?: VenueResponse
 ) {
   return render(
     reactQueryProviderHOC(

--- a/src/features/gtlPlaylist/components/GtlPlaylist.tsx
+++ b/src/features/gtlPlaylist/components/GtlPlaylist.tsx
@@ -19,7 +19,7 @@ export interface GtlPlaylistProps {
   analyticsFrom: Referrals
   route: Extract<ScreenNames, 'Venue' | 'ThematicSearch'>
   playlist: GtlPlaylistData
-  venue?: Omit<VenueResponse, 'isVirtual'>
+  venue?: VenueResponse
   noMarginBottom?: boolean
   playlistRef?: Ref<FlatList>
   onViewableItemsChanged?: (info: { viewableItems: ViewToken<unknown>[] }) => void

--- a/src/features/gtlPlaylist/gtlPlaylistHelpers.test.ts
+++ b/src/features/gtlPlaylist/gtlPlaylistHelpers.test.ts
@@ -13,7 +13,7 @@ import {
   getLabelFilter,
 } from './gtlPlaylistHelpers'
 
-const mockVenue: Omit<VenueResponse, 'isVirtual'> = {
+const mockVenue: VenueResponse = {
   name: 'Une librairie',
   city: 'Jest',
   id: 123,

--- a/src/features/gtlPlaylist/gtlPlaylistHelpers.ts
+++ b/src/features/gtlPlaylist/gtlPlaylistHelpers.ts
@@ -40,7 +40,7 @@ export const filterGtlPlaylistConfigByLabel = (
 
 export const getGtlPlaylistsParams = (
   filteredPlaylistConfig: GtlPlaylistRequest[],
-  venue: Omit<VenueResponse, 'isVirtual'> | undefined,
+  venue: VenueResponse | undefined,
   adaptPlaylistParameters: (parameters: OffersModuleParameters) => PlaylistOffersParams
 ): PlaylistOffersParams[] => {
   return filteredPlaylistConfig.map((config) => {

--- a/src/features/gtlPlaylist/queries/useGTLPlaylistsQuery.native.test.ts
+++ b/src/features/gtlPlaylist/queries/useGTLPlaylistsQuery.native.test.ts
@@ -14,7 +14,7 @@ import { renderHook, waitFor } from 'tests/utils'
 
 jest.mock('libs/network/NetInfoWrapper')
 
-const defaultVenue: Omit<VenueResponse, 'isVirtual'> = {
+const defaultVenue: VenueResponse = {
   name: 'Une librairie',
   city: 'Jest',
   id: 123,
@@ -215,7 +215,7 @@ const renderUseGtlPlaylistsQuery = ({
   venue,
   searchGroupLabel,
 }: {
-  venue?: Omit<VenueResponse, 'isVirtual'>
+  venue?: VenueResponse
   searchGroupLabel?: ContentfulLabelCategories
 }) =>
   renderHook(

--- a/src/features/gtlPlaylist/queries/useGTLPlaylistsQuery.ts
+++ b/src/features/gtlPlaylist/queries/useGTLPlaylistsQuery.ts
@@ -9,7 +9,7 @@ import { LocationMode } from 'libs/location/types'
 import { QueryKeys } from 'libs/queryKeys'
 
 type UseGTLPlaylistsProps = {
-  venue?: Omit<VenueResponse, 'isVirtual'>
+  venue?: VenueResponse
   searchIndex?: string
   searchGroupLabel?: ContentfulLabelCategories
   userLocation: Position

--- a/src/features/gtlPlaylist/types.ts
+++ b/src/features/gtlPlaylist/types.ts
@@ -21,7 +21,7 @@ export type GtlPlaylistData = {
 
 export type UseGetOffersByGtlQueryArgs = {
   filteredGtlPlaylistsConfig: GtlPlaylistRequest[]
-  venue?: Omit<VenueResponse, 'isVirtual'>
+  venue?: VenueResponse
   searchIndex?: string
   userLocation: Position
   selectedLocationMode: LocationMode

--- a/src/features/home/components/modules/venues/VenueTile.tsx
+++ b/src/features/home/components/modules/venues/VenueTile.tsx
@@ -33,7 +33,7 @@ export interface VenueTileProps {
 
 const mergeVenueData =
   (venueHit: VenueHit) =>
-  (prevData: VenueResponse | undefined): Omit<VenueResponse, 'isVirtual'> => ({
+  (prevData: VenueResponse | undefined): VenueResponse => ({
     ...venueHit,
     timezone: '',
     ...prevData,

--- a/src/features/offer/components/OfferPlace/OfferPlace.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.tsx
@@ -28,7 +28,7 @@ type PartialVenue = Pick<
 
 const mergeVenueData =
   (venue: PartialVenue) =>
-  (prevData: VenueResponse | undefined): Omit<VenueResponse, 'isVirtual'> => ({
+  (prevData: VenueResponse | undefined): VenueResponse => ({
     id: venue.id,
     name: venue.name,
     // Info not available in OfferVenueResponse so we fallback to OTHER

--- a/src/features/proAdvices/pages/ProAdvicesVenue.native.test.tsx
+++ b/src/features/proAdvices/pages/ProAdvicesVenue.native.test.tsx
@@ -45,10 +45,7 @@ describe('ProAdvicesVenue', () => {
   beforeEach(() => {
     useRoute.mockReturnValue({ params: { venueId: venueDataTest.id } })
     setFeatureFlags([RemoteStoreFeatureFlags.WIP_PRO_REVIEWS_VENUE])
-    mockServer.getApi<Omit<VenueResponse, 'isVirtual'>>(
-      `/v2/venue/${venueDataTest.id}`,
-      venueDataTest
-    )
+    mockServer.getApi<VenueResponse>(`/v2/venue/${venueDataTest.id}`, venueDataTest)
     mockServer.getApi<VenueProAdvices>(`/v1/venue/${venueDataTest.id}/advices`, {
       proAdvices: [...venueProAdvicesFixture.proAdvices],
       nbResults: venueProAdvicesFixture.nbResults,

--- a/src/features/share/helpers/getShareVenue.ts
+++ b/src/features/share/helpers/getShareVenue.ts
@@ -10,7 +10,7 @@ function getVenueUrl(id: number, utmMedium: string) {
 }
 
 type Parameters = {
-  venue?: Omit<VenueResponse, 'isVirtual'>
+  venue?: VenueResponse
   utmMedium: string
 }
 

--- a/src/features/venue/components/ContactBlock/ContactBlock.tsx
+++ b/src/features/venue/components/ContactBlock/ContactBlock.tsx
@@ -12,7 +12,7 @@ import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { PhoneFilled } from 'ui/svg/icons/PhoneFilled'
 
-export const ContactBlock: React.FC<{ venue: Omit<VenueResponse, 'isVirtual'> }> = ({ venue }) => {
+export const ContactBlock: React.FC<{ venue: VenueResponse }> = ({ venue }) => {
   const { email, phoneNumber, website } = venue.contact || {}
 
   const onOpenUrlError = () => {

--- a/src/features/venue/components/PracticalInformation/PracticalInformation.tsx
+++ b/src/features/venue/components/PracticalInformation/PracticalInformation.tsx
@@ -14,7 +14,7 @@ import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 import { OpeningHours } from '../OpeningHours/OpeningHours'
 
 type Props = {
-  venue: Omit<VenueResponse, 'isVirtual'>
+  venue: VenueResponse
 }
 
 export const PracticalInformation: FunctionComponent<Props> = ({ venue }) => {

--- a/src/features/venue/components/VenueBody/VenueBody.native.test.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.native.test.tsx
@@ -205,7 +205,7 @@ const renderVenueBody = ({
   arePlaylistsLoading = false,
   nbAdvices = 0,
 }: {
-  venue?: Omit<VenueResponse, 'isVirtual'>
+  venue?: VenueResponse
   headlineOfferData?: HeadlineOfferData
   playlists?: GtlPlaylistData[]
   arePlaylistsLoading?: boolean

--- a/src/features/venue/components/VenueBody/VenueBody.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.tsx
@@ -23,7 +23,7 @@ import { Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 interface Props {
-  venue: Omit<VenueResponse, 'isVirtual'>
+  venue: VenueResponse
   venueArtists?: VenueOffersArtists
   venueOffers?: VenueOffersType
   playlists: GtlPlaylistData[]

--- a/src/features/venue/components/VenueContent/OldVenueContent.tsx
+++ b/src/features/venue/components/VenueContent/OldVenueContent.tsx
@@ -21,7 +21,7 @@ import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition
 import { AnchorProvider } from 'ui/components/anchor/AnchorContext'
 
 type Props = {
-  venue: Omit<VenueResponse, 'isVirtual'>
+  venue: VenueResponse
   isCTADisplayed?: boolean
   children: React.ReactNode
 }

--- a/src/features/venue/components/VenueContent/VenueContent.tsx
+++ b/src/features/venue/components/VenueContent/VenueContent.tsx
@@ -21,7 +21,7 @@ import { AnchorProvider } from 'ui/components/anchor/AnchorContext'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 type Props = {
-  venue: Omit<VenueResponse, 'isVirtual'>
+  venue: VenueResponse
   isCTADisplayed?: boolean
   children: React.ReactNode
   showSearchInVenueModal: () => void

--- a/src/features/venue/components/VenueHeader/VenueHeader.tsx
+++ b/src/features/venue/components/VenueHeader/VenueHeader.tsx
@@ -14,7 +14,7 @@ import { Share } from 'ui/svg/icons/Share'
 
 interface Props {
   headerTransition: Animated.AnimatedInterpolation<string | number>
-  venue: Omit<VenueResponse, 'isVirtual'>
+  venue: VenueResponse
 }
 
 /**

--- a/src/features/venue/components/VenueMessagingApps/VenueMessagingApps.native.test.tsx
+++ b/src/features/venue/components/VenueMessagingApps/VenueMessagingApps.native.test.tsx
@@ -20,10 +20,7 @@ jest.useFakeTimers()
 
 describe('<VenueMessagingApps />', () => {
   beforeEach(() => {
-    mockServer.getApi<Omit<VenueResponse, 'isVirtual'>>(
-      `/v2/venue/${venueDataTest.id}`,
-      venueDataTest
-    )
+    mockServer.getApi<VenueResponse>(`/v2/venue/${venueDataTest.id}`, venueDataTest)
   })
 
   it('should share on instagram', async () => {

--- a/src/features/venue/components/VenueMessagingApps/VenueMessagingApps.tsx
+++ b/src/features/venue/components/VenueMessagingApps/VenueMessagingApps.tsx
@@ -9,7 +9,7 @@ import { analytics } from 'libs/analytics/provider'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 
 type MessagingAppsProps = {
-  venue: Omit<VenueResponse, 'isVirtual'>
+  venue: VenueResponse
 }
 
 export const VenueMessagingApps = ({ venue }: MessagingAppsProps) => {

--- a/src/features/venue/components/VenueOffers/VenueOffers.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffers.tsx
@@ -24,7 +24,7 @@ import { Currency } from 'shared/currency/useGetCurrencyToDisplay'
 import { OfferPlaylistSkeleton, TileSize } from 'ui/components/placeholders/OfferPlaylistSkeleton'
 
 export interface VenueOffersProps {
-  venue: Omit<VenueResponse, 'isVirtual'>
+  venue: VenueResponse
   venueArtists?: VenueOffersArtists
   venueOffers?: VenueOffers
   playlists: GtlPlaylistData[]

--- a/src/features/venue/components/VenueThematicSection/VenueThematicSection.tsx
+++ b/src/features/venue/components/VenueThematicSection/VenueThematicSection.tsx
@@ -15,7 +15,7 @@ import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 import { showSuccessSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 
 interface Props {
-  venue: Omit<VenueResponse, 'isVirtual'>
+  venue: VenueResponse
 }
 
 export const VenueThematicSection: FunctionComponent<Props> = ({ venue }: Props) => {

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponent.native.test.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponent.native.test.tsx
@@ -39,7 +39,7 @@ describe('<VenueTopComponent />', () => {
   })
 
   it('should display venue type', async () => {
-    const culturalCenterVenue: Omit<VenueResponse, 'isVirtual'> = {
+    const culturalCenterVenue: VenueResponse = {
       ...venueOpenToPublic,
       activity: Activity.CULTURAL_CENTRE,
     }
@@ -54,7 +54,7 @@ describe('<VenueTopComponent />', () => {
       userLocation,
       hasGeolocPosition: true,
     } as ILocationContext)
-    const locatedVenue: Omit<VenueResponse, 'isVirtual'> = {
+    const locatedVenue: VenueResponse = {
       ...venueOpenToPublic,
       latitude: 30,
       longitude: 30,
@@ -69,7 +69,7 @@ describe('<VenueTopComponent />', () => {
     mockUseLocation.mockReturnValueOnce({
       hasGeolocPosition: false,
     } as ILocationContext)
-    const locatedVenue: Omit<VenueResponse, 'isVirtual'> = {
+    const locatedVenue: VenueResponse = {
       ...venueOpenToPublic,
       latitude: 30,
       longitude: 30,

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponent.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponent.tsx
@@ -6,7 +6,7 @@ import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { VenueTopComponentBase } from 'features/venue/components/VenueTopComponent/VenueTopComponentBase'
 
 type Props = {
-  venue: Omit<VenueResponse, 'isVirtual'>
+  venue: VenueResponse
   enableVolunteer?: boolean
   enableVolunteerNewTag?: boolean
   enableVolunteerFeedback?: boolean

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
@@ -27,7 +27,7 @@ import { Typo, getSpacing } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type Props = {
-  venue: Omit<VenueResponse, 'isVirtual'>
+  venue: VenueResponse
   onPressBannerImage?: () => void
   enableVolunteer?: boolean
   enableVolunteerNewTag?: boolean
@@ -212,7 +212,7 @@ const MarginContainer = styled.View(({ theme }) => ({
   justifyContent: 'center',
 }))
 
-const getVenue = (venue: Omit<VenueResponse, 'isVirtual'>): VenueBlockVenue => {
+const getVenue = (venue: VenueResponse): VenueBlockVenue => {
   return {
     ...venue,
     bannerUrl: venue.bannerUrl ?? undefined,

--- a/src/features/venue/fixtures/venueDataTest.ts
+++ b/src/features/venue/fixtures/venueDataTest.ts
@@ -1,6 +1,6 @@
 import { Activity, VenueResponse } from 'api/gen'
 
-export const venueDataTest: Omit<VenueResponse, 'isVirtual'> = {
+export const venueDataTest: VenueResponse = {
   accessibilityData: {
     isAccessibleAudioDisability: false,
     isAccessibleMentalDisability: false,

--- a/src/features/venue/helpers/useNavigateToSearchWithVenueOffers.ts
+++ b/src/features/venue/helpers/useNavigateToSearchWithVenueOffers.ts
@@ -5,7 +5,7 @@ import { getSearchPropConfig } from 'features/navigation/SearchStackNavigator/ge
 import { SearchStackParamList } from 'features/navigation/SearchStackNavigator/SearchStackTypes'
 import { useVenueSearchParameters } from 'features/venue/helpers/useVenueSearchParameters'
 
-export const useNavigateToSearchWithVenueOffers = (venue: Omit<VenueResponse, 'isVirtual'>) => {
+export const useNavigateToSearchWithVenueOffers = (venue: VenueResponse) => {
   const venueSearchParams: SearchStackParamList['SearchResults'] = useVenueSearchParameters(venue)
   return useMemo(
     () => ({

--- a/src/features/venue/helpers/useVenueSearchParameters.native.test.ts
+++ b/src/features/venue/helpers/useVenueSearchParameters.native.test.ts
@@ -10,7 +10,7 @@ jest.mock('features/search/context/SearchWrapper', () => ({
   useSearch: () => ({ searchState: mockSearchState, dispatch: jest.fn() }),
 }))
 
-const mockVenue: Omit<VenueResponse, 'isVirtual'> = venueDataTest
+const mockVenue: VenueResponse = venueDataTest
 
 jest.mock('features/venue/queries/useVenueQuery', () => ({
   useVenueQuery: jest.fn((venueId) => ({ data: venueId === mockVenue.id ? mockVenue : undefined })),

--- a/src/features/venue/helpers/useVenueSearchParameters.ts
+++ b/src/features/venue/helpers/useVenueSearchParameters.ts
@@ -6,9 +6,7 @@ import { useMaxPrice } from 'features/search/helpers/useMaxPrice/useMaxPrice'
 import { SearchState } from 'features/search/types'
 import { convertCentsToEuros } from 'libs/parsers/pricesConversion'
 
-export const useVenueSearchParameters = (
-  dataVenue?: Omit<VenueResponse, 'isVirtual'>
-): SearchState => {
+export const useVenueSearchParameters = (dataVenue?: VenueResponse): SearchState => {
   const {
     searchState: { locationFilter },
   } = useSearch()

--- a/src/features/venue/pages/Venue/Venue.native.test.tsx
+++ b/src/features/venue/pages/Venue/Venue.native.test.tsx
@@ -123,7 +123,7 @@ describe('<Venue />', () => {
     getItemSpy.mockReset()
     mockServer.postApi<OffersStocksResponseV2>('/v2/offers/stocks', {})
     mockServer.patchApi<UserProfile>('/v1/profile', {})
-    mockServer.getApi<Omit<VenueResponse, 'isVirtual'>>(`/v2/venue/${venueId}`, {
+    mockServer.getApi<VenueResponse>(`/v2/venue/${venueId}`, {
       ...venueDataTest,
       isOpenToPublic: true,
     })
@@ -263,7 +263,7 @@ describe('<Venue />', () => {
     it('should not display CTA if venueTypeCode is Movie', async () => {
       const mockedVenue = { ...venueDataTest, activity: Activity.CINEMA }
 
-      mockServer.getApi<Omit<VenueResponse, 'isVirtual'>>(`/v2/venue/${venueId}`, mockedVenue)
+      mockServer.getApi<VenueResponse>(`/v2/venue/${venueId}`, mockedVenue)
 
       renderVenue(venueId)
 
@@ -350,7 +350,7 @@ describe('<Venue />', () => {
     beforeEach(() => {
       // Mock API Calls
       const mockedVenue = { ...venueDataTest, activity: Activity.CINEMA }
-      mockServer.getApi<Omit<VenueResponse, 'isVirtual'>>(`/v2/venue/${venueId}`, mockedVenue)
+      mockServer.getApi<VenueResponse>(`/v2/venue/${venueId}`, mockedVenue)
       mockServer.postApi<OffersStocksResponseV2>(`/v2/offers/stocks`, {})
     })
 

--- a/src/features/venue/pages/VenuePreviewCarousel/VenuePreviewCarousel.native.test.tsx
+++ b/src/features/venue/pages/VenuePreviewCarousel/VenuePreviewCarousel.native.test.tsx
@@ -6,7 +6,7 @@ import { VenuePreviewCarousel } from 'features/venue/pages/VenuePreviewCarousel/
 import mockVenueResponse from 'fixtures/venueResponse'
 import { render, screen } from 'tests/utils'
 
-const mockUseVenue = jest.fn((): { data: Omit<VenueResponse, 'isVirtual'> } => ({
+const mockUseVenue = jest.fn((): { data: VenueResponse } => ({
   data: mockVenueResponse,
 }))
 

--- a/src/features/venue/queries/useVenueQuery.native.test.ts
+++ b/src/features/venue/queries/useVenueQuery.native.test.ts
@@ -17,10 +17,7 @@ const spyApiGetVenue = jest.spyOn(api, 'getNativeV2VenuevenueId')
 
 describe('useVenueQuery', () => {
   it('should call API otherwise', async () => {
-    mockServer.getApi<Omit<VenueResponse, 'isVirtual'>>(
-      `/v2/venue/${venueDataTest.id}`,
-      venueDataTest
-    )
+    mockServer.getApi<VenueResponse>(`/v2/venue/${venueDataTest.id}`, venueDataTest)
     const { result } = renderHook(() => useVenueQuery(venueDataTest.id), {
       wrapper: ({ children }) => reactQueryProviderHOC(children),
     })

--- a/src/features/venueMap/helpers/geoLocatedVenueToVenueResponse/geoLocatedVenueToVenueResponse.test.ts
+++ b/src/features/venueMap/helpers/geoLocatedVenueToVenueResponse/geoLocatedVenueToVenueResponse.test.ts
@@ -27,7 +27,7 @@ describe('transformGeoLocatedVenueToVenueResponse', () => {
       isOpenToPublic: true,
       activity: Activity.BOOKSTORE,
       isPermanent: true,
-    } satisfies Omit<VenueResponse, 'isVirtual'>
+    } satisfies VenueResponse
 
     expect(transformGeoLocatedVenueToVenueResponse(geolocatedData)).toMatchObject(
       expectedVenueResponse

--- a/src/features/venueMap/helpers/geoLocatedVenueToVenueResponse/geoLocatedVenueToVenueResponse.ts
+++ b/src/features/venueMap/helpers/geoLocatedVenueToVenueResponse/geoLocatedVenueToVenueResponse.ts
@@ -3,7 +3,7 @@ import { GeolocatedVenue } from 'features/venueMap/components/VenueMapView/types
 
 export const transformGeoLocatedVenueToVenueResponse = (
   data?: GeolocatedVenue | null
-): Omit<VenueResponse, 'isVirtual'> | undefined => {
+): VenueResponse | undefined => {
   if (data && data !== null) {
     const { venueId, label, _geoloc, isOpenToPublic, activity, isPermanent } = data
     return {

--- a/src/fixtures/venueResponse.ts
+++ b/src/fixtures/venueResponse.ts
@@ -15,4 +15,4 @@ export default {
   timezone: 'Europe/Paris',
   accessibilityData: {},
   activity: Activity.CINEMA,
-} satisfies Omit<VenueResponse, 'isVirtual'>
+} satisfies VenueResponse

--- a/src/queries/venue/useVenueOffersQuery.ts
+++ b/src/queries/venue/useVenueOffersQuery.ts
@@ -21,7 +21,7 @@ type UseVenueOffersParams = {
   venueSearchParams: SearchState
   searchState: SearchState
   transformHits: (hit: AlgoliaOffer<HitOffer>) => AlgoliaOffer<HitOffer>
-  venue?: Omit<VenueResponse, 'isVirtual'>
+  venue?: VenueResponse
   includeHitsWithoutImage?: boolean
   mapping?: SubcategoriesMapping
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41649

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
