### PR TITLE
(PC-42030) refactor(location): bind location modals to Zustand

### DIFF
--- a/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
@@ -26,7 +26,7 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
     ]
   }
   swipeThreshold={100}
-  testID="modal"
+  testID="location-modal"
   transparent={true}
   visible={true}
 >

--- a/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
@@ -85,7 +85,7 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
       ]
     }
     swipeThreshold={100}
-    testID="modal"
+    testID="location-modal"
     transparent={true}
     visible={true}
   >

--- a/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
@@ -87,7 +87,7 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
       ]
     }
     swipeThreshold={100}
-    testID="modal"
+    testID="location-modal"
     transparent={true}
     visible={true}
   >

--- a/src/features/location/components/HomeLocationModal.native.test.tsx
+++ b/src/features/location/components/HomeLocationModal.native.test.tsx
@@ -9,13 +9,13 @@ import {
   GeolocPermissionState,
   LocationWrapper,
 } from 'libs/location/location'
+import { locationModalActions } from 'libs/locationV2/locationModal.store'
 import { SuggestedPlace } from 'libs/place/types'
-import { MODAL_TO_SHOW_TIME } from 'tests/constants'
-import { act, fireEvent, render, screen, userEvent } from 'tests/utils'
+import { MODAL_TO_HIDE_TIME, MODAL_TO_SHOW_TIME } from 'tests/constants'
+import { act, fireEvent, render, screen, userEvent, waitFor } from 'tests/utils'
+import { Button } from 'ui/designSystem/Button/Button'
 
 jest.useFakeTimers()
-
-const hideModalMock = jest.fn()
 
 jest.mock('libs/location/geolocation/getGeolocPosition/getGeolocPosition')
 const getGeolocPositionMock = getGeolocPosition as jest.MockedFunction<typeof getGeolocPosition>
@@ -52,10 +52,11 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 
 const user = userEvent.setup()
 
