### PR TITLE
(PC-41787) feat(e2e): re-adapt new e2e archi for nightly runs

### DIFF
--- a/.github/workflows/dev_on_pull_request_run_e2e.yml
+++ b/.github/workflows/dev_on_pull_request_run_e2e.yml
@@ -11,44 +11,24 @@ permissions:
 
 jobs:
   notify_test_launch:
-    if: ${{ github.event.label.name == 'e2e' || github.event.label.name == 'e2e iOS' || github.event.label.name == 'e2e Android' }}
+    if: ${{ github.event.label.name == 'e2e' }}
     runs-on: ubuntu-latest
     steps:
       - name: Comment PR
         uses: actions/github-script@v7
         with:
           script: |
-            const label = context.payload.label.name;
-            let platform = label.includes('iOS') ? 'iOS' : label.includes('Android') ? 'Android' : 'iOS et Android';
-            let scope = '';
-
-            if (label.includes(':')) {
-              scope = ` pour le scope ${label.split(':')[1]}`;
-            }
-
-            let dashboardLinks = '';
-
-            if (label === 'e2e' || label.includes('iOS')) {
-              dashboardLinks += '- [Dashboard iOS](https://app.maestro.dev/project/proj_01javz1ncreqb9dcshv3y4da44/maestro-tests/app/app_01jk8x3ck0e6dansmsrx4g1h6z)\n';
-            }
-            if (label === 'e2e' || label.includes('Android')) {
-              dashboardLinks += '- [Dashboard Android](https://app.maestro.dev/project/proj_01javz1ncreqb9dcshv3y4da44/maestro-tests/app/app_01jawmdb0kfyk9tpg40habrw36)\n';
-            }
-
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🚀 Les tests E2E ${platform}${scope} ont été lancés !
+              body: `🚀 Les tests E2E iOS et Android ont été lancés !
 
-              Les résultats seront disponibles :
-              - Dans le canal Slack #equipe-e2e-jeunes
-              ${dashboardLinks}
-              Bonne journée ! 🌟`
+              Les résultats et les liens vers Maestro seront disponibles directement depuis la CI via l'app GitHub Maestro.`
             })
 
   e2e-tests-ios:
-    if: ${{ startsWith(github.event.label.name, 'e2e') && (contains(github.event.label.name, 'iOS') || !contains(github.event.label.name, 'Android')) }}
+    if: ${{ github.event.label.name == 'e2e' }}
     needs: notify_test_launch
     concurrency:
       group: e2e-ios-${{ github.head_ref }}
@@ -56,19 +36,12 @@ jobs:
     uses: ./.github/workflows/dev_on_workflow_call_e2e_ios.yml
     with:
       upload_name_prefix: '[PR]'
-      test_tags: >-
-        ${{
-          contains(github.event.label.name, ':squad-activation') && 'squad-activation' ||
-          contains(github.event.label.name, ':squad-decouverte') && 'squad-decouverte' ||
-          contains(github.event.label.name, ':squad-conversion') && 'squad-conversion' ||
-          'nightlyIOS'
-        }}
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
 
   e2e-tests-android:
-    if: ${{ startsWith(github.event.label.name, 'e2e') && (contains(github.event.label.name, 'Android') || !contains(github.event.label.name, 'iOS')) }}
+    if: ${{ github.event.label.name == 'e2e' }}
     needs: notify_test_launch
     concurrency:
       group: e2e-android-${{ github.head_ref }}
@@ -76,13 +49,6 @@ jobs:
     uses: ./.github/workflows/dev_on_workflow_call_e2e_android.yml
     with:
       upload_name_prefix: '[PR]'
-      test_tags: >-
-        ${{
-          contains(github.event.label.name, ':squad-activation') && 'squad-activation' ||
-          contains(github.event.label.name, ':squad-decouverte') && 'squad-decouverte' ||
-          contains(github.event.label.name, ':squad-conversion') && 'squad-conversion' ||
-          'nightlyAndroid'
-        }}
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/dev_on_workflow_call_e2e_android.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_android.yml
@@ -9,10 +9,9 @@ on:
         type: string
         default: '[MES]'
       test_tags:
-        description: 'Tags to include in the test run (activation, decouverte, conversion, or nightlyAndroid)'
+        description: 'Tags to include in the test run. If empty, all tests are run.'
         required: false
         type: string
-        default: 'nightlyAndroid'
     secrets:
       GCP_EHP_SERVICE_ACCOUNT:
         required: true
