### PR TITLE
(PC-41752) feat(reviewInApp): trigger review after 10 offer consultat…

### DIFF
--- a/src/cheatcodes/pages/features/reviewInApp/CheatcodesNavigationReviewInApp.native.test.tsx
+++ b/src/cheatcodes/pages/features/reviewInApp/CheatcodesNavigationReviewInApp.native.test.tsx
@@ -20,6 +20,7 @@ describe('<CheatcodesNavigationReviewInApp/>', () => {
   beforeEach(async () => {
     jest.setSystemTime(NOW)
     await clearHistory()
+    await storage.clear('offers_viewed_count')
     await storage.clear('times_review_has_been_requested')
     await storage.clear('first_time_review_has_been_requested')
     mockIsAvailable.mockReturnValue(true)
@@ -35,22 +36,19 @@ describe('<CheatcodesNavigationReviewInApp/>', () => {
   it('renders the empty initial state', async () => {
     render(<CheatcodesNavigationReviewInApp />)
 
-    await waitFor(() => {
-      expect(screen.getByText(/quota restant\s*:\s*3\/3/)).toBeOnTheScreen()
-    })
-
+    expect(await screen.findByText(/quota restant\s*:\s*3\/3/)).toBeOnTheScreen()
     expect(screen.getAllByText('Oui').length).toBeGreaterThan(0)
   })
 
   it('saturates the quota when pressing the dedicated button', async () => {
     render(<CheatcodesNavigationReviewInApp />)
-    await waitFor(() => expect(screen.getByText(/quota restant\s*:\s*3\/3/)).toBeOnTheScreen())
+
+    expect(await screen.findByText(/quota restant\s*:\s*3\/3/)).toBeOnTheScreen()
 
     await user.press(screen.getByText('Saturer le quota (3 prompts récents)'))
 
-    await waitFor(() => {
-      expect(screen.getByText(/quota restant\s*:\s*0\/3/)).toBeOnTheScreen()
-    })
+    expect(await screen.findByText(/quota restant\s*:\s*0\/3/)).toBeOnTheScreen()
+
     const stored = await readHistory(NOW)
 
     expect(stored).toHaveLength(3)
@@ -60,20 +58,19 @@ describe('<CheatcodesNavigationReviewInApp/>', () => {
     await storage.saveObject('review_request_history', [NOW, NOW - 1000, NOW - 2000])
 
     render(<CheatcodesNavigationReviewInApp />)
-    await waitFor(() => expect(screen.getByText(/quota restant\s*:\s*0\/3/)).toBeOnTheScreen())
+
+    expect(await screen.findByText(/quota restant\s*:\s*0\/3/)).toBeOnTheScreen()
 
     await user.press(screen.getByText('Vider l’historique'))
 
-    await waitFor(() => {
-      expect(screen.getByText(/quota restant\s*:\s*3\/3/)).toBeOnTheScreen()
-    })
-
+    expect(await screen.findByText(/quota restant\s*:\s*3\/3/)).toBeOnTheScreen()
     expect(await readHistory(NOW)).toEqual([])
   })
 
   it('triggers the native prompt when pressing a source button', async () => {
     render(<CheatcodesNavigationReviewInApp />)
-    await waitFor(() => expect(screen.getByText(/quota restant\s*:\s*3\/3/)).toBeOnTheScreen())
+
+    expect(await screen.findByText(/quota restant\s*:\s*3\/3/)).toBeOnTheScreen()
 
     await user.press(screen.getByText('Booking success'))
     jest.advanceTimersByTime(1000)
@@ -81,5 +78,43 @@ describe('<CheatcodesNavigationReviewInApp/>', () => {
     await waitFor(() => {
       expect(mockRequestInAppReview).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it('renders the offers_viewed counter at 0 by default', async () => {
+    render(<CheatcodesNavigationReviewInApp />)
+
+    expect(await screen.findByText('0 / 10')).toBeOnTheScreen()
+  })
+
+  it('increments the offers_viewed counter when pressing the +1 button', async () => {
+    render(<CheatcodesNavigationReviewInApp />)
+
+    expect(await screen.findByText('0 / 10')).toBeOnTheScreen()
+
+    await user.press(screen.getByText('Incrémenter d’1 (simuler une vue d’offre)'))
+
+    expect(await screen.findByText('1 / 10')).toBeOnTheScreen()
+  })
+
+  it('seeds the offers_viewed counter at threshold-1', async () => {
+    render(<CheatcodesNavigationReviewInApp />)
+
+    expect(await screen.findByText('0 / 10')).toBeOnTheScreen()
+
+    await user.press(screen.getByText(/Placer le compteur à 9/))
+
+    expect(await screen.findByText('9 / 10')).toBeOnTheScreen()
+  })
+
+  it('resets the offers_viewed counter when pressing the reset button', async () => {
+    await storage.saveObject('offers_viewed_count', 5)
+
+    render(<CheatcodesNavigationReviewInApp />)
+
+    expect(await screen.findByText('5 / 10')).toBeOnTheScreen()
+
+    await user.press(screen.getByText('Réinitialiser le compteur'))
+
+    expect(await screen.findByText('0 / 10')).toBeOnTheScreen()
   })
 })

--- a/src/cheatcodes/pages/features/reviewInApp/CheatcodesNavigationReviewInApp.tsx
+++ b/src/cheatcodes/pages/features/reviewInApp/CheatcodesNavigationReviewInApp.tsx
@@ -5,8 +5,11 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import {
+  incrementOffersViewed,
   replayMigrationFromV1,
   resetHistory,
+  resetOffersViewed,
+  seedOffersViewedAtThresholdMinusOne,
   seedPromptNow,
   seedPromptOutOfLock,
   seedQuotaSaturated,
@@ -20,7 +23,7 @@ import { CheatcodeCategory } from 'cheatcodes/types'
 import { getCheatcodesHookConfig } from 'features/navigation/CheatcodesStackNavigator/getCheatcodesHookConfig'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { useGoBack } from 'features/navigation/useGoBack'
-import { ReviewTriggerSource } from 'libs/reviewInApp/types'
+import { OFFERS_VIEWED_REVIEW_THRESHOLD, ReviewTriggerSource } from 'libs/reviewInApp/types'
 import { useReviewInApp } from 'libs/reviewInApp/useReviewInApp'
 import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -117,6 +120,28 @@ export function CheatcodesNavigationReviewInApp(): React.JSX.Element {
       <StyledSeparator />
 
       <Section gap={2}>
+        <Typo.Title3>Compteur «&nbsp;offres consultées&nbsp;»</Typo.Title3>
+        <Typo.BodyAccentS>
+          Seuil&nbsp;: {OFFERS_VIEWED_REVIEW_THRESHOLD} consultations → trigger automatique sur la
+          page d’offre.
+        </Typo.BodyAccentS>
+        <Button
+          wording="Incrémenter d’1 (simuler une vue d’offre)"
+          onPress={wrap('Compteur +1', incrementOffersViewed)}
+        />
+        <Button
+          wording={`Placer le compteur à ${OFFERS_VIEWED_REVIEW_THRESHOLD - 1} (1 vue avant trigger)`}
+          onPress={wrap('Compteur au seuil-1', seedOffersViewedAtThresholdMinusOne)}
+        />
+        <Button
+          wording="Réinitialiser le compteur"
+          onPress={wrap('Compteur remis à 0', resetOffersViewed)}
+        />
+      </Section>
+
+      <StyledSeparator />
+
+      <Section gap={2}>
         <Typo.Title3>Déclencher manuellement</Typo.Title3>
         <Typo.BodyAccentS>
           Appelle requestReview(source) avec un délai de {TRIGGER_DELAY_MS}ms.
@@ -164,6 +189,13 @@ const StateBlock: React.FC<{ state: ReviewInAppCheatcodeState | null }> = ({ sta
       />
       <Row label="Dernier prompt" value={formatDate(state.lastPromptAt)} />
       <Row label="Verrou actif jusqu’à" value={formatDate(state.lockUntil)} />
+      <Row
+        label="Offres consultées (trigger offers_viewed)"
+        value={`${state.offersViewedCount} / ${state.offersViewedThreshold}`}
+        emphasis={
+          state.offersViewedCount >= state.offersViewedThreshold - 1 ? 'success' : undefined
+        }
+      />
       {state.history.length > 0 ? (
         <ViewGap gap={1}>
           <Typo.BodyAccentS>Timestamps&nbsp;:</Typo.BodyAccentS>

--- a/src/cheatcodes/pages/features/reviewInApp/reviewInAppCheatcodeActions.ts
+++ b/src/cheatcodes/pages/features/reviewInApp/reviewInAppCheatcodeActions.ts
@@ -1,6 +1,15 @@
 import { MIGRATION_DONE_KEY, runMigrationFromV1 } from 'libs/reviewInApp/migrateFromV1'
+import {
+  incrementOffersViewedCount,
+  OFFERS_VIEWED_COUNT_STORAGE_KEY,
+  resetOffersViewedCount,
+} from 'libs/reviewInApp/offersViewedCounter'
 import { appendHistory, clearHistory, STORAGE_KEY } from 'libs/reviewInApp/reviewHistory'
-import { REVIEW_LOCK_DURATION_MS, REVIEW_QUOTA_LIMIT } from 'libs/reviewInApp/types'
+import {
+  OFFERS_VIEWED_REVIEW_THRESHOLD,
+  REVIEW_LOCK_DURATION_MS,
+  REVIEW_QUOTA_LIMIT,
+} from 'libs/reviewInApp/types'
 import { storage } from 'libs/storage'
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000
@@ -34,4 +43,16 @@ export const seedV1Data = async (): Promise<void> => {
 export const replayMigrationFromV1 = async (): Promise<void> => {
   await storage.clear(MIGRATION_DONE_KEY)
   await runMigrationFromV1()
+}
+
+export const incrementOffersViewed = async (): Promise<void> => {
+  await incrementOffersViewedCount()
+}
+
+export const resetOffersViewed = async (): Promise<void> => {
+  await resetOffersViewedCount()
+}
+
+export const seedOffersViewedAtThresholdMinusOne = async (): Promise<void> => {
+  await storage.saveObject(OFFERS_VIEWED_COUNT_STORAGE_KEY, OFFERS_VIEWED_REVIEW_THRESHOLD - 1)
 }

--- a/src/cheatcodes/pages/features/reviewInApp/useReviewInAppCheatcodeState.ts
+++ b/src/cheatcodes/pages/features/reviewInApp/useReviewInAppCheatcodeState.ts
@@ -3,8 +3,13 @@ import InAppReview from 'react-native-in-app-review'
 
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { readOffersViewedCount } from 'libs/reviewInApp/offersViewedCounter'
 import { canRequestReview, readHistory } from 'libs/reviewInApp/reviewHistory'
-import { REVIEW_LOCK_DURATION_MS, REVIEW_QUOTA_LIMIT } from 'libs/reviewInApp/types'
+import {
+  OFFERS_VIEWED_REVIEW_THRESHOLD,
+  REVIEW_LOCK_DURATION_MS,
+  REVIEW_QUOTA_LIMIT,
+} from 'libs/reviewInApp/types'
 
 export type ReviewInAppCheatcodeState = {
   isNativeAvailable: boolean
@@ -15,10 +20,13 @@ export type ReviewInAppCheatcodeState = {
   canRequest: boolean
   lastPromptAt: number | null
   lockUntil: number | null
+  offersViewedCount: number
+  offersViewedThreshold: number
 }
 
 const computeState = (
   history: number[],
+  offersViewedCount: number,
   isNativeAvailable: boolean,
   isKillSwitchOn: boolean,
   now: number
@@ -33,6 +41,8 @@ const computeState = (
     canRequest: !isKillSwitchOn && isNativeAvailable && canRequestReview(history, now),
     lastPromptAt,
     lockUntil: lastPromptAt === null ? null : lastPromptAt + REVIEW_LOCK_DURATION_MS,
+    offersViewedCount,
+    offersViewedThreshold: OFFERS_VIEWED_REVIEW_THRESHOLD,
   }
 }
 
@@ -45,8 +55,13 @@ export const useReviewInAppCheatcodeState = (): {
 
   const refresh = useCallback(async () => {
     const now = Date.now()
-    const history = await readHistory(now)
-    setState(computeState(history, InAppReview.isAvailable(), isKillSwitchOn, now))
+    const [history, offersViewedCount] = await Promise.all([
+      readHistory(now),
+      readOffersViewedCount(),
+    ])
+    setState(
+      computeState(history, offersViewedCount, InAppReview.isAvailable(), isKillSwitchOn, now)
+    )
   }, [isKillSwitchOn])
 
   useEffect(() => {

--- a/src/features/auth/queries/useUserProfileInfoQuery.ts
+++ b/src/features/auth/queries/useUserProfileInfoQuery.ts
@@ -19,7 +19,7 @@ const sanitizeUser = (user: UserProfileResponse): UserProfile => {
   const { statusType, creditType, eligibilityType } = getUserProfileState(user)
   return {
     ...rest,
-    subscriptionStatus: user.status.subscriptionStatus,
+    subscriptionStatus: user.status?.subscriptionStatus,
     statusType,
     creditType,
     eligibilityType,

--- a/src/features/offer/pages/Offer/Offer.native.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.native.test.tsx
@@ -1,3 +1,4 @@
+import InAppReview from 'react-native-in-app-review'
 import { ReactTestInstance } from 'react-test-renderer'
 
 import {
@@ -21,11 +22,18 @@ import { mockedAlgoliaOffersWithSameArtistResponse } from 'libs/algolia/fixtures
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import {
+  OFFERS_VIEWED_COUNT_STORAGE_KEY,
+  readOffersViewedCount,
+} from 'libs/reviewInApp/offersViewedCounter'
+import { clearHistory } from 'libs/reviewInApp/reviewHistory'
+import { OFFERS_VIEWED_REVIEW_THRESHOLD } from 'libs/reviewInApp/types'
+import { storage } from 'libs/storage'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
 import * as useArtistResultsAPI from 'queries/offer/useArtistResultsQuery'
 import * as ABSegmentModule from 'shared/useABSegment/useABSegment'
 import { mockServer } from 'tests/mswServer'
-import { screen, userEvent, waitFor } from 'tests/utils'
+import { act, screen, userEvent, waitFor } from 'tests/utils'
 import * as useModal from 'ui/components/modals/useModal'
 
 jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
@@ -66,6 +74,10 @@ jest.spyOn(useModal, 'useModal').mockReturnValue({
 
 jest.mock('libs/firebase/analytics/analytics')
 jest.useFakeTimers()
+
+jest.mock('react-native-in-app-review')
+const mockIsAvailable = InAppReview.isAvailable as jest.Mock
+const mockRequestInAppReview = InAppReview.RequestInAppReview as jest.Mock
 
 const mockUseAuthContext = jest.fn()
 jest.mock('features/auth/context/AuthContext', () => ({
@@ -393,6 +405,47 @@ describe('<Offer />', () => {
           accepted: [...acceptedWithoutVideo, CookieNameEnum.VIDEO_PLAYBACK],
           refused: [],
         })
+      })
+    })
+  })
+
+  describe('offers_viewed review trigger', () => {
+    beforeEach(async () => {
+      mockIsAvailable.mockReturnValue(true)
+      mockRequestInAppReview.mockResolvedValue(true)
+      await storage.clear(OFFERS_VIEWED_COUNT_STORAGE_KEY)
+      await clearHistory()
+    })
+
+    it('calls RequestInAppReview after 2s when the threshold is reached and the flag is on', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_REVIEW_TRIGGER_OFFERS])
+      await storage.saveObject(OFFERS_VIEWED_COUNT_STORAGE_KEY, OFFERS_VIEWED_REVIEW_THRESHOLD - 1)
+
+      renderOfferPage({ mockOffer: offerResponseSnap })
+      await act(async () => {})
+      jest.advanceTimersByTime(2000)
+      await act(async () => {})
+
+      await waitFor(() => {
+        expect(mockRequestInAppReview).toHaveBeenCalledTimes(1)
+      })
+
+      expect(await readOffersViewedCount()).toBe(0)
+    })
+
+    it('does not call RequestInAppReview when the flag is off and preserves the counter', async () => {
+      setFeatureFlags([])
+      await storage.saveObject(OFFERS_VIEWED_COUNT_STORAGE_KEY, OFFERS_VIEWED_REVIEW_THRESHOLD - 1)
+
+      renderOfferPage({ mockOffer: offerResponseSnap })
+      await act(async () => {})
+      jest.advanceTimersByTime(2000)
+      await act(async () => {})
+
+      expect(mockRequestInAppReview).not.toHaveBeenCalled()
+
+      await waitFor(async () => {
+        expect(await readOffersViewedCount()).toBe(OFFERS_VIEWED_REVIEW_THRESHOLD)
       })
     })
   })

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -25,6 +25,7 @@ import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureF
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useIsFalseWithDelay } from 'libs/hooks/useIsFalseWithDelay'
 import { useLocation } from 'libs/location/LocationWrapper'
+import { useOffersViewedReviewTrigger } from 'libs/reviewInApp/useOffersViewedReviewTrigger'
 import { useSubcategoriesMapping } from 'libs/subcategories/mappings'
 import { useEndedBookingFromOfferIdQueryV2 } from 'queries/bookings/useEndedBookingFromOfferIdQuery'
 import { useOfferQuery } from 'queries/offer/useOfferQuery'
@@ -57,6 +58,8 @@ export function Offer() {
       reactionsCount: { likes: data.reactionsCount.likes },
     }),
   })
+
+  useOffersViewedReviewTrigger(offer?.id)
   const showSkeleton = useIsFalseWithDelay(isLoading, ANIMATION_DURATION)
   const { data: subcategories } = useSubcategoriesQuery()
   const subcategoriesMapping = useSubcategoriesMapping()

--- a/src/libs/reviewInApp/offersViewedCounter.native.test.ts
+++ b/src/libs/reviewInApp/offersViewedCounter.native.test.ts
@@ -1,0 +1,67 @@
+import {
+  incrementOffersViewedCount,
+  OFFERS_VIEWED_COUNT_STORAGE_KEY,
+  readOffersViewedCount,
+  resetOffersViewedCount,
+} from 'libs/reviewInApp/offersViewedCounter'
+import { storage } from 'libs/storage'
+
+describe('offersViewedCounter', () => {
+  beforeEach(async () => {
+    await storage.clear(OFFERS_VIEWED_COUNT_STORAGE_KEY)
+  })
+
+  describe('readOffersViewedCount', () => {
+    it('returns 0 when storage is empty', async () => {
+      expect(await readOffersViewedCount()).toBe(0)
+    })
+
+    it('returns 0 when stored value is not a number', async () => {
+      await storage.saveObject(OFFERS_VIEWED_COUNT_STORAGE_KEY, 'not-a-number')
+
+      expect(await readOffersViewedCount()).toBe(0)
+    })
+
+    it('returns 0 when stored value is negative', async () => {
+      await storage.saveObject(OFFERS_VIEWED_COUNT_STORAGE_KEY, -3)
+
+      expect(await readOffersViewedCount()).toBe(0)
+    })
+
+    it('returns the stored value when valid', async () => {
+      await storage.saveObject(OFFERS_VIEWED_COUNT_STORAGE_KEY, 7)
+
+      expect(await readOffersViewedCount()).toBe(7)
+    })
+  })
+
+  describe('incrementOffersViewedCount', () => {
+    it('returns 1 on first call', async () => {
+      expect(await incrementOffersViewedCount()).toBe(1)
+    })
+
+    it('returns successive values on repeated calls', async () => {
+      expect(await incrementOffersViewedCount()).toBe(1)
+      expect(await incrementOffersViewedCount()).toBe(2)
+      expect(await incrementOffersViewedCount()).toBe(3)
+    })
+
+    it('persists the new value to storage', async () => {
+      await incrementOffersViewedCount()
+      await incrementOffersViewedCount()
+
+      expect(await readOffersViewedCount()).toBe(2)
+    })
+  })
+
+  describe('resetOffersViewedCount', () => {
+    it('sets the counter to 0', async () => {
+      await incrementOffersViewedCount()
+      await incrementOffersViewedCount()
+
+      await resetOffersViewedCount()
+
+      expect(await readOffersViewedCount()).toBe(0)
+    })
+  })
+})

--- a/src/libs/reviewInApp/offersViewedCounter.ts
+++ b/src/libs/reviewInApp/offersViewedCounter.ts
@@ -1,0 +1,18 @@
+import { storage } from 'libs/storage'
+
+export const OFFERS_VIEWED_COUNT_STORAGE_KEY = 'offers_viewed_count'
+
+export const readOffersViewedCount = async (): Promise<number> => {
+  const raw = await storage.readObject<number>(OFFERS_VIEWED_COUNT_STORAGE_KEY)
+  return typeof raw === 'number' && raw >= 0 ? raw : 0
+}
+
+export const incrementOffersViewedCount = async (): Promise<number> => {
+  const next = (await readOffersViewedCount()) + 1
+  await storage.saveObject(OFFERS_VIEWED_COUNT_STORAGE_KEY, next)
+  return next
+}
+
+export const resetOffersViewedCount = async (): Promise<void> => {
+  await storage.saveObject(OFFERS_VIEWED_COUNT_STORAGE_KEY, 0)
+}

--- a/src/libs/reviewInApp/types.ts
+++ b/src/libs/reviewInApp/types.ts
@@ -10,6 +10,8 @@ export const REVIEW_QUOTA_LIMIT = 3
 export const REVIEW_LOCK_DURATION_MS = 30 * 24 * 60 * 60 * 1000
 export const REVIEW_WINDOW_MS = 365 * 24 * 60 * 60 * 1000
 export const DEFAULT_DELAY_MS = 1000
+export const OFFERS_VIEWED_REVIEW_THRESHOLD = 10
+export const OFFERS_VIEWED_REVIEW_DELAY_MS = 2000
 
 export const REVIEW_TRIGGER_FEATURE_FLAGS: Record<ReviewTriggerSource, RemoteStoreFeatureFlags> = {
   booking_success: RemoteStoreFeatureFlags.WIP_REVIEW_TRIGGER_BOOKING,

--- a/src/libs/reviewInApp/useOffersViewedReviewTrigger.native.test.ts
+++ b/src/libs/reviewInApp/useOffersViewedReviewTrigger.native.test.ts
@@ -1,0 +1,98 @@
+import InAppReview from 'react-native-in-app-review'
+
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import {
+  OFFERS_VIEWED_COUNT_STORAGE_KEY,
+  readOffersViewedCount,
+} from 'libs/reviewInApp/offersViewedCounter'
+import { clearHistory } from 'libs/reviewInApp/reviewHistory'
+import { OFFERS_VIEWED_REVIEW_THRESHOLD } from 'libs/reviewInApp/types'
+import { useOffersViewedReviewTrigger } from 'libs/reviewInApp/useOffersViewedReviewTrigger'
+import { storage } from 'libs/storage'
+import { act, renderHook, waitFor } from 'tests/utils'
+
+jest.unmock('libs/appState')
+jest.mock('react-native-in-app-review')
+const mockIsAvailable = InAppReview.isAvailable as jest.Mock
+const mockRequestInAppReview = InAppReview.RequestInAppReview as jest.Mock
+
+jest.useFakeTimers()
+
+// The hook awaits the persistent counter before scheduling the delayed prompt,
+// so we flush pending promises (act) once to reach the setTimeout, then again
+// after advancing fake timers to resolve the native call and the counter reset.
+const flushAsync = () => act(async () => {})
+
+describe('useOffersViewedReviewTrigger', () => {
+  beforeEach(async () => {
+    await storage.clear(OFFERS_VIEWED_COUNT_STORAGE_KEY)
+    await clearHistory()
+    mockIsAvailable.mockReturnValue(true)
+    mockRequestInAppReview.mockResolvedValue(true)
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_REVIEW_TRIGGER_OFFERS])
+  })
+
+  it('does not trigger before the threshold is reached', async () => {
+    for (let i = 1; i < OFFERS_VIEWED_REVIEW_THRESHOLD; i++) {
+      renderHook(() => useOffersViewedReviewTrigger(i))
+      await flushAsync()
+    }
+    jest.advanceTimersByTime(5000)
+
+    expect(mockRequestInAppReview).not.toHaveBeenCalled()
+    expect(await readOffersViewedCount()).toBe(OFFERS_VIEWED_REVIEW_THRESHOLD - 1)
+  })
+
+  it('triggers the review and resets the counter when the threshold is reached', async () => {
+    for (let i = 1; i <= OFFERS_VIEWED_REVIEW_THRESHOLD; i++) {
+      renderHook(() => useOffersViewedReviewTrigger(i))
+      await flushAsync()
+    }
+    jest.advanceTimersByTime(2000)
+    await flushAsync()
+
+    await waitFor(() => {
+      expect(mockRequestInAppReview).toHaveBeenCalledTimes(1)
+    })
+
+    expect(await readOffersViewedCount()).toBe(0)
+  })
+
+  it('persists the counter across hook instances', async () => {
+    await storage.saveObject(OFFERS_VIEWED_COUNT_STORAGE_KEY, 5)
+
+    for (let i = 6; i <= OFFERS_VIEWED_REVIEW_THRESHOLD; i++) {
+      renderHook(() => useOffersViewedReviewTrigger(i))
+      await flushAsync()
+    }
+    jest.advanceTimersByTime(2000)
+    await flushAsync()
+
+    await waitFor(() => {
+      expect(mockRequestInAppReview).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('preserves the counter when the feature flag is off so the signal is not lost', async () => {
+    setFeatureFlags([])
+    await storage.saveObject(OFFERS_VIEWED_COUNT_STORAGE_KEY, OFFERS_VIEWED_REVIEW_THRESHOLD - 1)
+
+    renderHook(() => useOffersViewedReviewTrigger(42))
+    await flushAsync()
+    jest.advanceTimersByTime(2000)
+    await flushAsync()
+
+    expect(mockRequestInAppReview).not.toHaveBeenCalled()
+    expect(await readOffersViewedCount()).toBe(OFFERS_VIEWED_REVIEW_THRESHOLD)
+  })
+
+  it('does nothing when offerId is undefined', async () => {
+    renderHook(() => useOffersViewedReviewTrigger(undefined))
+    await flushAsync()
+    jest.advanceTimersByTime(2000)
+
+    expect(mockRequestInAppReview).not.toHaveBeenCalled()
+    expect(await readOffersViewedCount()).toBe(0)
+  })
+})

--- a/src/libs/reviewInApp/useOffersViewedReviewTrigger.ts
+++ b/src/libs/reviewInApp/useOffersViewedReviewTrigger.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react'
+
+import {
+  incrementOffersViewedCount,
+  resetOffersViewedCount,
+} from 'libs/reviewInApp/offersViewedCounter'
+import {
+  OFFERS_VIEWED_REVIEW_DELAY_MS,
+  OFFERS_VIEWED_REVIEW_THRESHOLD,
+} from 'libs/reviewInApp/types'
+import { useReviewInApp } from 'libs/reviewInApp/useReviewInApp'
+
+export const useOffersViewedReviewTrigger = (offerId: number | undefined): void => {
+  const { requestReview } = useReviewInApp()
+  const requestReviewRef = useRef(requestReview)
+
+  useEffect(() => {
+    requestReviewRef.current = requestReview
+  })
+
+  // Guard against StrictMode double-mount and consecutive remounts on the same offerId.
+  const processedOfferIdRef = useRef<number | undefined>(undefined)
+
+  useEffect(() => {
+    if (!offerId) return
+    if (processedOfferIdRef.current === offerId) return
+    processedOfferIdRef.current = offerId
+
+    let cancelled = false
+
+    const recordOfferViewAndMaybeRequestReview = async () => {
+      const count = await incrementOffersViewedCount()
+      if (cancelled) return
+      if (count < OFFERS_VIEWED_REVIEW_THRESHOLD) return
+
+      const scheduled = await requestReviewRef.current('offers_viewed', {
+        delayMs: OFFERS_VIEWED_REVIEW_DELAY_MS,
+      })
+      if (scheduled) {
+        await resetOffersViewedCount()
+      }
+    }
+
+    void recordOfferViewAndMaybeRequestReview()
+
+    return () => {
+      cancelled = true
+    }
+  }, [offerId])
+}

--- a/src/libs/reviewInApp/useReviewInApp.ts
+++ b/src/libs/reviewInApp/useReviewInApp.ts
@@ -47,16 +47,16 @@ export const useReviewInApp = () => {
   useAppStateChange(undefined, cancelPending, [])
 
   const requestReview = useCallback(
-    async (source: ReviewTriggerSource, options?: RequestReviewOptions): Promise<void> => {
-      if (!InAppReview.isAvailable()) return
-      if (disableStoreReview) return
-      if (!triggerEnabledBySource[source]) return
+    async (source: ReviewTriggerSource, options?: RequestReviewOptions): Promise<boolean> => {
+      if (!InAppReview.isAvailable()) return false
+      if (disableStoreReview) return false
+      if (!triggerEnabledBySource[source]) return false
 
-      if (inFlightRef.current) return
-      if (timeoutRef.current !== undefined) return
+      if (inFlightRef.current) return false
+      if (timeoutRef.current !== undefined) return false
 
       const history = await readHistory()
-      if (!canRequestReview(history, Date.now())) return
+      if (!canRequestReview(history, Date.now())) return false
 
       inFlightRef.current = true
       timeoutRef.current = setTimeout(() => {
@@ -70,6 +70,7 @@ export const useReviewInApp = () => {
             inFlightRef.current = false
           })
       }, options?.delayMs ?? DEFAULT_DELAY_MS)
+      return true
     },
     [disableStoreReview, triggerEnabledBySource]
   )

--- a/src/libs/storage.ts
+++ b/src/libs/storage.ts
@@ -16,6 +16,7 @@ export type StorageKey =
   | 'has_seen_push_notifications_modal_once'
   | 'has_seen_tutorials'
   | 'logged_in_session_count'
+  | 'offers_viewed_count'
   | 'PASSCULTURE_REFRESH_TOKEN'
   | 'profile-address'
   | 'profile-city'


### PR DESCRIPTION
…ions

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41752

## Résumé

Implémentation du trigger `offers_viewed` du système de notation in-app : après **10 consultations** de pages d'offre (cumulées entre sessions), proposition à l'utilisateur de noter l'application.

- Compteur incrémenté à chaque montage de la page d'offre, **persistant** dans AsyncStorage pour survivre à un redémarrage de l'app
- Déclenchement de la popup native à la 10ᵉ vue, après un délai de **2 secondes**
- Réinitialisation du compteur **uniquement quand la popup est effectivement programmée** → si le flag est OFF, le quota atteint ou le verrou actif, le signal est préservé pour la prochaine occasion (pas de perte d'engagement utilisateur)
- Conditionné au feature flag `WIP_REVIEW_TRIGGER_OFFERS` (déjà câblé dans `useReviewInApp`)
- Garde contre les double-montages StrictMode / remounts consécutifs sur le même `offerId`

## Cheatcodes

Extension de l'écran cheatcode **In-App Review** pour faciliter la validation manuelle :

- Affichage de la ligne **« Offres consultées : X / 10 »** dans le bloc d'état (surlignée en vert dès qu'on est à seuil-1)
- Nouvelle section **« Compteur "offres consultées" »** avec 3 boutons :
  - Incrémenter d'1 (simuler une vue d'offre)
  - Placer le compteur à 9 (1 vue avant trigger)
  - Réinitialiser le compteur

## Vidéo

https://github.com/user-attachments/assets/950234e2-e878-4909-ae62-99d4a1c75d74

## Règles métier

| Règle | Implémentation |
|-------|----------------|
| Incrémenter à chaque vue de détail d'offre | `useOffersViewedReviewTrigger(offerId)` dans `Offer.tsx` |
| Seuil : 10ᵉ vue | `OFFERS_VIEWED_REVIEW_THRESHOLD = 10` |
| Délai : 2 secondes | `OFFERS_VIEWED_REVIEW_DELAY_MS = 2000` |
| Persistance | `libs/storage` — clé `offers_viewed_count` |
| Flag | `WIP_REVIEW_TRIGGER_OFFERS` |

## Test plan

- [ ] Ouvrir 9 fois la page d'une offre puis la 10ᵉ : la popup native s'affiche après 2 s, le compteur retombe à 0
- [ ] Couper l'app après 5 vues, rouvrir, faire 5 vues : la popup s'affiche bien à la 10ᵉ consultation totale
- [ ] Couper le flag `WIP_REVIEW_TRIGGER_OFFERS`, faire 10 vues : pas de popup, le compteur reste à 10 (signal préservé pour quand le flag passera ON)
- [ ] Cheatcodes : appuyer sur « Placer le compteur à 9 » puis ouvrir une offre → popup affichée après 2 s
- [ ] Cheatcodes : appuyer 3× sur « Incrémenter d'1 » → l'état affiche `3 / 10`
- [ ] `yarn jest src/libs/reviewInApp src/features/offer/pages/Offer src/cheatcodes/pages/features/reviewInApp` — vert
- [ ] `yarn test:types` + `yarn test:lint` — vert