### PR TITLE
(PC-42027) fix(modals): fix truncated bottom

### DIFF
--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
@@ -360,9 +360,7 @@ exports[`<EmailResendModal /> should render correctly 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
@@ -360,9 +360,7 @@ exports[`<DMSModal/> should render correctly 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
@@ -359,9 +359,7 @@ exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
@@ -361,9 +361,7 @@ retrouver tes favoris
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/features/offer/components/NotificationAuthModal/NotificationAuthModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/NotificationAuthModal/NotificationAuthModal.native.test.tsx.native-snap
@@ -361,9 +361,7 @@ activer un rappel
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
@@ -315,9 +315,7 @@ exports[`ShareAppModalVersionA should match snapshot 1`] = `
         paddingBottom={5}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 5,
             "width": "100%",

--- a/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
@@ -315,9 +315,7 @@ exports[`ShareAppModalVersionB should match snapshot 1`] = `
         paddingBottom={5}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 5,
             "width": "100%",

--- a/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
+++ b/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
@@ -210,7 +210,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                   data-testid="spacerBetweenHeaderAndContent"
                 />
                 <div
-                  class="css-view-175oi2r r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-maxWidth-iz080l r-paddingBottom-xd6kpl r-width-13qz1uu"
+                  class="css-view-175oi2r r-height-1pi2tsx r-maxWidth-iz080l r-paddingBottom-xd6kpl r-width-13qz1uu"
                 >
                   <div
                     class="css-view-175oi2r r-WebkitOverflowScrolling-150rngu r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-11yh6sk r-overflowY-1rnoaur r-transform-agouwx"

--- a/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
@@ -360,9 +360,7 @@ exports[`<NotificationsLoggedOutModal /> should render correctly 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
@@ -360,9 +360,7 @@ exports[`<NotificationsSettingsModal /> should render correctly 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
@@ -360,9 +360,7 @@ exports[`<OnboardingSubscriptionModal /> should display correctly 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
@@ -360,9 +360,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for activites_crea
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -1041,9 +1039,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for cinema 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -1722,9 +1718,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for lecture 1`] = 
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -2403,9 +2397,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for musique 1`] = 
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -3084,9 +3076,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for spectacles 1`]
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -3765,9 +3755,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for visites 1`] = 
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
@@ -360,9 +360,7 @@ exports[`<UnsubscribingConfirmationModal /> should render correctly 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
@@ -360,9 +360,7 @@ exports[`<ApplicationProcessingModal /> should match previous snapshot 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
@@ -360,9 +360,7 @@ exports[`<AuthenticationModal /> should render correctly 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
@@ -361,9 +361,7 @@ ton crédit
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
@@ -361,9 +361,7 @@ pour réserver cette offre
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -919,9 +917,7 @@ pour réserver cette offre
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -1477,9 +1473,7 @@ pour réserver cette offre
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/__snapshots__/ui/components/modals/AppModal.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/modals/AppModal.native.test.tsx.native-snap
@@ -259,9 +259,7 @@ exports[`<AppModal /> on big screen 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -548,9 +546,7 @@ exports[`<AppModal /> on small screen 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -791,9 +787,7 @@ exports[`<AppModal /> with backdrop disabled 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -1080,9 +1074,7 @@ exports[`<AppModal /> with backdrop enabled by default 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -1369,9 +1361,7 @@ exports[`<AppModal /> with backdrop explicitly enabled 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -1764,9 +1754,7 @@ exports[`<AppModal /> with left icon render 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -2053,9 +2041,7 @@ exports[`<AppModal /> with minimal props 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -2449,9 +2435,7 @@ exports[`<AppModal /> with right icon render 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
@@ -2738,9 +2722,7 @@ exports[`<AppModal /> without children 1`] = `
         paddingBottom={8}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "height": "100%",
             "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",

--- a/src/ui/components/modals/AppModal.tsx
+++ b/src/ui/components/modals/AppModal.tsx
@@ -340,7 +340,7 @@ const ScrollViewContainer = styled.View.attrs<{ backdropColor?: string }>(({ the
 }))<{ paddingBottom: number; modalSpacing?: ModalSpacing }>(({ paddingBottom, modalSpacing }) => ({
   width: '100%', // do not use `flex: 1` here if you want full width
   maxWidth: getSpacing(120),
-  flex: 1,
+  height: '100%',
   paddingBottom,
   ...(modalSpacing ? { paddingHorizontal: modalSpacing } : {}),
 }))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42027

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | 100% | 200% |
| :--------------- | :-----------: | :---: |
|  login modal           |   <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-26 at 14 32 24" src="https://github.com/user-attachments/assets/c3151827-6174-4ef0-93f8-7df78834e32d" />| https://github.com/user-attachments/assets/36c37a86-dee1-4bfc-b37d-5f534cf4066e|
| modale de changement d'email         |    <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-26 at 14 35 00" src="https://github.com/user-attachments/assets/bbe0f260-c979-4393-8865-83f97feeeb08" />|   <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-26 at 15 10 46" src="https://github.com/user-attachments/assets/4fd59844-7e96-44f5-8a23-1b1b9acf4143" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
