### PR TITLE
(PC-41762) fix(e2e): use secret to disable recaptcha in staging env

### DIFF
--- a/.github/workflows/dev_on_workflow_call_e2e_android.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_android.yml
@@ -113,6 +113,8 @@ jobs:
       - name: Disable staging reCAPTCHA for E2E
         run: |
           yarn ts-node --compilerOptions '{"module": "commonjs"}' ./scripts/enableNativeAppRecaptcha.ts staging false
+        env:
+          MAESTRO_E2E_API_KEY: ${{ steps.secrets.outputs.MAESTRO_E2E_API_KEY }}
 
       - name: Build android apk
         run: |

--- a/.github/workflows/dev_on_workflow_call_e2e_ios.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_ios.yml
@@ -100,6 +100,8 @@ jobs:
       - name: Disable staging reCAPTCHA for E2E
         run: |
           yarn ts-node --compilerOptions '{"module": "commonjs"}' ./scripts/enableNativeAppRecaptcha.ts staging false
+        env:
+          MAESTRO_E2E_API_KEY: ${{ steps.secrets.outputs.MAESTRO_E2E_API_KEY }}
       - name: Build E2E IOS Staging
         id: build_e2e
         run: |

--- a/scripts/enableNativeAppRecaptcha.ts
+++ b/scripts/enableNativeAppRecaptcha.ts
@@ -1,5 +1,10 @@
 /// <reference types="node" />
 
+import path from 'path'
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import dotenv from 'dotenv'
+
 import { getErrorMessage } from '../src/shared/getErrorMessage/getErrorMessage'
 
 type Feature = { name: string; isActive: boolean }
@@ -10,6 +15,14 @@ const RED = '\x1b[31m'
 const RESET_COLOR = '\x1b[0m'
 const API_BASE_URL = process.argv[2] ? `https://backend.${process.argv[2]}.passculture.team` : ''
 
+dotenv.config({ path: path.resolve(__dirname, '../.maestro/.env.secret') })
+
+const MAESTRO_E2E_API_KEY = process.env.MAESTRO_E2E_API_KEY
+
+if (!MAESTRO_E2E_API_KEY) {
+  throw new Error('Missing MAESTRO_E2E_API_KEY. Locally it is read from .maestro/.env.secret.')
+}
+
 async function patchFeatures(features: Features) {
   try {
     const response = await fetch(`${API_BASE_URL}/testing/features`, {
@@ -18,6 +31,7 @@ async function patchFeatures(features: Features) {
       headers: new Headers({
         'Content-Type': 'application/json',
         Accept: 'application/json',
+        'x-api-key': MAESTRO_E2E_API_KEY as string,
       }),
       body: JSON.stringify({
         features,
@@ -53,6 +67,6 @@ const enableNativeAppRecaptcha = async (isActive: boolean) => {
   ])
 }
 
-enableNativeAppRecaptcha(process.argv[3] as unknown as boolean)
+void enableNativeAppRecaptcha(process.argv[3] as unknown as boolean)
 
 export {}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41762

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.
