### PR TITLE
(PC-39127) feat(venue): add tags with cultural domains for venue not open to public

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -1608,6 +1608,22 @@ export interface Credit {
 }
 /**
  * @export
+ * @interface CulturalDomainItem
+ */
+export interface CulturalDomainItem {
+  /**
+   * @type {number}
+   * @memberof CulturalDomainItem
+   */
+  id: number
+  /**
+   * @type {string}
+   * @memberof CulturalDomainItem
+   */
+  name: string
+}
+/**
+ * @export
  * @interface CulturalSurveyAnswer
  */
 export interface CulturalSurveyAnswer {
@@ -5263,6 +5279,11 @@ export interface VenueResponse {
    * @memberof VenueResponse
    */
   contact?: VenueContact | null
+  /**
+   * @type {Array<CulturalDomainItem> | null}
+   * @memberof VenueResponse
+   */
+  culturalDomains?: Array<CulturalDomainItem> | null
   /**
    * @type {string | null}
    * @memberof VenueResponse

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponent.native.test.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponent.native.test.tsx
@@ -48,7 +48,7 @@ describe('<VenueTopComponent />', () => {
     expect(await screen.findByText('Centre culturel')).toBeOnTheScreen()
   })
 
-  it('should display distance between user and venue when geolocation is activated', async () => {
+  it('should display distance between user and venue when geolocation is activated and venue open to public', async () => {
     const userLocation = { latitude: 30, longitude: 30.1 }
     mockUseLocation.mockReturnValueOnce({
       userLocation,
@@ -63,6 +63,21 @@ describe('<VenueTopComponent />', () => {
     renderVenueTopComponent({ venue: locatedVenue })
 
     expect(await screen.findByText('À 10 km')).toBeOnTheScreen()
+  })
+
+  it('should not display cultural domains when specified if venue is open to public', async () => {
+    renderVenueTopComponent({
+      venue: {
+        ...venueOpenToPublic,
+        culturalDomains: [
+          { id: 1, name: 'Architecture' },
+          { id: 2, name: 'Arts numériques' },
+        ],
+      },
+    })
+
+    expect(screen.queryByText('Architecture')).not.toBeOnTheScreen()
+    expect(screen.queryByText('Arts numériques')).not.toBeOnTheScreen()
   })
 
   it('should not display distance between user and venue when geolocation is not activated', async () => {
@@ -157,6 +172,40 @@ describe('<VenueTopComponent />', () => {
       render(<VenueTopComponent venue={{ ...venueDataTest, isOpenToPublic: false }} />)
 
       expect(screen.queryByText('1 boulevard Poissonnière, 75000 Paris')).not.toBeOnTheScreen()
+    })
+
+    it('should not display distance between user and venue when geolocation is activated', async () => {
+      const userLocation = { latitude: 30, longitude: 30.1 }
+      mockUseLocation.mockReturnValueOnce({
+        userLocation,
+        hasGeolocPosition: true,
+      } as ILocationContext)
+      const locatedVenue: VenueResponse = {
+        ...venueDataTest,
+        latitude: 30,
+        longitude: 30,
+        isOpenToPublic: false,
+      }
+
+      renderVenueTopComponent({ venue: locatedVenue })
+
+      expect(screen.queryByText('À 10 km')).not.toBeOnTheScreen()
+    })
+
+    it('should display cultural domains when specified', async () => {
+      renderVenueTopComponent({
+        venue: {
+          ...venueDataTest,
+          isOpenToPublic: false,
+          culturalDomains: [
+            { id: 1, name: 'Architecture' },
+            { id: 2, name: 'Arts numériques' },
+          ],
+        },
+      })
+
+      expect(await screen.findByText('Architecture')).toBeOnTheScreen()
+      expect(screen.getByText('Arts numériques')).toBeOnTheScreen()
     })
   })
 

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
@@ -9,13 +9,12 @@ import { VenueBlockVenue } from 'features/offer/components/OfferVenueBlock/type'
 import { FeedBack } from 'features/reactions/components/FeedBack'
 import { OpeningHoursStatus } from 'features/venue/components/OpeningHoursStatus/OpeningHoursStatus'
 import { VenueBanner } from 'features/venue/components/VenueBody/VenueBanner'
+import { getVenueTopComponentTags } from 'features/venue/helpers/getVenueTopComponentTags'
 import { analytics } from 'libs/analytics/provider'
 import { useHandleFocus } from 'libs/hooks/useHandleFocus'
 import { SeeItineraryButton } from 'libs/itinerary/components/SeeItineraryButton'
 import { getGoogleMapsItineraryUrl } from 'libs/itinerary/openGoogleMapsItinerary'
-import { getDistance } from 'libs/location/getDistance'
 import { useLocation } from 'libs/location/location'
-import { MAP_ACTIVITY_TO_LABEL } from 'libs/parsers/activity'
 import { CopyToClipboardButton } from 'shared/CopyToClipboardButton/CopyToClipboardButton'
 import { EditorialCard, EditorialCardInfo } from 'ui/components/EditorialCard'
 import { Separator } from 'ui/components/Separator'
@@ -54,16 +53,12 @@ export const VenueTopComponentBase: React.FunctionComponent<Props> = ({
 
   const { bannerUrl, bannerIsFromGoogle, bannerCredit } = venue
 
-  const distanceToVenue = getDistance(
-    { lat: venue.latitude, lng: venue.longitude },
-    { userLocation, selectedPlace, selectedLocationMode }
+  const venueTags: string[] = getVenueTopComponentTags(
+    venue,
+    userLocation,
+    selectedPlace,
+    selectedLocationMode
   )
-  const activityLabel = venue.activity ? MAP_ACTIVITY_TO_LABEL[venue.activity] : undefined
-
-  const venueTags: string[] = []
-  activityLabel && venueTags.push(activityLabel)
-  distanceToVenue && venueTags.push(`À ${distanceToVenue}`)
-
   const currentDate = new Date()
 
   const isDynamicOpeningHoursDisplayed = venue.openingHours && venue.isOpenToPublic

--- a/src/features/venue/helpers/getVenueTopComponentTags.native.test.ts
+++ b/src/features/venue/helpers/getVenueTopComponentTags.native.test.ts
@@ -1,0 +1,108 @@
+import { VenueResponse } from 'api/gen'
+import { venueDataTest } from 'features/venue/fixtures/venueDataTest'
+import { getVenueTopComponentTags } from 'features/venue/helpers/getVenueTopComponentTags'
+import { LocationMode } from 'libs/location/types'
+
+describe('getVenueTopComponentTags', () => {
+  describe('When venue is open to public', () => {
+    it('should return activity and distance when defined', () => {
+      const userLocation = { latitude: 30, longitude: 30.1 }
+      const locatedVenue: VenueResponse = {
+        ...venueDataTest,
+        latitude: 30,
+        longitude: 30,
+        isOpenToPublic: true,
+      }
+      const tags = getVenueTopComponentTags(
+        locatedVenue,
+        userLocation,
+        null,
+        LocationMode.AROUND_ME
+      )
+
+      expect(tags).toEqual(['Librairie', 'À 10 km'])
+    })
+
+    it('should return only activity when distance not defined', () => {
+      const tags = getVenueTopComponentTags(
+        {
+          ...venueDataTest,
+          isOpenToPublic: true,
+        },
+        undefined,
+        null,
+        LocationMode.EVERYWHERE
+      )
+
+      expect(tags).toEqual(['Librairie'])
+    })
+
+    it('should return only distance when activity not defined', () => {
+      const userLocation = { latitude: 30, longitude: 30.1 }
+      const locatedVenue: VenueResponse = {
+        ...venueDataTest,
+        latitude: 30,
+        longitude: 30,
+        isOpenToPublic: true,
+        activity: null,
+      }
+      const tags = getVenueTopComponentTags(
+        locatedVenue,
+        userLocation,
+        null,
+        LocationMode.AROUND_ME
+      )
+
+      expect(tags).toEqual(['À 10 km'])
+    })
+
+    it('should return empty array when activity and distance not defined', () => {
+      const tags = getVenueTopComponentTags(
+        {
+          ...venueDataTest,
+          isOpenToPublic: true,
+          activity: null,
+        },
+        undefined,
+        null,
+        LocationMode.EVERYWHERE
+      )
+
+      expect(tags).toEqual([])
+    })
+  })
+
+  describe('When venue is not open to public', () => {
+    it('should return cultural domains when defined', () => {
+      const tags = getVenueTopComponentTags(
+        {
+          ...venueDataTest,
+          isOpenToPublic: false,
+          culturalDomains: [
+            { id: 1, name: 'Architecture' },
+            { id: 2, name: 'Arts numériques' },
+          ],
+        },
+        undefined,
+        null,
+        LocationMode.EVERYWHERE
+      )
+
+      expect(tags).toEqual(['Architecture', 'Arts numériques'])
+    })
+
+    it('should return empty array when cultural domains not defined', () => {
+      const tags = getVenueTopComponentTags(
+        {
+          ...venueDataTest,
+          isOpenToPublic: false,
+        },
+        undefined,
+        null,
+        LocationMode.EVERYWHERE
+      )
+
+      expect(tags).toEqual([])
+    })
+  })
+})

--- a/src/features/venue/helpers/getVenueTopComponentTags.ts
+++ b/src/features/venue/helpers/getVenueTopComponentTags.ts
@@ -1,0 +1,25 @@
+import { VenueResponse } from 'api/gen'
+import { getDistance } from 'libs/location/getDistance'
+import { LocationMode, Position } from 'libs/location/types'
+import { MAP_ACTIVITY_TO_LABEL } from 'libs/parsers/activity'
+import { SuggestedPlace } from 'libs/place/types'
+
+export const getVenueTopComponentTags = (
+  venue: VenueResponse,
+  userLocation: Position,
+  selectedPlace: SuggestedPlace | null,
+  selectedLocationMode: LocationMode
+) => {
+  if (venue.isOpenToPublic) {
+    const distanceToVenue = getDistance(
+      { lat: venue.latitude, lng: venue.longitude },
+      { userLocation, selectedPlace, selectedLocationMode }
+    )
+    const distanceLabel = distanceToVenue ? `À ${distanceToVenue}` : undefined
+    const activityLabel = venue.activity ? MAP_ACTIVITY_TO_LABEL[venue.activity] : undefined
+
+    return [activityLabel, distanceLabel].filter((tag): tag is string => !!tag)
+  }
+
+  return (venue.culturalDomains ?? []).map((domain) => domain.name)
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-39127

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-07 at 11 24 07" src="https://github.com/user-attachments/assets/37c11b79-6f89-40c9-84b2-8b9c6a58c19d" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-07 at 11 28 25" src="https://github.com/user-attachments/assets/44b2c472-9d92-4f0c-bbe3-80399b8d5b68" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-07 at 11 32 01" src="https://github.com/user-attachments/assets/113b5320-ebd1-4231-a224-b570b35b176e" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-07 at 11 31 17" src="https://github.com/user-attachments/assets/bf1370d9-e11a-4f11-9928-56b349c0276e" />|
| Android          |<img width="1080" height="2400" alt="Screenshot_1778146069" src="https://github.com/user-attachments/assets/66fb761f-9aa2-44cd-9575-d8c1293a1f18" /> <img width="1080" height="2400" alt="Screenshot_1778146121" src="https://github.com/user-attachments/assets/9e774ce0-8207-4f4f-b6af-bf18c16abea1" />|<img width="1080" height="2400" alt="Screenshot_1778146305" src="https://github.com/user-attachments/assets/52429e72-c613-49b0-b9ef-706c58ceb911" /> <img width="1080" height="2400" alt="Screenshot_1778146292" src="https://github.com/user-attachments/assets/d277292e-fd3e-49ae-9193-90d60f4f9939" />|
| Phone - Chrome   |<img width="407" height="698" alt="Capture d’écran 2026-05-07 à 11 23 52" src="https://github.com/user-attachments/assets/07ffd4da-90c7-4805-a8ea-ed038d769ab1" /> <img width="403" height="693" alt="Capture d’écran 2026-05-07 à 11 28 14" src="https://github.com/user-attachments/assets/bd0f5576-1e3c-4d68-a1cc-42829200f796" />|<img width="392" height="689" alt="Capture d’écran 2026-05-07 à 11 32 29" src="https://github.com/user-attachments/assets/5477eb85-8a74-4686-8d8e-9076c6d5a6f6" /> <img width="391" height="688" alt="Capture d’écran 2026-05-07 à 11 30 44" src="https://github.com/user-attachments/assets/671d479e-4924-4dee-99bd-8e8029b8ffe7" />|
| Desktop - Chrome |<img width="1509" height="766" alt="Capture d’écran 2026-05-07 à 11 23 25" src="https://github.com/user-attachments/assets/36909962-e530-46ec-ac9f-71b964912b7d" /> <img width="1504" height="761" alt="Capture d’écran 2026-05-07 à 11 28 06" src="https://github.com/user-attachments/assets/bb3b4c16-8da8-493a-a7de-bd45da700d77" />|<img width="1508" height="768" alt="Capture d’écran 2026-05-07 à 11 32 21" src="https://github.com/user-attachments/assets/e18003e6-0d9f-42af-bdb6-8b363b946ab1" /> <img width="1509" height="767" alt="Capture d’écran 2026-05-07 à 11 30 54" src="https://github.com/user-attachments/assets/2b7e0f99-e655-486a-a612-66b0fe4c6cff" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
