### PR TITLE
(PC-41954) refactor(location): move locationType logic to zustand

### DIFF
--- a/jest/jest.setup.ts
+++ b/jest/jest.setup.ts
@@ -18,6 +18,7 @@ import 'react-native-gesture-handler/jestSetup'
   }
 } */
 jest.mock('libs/analytics/provider')
+jest.mock('libs/firebase/analytics/analytics')
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
 
 /* See the corresponding mock in libs/environment/__mocks__ */

--- a/src/libs/analytics/__mocks__/provider.ts
+++ b/src/libs/analytics/__mocks__/provider.ts
@@ -6,6 +6,5 @@ export const analytics: AnalyticsProvider = {
   disableCollection: jest.fn(),
   logScreenView: jest.fn(),
   logEvent: jest.fn(),
-  setEventLocationType: jest.fn(),
   ...logEventAnalytics,
 }

--- a/src/libs/analytics/provider.test.ts
+++ b/src/libs/analytics/provider.test.ts
@@ -2,10 +2,12 @@
 import { resetDedupCache } from 'libs/analytics/eventDeduplication'
 // eslint-disable-next-line no-restricted-imports
 import { analytics } from 'libs/analytics/provider'
+import { LocationType } from 'libs/analytics/types'
 // eslint-disable-next-line no-restricted-imports
 import { firebaseAnalytics } from 'libs/firebase/analytics/analytics'
 import { AnalyticsEvent } from 'libs/firebase/analytics/events'
-import { storage } from 'libs/storage'
+import { LocationMode } from 'libs/location/types'
+import { locationActions } from 'libs/locationV2/location.store'
 import { act } from 'tests/utils'
 
 const EVENT_PARAMS = { param: 1 }
