### PR TITLE
(PC-41774) feat(reviewInApp): trigger store review after liking an en…

### DIFF
--- a/src/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx
@@ -1,5 +1,6 @@
 import { UseQueryResult } from '@tanstack/react-query'
 import React from 'react'
+import InAppReview from 'react-native-in-app-review'
 
 import { BookingsListResponseV2, SubcategoriesResponseModelv2 } from 'api/gen'
 import { availableReactionsSnap } from 'features/bookings/fixtures/availableReactionSnap'
@@ -8,10 +9,12 @@ import * as useGoBack from 'features/navigation/useGoBack'
 import { UserProfile } from 'features/share/types'
 import { beneficiaryUser } from 'fixtures/user'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { appendHistory, clearHistory } from 'libs/reviewInApp/reviewHistory'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render, screen, userEvent } from 'tests/utils'
+import { act, render, screen, userEvent } from 'tests/utils'
 
 import { EndedBookings } from './EndedBookings'
 
@@ -47,6 +50,10 @@ jest.mock('features/search/context/SearchWrapper', () => ({
   }),
 }))
 
+jest.mock('react-native-in-app-review')
+const mockIsAvailable = InAppReview.isAvailable as jest.Mock
+const mockRequestInAppReview = InAppReview.RequestInAppReview as jest.Mock
+
 const user = userEvent.setup()
 
 jest.useFakeTimers()
@@ -76,6 +83,69 @@ describe('EndedBookings', () => {
     await user.press(screen.getByText('Valider la réaction'))
 
     expect(mockMutate).toHaveBeenCalledTimes(1)
+  })
+
+  describe('booking_liked review trigger', () => {
+    beforeEach(async () => {
+      mockIsAvailable.mockReturnValue(true)
+      mockRequestInAppReview.mockResolvedValue(true)
+      await clearHistory()
+    })
+
+    const submitReaction = async (reactionWording: string) => {
+      await user.press(await screen.findByLabelText('Réagis à ta réservation'))
+      await user.press(await screen.findByText(reactionWording))
+      await user.press(screen.getByText('Valider la réaction'))
+    }
+
+    it('calls RequestInAppReview after 3s when a Like is submitted and the flag is on', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_REVIEW_TRIGGER_LIKE])
+      renderEndedBookings()
+
+      await submitReaction('J’aime')
+      await act(async () => {
+        jest.advanceTimersByTime(3000)
+      })
+
+      expect(mockRequestInAppReview).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not call RequestInAppReview when the system was already prompted less than 30 days ago', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_REVIEW_TRIGGER_LIKE])
+      await appendHistory(Date.now() - 10 * 24 * 60 * 60 * 1000)
+      renderEndedBookings()
+
+      await submitReaction('J’aime')
+      await act(async () => {
+        jest.advanceTimersByTime(3000)
+      })
+
+      expect(mockRequestInAppReview).not.toHaveBeenCalled()
+    })
+
+    it('does not call RequestInAppReview when the flag is off', async () => {
+      setFeatureFlags([])
+      renderEndedBookings()
+
+      await submitReaction('J’aime')
+      await act(async () => {
+        jest.advanceTimersByTime(3000)
+      })
+
+      expect(mockRequestInAppReview).not.toHaveBeenCalled()
+    })
+
+    it('does not call RequestInAppReview when the reaction is not a Like', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_REVIEW_TRIGGER_LIKE])
+      renderEndedBookings()
+
+      await submitReaction('Je n’aime pas')
+      await act(async () => {
+        jest.advanceTimersByTime(3000)
+      })
+
+      expect(mockRequestInAppReview).not.toHaveBeenCalled()
+    })
   })
 })
 

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.tsx
@@ -21,6 +21,8 @@ import { useReactionMutation } from 'features/reactions/queries/useReactionMutat
 import { WebShareModal } from 'features/share/pages/WebShareModal'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { LIKE_REVIEW_DELAY_MS } from 'libs/reviewInApp/types'
+import { useReviewInApp } from 'libs/reviewInApp/useReviewInApp'
 import { ShareContent } from 'libs/share/types'
 import { useModal } from 'ui/components/modals/useModal'
 import { Separator } from 'ui/components/Separator'
