### PR TITLE
(PC-41732) fix(CI): revert condition on server chance for sonar check

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -84,12 +84,11 @@ jobs:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
   yarn-tester:
-    needs: [yarn-linter, check-server-folder-changes]
+    needs: yarn-linter
     uses: ./.github/workflows/dev_on_workflow_tester.yml
     with:
       CACHE_BUCKET_NAME: passculture-infra-prod-github-runner-cache
       HAS_BREAKING_CHANGE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'breaking change') }}
-      HAS_PROXY_CHANGED: ${{ needs.check-server-folder-changes.outputs.folder_changed == 'true' }}
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/dev_on_workflow_tester.yml
+++ b/.github/workflows/dev_on_workflow_tester.yml
@@ -10,10 +10,6 @@ on:
         type: boolean
         required: false
         default: false
-      HAS_PROXY_CHANGED:
-        type: boolean
-        required: false
-        default: false
     secrets:
       GCP_EHP_SERVICE_ACCOUNT:
         required: true
@@ -225,7 +221,6 @@ jobs:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
 
   yarn_test_proxy:
-    if: ${{ inputs.HAS_PROXY_CHANGED }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
This reverts commit afe9e8f4d7dcbecf672436956fccb78873f9fca0.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41732

La dépendance à `check-server-folder-changes` est utile pour les PRs, mais ce job n'étant pas joué pour les déploiements, `yarn-tester` n'est pas lancé et bloque le déploiement
