### PR TITLE
(PC-42012) fix(SetAddress): suggestions depend on stored city

### DIFF
--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -68,16 +68,14 @@ export const SetAddress = () => {
   const [debouncedQuery, setDebouncedQuery] = useState<string>(query)
   const [selectedAddress, setSelectedAddress] = useState<string | null>(defaultAddress ?? null)
   const debouncedSetQuery = useRef(debounce(setDebouncedQuery, 500)).current
-  const defaultCity = user?.city ?? storedCity?.name
-  const defaultPostalCode = user?.postalCode ?? storedCity?.postalCode
   const {
     data: addresses = [],
     isLoading,
     isError,
   } = useAddressesQuery({
     query: debouncedQuery,
-    cityCode: defaultCity ?? '',
-    postalCode: defaultPostalCode ?? '',
+    cityCode: storedCity?.code ?? '',
+    postalCode: storedCity?.postalCode ?? '',
     enabled: !!idCheckAddressAutocompletion && debouncedQuery.length > 0,
     limit: 10,
   })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42012

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome | https://github.com/user-attachments/assets/174cf5fe-18e9-40cd-9c4b-ec7cb5a9d7a2 |     https://github.com/user-attachments/assets/6e029395-fc14-41d9-b7dd-fecb8c575d58|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