@@ -155,7 +154,7 @@ jobs:
           name: ${{ steps.generate_name.outputs.CUSTOM_NAME }}
           device-locale: fr_FR
           android-api-level: 34
-          workspace: .maestro/tests/
+          workspace: .maestro/testsV3/
           include-tags: ${{ inputs.test_tags }}
           async: true
           env: |

--- a/.github/workflows/dev_on_workflow_call_e2e_ios.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_ios.yml
@@ -9,10 +9,9 @@ on:
         type: string
         default: '[MES]'
       test_tags:
-        description: 'Tags to include in the test run (activation, decouverte, conversion, or nightlyIOS)'
+        description: 'Tags to include in the test run. If empty, all tests are run.'
         required: false
         type: string
-        default: 'nightlyIOS'
     secrets:
       GCP_EHP_SERVICE_ACCOUNT:
         required: true
@@ -139,7 +138,7 @@ jobs:
           project-id: proj_01javz1ncreqb9dcshv3y4da44
           app-file: ${{ steps.find_app.outputs.APP_PATH }}
           name: ${{ steps.generate_name.outputs.CUSTOM_NAME }}
-          workspace: .maestro/tests/
+          workspace: .maestro/testsV3/
           device-locale: fr_FR
           device-os: iOS-17-5
           device-model: iPhone-11

--- a/.github/workflows/dev_on_workflow_tester.yml
+++ b/.github/workflows/dev_on_workflow_tester.yml
@@ -204,7 +204,6 @@ jobs:
     uses: ./.github/workflows/dev_on_workflow_call_e2e_android.yml
     with:
       upload_name_prefix: '[PR]'
-      test_tags: 'nightlyAndroid'
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -215,7 +214,6 @@ jobs:
     uses: ./.github/workflows/dev_on_workflow_call_e2e_ios.yml
     with:
       upload_name_prefix: '[PR]'
-      test_tags: 'nightlyIOS'
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.maestro/testsV3/artist/CheckArtistPage.yml
+++ b/.maestro/testsV3/artist/CheckArtistPage.yml
@@ -6,7 +6,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToHome.yml
+- runFlow: ../common/DeeplinkToHome.yml
 
 - runFlow: ../common/GoToSearchFromTabBar.yml
 

--- a/.maestro/testsV3/auth/AgeStepInfoLoss.yml
+++ b/.maestro/testsV3/auth/AgeStepInfoLoss.yml
@@ -6,7 +6,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToProfile.yml
+- runFlow: ../common/DeeplinkToProfile.yml
 
 - assertVisible: 'Mon profil'
 - tapOn: 'Créer un compte'

--- a/.maestro/testsV3/auth/LoginFromOffer.yml
+++ b/.maestro/testsV3/auth/LoginFromOffer.yml
@@ -1,6 +1,7 @@
 appId: ${MAESTRO_APP_ID}
 tags:
   - auth
+  - fix
 onFlowStart:
   - runScript: ../common/DeepLink.js
   - runScript:
@@ -12,7 +13,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToHome.yml
+- runFlow: ../common/DeeplinkToHome.yml
 
 - runFlow: ../common/GoToSearchFromTabBar.yml
 
@@ -32,7 +33,7 @@ onFlowStart:
 
 - swipe:
     from:
-      text: '.*Les lieux culturels.*'
+      text: 'Les offres'
     direction: UP
 
 - extractTextWithAI:

--- a/.maestro/testsV3/auth/LoginWithWrongEmail.yml
+++ b/.maestro/testsV3/auth/LoginWithWrongEmail.yml
@@ -6,7 +6,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToProfile.yml
+- runFlow: ../common/DeeplinkToProfile.yml
 
 - tapOn: 'Se connecter'
 

--- a/.maestro/testsV3/auth/LoginWithWrongPassword.yml
+++ b/.maestro/testsV3/auth/LoginWithWrongPassword.yml
@@ -6,7 +6,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToProfile.yml
+- runFlow: ../common/DeeplinkToProfile.yml
 
 - tapOn: 'Se connecter'
 

--- a/.maestro/testsV3/auth/LogoutFromProfile.yml
+++ b/.maestro/testsV3/auth/LogoutFromProfile.yml
@@ -12,7 +12,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkBeneficiaryUser.yml
+- runFlow: ../common/DeeplinkBeneficiaryUser.yml
 - runFlow: ../common/GoToProfileFromTabBar.yml
 
 - assertVisible: 'Profil'

