### PR TITLE
(PC-41962) fix(navigation): goBack button should trigger a goBack and not a navigation

### DIFF
--- a/src/features/home/pages/ThematicHome.native.test.tsx
+++ b/src/features/home/pages/ThematicHome.native.test.tsx
@@ -23,7 +23,7 @@ import { LocationMode } from 'libs/location/types'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('libs/network/NetInfoWrapper')
 
@@ -103,6 +103,12 @@ jest.spyOn(useGoBack, 'useGoBack').mockReturnValue({
   canGoBack: jest.fn(() => true),
 })
 
+const mockGoBack = jest.fn()
+jest.spyOn(useGoBack, 'useGoBack').mockReturnValue({
+  goBack: mockGoBack,
+  canGoBack: jest.fn(() => true),
+})
+
 const mockNavigate = jest.fn()
 jest.spyOn(reactNavigationNative, 'useNavigation').mockReturnValue({
   navigate: mockNavigate,
@@ -110,6 +116,8 @@ jest.spyOn(reactNavigationNative, 'useNavigation').mockReturnValue({
 })
 
 jest.useFakeTimers()
+
+const user = userEvent.setup()
 
 describe('ThematicHome', () => {
   useRoute.mockReturnValue({ params: { entryId: 'fakeEntryId' } })
@@ -226,6 +234,44 @@ describe('ThematicHome', () => {
 
       expect(await screen.findAllByText('Catégorie cinéma')).not.toHaveLength(0)
       expect(screen.getByText('Un sous-titre')).toBeOnTheScreen()
+    })
+
+    it('should execute go back when pressing back button and url has chronicles from parameter', async () => {
+      useRoute.mockReturnValueOnce({
+        params: {
+          entryId: 'fakeEntryId',
+          from: 'chronicles',
+        },
+      })
+      renderThematicHome()
+
+      await user.press(await screen.findByLabelText('Revenir en arrière'))
+
+      expect(mockGoBack).toHaveBeenCalledTimes(1)
+    })
+
+    it('should execute go back when pressing back button and url has deeplink from parameter', async () => {
+      useRoute.mockReturnValueOnce({
+        params: {
+          entryId: 'fakeEntryId',
+          from: 'deeplink',
+        },
+      })
+      renderThematicHome()
+
+      await user.press(await screen.findByLabelText('Revenir en arrière'))
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1)
+    })
+
+    it('should execute go back when pressing back button without from parameter', async () => {
+      useRoute.mockReturnValueOnce({ params: { entryId: 'fakeEntryId' } })
+
+      renderThematicHome()
+
+      await user.press(await screen.findByLabelText('Revenir en arrière'))
+
+      expect(mockGoBack).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/features/home/pages/ThematicHome.tsx
+++ b/src/features/home/pages/ThematicHome.tsx
@@ -1,4 +1,4 @@
-import { useRoute } from '@react-navigation/native'
+import { useNavigation, useRoute } from '@react-navigation/native'
 import React, { FunctionComponent, useEffect } from 'react'
 import { Animated, Platform } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
@@ -19,7 +19,8 @@ import { HighlightThematicHomeHeader } from 'features/home/components/headers/Hi
 import { ThematicHomeHeader } from 'features/home/components/headers/ThematicHomeHeader'
 import { GenericHome } from 'features/home/pages/GenericHome'
 import { ThematicHeader, ThematicHeaderType } from 'features/home/types'
-import { UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
+import { UseNavigationType, UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
+import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { analytics } from 'libs/analytics/provider'
 import { useLocation } from 'libs/location/LocationWrapper'
@@ -140,6 +141,8 @@ export const ThematicHome: FunctionComponent = () => {
   } = useRoute<UseRouteType<'ThematicHome'>>()
   const { goBack } = useGoBack('ClubAdvices')
   const isFromDeeplink = from === 'deeplink'
+  const { navigate } = useNavigation<UseNavigationType>()
+
   // if homepage fails to be fetched, `homeId` should not be `requestHomeId`, it would mislead tracker's data
   const { id: homeId, modules, thematicHeader } = useGetHomepageById(requestHomeId)
   const {
@@ -207,6 +210,10 @@ export const ThematicHome: FunctionComponent = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasGeolocPosition, isFromDeeplink])
 
+  const handleBackPress = () => {
+    isFromDeeplink ? navigate(...homeNavigationConfig) : goBack()
+  }
+
   const getPlaceholderHeight = () => {
     if (thematicHeader?.type === ThematicHeaderType.Category) {
       return 0
@@ -238,7 +245,7 @@ export const ThematicHome: FunctionComponent = () => {
         thematicHeader={thematicHeader}
         headerTransition={headerTransition}
         homeId={homeId}
-        onBackPress={goBack}
+        onBackPress={handleBackPress}
       />
       {/* Animated header is called only for iOS */}
       {Platform.OS === 'ios' ? (


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41962

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |  https://github.com/user-attachments/assets/2a995fd5-6b4f-488c-8bf4-25d7d58cc59f|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
