### PR TITLE
(PC-41999) refactor(location): remove onModalHideRef

### DIFF
--- a/src/features/location/components/HomeLocationModal.native.test.tsx
+++ b/src/features/location/components/HomeLocationModal.native.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Button } from 'react-native'
 
 import { HomeLocationModal } from 'features/location/components/HomeLocationModal'
 import { analytics } from 'libs/analytics/provider'
@@ -11,7 +10,7 @@ import {
   LocationWrapper,
 } from 'libs/location/location'
 import { SuggestedPlace } from 'libs/place/types'
-import { MODAL_TO_HIDE_TIME, MODAL_TO_SHOW_TIME } from 'tests/constants'
+import { MODAL_TO_SHOW_TIME } from 'tests/constants'
 import { act, fireEvent, render, screen, userEvent } from 'tests/utils'
 
 jest.useFakeTimers()
@@ -137,43 +136,6 @@ describe('HomeLocationModal', () => {
     await user.press(screen.getByText('Utiliser ma position actuelle'))
 
     expect(mockRequestGeolocPermission).toHaveBeenCalledTimes(1)
-  })
-
-  it('should show geolocation modal if geolocation is never_ask_again on closing the modal after a geolocation button press', async () => {
-    mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.NEVER_ASK_AGAIN)
-    hideModalMock.mockImplementationOnce(() => {
-      // simulate the modal closing
-      // userEvent.press not working correctly here
-      // eslint-disable-next-line local-rules/no-fireEvent
-      fireEvent.press(screen.getByText('Close'))
-    })
-
-    const Container = () => {
-      const [visible, setVisible] = React.useState(true)
-      return (
-        <LocationWrapper>
-          <React.Fragment>
-            <HomeLocationModal visible={visible} dismissModal={hideModalMock} />
-            <Button title="Close" onPress={() => setVisible(false)} />
-          </React.Fragment>
-        </LocationWrapper>
-      )
-    }
-    render(<Container />)
-    await act(async () => {
-      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
-    })
-
-    await user.press(screen.getByText('Utiliser ma position actuelle'))
-
-    expect(hideModalMock).toHaveBeenCalledTimes(1)
-
-    await act(async () => {
-      jest.advanceTimersByTime(MODAL_TO_HIDE_TIME)
-      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
-    })
-
-    expect(screen.getByText('Paramètres de localisation')).toBeOnTheScreen()
   })
 })
 