--- a/.maestro/testsV3/auth/PasswordStepInfoLoss.yml
+++ b/.maestro/testsV3/auth/PasswordStepInfoLoss.yml
@@ -6,7 +6,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToProfile.yml
+- runFlow: ../common/DeeplinkToProfile.yml
 
 - assertVisible: 'Mon profil'
 - tapOn: 'Créer un compte'

--- a/.maestro/testsV3/auth/SignupFromProfile.yml
+++ b/.maestro/testsV3/auth/SignupFromProfile.yml
@@ -6,7 +6,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToProfile.yml
+- runFlow: ../common/DeeplinkToProfile.yml
 
 - assertVisible: 'Mon profil'
 - tapOn: 'Créer un compte'

--- a/.maestro/testsV3/booking/BookDigitalOffer.yml
+++ b/.maestro/testsV3/booking/BookDigitalOffer.yml
@@ -1,6 +1,7 @@
 appId: ${MAESTRO_APP_ID}
 tags:
   - booking
+  - fix
 onFlowStart:
   - runScript: ../common/DeepLink.js
   - runScript:
@@ -12,7 +13,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkBeneficiaryUser.yml
+- runFlow: ../common/DeeplinkBeneficiaryUser.yml
 
 - runFlow: ../common/GoToSearchFromTabBar.yml
 
@@ -47,7 +48,7 @@ onFlowStart:
 - assertVisible: 'Rechercher'
 - swipe:
     from:
-      text: 'Les lieux culturels'
+      text: 'Les offres'
     direction: UP
 - tapOn: 'Abonnement presse en ligne'
 

--- a/.maestro/testsV3/booking/BookMusicalOffer.yml
+++ b/.maestro/testsV3/booking/BookMusicalOffer.yml
@@ -12,7 +12,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkBeneficiaryUser.yml
+- runFlow: ../common/DeeplinkBeneficiaryUser.yml
 
 - runFlow: ../common/GoToSearchFromTabBar.yml
 

--- a/.maestro/testsV3/booking/BookPhysicalOffer.yml
+++ b/.maestro/testsV3/booking/BookPhysicalOffer.yml
@@ -12,7 +12,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkBeneficiaryUser.yml
+- runFlow: ../common/DeeplinkBeneficiaryUser.yml
 
 - runFlow: ../common/GoToSearchFromTabBar.yml
 

--- a/.maestro/testsV3/booking/BookingSectionNotAvailableUnlogged.yml
+++ b/.maestro/testsV3/booking/BookingSectionNotAvailableUnlogged.yml
@@ -6,7 +6,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToProfile.yml
+- runFlow: ../common/DeeplinkToProfile.yml
 
 - assertNotVisible:
     id: 'Mes réservations'

--- a/.maestro/testsV3/common/GoToFavoritesFromTabBar.yml
+++ b/.maestro/testsV3/common/GoToFavoritesFromTabBar.yml
@@ -4,18 +4,16 @@ appId: ${MAESTRO_APP_ID}
     when:
       platform: Android
     commands:
-      - tapOn: 'Rechercher des offres.*'
+      - tapOn: 'Mes favoris.*'
 
 - runFlow:
     when:
       platform: iOS
     commands:
-      - tapOn: 'Rechercher des offres.*'
+      - tapOn: 'Mes favoris.*'
 
 - runFlow:
     when:
       platform: Web
     commands:
-      - tapOn: 'Recherche'
-
-- waitForAnimationToEnd
+      - tapOn: 'Favoris'

