### PR TITLE
(PC-41795) feat(cheatcodes): add direct ID access screen

### DIFF
--- a/src/cheatcodes/helpers/directIdAccessConfig.ts
+++ b/src/cheatcodes/helpers/directIdAccessConfig.ts
@@ -1,0 +1,48 @@
+import { api } from 'api/api'
+import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+
+export type DirectIdEntityKey = 'offer' | 'venue' | 'artist'
+
+type DirectIdEntity = {
+  key: DirectIdEntityKey
+  label: string
+  idType: 'number' | 'string'
+  navigate: (navigation: UseNavigationType, id: string) => void
+  validate?: (id: string) => Promise<unknown>
+}
+
+export const DIRECT_ID_ENTITIES: Record<DirectIdEntityKey, DirectIdEntity> = {
+  offer: {
+    key: 'offer',
+    label: 'Offre',
+    idType: 'number',
+    navigate: (navigation, id) =>
+      navigation.navigate('Offer', { id: Number(id), from: 'deeplink' }),
+    validate: (id) => api.getNativeV3OfferofferId(Number(id)),
+  },
+  venue: {
+    key: 'venue',
+    label: 'Lieu',
+    idType: 'number',
+    navigate: (navigation, id) =>
+      navigation.navigate('Venue', { id: Number(id), from: 'deeplink' }),
+    validate: (id) => api.getNativeV2VenuevenueId(Number(id)),
+  },
+  artist: {
+    key: 'artist',
+    label: 'Artiste',
+    idType: 'string',
+    navigate: (navigation, id) => navigation.navigate('Artist', { id }),
+  },
+}
+
+export const DIRECT_ID_ENTITY_KEYS = Object.keys(DIRECT_ID_ENTITIES) as DirectIdEntityKey[]
+
+export const DEFAULT_DIRECT_ID_ENTITY_KEY: DirectIdEntityKey = 'offer'
+
+export const isDirectIdValueValid = (entity: DirectIdEntity, value: string): boolean => {
+  const trimmed = value.trim()
+  if (!trimmed) return false
+  if (entity.idType === 'number') return /^\d+$/.test(trimmed)
+  return true
+}