--- a/src/features/location/components/HomeLocationModal.tsx
+++ b/src/features/location/components/HomeLocationModal.tsx
@@ -24,7 +24,6 @@ export const HomeLocationModal = ({ visible, dismissModal }: HomeLocationModalPr
     permissionState,
     showGeolocPermissionModal,
     requestGeolocPermission,
-    onModalHideRef,
   } = useLocation()
 
   const { tempLocationMode, setTempLocationMode } = useLocationState({
@@ -50,7 +49,6 @@ export const HomeLocationModal = ({ visible, dismissModal }: HomeLocationModalPr
     setTempLocationMode,
     setSelectedLocationMode,
     setPlace,
-    onModalHideRef,
     showGeolocPermissionModal,
     requestGeolocPermission,
     tempLocationMode,
@@ -65,7 +63,6 @@ export const HomeLocationModal = ({ visible, dismissModal }: HomeLocationModalPr
       tempLocationMode={tempLocationMode}
       onClose={onClose}
       selectLocationMode={selectLocationMode}
-      onModalHideRef={onModalHideRef}
       selectedPlace={selectedPlace}
       setSelectedPlace={setSelectedPlace}
       placeQuery={placeQuery}

--- a/src/features/location/components/LocationModal.tsx
+++ b/src/features/location/components/LocationModal.tsx
@@ -3,7 +3,9 @@ import styled from 'styled-components/native'
 
 import { LocationModalFooter } from 'features/location/components/LocationModalFooter'
 import { LocationState } from 'features/location/types'
+import { GeolocPermissionState } from 'libs/location/location'
 import { LocationLabel, LocationMode } from 'libs/location/types'
+import { locationActions, locationSelectors } from 'libs/locationV2/location.store'
 import { LocationSearchFilters } from 'shared/location/LocationSearchFilters'
 import { LocationSearchInput } from 'shared/location/LocationSearchInput'
 import { AppModal } from 'ui/components/modals/AppModal'
@@ -19,7 +21,6 @@ type LocationModalProps = {
   visible: boolean
   onSubmit: () => void
   onClose: () => void
-  onModalHideRef: LocationState['onModalHideRef']
   selectLocationMode: (mode: LocationMode) => () => void
   tempLocationMode: LocationState['tempLocationMode']
   hasGeolocPosition: LocationState['hasGeolocPosition']
@@ -61,7 +62,6 @@ export const LocationModal = ({
   tempLocationMode,
   onClose,
   selectLocationMode,
-  onModalHideRef,
   selectedPlace,
   tempAroundMeRadius,
   onTempAroundMeRadiusValueChange,
@@ -171,6 +171,12 @@ export const LocationModal = ({
     }
   }
 
+  const onModalHide = () => {
+    if (locationSelectors.selectPermissionState() === GeolocPermissionState.NEVER_ASK_AGAIN) {
+      locationActions.showPermissionModal()
+    }
+  }
+
   return (
     <AppModal
       visible={visible}
@@ -178,7 +184,7 @@ export const LocationModal = ({
       noPadding
       isUpToStatusBar
       scrollEnabled={false}
-      onModalHide={onModalHideRef.current}
+      onModalHide={onModalHide}
       keyboardShouldPersistTaps="handled"
       customModalHeader={
         <HeaderContainer>

--- a/src/features/location/components/LocationModal.tsx
+++ b/src/features/location/components/LocationModal.tsx
@@ -3,9 +3,7 @@ import styled from 'styled-components/native'
 
 import { LocationModalFooter } from 'features/location/components/LocationModalFooter'
 import { LocationState } from 'features/location/types'
-import { GeolocPermissionState } from 'libs/location/location'
 import { LocationLabel, LocationMode } from 'libs/location/types'
-import { locationActions, locationSelectors } from 'libs/locationV2/location.store'
 import { LocationSearchFilters } from 'shared/location/LocationSearchFilters'
 import { LocationSearchInput } from 'shared/location/LocationSearchInput'
 import { AppModal } from 'ui/components/modals/AppModal'
@@ -171,12 +169,6 @@ export const LocationModal = ({
     }
   }
 
-  const onModalHide = () => {
-    if (locationSelectors.selectPermissionState() === GeolocPermissionState.NEVER_ASK_AGAIN) {
-      locationActions.showPermissionModal()
-    }
-  }
-
   return (
     <AppModal
       visible={visible}
@@ -184,7 +176,6 @@ export const LocationModal = ({
       noPadding
       isUpToStatusBar
       scrollEnabled={false}
-      onModalHide={onModalHide}
       keyboardShouldPersistTaps="handled"
       customModalHeader={
         <HeaderContainer>

--- a/src/features/location/components/SearchLocationModal.tsx
+++ b/src/features/location/components/SearchLocationModal.tsx
@@ -33,7 +33,6 @@ export const SearchLocationModal = ({ visible, dismissModal }: LocationModalProp
     permissionState,
     showGeolocPermissionModal,
     requestGeolocPermission,
-    onModalHideRef,
   } = useLocation()
 
   const {
@@ -79,7 +78,6 @@ export const SearchLocationModal = ({ visible, dismissModal }: LocationModalProp
     setSelectedLocationMode,
     permissionState,
     setPlace,
-    onModalHideRef,
     showGeolocPermissionModal,
     requestGeolocPermission,
     hasGeolocPosition,
@@ -94,7 +92,6 @@ export const SearchLocationModal = ({ visible, dismissModal }: LocationModalProp
       tempLocationMode={tempLocationMode}
       onClose={onClose}
       selectLocationMode={selectLocationMode}
-      onModalHideRef={onModalHideRef}
       selectedPlace={selectedPlace}
       setSelectedPlace={setSelectedPlace}
       placeQuery={placeQuery}

--- a/src/features/location/components/VenueMapLocationModal.tsx
+++ b/src/features/location/components/VenueMapLocationModal.tsx
@@ -43,7 +43,6 @@ export const VenueMapLocationModal = ({
     permissionState,
     requestGeolocPermission,
     showGeolocPermissionModal,
-    onModalHideRef,
   } = useLocation()
 
   const {
@@ -90,7 +89,6 @@ export const VenueMapLocationModal = ({
     shouldOpenDirectlySettings: true,
     setSelectedLocationMode,
     setPlace,
-    onModalHideRef,
     hasGeolocPosition,
     tempLocationMode,
     onSubmit,
@@ -118,7 +116,6 @@ export const VenueMapLocationModal = ({
       tempLocationMode={tempLocationMode}
       onClose={onClose}
       selectLocationMode={selectLocationMode}
-      onModalHideRef={onModalHideRef}
       selectedPlace={selectedPlace}
       setSelectedPlace={setSelectedPlace}
       placeQuery={placeQuery}

--- a/src/features/location/fixtures/mockLocationState.ts
+++ b/src/features/location/fixtures/mockLocationState.ts
@@ -11,7 +11,6 @@ export const mockLocationState: LocationState = {
   setSelectedPlace: jest.fn(),
   onResetPlace: jest.fn(),
   setPlace: jest.fn(),
-  onModalHideRef: { current: jest.fn() },
   permissionState: GeolocPermissionState.GRANTED,
   requestGeolocPermission: jest.fn(),
   aroundPlaceRadius: 1000,

--- a/src/features/location/helpers/useGeolocationDialog.native.test.ts
+++ b/src/features/location/helpers/useGeolocationDialog.native.test.ts
@@ -69,74 +69,61 @@ describe('useGeolocationDialogs', () => {
       })
     })
 
-    it('should not call dismiss modal function when shouldDirectlyValidate is true', async () => {
-      const mockPropsNeverAskAgain = {
+    it('should reset place selection when permission state is GRANTED and shouldDirectlyValidate is true', async () => {
+      const mockPropsGranted = {
         ...mockProps,
-        permissionState: GeolocPermissionState.NEVER_ASK_AGAIN,
+        permissionState: GeolocPermissionState.GRANTED,
         shouldDirectlyValidate: true,
       }
-      const { result } = renderHook(() => useGeolocationDialogs(mockPropsNeverAskAgain))
+      const { result } = renderHook(() => useGeolocationDialogs(mockPropsGranted))
 
       await result.current.runGeolocationDialogs()
 
-      expect(mockProps.dismissModal).not.toHaveBeenCalled()
-    })
-  })
-
-  it('should reset place selection when permission state is GRANTED and shouldDirectlyValidate is true', async () => {
-    const mockPropsGranted = {
-      ...mockProps,
-      permissionState: GeolocPermissionState.GRANTED,
-      shouldDirectlyValidate: true,
-    }
-    const { result } = renderHook(() => useGeolocationDialogs(mockPropsGranted))
-
-    await result.current.runGeolocationDialogs()
-
-    expect(mockProps.setPlace).toHaveBeenNthCalledWith(1, null)
-  })
-
-  it('should select around me mode when permission state is GRANTED and shouldDirectlyValidate is true', async () => {
-    const mockPropsGranted = {
-      ...mockProps,
-      permissionState: GeolocPermissionState.GRANTED,
-      shouldDirectlyValidate: true,
-    }
-    const { result } = renderHook(() => useGeolocationDialogs(mockPropsGranted))
-
-    await result.current.runGeolocationDialogs()
-
-    expect(mockProps.setSelectedLocationMode).toHaveBeenNthCalledWith(1, LocationMode.AROUND_ME)
-  })
-
-  it('should show alert and select everywhere mode when permission state is GRANTED but we do not have access to a position', async () => {
-    const mockPropsGrantedWithoutPosition = {
-      ...mockProps,
-      permissionState: GeolocPermissionState.GRANTED,
-      hasGeolocPosition: false,
-    }
-    const { result } = renderHook(() => useGeolocationDialogs(mockPropsGrantedWithoutPosition))
-
-    alertSpy.mockImplementationOnce((_title, _message, buttons) => {
-      buttons?.[0]?.onPress?.()
+      expect(mockProps.setPlace).toHaveBeenNthCalledWith(1, null)
     })
 
-    await result.current.runGeolocationDialogs()
+    it('should select around me mode when permission state is GRANTED and shouldDirectlyValidate is true', async () => {
+      const mockPropsGranted = {
+        ...mockProps,
+        permissionState: GeolocPermissionState.GRANTED,
+        shouldDirectlyValidate: true,
+      }
+      const { result } = renderHook(() => useGeolocationDialogs(mockPropsGranted))
 
-    expect(alertSpy).toHaveBeenCalledWith(
-      'Paramètres de localisation',
-      'Nous n’avons pas pu récupérer ta position. Vérifie que la localisation est bien activée sur ton téléphone.',
-      [{ text: 'OK', onPress: expect.any(Function) }]
-    )
+      await result.current.runGeolocationDialogs()
 
-    expect(mockProps.setSelectedLocationMode).toHaveBeenCalledWith(LocationMode.EVERYWHERE)
-  })
+      expect(mockProps.setSelectedLocationMode).toHaveBeenNthCalledWith(1, LocationMode.AROUND_ME)
+    })
 
-  it('should call requestGeolocPermission when permission is DENIED', async () => {
-    const { result } = renderHook(() => useGeolocationDialogs(mockProps))
+    it('should show alert and select everywhere mode when permission state is GRANTED but we do not have access to a position', async () => {
+      const mockPropsGrantedWithoutPosition = {
+        ...mockProps,
+        permissionState: GeolocPermissionState.GRANTED,
+        hasGeolocPosition: false,
+      }
+      const { result } = renderHook(() => useGeolocationDialogs(mockPropsGrantedWithoutPosition))
 
-    await result.current.runGeolocationDialogs()
+      alertSpy.mockImplementationOnce((_title, _message, buttons) => {
+        buttons?.[0]?.onPress?.()
+      })
 
-    expect(mockProps.requestGeolocPermission).toHaveBeenCalledTimes(1)
+      await result.current.runGeolocationDialogs()
+
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Paramètres de localisation',
+        'Nous n’avons pas pu récupérer ta position. Vérifie que la localisation est bien activée sur ton téléphone.',
+        [{ text: 'OK', onPress: expect.any(Function) }]
+      )
+
+      expect(mockProps.setSelectedLocationMode).toHaveBeenCalledWith(LocationMode.EVERYWHERE)
+    })
+
+    it('should call requestGeolocPermission when permission is DENIED', async () => {
+      const { result } = renderHook(() => useGeolocationDialogs(mockProps))
+
+      await result.current.runGeolocationDialogs()
+
+      expect(mockProps.requestGeolocPermission).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/src/features/location/helpers/useGeolocationDialog.native.test.ts
+++ b/src/features/location/helpers/useGeolocationDialog.native.test.ts
@@ -67,18 +67,6 @@ describe('useGeolocationDialogs', () => {
 
         expect(mockProps.dismissModal).toHaveBeenCalledTimes(1)
       })
-
-      it('should open geoloc permission modal when current modal closed', async () => {
-        const mockPropsNeverAskAgain = {
-          ...mockProps,
-          permissionState: GeolocPermissionState.NEVER_ASK_AGAIN,
-        }
-        const { result } = renderHook(() => useGeolocationDialogs(mockPropsNeverAskAgain))
-
-        await result.current.runGeolocationDialogs()
-
-        expect(mockProps.onModalHideRef.current).toEqual(mockProps.showGeolocPermissionModal)
-      })
     })
 
     it('should not call dismiss modal function when shouldDirectlyValidate is true', async () => {

--- a/src/features/location/helpers/useGeolocationDialogs.ts
+++ b/src/features/location/helpers/useGeolocationDialogs.ts
@@ -4,6 +4,7 @@ import { Alert, Linking } from 'react-native'
 import { LocationState } from 'features/location/types'
 import { GeolocPermissionState } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
+import { locationActions } from 'libs/locationV2/location.store'
 
 type Props = {
   dismissModal: () => void
@@ -37,10 +38,14 @@ export const useGeolocationDialogs = ({
       setPlace(null)
       selectEverywhereMode()
       if (shouldOpenDirectlySettings) {
-        Linking.openSettings()
-      }
-      if (!shouldDirectlyValidate) {
+        void Linking.openSettings()
+      } else {
         dismissModal()
+        // 2 native modals can't be opened at the same time or the app will freeze, so we need to wait for the first one to be closed
+        // we keep the imperative approach to avoid using onModalHide that bursts the logic between files
+        setTimeout(() => {
+          locationActions.showPermissionModal()
+        }, 500)
       }
     } else if (permissionState === GeolocPermissionState.GRANTED && !hasGeolocPosition) {
       Alert.alert(

--- a/src/features/location/helpers/useGeolocationDialogs.ts
+++ b/src/features/location/helpers/useGeolocationDialogs.ts
@@ -13,8 +13,6 @@ type Props = {
   setSelectedLocationMode: LocationState['setSelectedLocationMode']
   permissionState: LocationState['permissionState']
   setPlace: LocationState['setPlace']
-  onModalHideRef: LocationState['onModalHideRef']
-  showGeolocPermissionModal: LocationState['showGeolocPermissionModal']
   requestGeolocPermission: LocationState['requestGeolocPermission']
   hasGeolocPosition: LocationState['hasGeolocPosition']
 }
@@ -27,8 +25,6 @@ export const useGeolocationDialogs = ({
   setSelectedLocationMode,
   permissionState,
   setPlace,
-  onModalHideRef,
-  showGeolocPermissionModal,
   requestGeolocPermission,
   hasGeolocPosition,
 }: Props) => {
@@ -42,11 +38,9 @@ export const useGeolocationDialogs = ({
       selectEverywhereMode()
       if (shouldOpenDirectlySettings) {
         Linking.openSettings()
-      } else {
-        if (!shouldDirectlyValidate) {
-          dismissModal()
-        }
-        onModalHideRef.current = showGeolocPermissionModal
+      }
+      if (!shouldDirectlyValidate) {
+        dismissModal()
       }
     } else if (permissionState === GeolocPermissionState.GRANTED && !hasGeolocPosition) {
       Alert.alert(
@@ -64,17 +58,15 @@ export const useGeolocationDialogs = ({
       })
     }
   }, [
-    permissionState,
-    setTempLocationMode,
-    setSelectedLocationMode,
-    setPlace,
-    shouldOpenDirectlySettings,
     dismissModal,
-    onModalHideRef,
-    showGeolocPermissionModal,
-    shouldDirectlyValidate,
-    requestGeolocPermission,
     hasGeolocPosition,
+    permissionState,
+    requestGeolocPermission,
+    setPlace,
+    setSelectedLocationMode,
+    setTempLocationMode,
+    shouldDirectlyValidate,
+    shouldOpenDirectlySettings,
   ])
 
   return { runGeolocationDialogs }

--- a/src/features/location/helpers/useLocationMode.ts
+++ b/src/features/location/helpers/useLocationMode.ts
@@ -10,7 +10,6 @@ type Props = {
   setSelectedLocationMode: LocationState['setSelectedLocationMode']
   permissionState: LocationState['permissionState']
   setPlace: LocationState['setPlace']
-  onModalHideRef: LocationState['onModalHideRef']
   showGeolocPermissionModal: LocationState['showGeolocPermissionModal']
   requestGeolocPermission: LocationState['requestGeolocPermission']
   hasGeolocPosition: LocationState['hasGeolocPosition']
@@ -26,8 +25,6 @@ export const useLocationMode = ({
   setSelectedLocationMode,
   permissionState,
   setPlace,
-  onModalHideRef,
-  showGeolocPermissionModal,
   requestGeolocPermission,
   hasGeolocPosition,
   onSubmit,
@@ -40,8 +37,6 @@ export const useLocationMode = ({
     setSelectedLocationMode,
     permissionState,
     setPlace,
-    onModalHideRef,
-    showGeolocPermissionModal,
     requestGeolocPermission,
     hasGeolocPosition,
   })

--- a/src/features/location/helpers/useLocationState.ts
+++ b/src/features/location/helpers/useLocationState.ts
@@ -9,8 +9,7 @@ type Props = {
 }
 
 export const useLocationState = ({ visible }: Props) => {
-  const { setPlaceQuery, setSelectedPlace, onModalHideRef, selectedLocationMode, place } =
-    useLocation()
+  const { setPlaceQuery, setSelectedPlace, selectedLocationMode, place } = useLocation()
 
   const [tempAroundMeRadius, setTempAroundMeRadius] = useState<number>(DEFAULT_RADIUS)
   const [tempAroundPlaceRadius, setTempAroundPlaceRadius] = useState<number>(DEFAULT_RADIUS)
@@ -25,7 +24,6 @@ export const useLocationState = ({ visible }: Props) => {
 
   useEffect(() => {
     if (visible) {
-      onModalHideRef.current = undefined
       setPlaceQuery(place?.label ?? '')
       setSelectedPlace(place)
     }

--- a/src/features/location/types.ts
+++ b/src/features/location/types.ts
@@ -1,5 +1,3 @@
-import { MutableRefObject } from 'react'
-
 import { GeolocPermissionState } from 'libs/location/location'
 import { RequestGeolocPermissionParams, LocationMode } from 'libs/location/types'
 import { SuggestedPlace } from 'libs/place/types'
@@ -8,7 +6,6 @@ export type LocationState = {
   hasGeolocPosition: boolean
   place: SuggestedPlace | null
   setPlace: (place: SuggestedPlace | null) => void
-  onModalHideRef: MutableRefObject<(() => void) | undefined>
   permissionState: GeolocPermissionState | null
   requestGeolocPermission: (params?: RequestGeolocPermissionParams) => Promise<void>
   showGeolocPermissionModal: () => void

--- a/src/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx
+++ b/src/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx
@@ -205,7 +205,6 @@ const getAroundPlaceUserPosition = ({
   geolocPosition?: Position
 }): Partial<ILocationContext> => ({
   setPlace: jest.fn(),
-  onModalHideRef: { current: jest.fn() },
   setSelectedLocationMode: jest.fn(),
   userLocation: DEFAULT_USER_LOCATION,
   selectedLocationMode: LocationMode.AROUND_PLACE,

--- a/src/libs/analytics/provider.test.ts
+++ b/src/libs/analytics/provider.test.ts
@@ -75,7 +75,6 @@ describe('analyticsProvider - logEvent', () => {
     it('should not send the same screen view twice within the dedup window', async () => {
       await analytics.logScreenView(SCREEN_NAME)
       await analytics.logScreenView(SCREEN_NAME)
-      await act(() => {})
 
       expect(firebaseAnalytics.logScreenView).toHaveBeenCalledTimes(1)
     })
@@ -83,7 +82,6 @@ describe('analyticsProvider - logEvent', () => {
     it('should send different screen views', async () => {
       await analytics.logScreenView('Home')
       await analytics.logScreenView('Offer')
-      await act(() => {})
 
       expect(firebaseAnalytics.logScreenView).toHaveBeenCalledTimes(2)
     })

--- a/src/libs/location/LocationWrapper.tsx
+++ b/src/libs/location/LocationWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import React, { memo, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 
 import { DEFAULT_RADIUS } from 'features/search/constants'
 import { useAppStateChange } from 'libs/appState'
@@ -26,7 +26,6 @@ const LocationContext = React.createContext<ILocationContext>({
   hasGeolocPosition: false,
   place: null,
   setPlace: () => {},
-  onModalHideRef: { current: undefined },
   geolocPosition: undefined,
   geolocPositionError: null,
   permissionState: null,
@@ -69,8 +68,6 @@ export const LocationWrapper = memo(function LocationWrapper({
     hidePermissionModal: hideGeolocPermissionModal,
   } = locationActions
 
-  const onModalHideRef = useRef<() => void>(() => null)
-
   // app state
   const { radius: aroundPlaceRadius } = useLocationConfiguration(LocationMode.AROUND_PLACE)
   const place = usePlace()
@@ -102,7 +99,6 @@ export const LocationWrapper = memo(function LocationWrapper({
       geolocPositionError,
       permissionState,
       hasGeolocPosition,
-      onModalHideRef,
       requestGeolocPermission: contextualRequestGeolocPermission,
       triggerPositionUpdate,
       onPressGeolocPermissionModalButton,

--- a/src/libs/location/__mocks__/location.ts
+++ b/src/libs/location/__mocks__/location.ts
@@ -30,7 +30,6 @@ const locationContext: ILocationContext = {
   showGeolocPermissionModal,
   onPressGeolocPermissionModalButton,
   hasGeolocPosition: true,
-  onModalHideRef: { current: undefined },
   place: null,
   setPlace,
   selectedLocationMode: LocationMode.AROUND_ME,

--- a/src/libs/location/types.ts
+++ b/src/libs/location/types.ts
@@ -1,5 +1,3 @@
-import { MutableRefObject } from 'react'
-
 import { SuggestedPlace } from 'libs/place/types'
 
 import { GeolocPermissionState, GeolocPositionError } from './geolocation/enums'
@@ -40,7 +38,6 @@ export type ILocationContext = {
   hasGeolocPosition: boolean
   place: SuggestedPlace | null
   setPlace: (place: SuggestedPlace | null) => void
-  onModalHideRef: MutableRefObject<(() => void) | undefined>
   geolocPosition: Position
   geolocPositionError: GeolocationError | null
   permissionState: GeolocPermissionState | null

--- a/src/libs/locationV2/location.store.ts
+++ b/src/libs/locationV2/location.store.ts
@@ -108,6 +108,7 @@ const locationStore = createStore({
   selectors: {
     selectState: () => (state) => state,
     selectLocationMode: () => (state) => state.locationMode,
+    selectPermissionState: () => (state) => state.permissionState,
     selectLocationConfiguration: (configurationKey: LocationMode) => (state) =>
       state.configuration[configurationKey],
     selectPlace: () => (state) => {
@@ -136,7 +137,7 @@ locationStore.store.subscribe(locationStore.selectors.selectLocationType, (locat
   firebaseAnalytics.setDefaultEventParameters({ locationType })
 )
 
-function isRejected(permission: GeolocPermissionState | null) {
+const isRejected = (permission: GeolocPermissionState | null) => {
   return (
     !permission ||
     permission === GeolocPermissionState.DENIED ||


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41999

Le onModalHideRef sert à attribuer une fonction ou non à la props `onModalHide` de la modale de localisation.

Comportement initial:
- A l'ouverture de la modale, la ref est attribuée à `undefined`
- Si l'utilisateur a un état de permission `NEVER_ASK_AGAIN` et qu'il clique sur `Ma position`, la ref est attribuée à `showGeolocationModal` qui est une callback qui s'éxecutera à la fermeture de la modale.
- La modale se ferme dès que l'on clique sur ma position, quelle que soit la modale.

De ce fait, j'ai supprimé la complexité du code attribuant une ref en le rendant impératif en fermant la modale et ouvrant la modale de permission à l'endroit où la ref était précedemment attribuée.

Le comportement est resté le même j'ai pu donc supprimer les tests superflus:
- Un test qui vérifie que le dismiss modal n'est pas appelé deux fois, on en n'a cure, car c'est une fonction qui met un booléen à false
- Un test qui vérifie que lorsque l'utilisateur ferme la modale, la nouvelle modale s'ouvre. Nous n'arrivons jamais à ce cas car la modale se ferme toujours au clique sur `ma position`