@@ -17,60 +19,41 @@ jest.mock('libs/firebase/analytics/analytics')
 
 describe('analyticsProvider - logEvent', () => {
   afterEach(() => {
-    storage.clear('location_type')
+    locationActions.setLocationMode(LocationMode.EVERYWHERE)
     resetDedupCache()
   })
 
   describe('with firebase', () => {
-    it('should log event when firebase event name is specified', async () => {
-      await analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_OFFER }, EVENT_PARAMS)
-
-      expect(firebaseAnalytics.logEvent).toHaveBeenCalledWith(AnalyticsEvent.CONSULT_OFFER, {
-        ...EVENT_PARAMS,
-        locationType: 'undefined',
-      })
-    })
-
     it.each`
-      locationType
-      ${'UserGeolocation'}
-      ${'UserSpecificLocation'}
-    `('should log firebase event with locationType=$locationType', async ({ locationType }) => {
-      await storage.saveString('location_type', locationType)
+      locationType              | locationMode
+      ${'UserGeolocation'}      | ${LocationMode.AROUND_ME}
+      ${'UserSpecificLocation'} | ${LocationMode.AROUND_PLACE}
+      ${'undefined'}            | ${LocationMode.EVERYWHERE}
+    `(
+      'should log firebase event with locationType=$locationType and locationMode=$locationMode',
+      async ({
+        locationType,
+        locationMode,
+      }: {
+        locationType: LocationType
+        locationMode: LocationMode
+      }) => {
+        locationActions.setLocationMode(locationMode)
 
-      await analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_OFFER }, EVENT_PARAMS)
+        await analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_OFFER }, EVENT_PARAMS)
 
-      expect(firebaseAnalytics.logEvent).toHaveBeenCalledWith(AnalyticsEvent.CONSULT_OFFER, {
-        ...EVENT_PARAMS,
-        locationType: locationType,
-      })
-    })
-
-    it('should log firebase event with locationType: undefined when locationType is cleared', async () => {
-      await storage.clear('location_type')
-
-      await analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_OFFER }, EVENT_PARAMS)
-
-      expect(firebaseAnalytics.logEvent).toHaveBeenCalledWith(AnalyticsEvent.CONSULT_OFFER, {
-        ...EVENT_PARAMS,
-        locationType: 'undefined',
-      })
-    })
+        expect(firebaseAnalytics.logEvent).toHaveBeenCalledWith(AnalyticsEvent.CONSULT_OFFER, {
+          ...EVENT_PARAMS,
+          locationType,
+        })
+      }
+    )
 
     it('should log screen view when logScreenView is called', async () => {
-      analytics.logScreenView(SCREEN_NAME)
+      await analytics.logScreenView(SCREEN_NAME)
       await act(() => {})
 
       expect(firebaseAnalytics.logScreenView).toHaveBeenCalledWith(SCREEN_NAME, 'undefined')
-    })
-
-    it('should set default event parameters when setEventLocationType is called', async () => {
-      analytics.setEventLocationType()
-      await act(() => {})
-
-      expect(firebaseAnalytics.setDefaultEventParameters).toHaveBeenCalledWith({
-        locationType: 'undefined',
-      })
     })
   })
 
@@ -90,16 +73,16 @@ describe('analyticsProvider - logEvent', () => {
     })
 
     it('should not send the same screen view twice within the dedup window', async () => {
-      analytics.logScreenView(SCREEN_NAME)
-      analytics.logScreenView(SCREEN_NAME)
+      await analytics.logScreenView(SCREEN_NAME)
+      await analytics.logScreenView(SCREEN_NAME)
       await act(() => {})
 
       expect(firebaseAnalytics.logScreenView).toHaveBeenCalledTimes(1)
     })
 
     it('should send different screen views', async () => {
-      analytics.logScreenView('Home')
-      analytics.logScreenView('Offer')
+      await analytics.logScreenView('Home')
+      await analytics.logScreenView('Offer')
       await act(() => {})
 
       expect(firebaseAnalytics.logScreenView).toHaveBeenCalledTimes(2)

--- a/src/libs/analytics/provider.ts
+++ b/src/libs/analytics/provider.ts
@@ -5,7 +5,7 @@ import { logEventAnalytics } from 'libs/analytics/logEventAnalytics'
 import { AnalyticsProvider } from 'libs/analytics/types'
 // eslint-disable-next-line no-restricted-imports
 import { firebaseAnalytics } from 'libs/firebase/analytics/analytics'
-import { storage } from 'libs/storage'
+import { locationSelectors } from 'libs/locationV2/location.store'
 
 export const analytics: AnalyticsProvider = {
   enableCollection: async () => {
@@ -17,19 +17,15 @@ export const analytics: AnalyticsProvider = {
 
   logScreenView: async (screenName) => {
     if (isDuplicateEvent('screen_view', { screenName })) return
-    const locationType = (await storage.readString('location_type')) ?? 'undefined'
+    const locationType = locationSelectors.selectLocationType()
     await firebaseAnalytics.logScreenView(screenName, locationType)
   },
   logEvent: async (eventName, params) => {
     if (eventName.firebase) {
       if (isDuplicateEvent(eventName.firebase, params)) return
-      const locationType = (await storage.readString('location_type')) ?? 'undefined'
+      const locationType = locationSelectors.selectLocationType()
       await firebaseAnalytics.logEvent(eventName.firebase, { ...params, locationType })
     }
-  },
-  setEventLocationType: async () => {
-    const locationType = (await storage.readString('location_type')) ?? 'undefined'
-    await firebaseAnalytics.setDefaultEventParameters({ locationType })
   },
   ...logEventAnalytics,
 }

--- a/src/libs/analytics/types.ts
+++ b/src/libs/analytics/types.ts
@@ -10,8 +10,9 @@ export type AnalyticsProvider = {
   enableCollection: () => Promise<void>
   logScreenView: (screenName: ScreenNames) => Promise<void>
   logEvent: (eventName: EventName, params?: Record<string, unknown>) => Promise<void>
-  setEventLocationType: () => Promise<void>
 } & typeof logEventAnalytics
+
+export type LocationType = 'UserGeolocation' | 'UserSpecificLocation' | 'undefined'
 
 export type OfferAnalyticsParams = {
   from: Referrals

--- a/src/libs/firebase/analytics/__mocks__/analytics.ts
+++ b/src/libs/firebase/analytics/__mocks__/analytics.ts
@@ -1,4 +1,4 @@
-import { firebaseAnalytics as actualAnalytics } from '../analytics'
+import type { firebaseAnalytics as actualAnalytics } from '../analytics'
 
 export const firebaseAnalytics: typeof actualAnalytics = {
   disableCollection: jest.fn(),

--- a/src/libs/location/LocationWrapper.native.test.tsx
+++ b/src/libs/location/LocationWrapper.native.test.tsx
@@ -1,8 +1,7 @@
 import { checkGeolocPermission } from 'libs/location/geolocation/checkGeolocPermission/checkGeolocPermission'
 import { getGeolocPosition } from 'libs/location/geolocation/getGeolocPosition/getGeolocPosition'
 import { requestGeolocPermission } from 'libs/location/geolocation/requestGeolocPermission/requestGeolocPermission'
-import { storage } from 'libs/storage'
-import { act, renderHook, waitFor } from 'tests/utils'
+import { renderHook, waitFor } from 'tests/utils'
 
 import { GeolocPermissionState, GeolocPositionError } from './geolocation/enums'
 import { LocationWrapper, useLocation } from './LocationWrapper'
@@ -136,31 +135,6 @@ describe('useLocation()', () => {
         })
       }
     )
-  })
-
-  describe('location_type', () => {
-    it('should write UserGeolocation in location_type async storage when geolocation is turned on', async () => {
-      mockPermissionResult(GeolocPermissionState.GRANTED)
-      const { result } = renderLocationHook()
-      result.current.requestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
-      await waitFor(() => {
-        expect(onAcceptance).toHaveBeenCalledTimes(1)
-      })
-      const localStorageLocationType = await storage.readString('location_type')
-
-      expect(localStorageLocationType).toEqual('UserGeolocation')
-    })
-
-    it('should clear location_type async storage when neither place nor geolocPosition are set', async () => {
-      mockPermissionResult(GeolocPermissionState.DENIED)
-      const { result } = renderLocationHook()
-      await act(async () => {
-        result.current.setPlace(null)
-      })
-      const localStorageLocationType = await storage.readString('location_type')
-
-      expect(localStorageLocationType).toEqual(null)
-    })
   })
 })
 

--- a/src/libs/location/LocationWrapper.tsx
+++ b/src/libs/location/LocationWrapper.tsx
@@ -1,7 +1,6 @@
 import React, { memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 
 import { DEFAULT_RADIUS } from 'features/search/constants'
-import { analytics } from 'libs/analytics/provider'
 import { useAppStateChange } from 'libs/appState'
 import { LocationMode, ILocationContext } from 'libs/location/types'
 import {
@@ -19,7 +18,6 @@ import {
   useUserLocation,
 } from 'libs/locationV2/location.store'
 import { SuggestedPlace } from 'libs/place/types'
-import { storage } from 'libs/storage'
 
 import { GeolocationActivationModal } from './geolocation/components/GeolocationActivationModal'
 
@@ -95,21 +93,6 @@ export const LocationWrapper = memo(function LocationWrapper({
   }, [])
 
   useAppStateChange(contextualCheckPermission, undefined, [])
-
-  useEffect(() => {
-    switch (true) {
-      case !!place:
-        void storage.saveString('location_type', 'UserSpecificLocation')
-        break
-      case hasGeolocPosition:
-        void storage.saveString('location_type', 'UserGeolocation')
-        break
-      default:
-        void storage.clear('location_type')
-        break
-    }
-    analytics.setEventLocationType()
-  }, [hasGeolocPosition, place])
 
   const userLocation = useUserLocation()
 

--- a/src/libs/locationV2/location.store.ts
+++ b/src/libs/locationV2/location.store.ts
@@ -1,3 +1,5 @@
+import { LocationType } from 'libs/analytics/types'
+import { firebaseAnalytics } from 'libs/firebase/analytics/analytics'
 import { GeolocPermissionState } from 'libs/location/location'
 import { GeoCoordinates, GeolocationError, LocationMode } from 'libs/location/types'
 import { SuggestedPlace } from 'libs/place/types'
@@ -117,9 +119,22 @@ const locationStore = createStore({
       ({ configuration, locationMode }) =>
         configuration[locationMode].geolocation,
     selectIsGeolocated: () => (state) => !!state.configuration[LocationMode.AROUND_ME].geolocation,
+    selectLocationType: () => (state) => {
+      const LocationModeToLocationTypeMap = {
+        [LocationMode.AROUND_PLACE]: 'UserSpecificLocation',
+        [LocationMode.AROUND_ME]: 'UserGeolocation',
+        [LocationMode.EVERYWHERE]: 'undefined',
+      } as const satisfies Record<LocationMode, LocationType>
+
+      return LocationModeToLocationTypeMap[state.locationMode]
+    },
   },
   options: { persist: false },
 })
+
+locationStore.store.subscribe(locationStore.selectors.selectLocationType, (locationType) =>
+  firebaseAnalytics.setDefaultEventParameters({ locationType })
+)
 
 function isRejected(permission: GeolocPermissionState | null) {
   return (

--- a/src/libs/storage.ts
+++ b/src/libs/storage.ts
@@ -35,7 +35,6 @@ export type StorageKey =
   | 'traffic_medium'
   | 'traffic_source'
   | 'user_age'
-  | 'location_type'
   | 'times_user_subscribed_to_a_theme'
   | 'times_music_live_booking_survey_has_been_displayed'
   | '@passculture.venue.video_seen'

--- a/src/libs/store/createStore.ts
+++ b/src/libs/store/createStore.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 // eslint-disable-next-line no-restricted-imports
 import { create } from 'zustand'
-import { createJSONStorage, devtools, persist } from 'zustand/middleware'
+import { createJSONStorage, devtools, persist, subscribeWithSelector } from 'zustand/middleware'
 
 import {
   AnyFunction,
@@ -31,7 +31,9 @@ export function createStore<
   })
 
   const store = create<State>()(
-    devtools(options?.persist ? persistedStore : defaultStore, { enabled: false, name })
+    subscribeWithSelector(
+      devtools(options?.persist ? persistedStore : defaultStore, { enabled: false, name })
+    )
   )
 
   const actions = createActions(store.setState)

--- a/src/libs/store/store.types.ts
+++ b/src/libs/store/store.types.ts
@@ -1,4 +1,4 @@
-import { StoreApi, UseBoundStore } from 'zustand'
+import { Mutate, StoreApi, UseBoundStore } from 'zustand'
 
 export type AnyFunction = (...args: never[]) => unknown
 
@@ -7,7 +7,9 @@ type Options = {
   persist?: boolean
 }
 type ReplaceSelectByUse<T extends string> = T extends `select${infer U}` ? `use${U}` : never
-type StoreType<State> = UseBoundStore<StoreApi<State>>
+type StoreType<State> = UseBoundStore<
+  Mutate<StoreApi<State>, [['zustand/subscribeWithSelector', never]]>
+>
 
 export type StoreConfig<
   State,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41954

### Suppression d'un antipattern

Le storage n'était utilisé que pour servir de passe plat entre le contexte et l'envoi de logs firebase (en dehors de React)
Zustand étant également en dehors de React, les deux services peuvent s'appeler sans stratagème
L'utilisation du storage à cet endroit a donc pu être supprimée

### Ajout d'une logique de listener par selecteur sur la surcouche Zustand

```ts
locationStore.store.subscribe(locationStore.selectors.selectLocationType, (locationType) =>
  firebaseAnalytics.setDefaultEventParameters({ locationType })
)
```

Il est préférable d'avoir les effets de bord séparés des setters de Zustand pour ne pas y coupler la logique.
Cette technique nous permet de nous débarasser du couplage au `UseEffect` de React

### Modification de la logique d'envoi de log

On écoute sur le changement de mode de localisation au lieu du changement de la donnée 
Ce point pourra peut-être nous débarrasser du isDuplicateEvent qui était une stratégie défensive quant aux événements dupliqués.
En effet, en se basant sur un contexte, les événements envoyés sont dépendants des re-renders du contexte. A la suppression du contexte, ce problème sera probablement réglé.

### Modification des tests

Tests de logs firebase plus clairs qui testent tous les cas

