### PR TITLE
(PC-41509) feat(home): include venues not open to public in volunteer…

### DIFF
--- a/src/libs/algolia/fetchAlgolia/buildVenuesQueryOptions.test.ts
+++ b/src/libs/algolia/fetchAlgolia/buildVenuesQueryOptions.test.ts
@@ -59,12 +59,30 @@ describe('buildVenuesQueryOptions', () => {
     })
   })
 
-  it('should filter venue having volunteering if provided', () => {
+  it('should filter venue having volunteering and not apply is_open_to_public filter when hasVolunteering is provided', () => {
     const params = { ...defaultParams, hasVolunteering: true }
     const options = buildVenuesQueryOptions(params, defaultBuildLocationParameterParams)
 
     expect(options).toEqual({
-      facetFilters: [['has_volunteering_url:true'], ...defaultFacetFilters],
+      facetFilters: [['has_volunteering_url:true']],
+    })
+  })
+
+  it('should combine tags with has_volunteering_url and still omit is_open_to_public when hasVolunteering is true', () => {
+    const params = { ...defaultParams, tags: ['cinema'], hasVolunteering: true }
+    const options = buildVenuesQueryOptions(params, defaultBuildLocationParameterParams)
+
+    expect(options).toEqual({
+      facetFilters: [['tags:cinema'], ['has_volunteering_url:true']],
+    })
+  })
+
+  it('should keep is_open_to_public filter when hasVolunteering is false', () => {
+    const params = { ...defaultParams, hasVolunteering: false }
+    const options = buildVenuesQueryOptions(params, defaultBuildLocationParameterParams)
+
+    expect(options).toEqual({
+      facetFilters: defaultFacetFilters,
     })
   })
 })

--- a/src/libs/algolia/fetchAlgolia/buildVenuesQueryOptions.ts
+++ b/src/libs/algolia/fetchAlgolia/buildVenuesQueryOptions.ts
@@ -26,13 +26,13 @@ export const buildVenuesQueryOptions = (
   }
 
   if (hasVolunteering) {
+    // Volunteering playlist is allowed to surface venues not open to public
     const hasVolunteeringPredicate = [`${VENUES_FACETS_ENUM.VENUE_HAS_VOLUNTEERING}:true`]
     facetFilters.push(hasVolunteeringPredicate)
+  } else {
+    const isOpenToPublicPredicate = [`${VENUES_FACETS_ENUM.VENUE_IS_OPEN_TO_PUBLIC}:true`]
+    facetFilters.push(isOpenToPublicPredicate)
   }
-
-  // We want to show on home page only venues that have at least one offer that is searchable in algolia
-  const isOpenToPublicPredicate = [`${VENUES_FACETS_ENUM.VENUE_IS_OPEN_TO_PUBLIC}:true`]
-  facetFilters.push(isOpenToPublicPredicate)
 
   return {
     ...buildLocationParameter(buildLocationParameterParams),


### PR DESCRIPTION
…ing playlist

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41509

## Context

Sur la home, la playlist Bénévolat n'affichait jusqu'ici que les structures (venues) ouvertes au public. La règle métier a évolué : la playlist Bénévolat doit faire remonter **tous les lieux**, ouverts ou non au public, dès lors qu'ils ont une URL de bénévolat renseignée (et au moins une offre active, contrainte appliquée par l'indexeur back).

## Cause

Dans `buildVenuesQueryOptions`, le filtre Algolia `is_open_to_public:true` était poussé **inconditionnellement** sur toutes les queries de playlists venues — y compris la playlist Bénévolat. Les venues `is_open_to_public=false` étaient donc systématiquement masquées, même quand elles avaient une URL bénévolat.

## Solution

Rendre les deux predicates mutuellement exclusifs :

- **Playlist Bénévolat** (`hasVolunteering=true`) → applique uniquement `has_volunteering_url:true`. Le filtre `is_open_to_public:true` est levé.
- **Toutes les autres playlists venues** (thématiques, etc.) → conservent `is_open_to_public:true` comme avant. Aucune régression.

Le commentaire obsolète référant à un ancien filtre (déjà retiré dans PC-39430) a été remplacé par une note explicative sur le découplage.

## Pourquoi pas côté back

L'indexeur backend respecte déjà la contrainte « au moins une offre active » via `Venue.is_eligible_for_search` (qui exige `hasAtLeastOneBookableOffer`). Et il n'exige plus `is_open_to_public=true` pour indexer (retiré dans PC-39305). Les venues cibles sont donc déjà présentes dans l'index Algolia — seul le filtre front les masquait.

## Périmètre des changements

- `src/libs/algolia/fetchAlgolia/buildVenuesQueryOptions.ts` : filtre `is_open_to_public:true` rendu exclusif avec `hasVolunteering`
- `src/libs/algolia/fetchAlgolia/buildVenuesQueryOptions.test.ts` : test existant adapté + 2 tests de non-régression ajoutés