--- a/src/cheatcodes/pages/CheatcodesMenu.tsx
+++ b/src/cheatcodes/pages/CheatcodesMenu.tsx
@@ -157,6 +157,15 @@ export function CheatcodesMenu(): React.JSX.Element {
     },
     {
       id: uuidv4(),
+      title: 'Accès direct par ID 🎯',
+      navigationTarget: {
+        screen: 'CheatcodesStackNavigator',
+        params: { screen: 'CheatcodesScreenDirectIdAccess' },
+      },
+      subscreens: [],
+    },
+    {
+      id: uuidv4(),
       title: 'Envoyer une erreur Sentry 📤',
       onPress: onPressSentry,
       subscreens: [],

--- a/src/cheatcodes/pages/others/CheatcodesScreenDirectIdAccess.native.test.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenDirectIdAccess.native.test.tsx
@@ -1,0 +1,97 @@
+import { useNavigation } from '@react-navigation/native'
+import React from 'react'
+
+import { api } from 'api/api'
+import { act, render, screen, userEvent } from 'tests/utils'
+import * as snackBarStoreModule from 'ui/designSystem/Snackbar/snackBar.store'
+
+import { CheatcodesScreenDirectIdAccess } from './CheatcodesScreenDirectIdAccess'
+
+jest.mock('@react-navigation/native')
+
+const mockNavigate = jest.fn()
+const mockUseNavigation = useNavigation as jest.Mock
+mockUseNavigation.mockReturnValue({ navigate: mockNavigate })
+
+const mockShowErrorSnackBar = jest.spyOn(snackBarStoreModule, 'showErrorSnackBar')
+
+const user = userEvent.setup()
+
+describe('<CheatcodesScreenDirectIdAccess />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should disable the navigate button when no id is entered', () => {
+    render(<CheatcodesScreenDirectIdAccess />)
+
+    const goButton = screen.getByText('Y aller')
+
+    expect(goButton).toBeDisabled()
+  })
+
+  it('should disable the navigate button for a non-numeric offer id', async () => {
+    render(<CheatcodesScreenDirectIdAccess />)
+
+    await user.type(screen.getByLabelText(/Identifiant offre/), 'not-a-number')
+
+    expect(screen.getByText('Y aller')).toBeDisabled()
+  })
+
+  it('should navigate to Offer when API validation succeeds', async () => {
+    jest.spyOn(api, 'getNativeV3OfferofferId').mockResolvedValueOnce({} as never)
+
+    render(<CheatcodesScreenDirectIdAccess />)
+
+    await user.type(screen.getByLabelText(/Identifiant offre/), '283')
+    await act(async () => {
+      await user.press(screen.getByText('Y aller'))
+    })
+
+    expect(api.getNativeV3OfferofferId).toHaveBeenCalledWith(283)
+    expect(mockNavigate).toHaveBeenCalledWith('Offer', { id: 283, from: 'deeplink' })
+    expect(mockShowErrorSnackBar).not.toHaveBeenCalled()
+  })
+
+  it('should show an error snackbar and not navigate when API validation fails', async () => {
+    jest.spyOn(api, 'getNativeV3OfferofferId').mockRejectedValueOnce(new Error('Offer not found'))
+
+    render(<CheatcodesScreenDirectIdAccess />)
+
+    await user.type(screen.getByLabelText(/Identifiant offre/), '999999')
+    await act(async () => {
+      await user.press(screen.getByText('Y aller'))
+    })
+
+    expect(mockShowErrorSnackBar).toHaveBeenCalledWith(expect.stringContaining('Offre introuvable'))
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('should navigate to Venue when API validation succeeds', async () => {
+    jest.spyOn(api, 'getNativeV2VenuevenueId').mockResolvedValueOnce({} as never)
+
+    render(<CheatcodesScreenDirectIdAccess />)
+
+    await user.press(screen.getByText('Lieu'))
+    await user.type(screen.getByLabelText(/Identifiant lieu/), '42')
+    await act(async () => {
+      await user.press(screen.getByText('Y aller'))
+    })
+
+    expect(api.getNativeV2VenuevenueId).toHaveBeenCalledWith(42)
+    expect(mockNavigate).toHaveBeenCalledWith('Venue', { id: 42, from: 'deeplink' })
+    expect(mockShowErrorSnackBar).not.toHaveBeenCalled()
+  })
+
+  it('should navigate to Artist without API validation', async () => {
+    render(<CheatcodesScreenDirectIdAccess />)
+
+    await user.press(screen.getByText('Artiste'))
+    await user.type(screen.getByLabelText(/Identifiant artiste/), 'artist-slug')
+    await act(async () => {
+      await user.press(screen.getByText('Y aller'))
+    })
+
+    expect(mockNavigate).toHaveBeenCalledWith('Artist', { id: 'artist-slug' })
+  })
+})

--- a/src/cheatcodes/pages/others/CheatcodesScreenDirectIdAccess.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenDirectIdAccess.tsx
@@ -1,0 +1,104 @@
+import { useNavigation } from '@react-navigation/native'
+import React, { useMemo, useState } from 'react'
+import styled from 'styled-components/native'
+
+import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
+import {
+  DEFAULT_DIRECT_ID_ENTITY_KEY,
+  DIRECT_ID_ENTITIES,
+  DIRECT_ID_ENTITY_KEYS,
+  DirectIdEntityKey,
+  isDirectIdValueValid,
+} from 'cheatcodes/helpers/directIdAccessConfig'
+import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
+import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { useGoBack } from 'features/navigation/useGoBack'
+import { getErrorMessage } from 'shared/getErrorMessage/getErrorMessage'
+import { Button } from 'ui/designSystem/Button/Button'
+import { RadioButtonGroup } from 'ui/designSystem/RadioButtonGroup/RadioButtonGroup'
+import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
+import { TextInput } from 'ui/designSystem/TextInput/TextInput'
+
+const TITLE = 'Accès direct par ID 🎯'
+
+export const CheatcodesScreenDirectIdAccess = (): React.JSX.Element => {
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesMenu'))
+  const navigation = useNavigation<UseNavigationType>()
+
+  const [selectedKey, setSelectedKey] = useState<DirectIdEntityKey>(DEFAULT_DIRECT_ID_ENTITY_KEY)
+  const [idValue, setIdValue] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  const selectedEntity = DIRECT_ID_ENTITIES[selectedKey]
+
+  const options = useMemo(
+    () =>
+      DIRECT_ID_ENTITY_KEYS.map((key) => ({
+        key,
+        label: DIRECT_ID_ENTITIES[key].label,
+      })),
+    []
+  )
+
+  const onSelectEntity = (label: string) => {
+    const next = DIRECT_ID_ENTITY_KEYS.find((key) => DIRECT_ID_ENTITIES[key].label === label)
+    if (!next || next === selectedKey) return
+    setSelectedKey(next)
+    setIdValue('')
+  }
+
+  const isValueValid = isDirectIdValueValid(selectedEntity, idValue)
+  const isDisabled = !isValueValid || isLoading
+
+  const onPress = async () => {
+    const trimmedId = idValue.trim()
+
+    if (!selectedEntity.validate) {
+      selectedEntity.navigate(navigation, trimmedId)
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      await selectedEntity.validate(trimmedId)
+      selectedEntity.navigate(navigation, trimmedId)
+    } catch (error) {
+      showErrorSnackBar(`${selectedEntity.label} introuvable\u00a0: ${getErrorMessage(error)}`)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <CheatcodesTemplateScreen title={TITLE} onGoBack={goBack} flexDirection="column">
+      <RadioButtonGroup
+        label="Type d’entité"
+        options={options}
+        value={selectedEntity.label}
+        onChange={onSelectEntity}
+      />
+      <Spacer />
+      <TextInput
+        label={`Identifiant ${selectedEntity.label.toLowerCase()}`}
+        value={idValue}
+        onChangeText={setIdValue}
+        keyboardType={selectedEntity.idType === 'number' ? 'numeric' : 'default'}
+        autoCapitalize="none"
+        autoComplete="off"
+        autoCorrect={false}
+      />
+      <Spacer />
+      <Button
+        wording="Y aller"
+        onPress={onPress}
+        disabled={isDisabled}
+        isLoading={isLoading}
+        fullWidth
+      />
+    </CheatcodesTemplateScreen>
+  )
+}
+
+const Spacer = styled.View(({ theme }) => ({
+  height: theme.designSystem.size.spacing.l,
+}))

--- a/src/features/navigation/CheatcodesStackNavigator/CheatcodesStackNavigator.tsx
+++ b/src/features/navigation/CheatcodesStackNavigator/CheatcodesStackNavigator.tsx
@@ -34,6 +34,7 @@ import { CheatcodesNavigationSignUp } from 'cheatcodes/pages/others/CheatcodesNa
 import { CheatcodesScreenAccesLibre } from 'cheatcodes/pages/others/CheatcodesScreenAccesLibre'
 import { CheatcodesScreenPageHeaderWithoutPlaceholder } from 'cheatcodes/pages/others/CheatcodesScreenCheatcodesScreenPageHeaderWithoutPlaceholder'
 import { CheatcodesScreenDebugInformations } from 'cheatcodes/pages/others/CheatcodesScreenDebugInformations'
+import { CheatcodesScreenDirectIdAccess } from 'cheatcodes/pages/others/CheatcodesScreenDirectIdAccess'
 import { CheatcodesScreenFeatureFlags } from 'cheatcodes/pages/others/CheatcodesScreenFeatureFlags'
 import { CheatcodesScreenGenericErrorPage } from 'cheatcodes/pages/others/CheatcodesScreenGenericErrorPage'
 import { CheatcodesScreenGenericInfoPage } from 'cheatcodes/pages/others/CheatcodesScreenGenericInfoPage'
@@ -236,6 +237,10 @@ const routes: CheatcodesStackRoute[] = [
   {
     name: 'CheatcodesScreenPageHeaderWithoutPlaceholder',
     component: CheatcodesScreenPageHeaderWithoutPlaceholder,
+  },
+  {
+    name: 'CheatcodesScreenDirectIdAccess',
+    component: CheatcodesScreenDirectIdAccess,
   },
 ]
 

--- a/src/features/navigation/CheatcodesStackNavigator/CheatcodesStackTypes.ts
+++ b/src/features/navigation/CheatcodesStackNavigator/CheatcodesStackTypes.ts
@@ -38,6 +38,7 @@ export type CheatcodesStackParamList = {
   CheatcodesNavigationSignUp: undefined
   CheatcodesScreenAccesLibre: undefined
   CheatcodesScreenDebugInformations: undefined
+  CheatcodesScreenDirectIdAccess: undefined
   CheatcodesScreenFeatureFlags: undefined
   CheatcodesScreenGenericErrorPage: undefined
   CheatcodesScreenGenericInfoPage: undefined


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41795

## Contexte

Côté web, on peut accéder à une page d'entité (offre, lieu, artiste) en tapant directement son ID dans l'URL. C'est précieux en local quand on injecte des données de test : l'indexation Algolia n'est pas faite, donc la recherche ne remonte rien et on ne peut pas atteindre la page autrement.

Côté mobile, ce raccourci n'existait pas. Cette PR ajoute un cheat code dédié pour combler ce manque.

## Ce que fait la PR

Ajout d'un nouvel écran dans les cheat codes : **« Accès direct par ID 🎯 »** (section *Autres*).

L'écran propose :
- un sélecteur du **type d'entité** (Offre, Lieu, Artiste) ;
- un **champ de saisie** d'ID adapté au type (numérique ou texte) ;
- un bouton **« Y aller »** qui navigue directement vers la page cible.

Comportement :
- bouton désactivé si l'ID est vide ou mal formé ;
- pour les offres et les lieux, validation **serveur** via les endpoints existants (`getNativeV3OfferofferId`, `getNativeV2VenuevenueId`) — si l'ID n'existe pas, une snackbar d'erreur s'affiche et la navigation est annulée ;
- pour les artistes, navigation directe sans validation (pas d'endpoint dédié côté front).

## Architecture

- `src/cheatcodes/helpers/directIdAccessConfig.ts` — config déclarative des entités supportées (label, type d'ID, fonction de navigation, validateur API optionnel). Facile à étendre avec d'autres entités (BookingDetails, ThematicHome, etc.).
- `src/cheatcodes/pages/others/CheatcodesScreenDirectIdAccess.tsx` — l'écran lui-même, monté dans le `CheatcodesStackNavigator`.

## Vidéo

https://github.com/user-attachments/assets/bb86d573-c24a-4792-98f9-bed8aea27924

## Test plan

- [ ] L'entrée **« Accès direct par ID 🎯 »** apparaît bien dans la section *Autres* du menu cheatcodes.
- [ ] Sélectionner **Offre**, saisir un ID valide existant → navigation vers la page offre.
- [ ] Sélectionner **Offre**, saisir un ID inexistant → snackbar d'erreur, pas de navigation.
- [ ] Sélectionner **Offre**, saisir du texte non numérique → bouton désactivé.
- [ ] Sélectionner **Lieu**, saisir un ID valide → navigation vers la page lieu.
- [ ] Sélectionner **Lieu**, saisir un ID inexistant → snackbar d'erreur.
- [ ] Sélectionner **Artiste**, saisir un slug → navigation vers la page artiste.
- [ ] Vérifier sur **iOS** et **Android**.
- [ ] Vérifier que l'écran n'est pas accessible en production (cheatcodes désactivés).