--- a/.maestro/testsV3/config.yaml
+++ b/.maestro/testsV3/config.yaml
@@ -7,3 +7,4 @@ flows:
   - booking/*
   - artist/*
   - offer/*
+  - web/*

--- a/.maestro/testsV3/offer/AccessPreviewModule.yml
+++ b/.maestro/testsV3/offer/AccessPreviewModule.yml
@@ -6,7 +6,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToHome.yml
+- runFlow: ../common/DeeplinkToHome.yml
 
 - runFlow: ../common/GoToSearchFromTabBar.yml
 

--- a/.maestro/testsV3/profile/AccessChatbot.yml
+++ b/.maestro/testsV3/profile/AccessChatbot.yml
@@ -12,7 +12,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkBeneficiaryUser.yml
+- runFlow: ../common/DeeplinkBeneficiaryUser.yml
 - runFlow: ../common/GoToProfileFromTabBar.yml
 
 - scrollUntilVisible:

--- a/.maestro/testsV3/profile/AccessDeletionReactivation.yml
+++ b/.maestro/testsV3/profile/AccessDeletionReactivation.yml
@@ -12,7 +12,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkBeneficiaryUser.yml
+- runFlow: ../common/DeeplinkBeneficiaryUser.yml
 - runFlow: ../common/GoToProfileFromTabBar.yml
 
 - tapOn: 'Informations personnelles'

--- a/.maestro/testsV3/profile/CantSetNotificationUnlogged.yml
+++ b/.maestro/testsV3/profile/CantSetNotificationUnlogged.yml
@@ -6,7 +6,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToProfile.yml
+- runFlow: ../common/DeeplinkToProfile.yml
 
 - scrollUntilVisible:
     element:

--- a/.maestro/testsV3/profile/CheckAccessibilitySection.yml
+++ b/.maestro/testsV3/profile/CheckAccessibilitySection.yml
@@ -12,7 +12,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkBeneficiaryUser.yml
+- runFlow: ../common/DeeplinkBeneficiaryUser.yml
 - runFlow: ../common/GoToProfileFromTabBar.yml
 
 - scrollUntilVisible:

--- a/.maestro/testsV3/profile/CheckAccountInfoNotAvailableUnlogged.yml
+++ b/.maestro/testsV3/profile/CheckAccountInfoNotAvailableUnlogged.yml
@@ -6,7 +6,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToProfile.yml
+- runFlow: ../common/DeeplinkToProfile.yml
 
 - assertNotVisible:
     text: 'Informations personnelles'

--- a/.maestro/testsV3/profile/CheckCreditAmount.yml
+++ b/.maestro/testsV3/profile/CheckCreditAmount.yml
@@ -12,7 +12,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkBeneficiaryUser.yml
+- runFlow: ../common/DeeplinkBeneficiaryUser.yml
 - runFlow: ../common/GoToProfileFromTabBar.yml
 
 - assertVisible: 'Profil'

--- a/.maestro/testsV3/profile/OpenConfidentialitySection.yml
+++ b/.maestro/testsV3/profile/OpenConfidentialitySection.yml
@@ -12,7 +12,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkBeneficiaryUser.yml
+- runFlow: ../common/DeeplinkBeneficiaryUser.yml
 - runFlow: ../common/GoToProfileFromTabBar.yml
 
 - scrollUntilVisible:

--- a/.maestro/testsV3/profile/OpenHelpCenter.yml
+++ b/.maestro/testsV3/profile/OpenHelpCenter.yml
@@ -12,7 +12,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkBeneficiaryUser.yml
+- runFlow: ../common/DeeplinkBeneficiaryUser.yml
 - runFlow: ../common/GoToProfileFromTabBar.yml
 
 - scrollUntilVisible:

--- a/.maestro/testsV3/profile/OpenLegalInfoSection.yml
+++ b/.maestro/testsV3/profile/OpenLegalInfoSection.yml
@@ -12,7 +12,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkBeneficiaryUser.yml
+- runFlow: ../common/DeeplinkBeneficiaryUser.yml
 - runFlow: ../common/GoToProfileFromTabBar.yml
 
 - scrollUntilVisible:

--- a/.maestro/testsV3/profile/OpenSocialNetworkLinks.yml
+++ b/.maestro/testsV3/profile/OpenSocialNetworkLinks.yml
@@ -12,7 +12,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkBeneficiaryUser.yml
+- runFlow: ../common/DeeplinkBeneficiaryUser.yml
 - runFlow: ../common/GoToProfileFromTabBar.yml
 
 - scrollUntilVisible:

--- a/.maestro/testsV3/search/ResetSearchFilters.yml
+++ b/.maestro/testsV3/search/ResetSearchFilters.yml
@@ -7,7 +7,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToHome.yml
+- runFlow: ../common/DeeplinkToHome.yml
 
 - runFlow: ../common/GoToSearchFromTabBar.yml
 - runFlow: ../common/GoToSearchFromTabBar.yml

--- a/.maestro/testsV3/search/SearchForNoResult.yml
+++ b/.maestro/testsV3/search/SearchForNoResult.yml
@@ -6,7 +6,7 @@ onFlowStart:
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToHome.yml
+- runFlow: ../common/DeeplinkToHome.yml
 
 - runFlow: ../common/GoToSearchFromTabBar.yml
 - runFlow: ../common/GoToSearchFromTabBar.yml

--- a/.maestro/testsV3/search/SearchOfferFromText.yml
+++ b/.maestro/testsV3/search/SearchOfferFromText.yml
@@ -1,12 +1,13 @@
 appId: ${MAESTRO_APP_ID}
 tags:
   - search
+  - fix
 onFlowStart:
   - runScript: ../common/DeepLink.js
 ---
 - runFlow: ../common/LaunchApp.yml
 - runFlow: ../common/StopApp.yml
-- runFlow: ../common/DeepLinkToHome.yml
+- runFlow: ../common/DeeplinkToHome.yml
 
 - runFlow: ../common/GoToSearchFromTabBar.yml
 
@@ -41,7 +42,7 @@ onFlowStart:
 
 - swipe:
     from:
-      text: '.*Les lieux culturels.*'
+      text: 'Les offres'
     direction: UP
 
 - extractTextWithAI:

--- a/.maestro/testsV3/web/SmokeTestWeb.yml
+++ b/.maestro/testsV3/web/SmokeTestWeb.yml
@@ -1,0 +1,38 @@
+url: http://localhost:5173/
+tags:
+  - web
+---
+- launchApp
+- extendedWaitUntil:
+    visible: 'Respect de ta vie privée'
+    timeout: 60000
+
+- runFlow: ../common/AcceptCookies.yml
+
+- assertVisible: "Bienvenue\_!"
+- assertVisible: 'Débloque ton crédit'
+
+- runFlow: ../common/GoToSearchFromTabBar.yml
+- assertVisible: 'Parcours les catégories'
+- tapOn: 'CINÉMA'
+- assertVisible: 'Cinéma'
+- tapOn: "Films à l'affiche"
+- runFlow:
+    when:
+      visible: 'Les artistes'
+    commands:
+      - assertVisible: '.*résultats'
+- runFlow:
+    when:
+      notVisible: 'Les artistes'
+    commands:
+      - assertVisible: 'Pas de résultat'
+
+- runFlow: ../common/GoToFavoritesFromTabBar.yml
+- assertVisible: 'Identifie-toi pour retrouver tes favoris'
+- assertVisible: 'Créer un compte'
+- assertVisible: 'Se connecter'
+
+- runFlow: ../common/GoToProfileFromTabBar.yml
+
+- stopApp

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -77,8 +77,8 @@ else
 fi
 
 if [ "$platform" = "web" ]; then
-  if [[ "$rest_of_arguments" != *".maestro/tests/SmokeTestWeb.yaml"* ]]; then
-    rest_of_arguments=".maestro/tests/ $rest_of_arguments"
+  if [[ "$rest_of_arguments" != *".maestro/testsV3/web/SmokeTestWeb.yaml"* ]]; then
+    rest_of_arguments=".maestro/testsV3/ $rest_of_arguments"
   fi
 fi
 

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -55,15 +55,15 @@ case "$target" in
 
   "cloud")
     if [ "$platform" = "ios" ]; then
-      TAGS="--include-tags nightlyIOS"
+      TAGS=""
     else
-      TAGS="--include-tags nightlyAndroid"
+      TAGS=""
     fi
     run_tracking_tests=false
     run_cloud_commands=true
     api_key=$(parse_env_variable ROBIN_API_KEY .maestro/.env.secret)
     project_id=$(parse_env_variable ROBIN_PROJECT_ID .maestro/.env.secret)
-    cloud_arguments="--api-key=$api_key --project-id=$project_id --flows .maestro/tests/ --device-locale fr_FR --android-api-level 34 --timeout 120 --ios-version 17"
+    cloud_arguments="--api-key=$api_key --project-id=$project_id --flows .maestro/testsV3/ --device-locale fr_FR --android-api-level 34 --timeout 120 --ios-version 17"
     ;;
 esac
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41787

## Context


## Résumé

- La nouvelle archi sera runs au nightly
- Pareil sur les PR
- Le système de runs par label a été simplifié (un tag pour run les tests Android & iOS)
- Le smokeTestWeb a été migré vers la nouvelle archi aussi

Les prochaines étapes :
- Mise en place d'un système pour déclencher certains tests en fonctions des fichiers modifié sur les PR
- Migrer les tests de bookings cinéma et le test des Favoris
- Supprimer le dead code des tests legacy