@@ -40,6 +42,7 @@ export const EndedBookings: FunctionComponent<Props> = ({ useEndedBookingsQuery 
   const { bookings: endedBookings } = bookings
 
   const { mutateAsync: addReaction } = useReactionMutation()
+  const { requestReview } = useReviewInApp()
 
   const [selectedBookingOffer, setSelectedBookingOffer] = useState<BookingListItemOfferResponse>()
   const [selectedBookingOfferEndedDateLabel, setSelectedBookingOfferEndedDateLabel] =
@@ -108,9 +111,12 @@ export const EndedBookings: FunctionComponent<Props> = ({ useEndedBookingsQuery 
   const handleSaveReaction = useCallback(
     async ({ offerId, reactionType }: PostOneReactionRequest) => {
       await onSaveReaction?.({ offerId, reactionType })
+      if (reactionType === ReactionTypeEnum.LIKE) {
+        void requestReview('booking_liked', { delayMs: LIKE_REVIEW_DELAY_MS })
+      }
       hideReactionModal()
     },
-    [hideReactionModal, onSaveReaction]
+    [hideReactionModal, onSaveReaction, requestReview]
   )
 
   const renderItem: ListRenderItem<BookingListItemResponse> = useCallback(

--- a/src/features/navigation/navigators/CheatcodesStackNavigator/CheatcodesStackNavigator.tsx
+++ b/src/features/navigation/navigators/CheatcodesStackNavigator/CheatcodesStackNavigator.tsx
@@ -22,6 +22,7 @@ import { CheatcodesScreenMaintenance } from 'cheatcodes/pages/features/maintenan
 import { CheatcodesNavigationOnboarding } from 'cheatcodes/pages/features/onboarding/CheatcodesNavigationOnboarding'
 import { CheatcodesNavigationProfile } from 'cheatcodes/pages/features/profile/CheatcodesNavigationProfile'
 import { CheatcodesScreenRemoteBanners } from 'cheatcodes/pages/features/remoteBanners/CheatcodesScreenRemoteBanners'
+import { CheatcodesNavigationReviewInApp } from 'cheatcodes/pages/features/reviewInApp/CheatcodesNavigationReviewInApp'
 import { CheatcodesNavigationShare } from 'cheatcodes/pages/features/share/CheatcodesNavigationShare'
 import { CheatcodesNavigationSubscription } from 'cheatcodes/pages/features/subscription/CheatcodesNavigationSubscription'
 import { CheatcodesNavigationTrustedDevice } from 'cheatcodes/pages/features/trustedDevice/CheatcodesNavigationTrustedDevice'
@@ -131,6 +132,12 @@ const cheatcodesStackNavigatorPathDefinition = {
       screen: CheatcodesNavigationProfile,
       linking: {
         path: 'cheatcodes/profile',
+      },
+    },
+    CheatcodesNavigationReviewInApp: {
+      screen: CheatcodesNavigationReviewInApp,
+      linking: {
+        path: 'cheatcodes/review-in-app',
       },
     },
     CheatcodesNavigationShare: {

--- a/src/libs/reviewInApp/types.ts
+++ b/src/libs/reviewInApp/types.ts
@@ -12,6 +12,7 @@ export const REVIEW_WINDOW_MS = 365 * 24 * 60 * 60 * 1000
 export const DEFAULT_DELAY_MS = 1000
 export const OFFERS_VIEWED_REVIEW_THRESHOLD = 10
 export const OFFERS_VIEWED_REVIEW_DELAY_MS = 2000
+export const LIKE_REVIEW_DELAY_MS = 3000
 
 export const REVIEW_TRIGGER_FEATURE_FLAGS: Record<ReviewTriggerSource, RemoteStoreFeatureFlags> = {
   booking_success: RemoteStoreFeatureFlags.WIP_REVIEW_TRIGGER_BOOKING,


### PR DESCRIPTION
…ded booking

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41774

## Contexte

Lorsqu'un utilisateur « like » une réservation consommée, il exprime explicitement sa
satisfaction : c'est un moment opportun pour solliciter une note sur le store. Cette PR
branche le déclencheur de notation in-app sur ce geste.

🔗 [Notion — Fonctionnement du système de notation in-app](https://www.notion.so/passcultureapp/Fonctionnement-du-syst-me-de-notation-in-app-store-review-357ad4e0ff9880a687b8ea1278c7cf07)

> En tant qu'utilisateur satisfait d'une expérience passée, j'aimerais être invité à noter
> l'application après avoir aimé ma réservation, afin de valoriser le service suite à une
> expérience réussie.

## Ce que fait la PR

- **Trigger « Like »** : à la validation d'une réaction `LIKE` sur une réservation terminée
  (onglet « Mes réservations »), on appelle `requestReview('booking_liked', { delayMs: 3000 })`.
  La popup de notation s'affiche après 3 s.
- Ajout de la constante `LIKE_REVIEW_DELAY_MS = 3000` (cohérente avec les autres délais de `reviewInApp`).
- **Fix annexe** : réenregistrement de l'écran cheatcode `CheatcodesNavigationReviewInApp` dans
  `CheatcodesStackNavigator`, perdu lors de la refonte de navigation `8b0f500ce0` (#9059). L'écran
  est de nouveau accessible depuis le menu cheatcodes, ce qui permet de tester le trigger.

L'infrastructure du système de notation (`useReviewInApp`, flag `WIP_REVIEW_TRIGGER_LIKE`,
verrou 30 j, quota, kill-switch) existait déjà : seul le câblage du déclencheur manquait.

## Règles de gestion respectées

- **Ciblage** : uniquement sur réservation consommée/réactable (`canReact`).
- **Trigger** : soumission d'une réaction `LIKE` (pas `DISLIKE`, pas `NO_REACTION`).
- **Délai** : 3 s.
- **Flag** : `WIP_REVIEW_TRIGGER_LIKE`.
- **Verrou 30 j / quota / kill-switch** : déjà garantis par `useReviewInApp`.

## Tests

Tests ajoutés sur `EndedBookings` couvrant les scénarios PM :
- déclenchement après un Like (flag ON) ;
- exclusion si déjà sollicité il y a moins de 30 jours ;
- pas de déclenchement si le flag est OFF ;
- pas de déclenchement pour une réaction non-Like.

## Comment tester

1. Cheatcodes → « In-App Review ⭐ » → activer `WIP_REVIEW_TRIGGER_LIKE`, vider l'historique.
2. Onglet « Mes réservations » → « Terminées » → liker une réservation consommée.
3. Après 3 s, la popup de notation native s'affiche.