-jest.useFakeTimers()
-
 describe('HomeLocationModal', () => {
   it('should render correctly if modal visible', async () => {
+    act(() => {
+      locationModalActions.show()
+    })
     renderHomeLocationModal()
 
     await act(async () => {
@@ -66,6 +67,9 @@ describe('HomeLocationModal', () => {
   })
 
   it('should trigger logEvent "logUserSetLocation" on onSubmit', async () => {
+    act(() => {
+      locationModalActions.show()
+    })
     renderHomeLocationModal()
     await act(async () => {
       jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
@@ -89,6 +93,9 @@ describe('HomeLocationModal', () => {
   })
 
   it('should hide modal on close modal button press', async () => {
+    act(() => {
+      locationModalActions.show()
+    })
     renderHomeLocationModal()
     await act(async () => {
       jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
@@ -96,26 +103,16 @@ describe('HomeLocationModal', () => {
 
     await user.press(screen.getByLabelText('Fermer la modale'))
 
-    expect(hideModalMock).toHaveBeenCalledTimes(1)
-  })
-
-  it('should highlight geolocation button if geolocation is selected', async () => {
-    getGeolocPositionMock.mockResolvedValueOnce({ latitude: 0, longitude: 0 })
-
-    renderHomeLocationModal()
-    await act(async () => {
-      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
-    })
-    const geolocPositionButton = screen.getByText('Utiliser ma position actuelle')
-    await user.press(geolocPositionButton)
-
-    expect(screen.getByLabelText(/Utiliser ma position actuelle/)).toHaveAccessibilityState({
-      checked: true,
+    await waitFor(() => {
+      expect(screen.queryByText('Localisation')).not.toBeOnTheScreen()
     })
   })
 
   it('should hide Géolocalisation désactivée if geolocation is enabled', async () => {
     getGeolocPositionMock.mockResolvedValueOnce({ latitude: 0, longitude: 0 })
+    act(() => {
+      locationModalActions.show()
+    })
 
     renderHomeLocationModal()
     await act(async () => {
@@ -127,6 +124,9 @@ describe('HomeLocationModal', () => {
 
   it('should request geolocation if geolocation is denied and the geolocation button pressed', async () => {
     mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.DENIED)
+    act(() => {
+      locationModalActions.show()
+    })
 
     renderHomeLocationModal()
     await act(async () => {
@@ -137,12 +137,47 @@ describe('HomeLocationModal', () => {
 
     expect(mockRequestGeolocPermission).toHaveBeenCalledTimes(1)
   })
+
+  it('should show geolocation modal if geolocation is never_ask_again on closing the modal after a geolocation button press', async () => {
+    mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.NEVER_ASK_AGAIN)
+    act(() => {
+      locationModalActions.show()
+    })
+
+    const Container = () => {
+      return (
+        <LocationWrapper>
+          <React.Fragment>
+            <HomeLocationModal />
+            <Button wording="Close" onPress={locationModalActions.hide} />
+          </React.Fragment>
+        </LocationWrapper>
+      )
+    }
+    render(<Container />)
+    await act(async () => {
+      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
+    })
+
+    await user.press(screen.getByText('Utiliser ma position actuelle'))
+
+    await act(async () => {
+      jest.advanceTimersByTime(MODAL_TO_HIDE_TIME)
+      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText('Localisation')).not.toBeOnTheScreen()
+    })
+
+    expect(screen.getByText('Paramètres de localisation')).toBeOnTheScreen()
+  })
 })
 
 function renderHomeLocationModal() {
   render(
     <LocationWrapper>
-      <HomeLocationModal visible dismissModal={hideModalMock} />
+      <HomeLocationModal />
     </LocationWrapper>
   )
 }

--- a/src/features/location/components/HomeLocationModal.tsx
+++ b/src/features/location/components/HomeLocationModal.tsx
@@ -5,13 +5,9 @@ import { useLocationMode } from 'features/location/helpers/useLocationMode'
 import { useLocationState } from 'features/location/helpers/useLocationState'
 import { analytics } from 'libs/analytics/provider'
 import { useLocation } from 'libs/location/LocationWrapper'
+import { locationModalActions, useLocationModal } from 'libs/locationV2/locationModal.store'
 
-interface HomeLocationModalProps {
-  visible: boolean
-  dismissModal: () => void
-}
-
-export const HomeLocationModal = ({ visible, dismissModal }: HomeLocationModalProps) => {
+export const HomeLocationModal = () => {
   const {
     hasGeolocPosition,
     placeQuery,
@@ -26,20 +22,15 @@ export const HomeLocationModal = ({ visible, dismissModal }: HomeLocationModalPr
     requestGeolocPermission,
   } = useLocation()
 
-  const { tempLocationMode, setTempLocationMode } = useLocationState({
-    visible,
-  })
+  const { visible } = useLocationModal()
+  const { submit, hide: dismissModal } = locationModalActions
 
   const onSubmit = () => {
-    setPlace(selectedPlace)
-    setSelectedLocationMode(tempLocationMode)
+    submit()
     analytics.logUserSetLocation('home')
-    dismissModal()
   }
 
-  const onClose = () => {
-    dismissModal()
-  }
+  const { tempLocationMode, setTempLocationMode } = useLocationState()
 
   const { selectLocationMode } = useLocationMode({
     dismissModal,
@@ -61,7 +52,7 @@ export const HomeLocationModal = ({ visible, dismissModal }: HomeLocationModalPr
       onSubmit={onSubmit}
       hasGeolocPosition={hasGeolocPosition}
       tempLocationMode={tempLocationMode}
-      onClose={onClose}
+      onClose={dismissModal}
       selectLocationMode={selectLocationMode}
       selectedPlace={selectedPlace}
       setSelectedPlace={setSelectedPlace}

--- a/src/features/location/components/LocationModal.tsx
+++ b/src/features/location/components/LocationModal.tsx
@@ -177,6 +177,7 @@ export const LocationModal = ({
       isUpToStatusBar
       scrollEnabled={false}
       keyboardShouldPersistTaps="handled"
+      testID="location-modal"
       customModalHeader={
         <HeaderContainer>
           <ModalHeader

--- a/src/features/location/components/LocationWidget.native.test.tsx
+++ b/src/features/location/components/LocationWidget.native.test.tsx
@@ -29,7 +29,7 @@ describe('LocationWidget', () => {
 
     await user.press(button)
 
-    expect(mockShowModal).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('location-modal')).toBeOnTheScreen()
   })
 
   it('should show tooltip after 1 second and hide 8 seconds after it appeared', async () => {

--- a/src/features/location/components/LocationWidget.tsx
+++ b/src/features/location/components/LocationWidget.tsx
@@ -9,10 +9,10 @@ import { getLocationTitle } from 'features/location/helpers/getLocationTitle'
 import { useLocationWidgetTooltip } from 'features/location/helpers/useLocationWidgetTooltip'
 import { useLocation } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
+import { locationModalActions } from 'libs/locationV2/locationModal.store'
 import { getComputedAccessibilityLabel } from 'shared/accessibility/helpers/getComputedAccessibilityLabel'
 import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
 import { styledButton } from 'ui/components/buttons/styledButton'
-import { useModal } from 'ui/components/modals/useModal'
 import { Tooltip } from 'ui/components/Tooltip'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { LocationPointerAppV2 } from 'ui/svg/icons/LocationPointerAppV2'
@@ -41,12 +41,6 @@ export const LocationWidget: FunctionComponent<Props> = ({ screenOrigin }) => {
 
   const locationTitle = getLocationTitle(place, selectedLocationMode)
 
-  const {
-    visible: locationModalVisible,
-    showModal: showLocationModal,
-    hideModal: hideLocationModal,
-  } = useModal()
-
   const isWidgetHighlighted = selectedLocationMode !== LocationMode.EVERYWHERE
 
   const locationIcon = isWidgetHighlighted ? (
@@ -66,17 +60,13 @@ export const LocationWidget: FunctionComponent<Props> = ({ screenOrigin }) => {
     <React.Fragment>
       <StyledTouchable
         testID={computedAccessibilityLabel}
-        onPress={showLocationModal}
+        onPress={locationModalActions.show}
         accessibilityLabel={computedAccessibilityLabel}
         {...(Platform.OS === 'web' ? { ref: touchableRef } : { onLayout: onWidgetLayout })}>
         <IconContainer isActive={isWidgetHighlighted}>{locationIcon}</IconContainer>
         <StyledCaption numberOfLines={numberOfLines}>{locationTitle}</StyledCaption>
       </StyledTouchable>
-      {shouldShowHomeLocationModal ? (
-        <HomeLocationModal visible={locationModalVisible} dismissModal={hideLocationModal} />
-      ) : (
-        <SearchLocationModal visible={locationModalVisible} dismissModal={hideLocationModal} />
-      )}
+      {shouldShowHomeLocationModal ? <HomeLocationModal /> : <SearchLocationModal />}
       {enableTooltip ? (
         <StyledTooltip
           label="Configure ta position et découvre les offres dans la zone géographique de ton choix."

--- a/src/features/location/components/LocationWidgetBadge.native.test.tsx
+++ b/src/features/location/components/LocationWidgetBadge.native.test.tsx
@@ -6,15 +6,6 @@ import { useLocation } from 'libs/location/location'
 import { LocationLabel, LocationMode } from 'libs/location/types'
 import { act, render, screen, userEvent } from 'tests/utils'
 
-const mockShowModal = jest.fn()
-jest.mock('ui/components/modals/useModal', () => ({
-  useModal: () => ({
-    visible: false,
-    showModal: mockShowModal,
-    hideModal: jest.fn(),
-  }),
-}))
-
 jest.mock('libs/location/location')
 const mockUseLocation = useLocation as jest.Mock
 
@@ -40,7 +31,7 @@ describe('LocationWidgetBadge', () => {
 
     await user.press(button)
 
-    expect(mockShowModal).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('location-modal')).toBeOnTheScreen()
   })
 
   it.each`

--- a/src/features/location/components/LocationWidgetBadge.tsx
+++ b/src/features/location/components/LocationWidgetBadge.tsx
@@ -7,9 +7,9 @@ import { getLocationTitle } from 'features/location/helpers/getLocationTitle'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { useLocation } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
+import { locationModalActions } from 'libs/locationV2/locationModal.store'
 import { getComputedAccessibilityLabel } from 'shared/accessibility/helpers/getComputedAccessibilityLabel'
 import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
-import { useModal } from 'ui/components/modals/useModal'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { LocationPointer } from 'ui/svg/icons/LocationPointer'
 import { Typo } from 'ui/theme'
@@ -21,12 +21,6 @@ export const LocationWidgetBadge = () => {
 
   const locationTitle = getLocationTitle(place, selectedLocationMode)
 
-  const {
-    visible: locationModalVisible,
-    showModal: showLocationModal,
-    hideModal: hideLocationModal,
-  } = useModal()
-
   const isWidgetHighlighted = selectedLocationMode !== LocationMode.EVERYWHERE
 
   const computedAccessibilityLabel = getComputedAccessibilityLabel(
@@ -37,7 +31,7 @@ export const LocationWidgetBadge = () => {
   return (
     <Container highlighted={isWidgetHighlighted}>
       <LocationButton
-        onPress={showLocationModal}
+        onPress={locationModalActions.show}
         accessibilityRole={AccessibilityRole.BUTTON}
         accessibilityLabel={computedAccessibilityLabel}>
         {isWidgetHighlighted ? (
@@ -47,7 +41,7 @@ export const LocationWidgetBadge = () => {
         )}
         <LocationTitle numberOfLines={numberOfLines}>{locationTitle}</LocationTitle>
       </LocationButton>
-      <SearchLocationModal visible={locationModalVisible} dismissModal={hideLocationModal} />
+      <SearchLocationModal />
     </Container>
   )
 }

--- a/src/features/location/components/LocationWidgetDesktop.native.test.tsx
+++ b/src/features/location/components/LocationWidgetDesktop.native.test.tsx
@@ -10,15 +10,6 @@ import { act, render, screen, userEvent } from 'tests/utils'
 jest.unmock('@react-navigation/native')
 jest.mock('libs/splashscreen/splashscreen')
 
-const mockShowModal = jest.fn()
-jest.mock('ui/components/modals/useModal', () => ({
-  useModal: () => ({
-    visible: false,
-    showModal: mockShowModal,
-    hideModal: jest.fn(),
-  }),
-}))
-
 jest.mock('libs/location/location')
 const mockUseLocation = useLocation as jest.Mock
 
@@ -27,18 +18,13 @@ jest.useFakeTimers()
 
 describe('LocationWidgetDesktop', () => {
   it('should show modal when pressing widget', async () => {
-    mockUseLocation.mockReturnValueOnce({
-      hasGeolocPosition: true,
-      place: { label: 'test' },
-      isCurrentLocationMode: jest.fn(),
-    })
     renderLocationWidgetDesktop()
 
     const button = screen.getByTestId('Ouvrir la modale de localisation depuis le titre')
 
     await user.press(button)
 
-    expect(mockShowModal).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('location-modal')).toBeOnTheScreen()
   })
 
   it.each`

--- a/src/features/location/components/LocationWidgetDesktop.tsx
+++ b/src/features/location/components/LocationWidgetDesktop.tsx
@@ -9,8 +9,6 @@ import { ScreenOrigin } from 'features/location/enums'
  */
 export const LocationWidgetDesktop = () => (
   <LocationWidgetWrapperDesktop screenOrigin={ScreenOrigin.HOME}>
-    {({ visible, dismissModal }) => (
-      <HomeLocationModal visible={visible} dismissModal={dismissModal} />
-    )}
+    <HomeLocationModal />
   </LocationWidgetWrapperDesktop>
 )

--- a/src/features/location/components/LocationWidgetWrapperDesktop.tsx
+++ b/src/features/location/components/LocationWidgetWrapperDesktop.tsx
@@ -5,8 +5,8 @@ import styled, { useTheme } from 'styled-components/native'
 import { useLocationForLocationWidgetDesktop } from 'features/location/components/useLocationForLocationWidgetDesktop'
 import { ScreenOrigin } from 'features/location/enums'
 import { useLocationWidgetTooltip } from 'features/location/helpers/useLocationWidgetTooltip'
+import { locationModalActions } from 'libs/locationV2/locationModal.store'
 import { styledButton } from 'ui/components/buttons/styledButton'
-import { useModal } from 'ui/components/modals/useModal'
 import { Tooltip } from 'ui/components/Tooltip'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { ArrowDown } from 'ui/svg/icons/ArrowDown'
@@ -16,17 +16,9 @@ import { getSpacing, Typo } from 'ui/theme'
 const TOOLTIP_WIDTH = getSpacing(58)
 const WIDGET_HEIGHT = getSpacing(5 + 1) // textSize + padding
 
-type LocationWidgetWrapperDesktopChildrenProps = {
-  visible: boolean
-  dismissModal: VoidFunction
-}
-
 type LocationWidgetWrapperDesktopProps = {
   screenOrigin: ScreenOrigin
-  children: ({
-    visible,
-    dismissModal,
-  }: LocationWidgetWrapperDesktopChildrenProps) => React.ReactNode
+  children: React.ReactNode
 }
 
 /**
@@ -54,15 +46,9 @@ export const LocationWidgetWrapperDesktop: React.FC<LocationWidgetWrapperDesktop
     enableTooltip,
   } = useLocationWidgetTooltip(screenOrigin)
 
-  const {
-    visible: locationModalVisible,
-    showModal: showLocationModal,
-    hideModal: hideLocationModal,
-  } = useModal()
-
   const onPressLocationButton = () => {
     hideTooltip()
-    showLocationModal()
+    locationModalActions.show()
   }
 
   const locationIcon = isWidgetHighlighted ? (
@@ -92,7 +78,7 @@ export const LocationWidgetWrapperDesktop: React.FC<LocationWidgetWrapperDesktop
           <ArrowDown size={designSystem.size.icon.s} />
         </NotShrunk>
       </LocationButton>
-      {children({ visible: locationModalVisible, dismissModal: hideLocationModal })}
+      {children}
     </React.Fragment>
   )
 }

--- a/src/features/location/components/LocationWidgetWrapperDesktop.tsx
+++ b/src/features/location/components/LocationWidgetWrapperDesktop.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import { Platform } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -26,10 +26,9 @@ type LocationWidgetWrapperDesktopProps = {
  * that will use modal props defined in
  * -> so children has to be a modal
  */
-export const LocationWidgetWrapperDesktop: React.FC<LocationWidgetWrapperDesktopProps> = ({
-  children,
-  screenOrigin,
-}) => {
+export const LocationWidgetWrapperDesktop: React.FC<
+  PropsWithChildren<LocationWidgetWrapperDesktopProps>
+> = ({ screenOrigin, children }) => {
   const { designSystem } = useTheme()
   const {
     title: locationTitle,

--- a/src/features/location/components/SearchLocationModal.native.test.tsx
+++ b/src/features/location/components/SearchLocationModal.native.test.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Button } from 'react-native'
 import { ReactTestInstance } from 'react-test-renderer'
 
@@ -16,12 +16,12 @@ import {
   LocationWrapper,
 } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
+import { locationModalActions } from 'libs/locationV2/locationModal.store'
 import { SuggestedPlace } from 'libs/place/types'
 import { MODAL_TO_HIDE_TIME, MODAL_TO_SHOW_TIME } from 'tests/constants'
 import { act, fireEvent, render, screen, userEvent, waitFor } from 'tests/utils'
 
 jest.useFakeTimers()
-jest.unmock('react-native/Libraries/Animated/createAnimatedComponent')
 
 const mockRadiusPlace = 37
 const mockAroundMeRadius = 73
@@ -76,6 +76,8 @@ const user = userEvent.setup()
 describe('SearchLocationModal', () => {
   it('should render correctly if modal visible', async () => {
     renderSearchLocationModal()
+    await user.press(screen.getByText('Open modal'))
+
     await act(async () => {
       jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
     })
@@ -85,6 +87,8 @@ describe('SearchLocationModal', () => {
 
   it('should trigger logEvent "logUserSetLocation" on onSubmit', async () => {
     renderSearchLocationModal()
+    await user.press(screen.getByText('Open modal'))
+
     await act(async () => {
       jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
     })
@@ -108,6 +112,7 @@ describe('SearchLocationModal', () => {
 
   it('should hide modal on close modal button press', async () => {
     renderSearchLocationModal()
+    await user.press(screen.getByText('Open modal'))
 
     await user.press(screen.getByLabelText('Fermer la modale'))
 
@@ -121,6 +126,8 @@ describe('SearchLocationModal', () => {
     mockRequestGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.GRANTED)
 
     renderSearchLocationModal()
+    await user.press(screen.getByText('Open modal'))
+
     await act(async () => {
       jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
     })
@@ -138,6 +145,8 @@ describe('SearchLocationModal', () => {
     getGeolocPositionMock.mockResolvedValueOnce({ latitude: 0, longitude: 0 })
 
     renderSearchLocationModal()
+    await user.press(screen.getByText('Open modal'))
+
     await act(async () => {
       jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
     })
@@ -149,6 +158,8 @@ describe('SearchLocationModal', () => {
     mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.DENIED)
 
     renderSearchLocationModal()
+    await user.press(screen.getByText('Open modal'))
+
     await act(async () => {
       jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
     })
@@ -162,30 +173,25 @@ describe('SearchLocationModal', () => {
     mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.NEVER_ASK_AGAIN)
 
     const Container = () => {
-      const [visible, setVisible] = React.useState(true)
       return (
         <LocationWrapper>
           <React.Fragment>
-            <SearchLocationModal
-              visible={visible}
-              // userEvent.press not working correctly here
-              // eslint-disable-next-line local-rules/no-fireEvent
-              dismissModal={async () => fireEvent.press(screen.getByText('Close'))}
-            />
-            <Button title="Close" onPress={() => setVisible(false)} />
+            <SearchLocationModal />
+            <Button title="Close" onPress={locationModalActions.hide} />
           </React.Fragment>
         </LocationWrapper>
       )
     }
     render(<Container />)
+    locationModalActions.show()
+
     await act(async () => {
       jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
     })
     await user.press(screen.getByText('Utiliser ma position actuelle'))
 
     await act(async () => {
-      jest.advanceTimersByTime(MODAL_TO_HIDE_TIME)
-      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
+      jest.advanceTimersByTime(MODAL_TO_HIDE_TIME * 10)
     })
 
     expect(screen.getByText('Paramètres de localisation')).toBeOnTheScreen()
@@ -194,6 +200,7 @@ describe('SearchLocationModal', () => {
   describe('PlaceRadius', () => {
     it("should display default radius if it wasn't set previously", async () => {
       renderSearchLocationModal()
+      await user.press(screen.getByText('Open modal'))
 
       const openLocationModalButton = screen.getByText('Choisir une zone géographique')
       await user.press(openLocationModalButton)
@@ -212,6 +219,8 @@ describe('SearchLocationModal', () => {
 
     it('should call searchContext dispatch with mockRadiusPlace when pressing "Valider la localisation"', async () => {
       renderSearchLocationModal()
+      await user.press(screen.getByText('Open modal'))
+
       await act(async () => {
         jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
       })
@@ -247,6 +256,8 @@ describe('SearchLocationModal', () => {
     it('should display default radius even if an AroundMeRadius was set previously', async () => {
       mockRequestGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.GRANTED)
       renderSearchLocationModal()
+      await user.press(screen.getByText('Open modal'))
+
       await act(async () => {
         jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
       })
@@ -277,6 +288,8 @@ describe('SearchLocationModal', () => {
     it("should display default radius if it wasn't set previously", async () => {
       mockRequestGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.GRANTED)
       renderSearchLocationModal()
+      await user.press(screen.getByText('Open modal'))
+
       await act(async () => {
         jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
       })
@@ -295,6 +308,8 @@ describe('SearchLocationModal', () => {
       mockRequestGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.GRANTED)
 
       renderSearchLocationModal()
+      await user.press(screen.getByText('Open modal'))
+
       await act(async () => {
         jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
       })
@@ -320,6 +335,8 @@ describe('SearchLocationModal', () => {
       mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.GRANTED)
 
       renderSearchLocationModal()
+      await user.press(screen.getByText('Open modal'))
+
       await act(async () => {
         jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
       })
@@ -358,18 +375,10 @@ describe('SearchLocationModal', () => {
 function renderSearchLocationModal() {
   render(
     <LocationWrapper>
-      <SearchLocationModalWithMockButton />
+      <React.Fragment>
+        <Button title="Open modal" onPress={locationModalActions.show} />
+        <SearchLocationModal />
+      </React.Fragment>
     </LocationWrapper>
-  )
-}
-
-const SearchLocationModalWithMockButton = () => {
-  const [visible, setVisible] = useState<boolean>(true)
-
-  return (
-    <React.Fragment>
-      <Button title="Open modal" onPress={() => setVisible(true)} />
-      <SearchLocationModal visible={visible} dismissModal={() => setVisible(false)} />
-    </React.Fragment>
   )
 }

--- a/src/features/location/components/SearchLocationModal.native.test.tsx
+++ b/src/features/location/components/SearchLocationModal.native.test.tsx
@@ -191,7 +191,8 @@ describe('SearchLocationModal', () => {
     await user.press(screen.getByText('Utiliser ma position actuelle'))
 
     await act(async () => {
-      jest.advanceTimersByTime(MODAL_TO_HIDE_TIME * 10)
+      jest.advanceTimersByTime(MODAL_TO_HIDE_TIME)
+      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
     })
 
     expect(screen.getByText('Paramètres de localisation')).toBeOnTheScreen()

--- a/src/features/location/components/SearchLocationModal.tsx
+++ b/src/features/location/components/SearchLocationModal.tsx
@@ -8,13 +8,9 @@ import { useRadiusChange } from 'features/location/helpers/useRadiusChange'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { useLocation } from 'libs/location/LocationWrapper'
 import { LocationMode } from 'libs/location/types'
+import { locationModalActions, useLocationModal } from 'libs/locationV2/locationModal.store'
 
-interface LocationModalProps {
-  visible: boolean
-  dismissModal: () => void
-}
-
-export const SearchLocationModal = ({ visible, dismissModal }: LocationModalProps) => {
+export const SearchLocationModal = () => {
   const { dispatch } = useSearch()
 
   const {
@@ -35,6 +31,8 @@ export const SearchLocationModal = ({ visible, dismissModal }: LocationModalProp
     requestGeolocPermission,
   } = useLocation()
 
+  const { visible } = useLocationModal()
+
   const {
     tempLocationMode,
     tempAroundPlaceRadius,
@@ -42,9 +40,9 @@ export const SearchLocationModal = ({ visible, dismissModal }: LocationModalProp
     setTempAroundMeRadius,
     setTempAroundPlaceRadius,
     setTempLocationMode,
-  } = useLocationState({
-    visible,
-  })
+  } = useLocationState()
+
+  const dismissModal = locationModalActions.hide
 
   const { onSubmit, onClose } = getLocationSubmit({
     dismissModal,

--- a/src/features/location/components/SearchLocationWidgetDesktop.tsx
+++ b/src/features/location/components/SearchLocationWidgetDesktop.tsx
@@ -7,9 +7,7 @@ import { ScreenOrigin } from 'features/location/enums'
 export const SearchLocationWidgetDesktop = () => {
   return (
     <LocationWidgetWrapperDesktop screenOrigin={ScreenOrigin.SEARCH}>
-      {({ visible, dismissModal }) => (
-        <SearchLocationModal visible={visible} dismissModal={dismissModal} />
-      )}
+      <SearchLocationModal />
     </LocationWidgetWrapperDesktop>
   )
 }

--- a/src/features/location/components/VenueMapLocationModal.native.test.tsx
+++ b/src/features/location/components/VenueMapLocationModal.native.test.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import { Button } from 'react-native'
 import { ReactTestInstance } from 'react-test-renderer'
 
+import { SearchLocationModal } from 'features/location/components/SearchLocationModal'
 import { VenueMapLocationModal } from 'features/location/components/VenueMapLocationModal'
 import { DEFAULT_RADIUS } from 'features/search/constants'
 import * as useVenueMapStore from 'features/venueMap/store/venueMapStore'
@@ -15,8 +16,9 @@ import {
   LocationWrapper,
 } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
+import { locationModalActions } from 'libs/locationV2/locationModal.store'
 import { SuggestedPlace } from 'libs/place/types'
-import { MODAL_TO_SHOW_TIME } from 'tests/constants'
+import { MODAL_TO_HIDE_TIME, MODAL_TO_SHOW_TIME } from 'tests/constants'
 import { act, fireEvent, render, screen, userEvent, waitFor } from 'tests/utils'
 
 jest.useFakeTimers()
@@ -326,6 +328,31 @@ describe('VenueMapLocationModal', () => {
     await user.press(screen.getByText('Utiliser ma position actuelle'))
 
     expect(mockRequestGeolocPermission).toHaveBeenCalledTimes(1)
+  })
+
+  it('should show geolocation modal if geolocation is never_ask_again on closing the modal after a geolocation button press', async () => {
+    mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.NEVER_ASK_AGAIN)
+    locationModalActions.show()
+
+    const Container = () => {
+      return (
+        <LocationWrapper>
+          <SearchLocationModal />
+        </LocationWrapper>
+      )
+    }
+    render(<Container />)
+    await act(async () => {
+      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
+    })
+    await user.press(screen.getByText('Utiliser ma position actuelle'))
+
+    await act(async () => {
+      jest.advanceTimersByTime(MODAL_TO_HIDE_TIME)
+      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
+    })
+
+    expect(screen.getByText('Paramètres de localisation')).toBeOnTheScreen()
   })
 
   describe('PlaceRadius', () => {

--- a/src/features/location/components/VenueMapLocationModal.native.test.tsx
+++ b/src/features/location/components/VenueMapLocationModal.native.test.tsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react'
 import { Button } from 'react-native'
 import { ReactTestInstance } from 'react-test-renderer'
 
-import { SearchLocationModal } from 'features/location/components/SearchLocationModal'
 import { VenueMapLocationModal } from 'features/location/components/VenueMapLocationModal'
 import { DEFAULT_RADIUS } from 'features/search/constants'
 import * as useVenueMapStore from 'features/venueMap/store/venueMapStore'
@@ -17,7 +16,7 @@ import {
 } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
 import { SuggestedPlace } from 'libs/place/types'
-import { MODAL_TO_HIDE_TIME, MODAL_TO_SHOW_TIME } from 'tests/constants'
+import { MODAL_TO_SHOW_TIME } from 'tests/constants'
 import { act, fireEvent, render, screen, userEvent, waitFor } from 'tests/utils'
 
 jest.useFakeTimers()
@@ -327,39 +326,6 @@ describe('VenueMapLocationModal', () => {
     await user.press(screen.getByText('Utiliser ma position actuelle'))
 
     expect(mockRequestGeolocPermission).toHaveBeenCalledTimes(1)
-  })
-
-  it('should show geolocation modal if geolocation is never_ask_again on closing the modal after a geolocation button press', async () => {
-    mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.NEVER_ASK_AGAIN)
-
-    const Container = () => {
-      const [visible, setVisible] = React.useState(true)
-      return (
-        <LocationWrapper>
-          <React.Fragment>
-            <SearchLocationModal
-              visible={visible}
-              // userEvent.press not working correctly here
-              // eslint-disable-next-line local-rules/no-fireEvent
-              dismissModal={() => fireEvent.press(screen.getByText('Close'))}
-            />
-            <Button title="Close" onPress={() => setVisible(false)} />
-          </React.Fragment>
-        </LocationWrapper>
-      )
-    }
-    render(<Container />)
-    await act(async () => {
-      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
-    })
-    await user.press(screen.getByText('Utiliser ma position actuelle'))
-
-    await act(async () => {
-      jest.advanceTimersByTime(MODAL_TO_HIDE_TIME)
-      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
-    })
-
-    expect(screen.getByText('Paramètres de localisation')).toBeOnTheScreen()
   })
 
   describe('PlaceRadius', () => {

--- a/src/features/location/components/VenueMapLocationModal.tsx
+++ b/src/features/location/components/VenueMapLocationModal.tsx
@@ -52,9 +52,7 @@ export const VenueMapLocationModal = ({
     setTempAroundPlaceRadius,
     setTempAroundMeRadius,
     setTempLocationMode,
-  } = useLocationState({
-    visible,
-  })
+  } = useLocationState()
 
   const { navigate } = useNavigation<UseNavigationType>()
 

--- a/src/features/location/helpers/useLocationState.ts
+++ b/src/features/location/helpers/useLocationState.ts
@@ -1,19 +1,25 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 
-import { DEFAULT_RADIUS } from 'features/search/constants'
-import { useLocation } from 'libs/location/location'
+import { useLocation } from 'libs/location/LocationWrapper'
 import { LocationMode } from 'libs/location/types'
+import {
+  locationModalActions,
+  useLocationModal,
+  useLocationModalConfiguration,
+} from 'libs/locationV2/locationModal.store'
 
-type Props = {
-  visible: boolean
-}
-
-export const useLocationState = ({ visible }: Props) => {
+export const useLocationState = () => {
   const { setPlaceQuery, setSelectedPlace, selectedLocationMode, place } = useLocation()
 
-  const [tempAroundMeRadius, setTempAroundMeRadius] = useState<number>(DEFAULT_RADIUS)
-  const [tempAroundPlaceRadius, setTempAroundPlaceRadius] = useState<number>(DEFAULT_RADIUS)
-  const [tempLocationMode, setTempLocationMode] = useState<LocationMode>(selectedLocationMode)
+  const { radius: tempAroundMeRadius } = useLocationModalConfiguration(LocationMode.AROUND_ME)
+  const { radius: tempAroundPlaceRadius } = useLocationModalConfiguration(LocationMode.AROUND_PLACE)
+  const { locationMode: tempLocationMode, visible } = useLocationModal()
+  const {
+    setAroundMeRadius: setTempAroundMeRadius,
+    setAroundPlaceRadius: setTempAroundPlaceRadius,
+  } = locationModalActions
+
+  const { setLocationMode: setTempLocationMode } = locationModalActions
 
   useEffect(() => {
     if (visible) {
@@ -31,7 +37,6 @@ export const useLocationState = ({ visible }: Props) => {
   }, [visible])
 
   return {
-    selectedLocationMode,
     tempAroundMeRadius,
     setTempAroundMeRadius,
     tempAroundPlaceRadius,

--- a/src/features/location/helpers/useLocationState.ts
+++ b/src/features/location/helpers/useLocationState.ts
@@ -17,9 +17,8 @@ export const useLocationState = () => {
   const {
     setAroundMeRadius: setTempAroundMeRadius,
     setAroundPlaceRadius: setTempAroundPlaceRadius,
+    setLocationMode: setTempLocationMode,
   } = locationModalActions
-
-  const { setLocationMode: setTempLocationMode } = locationModalActions
 
   useEffect(() => {
     if (visible) {

--- a/src/libs/location/LocationWrapper.tsx
+++ b/src/libs/location/LocationWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import React, { memo, useContext, useEffect, useMemo } from 'react'
 
 import { DEFAULT_RADIUS } from 'features/search/constants'
 import { useAppStateChange } from 'libs/appState'
@@ -17,7 +17,11 @@ import {
   usePlace,
   useUserLocation,
 } from 'libs/locationV2/location.store'
-import { SuggestedPlace } from 'libs/place/types'
+import {
+  locationModalActions,
+  useLocationModal,
+  useLocationModalPlace,
+} from 'libs/locationV2/locationModal.store'
 
 import { GeolocationActivationModal } from './geolocation/components/GeolocationActivationModal'
 
@@ -62,7 +66,9 @@ export const LocationWrapper = memo(function LocationWrapper({
     geolocationError: geolocPositionError,
     isPermissionModalVisible: isGeolocPermissionModalVisible,
   } = useLocationV2()
-  const { geolocation: geolocPosition } = useLocationConfiguration(LocationMode.AROUND_ME)
+  const { geolocation: geolocPosition, radius: aroundMeRadius } = useLocationConfiguration(
+    LocationMode.AROUND_ME
+  )
   const {
     showPermissionModal: showGeolocPermissionModal,
     hidePermissionModal: hideGeolocPermissionModal,
@@ -73,16 +79,15 @@ export const LocationWrapper = memo(function LocationWrapper({
   const place = usePlace()
   const { setPlace, setAroundPlaceRadius, setAroundMeRadius } = locationActions
 
-  const { radius: aroundMeRadius } = useLocationConfiguration(LocationMode.AROUND_ME)
-
   // modal state
-  const [placeQuery, setPlaceQuery] = useState('') // search input value
-  const [selectedPlace, setSelectedPlace] = useState<SuggestedPlace | null>(null) // selected suggested place
+  const selectedPlace = useLocationModalPlace()
+  const { setAddressInputValue: setPlaceQuery, setPlace: setSelectedPlace } = locationModalActions
+  const { addressInputValue: placeQuery } = useLocationModal()
 
-  const onResetPlace = useCallback(() => {
-    setSelectedPlace(null)
-    setPlaceQuery('')
-  }, [])
+  const onResetPlace = () => {
+    locationModalActions.setPlace(null)
+    locationModalActions.setAddressInputValue('')
+  }
 
   useEffect(() => {
     void contextualCheckPermission()
@@ -119,24 +124,23 @@ export const LocationWrapper = memo(function LocationWrapper({
       userLocation,
     }),
     [
+      aroundMeRadius,
+      aroundPlaceRadius,
       geolocPosition,
       geolocPositionError,
-      permissionState,
       hasGeolocPosition,
+      permissionState,
       place,
-      setPlace,
-      showGeolocPermissionModal,
-      selectedLocationMode,
-      setSelectedLocationMode,
-      onResetPlace,
-      selectedPlace,
-      setSelectedPlace,
       placeQuery,
-      setPlaceQuery,
-      aroundPlaceRadius,
-      setAroundPlaceRadius,
-      aroundMeRadius,
+      selectedLocationMode,
+      selectedPlace,
       setAroundMeRadius,
+      setAroundPlaceRadius,
+      setPlace,
+      setPlaceQuery,
+      setSelectedLocationMode,
+      setSelectedPlace,
+      showGeolocPermissionModal,
       userLocation,
     ]
   )

--- a/src/libs/locationV2/location.methods.ts
+++ b/src/libs/locationV2/location.methods.ts
@@ -1,8 +1,9 @@
 import { Linking } from 'react-native'
 
+import { checkGeolocPermission } from 'libs/location/geolocation/checkGeolocPermission/checkGeolocPermission'
+import { GeolocPermissionState } from 'libs/location/geolocation/enums'
 import { getGeolocPosition } from 'libs/location/geolocation/getGeolocPosition/getGeolocPosition'
 import { requestGeolocPermission } from 'libs/location/geolocation/requestGeolocPermission/requestGeolocPermission'
-import { GeolocPermissionState, checkGeolocPermission } from 'libs/location/location'
 import { GeolocationError, RequestGeolocPermissionParams } from 'libs/location/types'
 import { locationActions } from 'libs/locationV2/location.store'
 

--- a/src/libs/locationV2/location.store.ts
+++ b/src/libs/locationV2/location.store.ts
@@ -1,6 +1,6 @@
 import { LocationType } from 'libs/analytics/types'
 import { firebaseAnalytics } from 'libs/firebase/analytics/analytics'
-import { GeolocPermissionState } from 'libs/location/location'
+import { GeolocPermissionState } from 'libs/location/geolocation/enums'
 import { GeoCoordinates, GeolocationError, LocationMode } from 'libs/location/types'
 import { SuggestedPlace } from 'libs/place/types'
 import { createStore } from 'libs/store/createStore'

--- a/src/libs/locationV2/locationModal.store.ts
+++ b/src/libs/locationV2/locationModal.store.ts
@@ -5,6 +5,7 @@ import {
   locationActions,
   locationSelectors,
 } from 'libs/locationV2/location.store'
+import { SuggestedPlace } from 'libs/place/types'
 import { createStore } from 'libs/store/createStore'
 
 type LocationModalState = {
@@ -21,33 +22,73 @@ const defaultState: LocationModalState = {
 const locationModalStore = createStore({
   name: 'locationModal',
   defaultState,
-  actions: (set) => ({
-    show: () => {
-      const locationState = locationSelectors.selectState()
-      set({ ...locationState, visible: true })
-    },
-    hide: () => set({ visible: false }),
-    submit: () => {
-      set((state) => {
-        const { locationMode, configuration } = state
-        locationActions.setLocationMode(locationMode)
-        locationActions.setConfiguration(locationMode, configuration[locationMode])
-        return { visible: false }
-      })
-    },
-    setLocationMode: (locationMode: LocationMode) => set({ locationMode }),
-    updateConfig: (
+  actions: (set) => {
+    const setConfiguration = (
       mode: LocationMode,
-      data: Partial<LocationState['configuration'][LocationMode]>
+      configuration: Partial<LocationState['configuration'][LocationMode]>
     ) =>
       set((state) => ({
         configuration: {
           ...state.configuration,
-          [mode]: { ...state.configuration[mode], ...data },
+          [mode]: { ...state.configuration[mode], ...configuration },
         },
-      })),
-  }),
+      }))
+
+    return {
+      show: () => {
+        const locationState = locationSelectors.selectState()
+        set({
+          addressInputValue: locationState.configuration[LocationMode.AROUND_PLACE].label,
+          ...locationState,
+          visible: true,
+        })
+      },
+      hide: () => set({ visible: false }),
+      submit: () => {
+        set((state) => {
+          const { locationMode, configuration } = state
+          locationActions.setLocationMode(locationMode)
+          locationActions.setConfiguration(locationMode, configuration[locationMode])
+          return { visible: false }
+        })
+      },
+      setPlace: (place: SuggestedPlace | null) =>
+        setConfiguration(
+          LocationMode.AROUND_PLACE,
+          place || defaultLocationState.configuration[LocationMode.AROUND_PLACE]
+        ),
+      setAddressInputValue: (addressInputValue: string) => set({ addressInputValue }),
+      setAroundMeRadius: (radius: number) => setConfiguration(LocationMode.AROUND_ME, { radius }),
+      setAroundPlaceRadius: (radius: number) =>
+        setConfiguration(LocationMode.AROUND_PLACE, { radius }),
+      setLocationMode: (locationMode: LocationMode) => set({ locationMode }),
+      updateConfig: (
+        mode: LocationMode,
+        data: Partial<LocationState['configuration'][LocationMode]>
+      ) =>
+        set((state) => ({
+          configuration: {
+            ...state.configuration,
+            [mode]: { ...state.configuration[mode], ...data },
+          },
+        })),
+    }
+  },
+  selectors: {
+    selectLocationModalConfiguration: (configurationKey: LocationMode) => (state) =>
+      state.configuration[configurationKey],
+    selectPlace: () => (state) => {
+      const { radius: _, ...place } = state.configuration[LocationMode.AROUND_PLACE]
+      return place.label ? place : null
+    },
+  },
 })
 
 export const locationModalActions = locationModalStore.actions
 export const locationModalSelectors = locationModalStore.selectors
+
+export const {
+  useStore: useLocationModal,
+  useLocationModalConfiguration,
+  usePlace: useLocationModalPlace,
+} = locationModalStore.hooks


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42030

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
