### PR TITLE
(PC-41740) fix(security): bump fast-uri to 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -328,6 +328,7 @@
     "brace-expansion@>= 2.0.0, < 2.0.3": "^2.0.3",
     "color-name": "1.1.*",
     "cross-spawn": "^7.0.6",
+    "fast-uri": "^3.1.2",
     "fast-xml-parser": "^5.0.0",
     "flatted@<= 3.4.1": "^3.4.2",
     "follow-redirects@<= 1.15.11": "^1.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15924,10 +15924,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.0.6
-  resolution: "fast-uri@npm:3.0.6"
-  checksum: 7161ba2a7944778d679ba8e5f00d6a2bb479a2142df0982f541d67be6c979b17808f7edbb0ce78161c85035974bde3fa52b5137df31da46c0828cb629ba67c4e
+"fast-uri@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 73a6e1b04e6fcf7a09ed93316e72d643ef177d26969973784690708612141f2c2f74657120bab75bf5bbc26bfd535a32c90a8c3bc50aca50584cf01f98815afe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41740

## Contexte

Deux vulnérabilités de sévérité **haute** (CVSS 7.5) affectent `fast-uri` (présent en transitive via `ajv@8.17.1`) :

- **[CVE-2026-6321](https://github.com/advisories)** — path traversal via percent-encoded dot segments (versions ≤ 3.1.0)
- **[CVE-2026-6322](https://github.com/advisories)** — host confusion via percent-encoded authority delimiters (versions ≤ 3.1.1)

Version vulnérable installée : `3.0.6`
Version corrigée : `3.1.2`

## Changements

- Ajout d'une entrée `resolutions` dans `package.json` pour forcer `fast-uri` en `^3.1.2`
- Régénération de `yarn.lock` (`fast-uri` 3.0.6 → 3.1.2)
