### PR TITLE
(PC-41498) feat(Offer): add new playlist from data science for book

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -4208,6 +4208,11 @@ export interface SimilarOffersRequestQuery {
    */
   longitude?: number | null
   /**
+   * @type {string}
+   * @memberof SimilarOffersRequestQuery
+   */
+  retrievalModel?: SimilarOffersRequestQuery.RetrievalModelEnum
+  /**
    * @type {Array<string> | null}
    * @memberof SimilarOffersRequestQuery
    */
@@ -4217,6 +4222,21 @@ export interface SimilarOffersRequestQuery {
    * @memberof SimilarOffersRequestQuery
    */
   subcategories?: Array<string> | null
+}
+/**
+ *
+ * @export
+ * @namespace SimilarOffersRequestQuery
+ */
+export namespace SimilarOffersRequestQuery {
+  /**
+   * @export
+   * @enum {string}
+   */
+  export enum RetrievalModelEnum {
+    Coreservation = <any> 'coreservation',
+    Graph = <any> 'graph',
+  }
 }
 /**
  * @export
@@ -5988,10 +6008,11 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
      * @param {Array<string>} [categories] 
      * @param {Array<string>} [subcategories] 
      * @param {Array<string>} [search_group_names] 
+     * @param {string} [retrievalModel] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    async getNativeV1RecommendationSimilarOffersofferId(offer_id: number, longitude?: number, latitude?: number, categories?: Array<string>, subcategories?: Array<string>, search_group_names?: Array<string>, options: any = {}): Promise<FetchArgs> {
+    async getNativeV1RecommendationSimilarOffersofferId(offer_id: number, longitude?: number, latitude?: number, categories?: Array<string>, subcategories?: Array<string>, search_group_names?: Array<string>, retrievalModel?: SimilarOffersRequestQuery.RetrievalModelEnum, options: any = {}): Promise<FetchArgs> {
       // verify required parameter 'offer_id' is not null or undefined
       if (offer_id === null || offer_id === undefined) {
         throw new RequiredError(
@@ -6023,6 +6044,10 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
 
         if (search_group_names != null) {
             queryParameters['search_group_names'] = search_group_names;
+        }
+
+        if (retrievalModel != null) {
+            queryParameters['retrievalModel'] = retrievalModel;
         }
 
       const encodedQueryParams = '?' + Object.keys(queryParameters).map((key) => {
@@ -7913,11 +7938,12 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
      * @param {Array<string>} [categories] 
      * @param {Array<string>} [subcategories] 
      * @param {Array<string>} [search_group_names] 
+     * @param {string} [retrievalModel] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    async getNativeV1RecommendationSimilarOffersofferId(offer_id: number, longitude?: number, latitude?: number, categories?: Array<string>, subcategories?: Array<string>, search_group_names?: Array<string>, options?: any): Promise<SimilarOffersResponse> {
-      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1RecommendationSimilarOffersofferId(offer_id, longitude, latitude, categories, subcategories, search_group_names, options)
+    async getNativeV1RecommendationSimilarOffersofferId(offer_id: number, longitude?: number, latitude?: number, categories?: Array<string>, subcategories?: Array<string>, search_group_names?: Array<string>, retrievalModel?: SimilarOffersRequestQuery.RetrievalModelEnum, options?: any): Promise<SimilarOffersResponse> {
+      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1RecommendationSimilarOffersofferId(offer_id, longitude, latitude, categories, subcategories, search_group_names, retrievalModel, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
       return handleGeneratedApiResponse(response)
     },
@@ -8911,13 +8937,14 @@ export class DefaultApi extends BaseAPI {
     * @param {Array<string>} [categories] 
     * @param {Array<string>} [subcategories] 
     * @param {Array<string>} [search_group_names] 
+    * @param {string} [retrievalModel] 
     * @param {*} [options] Override http request option.
     * @throws {RequiredError}
     * @memberof DefaultApi
     */
-  public async getNativeV1RecommendationSimilarOffersofferId(offer_id: number, longitude?: number, latitude?: number, categories?: Array<string>, subcategories?: Array<string>, search_group_names?: Array<string>, options?: any) {
+  public async getNativeV1RecommendationSimilarOffersofferId(offer_id: number, longitude?: number, latitude?: number, categories?: Array<string>, subcategories?: Array<string>, search_group_names?: Array<string>, retrievalModel?: SimilarOffersRequestQuery.RetrievalModelEnum, options?: any) {
     const configuration = this.getConfiguration()
-    return DefaultApiFp(this, configuration).getNativeV1RecommendationSimilarOffersofferId(offer_id, longitude, latitude, categories, subcategories, search_group_names, options)
+    return DefaultApiFp(this, configuration).getNativeV1RecommendationSimilarOffersofferId(offer_id, longitude, latitude, categories, subcategories, search_group_names, retrievalModel, options)
   }
   /**
     * 

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -306,7 +306,7 @@ describe('<OfferContent />', () => {
 
         await screen.findByText('Réserver l’offre')
 
-        expect(screen.getByLabelText('Dans la même catégorie')).toBeOnTheScreen()
+        expect(screen.getByLabelText('Les fans aiment aussi')).toBeOnTheScreen()
       })
     })
 

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -140,7 +140,14 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
     apiRecoParamsSameCategory,
     otherCategoriesSimilarOffers,
     apiRecoParamsOtherCategories,
-  } = useOfferPlaylist({ offer, offerSearchGroup: subcategory.searchGroupName, searchGroupList })
+    booksSameCategorySimilarOffers,
+    apiRecoParamsBooksSameCategory,
+  } = useOfferPlaylist({
+    offer,
+    offerCategory: subcategory.categoryId,
+    offerSearchGroup: subcategory.searchGroupName,
+    searchGroupList,
+  })
   const scrollViewRef = useRef<ScrollView>(null)
   const scrollYRef = useRef<number>(0)
   const [isBottomReached, setIsBottomReached] = useState(false)
@@ -365,6 +372,7 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
       type: VerticalPlaylist.SimilarOffers,
       module: {
         offer,
+        offerCategory: subcategory.categoryId,
         offerSearchGroup: subcategory.searchGroupName,
         searchGroupList,
         type,
@@ -372,11 +380,16 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
     },
   })
 
-  const onBeforeNavigate = (type) => {
-    const moduleName =
-      type === PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS
-        ? 'Dans la même catégorie'
-        : 'Ça peut aussi te plaire'
+  const onBeforeNavigate = (type: PlaylistType) => {
+    const moduleNameByPlaylistType: Record<PlaylistType, string> = {
+      [PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS]: 'Les fans aiment aussi',
+      [PlaylistType.BOOKS_SAME_CATEGORY_SIMILAR_OFFERS]: 'Dans la même catégorie',
+      [PlaylistType.OTHER_CATEGORIES_SIMILAR_OFFERS]: 'Ça peut aussi te plaire',
+      [PlaylistType.SAME_ARTIST_PLAYLIST]: '',
+      [PlaylistType.SEARCH_RESULTS]: '',
+      [PlaylistType.TOP_OFFERS]: '',
+    }
+    const moduleName = moduleNameByPlaylistType[type]
 
     void analytics.logClickSeeAll({
       type: 'offers',
@@ -506,6 +519,8 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
             apiRecoParamsSameCategory={apiRecoParamsSameCategory}
             otherCategoriesSimilarOffers={otherCategoriesSimilarOffers}
             apiRecoParamsOtherCategories={apiRecoParamsOtherCategories}
+            booksSameCategorySimilarOffers={booksSameCategorySimilarOffers}
+            apiRecoParamsBooksSameCategory={apiRecoParamsBooksSameCategory}
             onViewableItemsChanged={handleViewableItemsChanged}
             seeAllButton={{
               navigateToVerticalPlaylist,

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -38,6 +38,7 @@ import { OfferImageContainer } from 'features/offer/components/OfferImageContain
 import { OfferMessagingApps } from 'features/offer/components/OfferMessagingApps/OfferMessagingApps'
 import { OfferPlaylistList } from 'features/offer/components/OfferPlaylistList/OfferPlaylistList'
 import { OfferWebMetaHeader } from 'features/offer/components/OfferWebMetaHeader'
+import { OFFER_SIMILAR_PLAYLIST_TITLES } from 'features/offer/constant'
 import { PlaylistType } from 'features/offer/enums'
 import { getIsAComingSoonOffer } from 'features/offer/helpers/getIsAComingSoonOffer'
 import { getVenue } from 'features/offer/helpers/getVenueBlockProps'
@@ -381,19 +382,13 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
   })
 
   const onBeforeNavigate = (type: PlaylistType) => {
-    const moduleNameByPlaylistType: Record<PlaylistType, string> = {
-      [PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS]: 'Les fans aiment aussi',
-      [PlaylistType.BOOKS_SAME_CATEGORY_SIMILAR_OFFERS]: 'Dans la même catégorie',
-      [PlaylistType.OTHER_CATEGORIES_SIMILAR_OFFERS]: 'Ça peut aussi te plaire',
-      [PlaylistType.SAME_ARTIST_PLAYLIST]: '',
-      [PlaylistType.SEARCH_RESULTS]: '',
-      [PlaylistType.TOP_OFFERS]: '',
-    }
-    const moduleName = moduleNameByPlaylistType[type]
+    const moduleName = OFFER_SIMILAR_PLAYLIST_TITLES[type]
+
+    if (!moduleName) return
 
     void analytics.logClickSeeAll({
       type: 'offers',
-      moduleName: moduleName,
+      moduleName,
       moduleId: offer.id.toString(),
       from: 'offer',
     })

--- a/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.native.test.tsx
+++ b/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.native.test.tsx
@@ -42,7 +42,7 @@ describe('<OfferPlaylistList />', () => {
 
         await act(() => {})
 
-        await expect(screen.queryByLabelText('Dans la même catégorie')).not.toBeOnTheScreen()
+        await expect(screen.queryByLabelText('Les fans aiment aussi')).not.toBeOnTheScreen()
       })
 
       it('should display same category playlist when offer has it', async () => {
@@ -51,9 +51,9 @@ describe('<OfferPlaylistList />', () => {
           sameCategorySimilarOffers: mockSearchHits,
         })
 
-        await screen.findByLabelText('Dans la même catégorie')
+        await screen.findByLabelText('Les fans aiment aussi')
 
-        expect(screen.getByLabelText('Dans la même catégorie')).toBeOnTheScreen()
+        expect(screen.getByLabelText('Les fans aiment aussi')).toBeOnTheScreen()
       })
 
       it('should navigate to an offer when pressing on it', async () => {
@@ -70,6 +70,19 @@ describe('<OfferPlaylistList />', () => {
           id: 102280,
           playlistType: PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS,
         })
+      })
+    })
+
+    describe('Books same category playlist', () => {
+      it('should display books same category playlist when offer has it', async () => {
+        renderOfferPlaylistList({
+          ...offerPlaylistListProps,
+          booksSameCategorySimilarOffers: mockSearchHits,
+        })
+
+        await screen.findByLabelText('Dans la même catégorie')
+
+        expect(screen.getByLabelText('Dans la même catégorie')).toBeOnTheScreen()
       })
     })
 
@@ -116,6 +129,7 @@ const renderOfferPlaylistList = ({
   offer = mockOffer,
   sameCategorySimilarOffers,
   otherCategoriesSimilarOffers,
+  booksSameCategorySimilarOffers,
 }: OfferPlaylistListProps) =>
   render(
     reactQueryProviderHOC(
@@ -123,6 +137,7 @@ const renderOfferPlaylistList = ({
         offer={offer}
         sameCategorySimilarOffers={sameCategorySimilarOffers}
         otherCategoriesSimilarOffers={otherCategoriesSimilarOffers}
+        booksSameCategorySimilarOffers={booksSameCategorySimilarOffers}
         onViewableItemsChanged={mockPlaylistViewableItemsChanged}
         seeAllButton={{ navigateToVerticalPlaylist: jest.fn(), onBeforeNavigate: jest.fn() }}
       />

--- a/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
+++ b/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
@@ -7,6 +7,7 @@ import styled, { useTheme } from 'styled-components/native'
 import { OfferResponse, RecommendationApiParams } from 'api/gen'
 import { UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
 import { OfferPlaylistItem } from 'features/offer/components/OfferPlaylistItem/OfferPlaylistItem'
+import { OFFER_SIMILAR_PLAYLIST_TITLES } from 'features/offer/constant'
 import { PlaylistType } from 'features/offer/enums'
 import { useLogPlaylist } from 'features/offer/helpers/useLogPlaylistVertical/useLogPlaylistVertical'
 import { useLogScrollHandler } from 'features/offer/helpers/useLogScrolHandler/useLogScrollHandler'
@@ -115,7 +116,7 @@ export function OfferPlaylistList({
 
   const sameCategorySimilarOffersPlaylist: SimilarOfferPlaylist = {
     type: PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS,
-    title: 'Les fans aiment aussi',
+    title: OFFER_SIMILAR_PLAYLIST_TITLES[PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS] ?? '',
     offers: sameCategorySimilarOffers,
     apiRecoParams: apiRecoParamsSameCategory,
     handleChangePlaylistDisplay: handleChangeSameCategoryPlaylistDisplay,
@@ -123,7 +124,7 @@ export function OfferPlaylistList({
 
   const booksSameCategorySimilarOffersPlaylist: SimilarOfferPlaylist = {
     type: PlaylistType.BOOKS_SAME_CATEGORY_SIMILAR_OFFERS,
-    title: 'Dans la même catégorie',
+    title: OFFER_SIMILAR_PLAYLIST_TITLES[PlaylistType.BOOKS_SAME_CATEGORY_SIMILAR_OFFERS] ?? '',
     offers: booksSameCategorySimilarOffers,
     apiRecoParams: apiRecoParamsBooksSameCategory,
     handleChangePlaylistDisplay: handleChangeBooksSameCategoryPlaylistDisplay,
@@ -131,7 +132,7 @@ export function OfferPlaylistList({
 
   const otherCategoriesSimilarOffersPlaylist: SimilarOfferPlaylist = {
     type: PlaylistType.OTHER_CATEGORIES_SIMILAR_OFFERS,
-    title: 'Ça peut aussi te plaire',
+    title: OFFER_SIMILAR_PLAYLIST_TITLES[PlaylistType.OTHER_CATEGORIES_SIMILAR_OFFERS] ?? '',
     offers: otherCategoriesSimilarOffers,
     apiRecoParams: apiRecoParamsOtherCategories,
     handleChangePlaylistDisplay: handleChangeOtherCategoriesPlaylistDisplay,

--- a/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
+++ b/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
@@ -32,6 +32,8 @@ export type OfferPlaylistListProps = {
   apiRecoParamsSameCategory?: RecommendationApiParams
   otherCategoriesSimilarOffers?: Offer[]
   apiRecoParamsOtherCategories?: RecommendationApiParams
+  booksSameCategorySimilarOffers?: Offer[]
+  apiRecoParamsBooksSameCategory?: RecommendationApiParams
   onViewableItemsChanged: (
     items: Pick<ViewToken, 'key' | 'index'>[],
     moduleId: string,
@@ -59,6 +61,8 @@ export function OfferPlaylistList({
   apiRecoParamsSameCategory,
   otherCategoriesSimilarOffers,
   apiRecoParamsOtherCategories,
+  booksSameCategorySimilarOffers,
+  apiRecoParamsBooksSameCategory,
   onViewableItemsChanged,
   seeAllButton,
   proAdvicesSegment,
@@ -75,21 +79,29 @@ export function OfferPlaylistList({
   const currency = useGetCurrencyToDisplay()
   const { data: euroToPacificFrancRate } = usePacificFrancToEuroRate()
   const enableProAdvicesTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_PRO_REVIEWS_PLAYLIST)
-  const { logSameCategoryPlaylistVerticalScroll, logOtherCategoriesPlaylistVerticalScroll } =
-    useLogPlaylist({
-      offerId: offer.id,
-      apiRecoParamsSameCategory,
-      nbSameCategorySimilarOffers: sameCategorySimilarOffers?.length ?? 0,
-      apiRecoParamsOtherCategories,
-      nbOtherCategoriesSimilarOffers: otherCategoriesSimilarOffers?.length ?? 0,
-      fromOfferId,
-    })
+  const {
+    logSameCategoryPlaylistVerticalScroll,
+    logBooksSameCategoryPlaylistVerticalScroll,
+    logOtherCategoriesPlaylistVerticalScroll,
+  } = useLogPlaylist({
+    offerId: offer.id,
+    apiRecoParamsSameCategory,
+    nbSameCategorySimilarOffers: sameCategorySimilarOffers?.length ?? 0,
+    apiRecoParamsBooksSameCategory,
+    nbBooksSameCategorySimilarOffers: booksSameCategorySimilarOffers?.length ?? 0,
+    apiRecoParamsOtherCategories,
+    nbOtherCategoriesSimilarOffers: otherCategoriesSimilarOffers?.length ?? 0,
+    fromOfferId,
+  })
 
   const handleChangeOtherCategoriesPlaylistDisplay = useLogScrollHandler(
     logOtherCategoriesPlaylistVerticalScroll
   )
   const handleChangeSameCategoryPlaylistDisplay = useLogScrollHandler(
     logSameCategoryPlaylistVerticalScroll
+  )
+  const handleChangeBooksSameCategoryPlaylistDisplay = useLogScrollHandler(
+    logBooksSameCategoryPlaylistVerticalScroll
   )
 
   const trackingOnHorizontalScroll = (
@@ -103,10 +115,18 @@ export function OfferPlaylistList({
 
   const sameCategorySimilarOffersPlaylist: SimilarOfferPlaylist = {
     type: PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS,
-    title: 'Dans la même catégorie',
+    title: 'Les fans aiment aussi',
     offers: sameCategorySimilarOffers,
     apiRecoParams: apiRecoParamsSameCategory,
     handleChangePlaylistDisplay: handleChangeSameCategoryPlaylistDisplay,
+  }
+
+  const booksSameCategorySimilarOffersPlaylist: SimilarOfferPlaylist = {
+    type: PlaylistType.BOOKS_SAME_CATEGORY_SIMILAR_OFFERS,
+    title: 'Dans la même catégorie',
+    offers: booksSameCategorySimilarOffers,
+    apiRecoParams: apiRecoParamsBooksSameCategory,
+    handleChangePlaylistDisplay: handleChangeBooksSameCategoryPlaylistDisplay,
   }
 
   const otherCategoriesSimilarOffersPlaylist: SimilarOfferPlaylist = {
@@ -119,11 +139,14 @@ export function OfferPlaylistList({
 
   const similarOffersPlaylist: SimilarOfferPlaylist[] = [
     sameCategorySimilarOffersPlaylist,
+    booksSameCategorySimilarOffersPlaylist,
     otherCategoriesSimilarOffersPlaylist,
   ]
 
   const shouldDisplayPlaylist =
-    isArrayNotEmpty(sameCategorySimilarOffers) || isArrayNotEmpty(otherCategoriesSimilarOffers)
+    isArrayNotEmpty(sameCategorySimilarOffers) ||
+    isArrayNotEmpty(booksSameCategorySimilarOffers) ||
+    isArrayNotEmpty(otherCategoriesSimilarOffers)
 
   const handleOfferPlaylistViewableItemsChanged = useCallback(
     (playlistType: string, playlistIndex: number) =>

--- a/src/features/offer/constant.tsx
+++ b/src/features/offer/constant.tsx
@@ -1,7 +1,14 @@
 import { ArtistType } from 'api/gen'
+import { PlaylistType } from 'features/offer/enums'
 
 export const MAX_WIDTH_VIDEO = 540
 
 export const OF_ROLES = [ArtistType.author, ArtistType.stage_director, ArtistType.film_director]
 
 export const WITH_ROLES = [ArtistType.performer, ArtistType.film_actor]
+
+export const OFFER_SIMILAR_PLAYLIST_TITLES: Partial<Record<PlaylistType, string>> = {
+  [PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS]: 'Les fans aiment aussi',
+  [PlaylistType.BOOKS_SAME_CATEGORY_SIMILAR_OFFERS]: 'Dans la même catégorie',
+  [PlaylistType.OTHER_CATEGORIES_SIMILAR_OFFERS]: 'Ça peut aussi te plaire',
+}

--- a/src/features/offer/enums.ts
+++ b/src/features/offer/enums.ts
@@ -1,5 +1,6 @@
 export enum PlaylistType {
   SAME_CATEGORY_SIMILAR_OFFERS = 'sameCategorySimilarOffers',
+  BOOKS_SAME_CATEGORY_SIMILAR_OFFERS = 'booksSameCategorySimilarOffers',
   OTHER_CATEGORIES_SIMILAR_OFFERS = 'otherCategoriesSimilarOffers',
   SAME_ARTIST_PLAYLIST = 'sameArtistPlaylist',
   SEARCH_RESULTS = 'searchResults',

--- a/src/features/offer/helpers/useLogPlaylistVertical/useLogPlaylistVertical.test.ts
+++ b/src/features/offer/helpers/useLogPlaylistVertical/useLogPlaylistVertical.test.ts
@@ -79,6 +79,50 @@ describe('useLogPlaylist', () => {
     })
   })
 
+  it('should logBooksSameCategoryPlaylistVerticalScroll correctly', () => {
+    const { result } = renderHook(() =>
+      useLogPlaylist({
+        offerId: 1,
+        nbSameCategorySimilarOffers: 0,
+        nbBooksSameCategorySimilarOffers: 5,
+        nbOtherCategoriesSimilarOffers: 0,
+        apiRecoParamsBooksSameCategory: apiRecoParams,
+        fromOfferId: 2,
+      })
+    )
+
+    result.current.logBooksSameCategoryPlaylistVerticalScroll()
+
+    expect(analytics.logPlaylistVerticalScroll).toHaveBeenNthCalledWith(1, {
+      ...apiRecoParams,
+      fromOfferId: 2,
+      offerId: 1,
+      playlistType: PlaylistType.BOOKS_SAME_CATEGORY_SIMILAR_OFFERS,
+      nbResults: 5,
+    })
+  })
+
+  it('should log only once logBooksSameCategoryPlaylistVerticalScroll', () => {
+    const { result } = renderHook(() =>
+      useLogPlaylist({
+        offerId: 1,
+        nbSameCategorySimilarOffers: 0,
+        nbBooksSameCategorySimilarOffers: 5,
+        nbOtherCategoriesSimilarOffers: 0,
+        apiRecoParamsBooksSameCategory: apiRecoParams,
+        fromOfferId: 2,
+      })
+    )
+
+    result.current.logBooksSameCategoryPlaylistVerticalScroll()
+
+    expect(analytics.logPlaylistVerticalScroll).toHaveBeenCalledTimes(1)
+
+    result.current.logBooksSameCategoryPlaylistVerticalScroll()
+
+    expect(analytics.logPlaylistVerticalScroll).toHaveBeenCalledTimes(1)
+  })
+
   it('should log only once logOtherCategoriesPlaylistVerticalScroll', () => {
     const { result } = renderHook(() =>
       useLogPlaylist({

--- a/src/features/offer/helpers/useLogPlaylistVertical/useLogPlaylistVertical.tsx
+++ b/src/features/offer/helpers/useLogPlaylistVertical/useLogPlaylistVertical.tsx
@@ -8,8 +8,10 @@ import { useFunctionOnce } from 'libs/hooks'
 type Props = {
   offerId: number
   nbSameCategorySimilarOffers: number
+  nbBooksSameCategorySimilarOffers?: number
   nbOtherCategoriesSimilarOffers: number
   apiRecoParamsSameCategory?: RecommendationApiParams
+  apiRecoParamsBooksSameCategory?: RecommendationApiParams
   apiRecoParamsOtherCategories?: RecommendationApiParams
   fromOfferId?: number
 }
@@ -17,23 +19,26 @@ type Props = {
 type UseLogPlaylistType = {
   logPlaylistHorizontalScroll: VoidFunction
   logSameCategoryPlaylistVerticalScroll: VoidFunction
+  logBooksSameCategoryPlaylistVerticalScroll: VoidFunction
   logOtherCategoriesPlaylistVerticalScroll: VoidFunction
 }
 
 export const useLogPlaylist = ({
   apiRecoParamsSameCategory,
   nbSameCategorySimilarOffers,
+  apiRecoParamsBooksSameCategory,
+  nbBooksSameCategorySimilarOffers = 0,
   apiRecoParamsOtherCategories,
   nbOtherCategoriesSimilarOffers,
   offerId,
   fromOfferId,
 }: Props): UseLogPlaylistType => {
   const logPlaylistHorizontalScroll = useCallback(() => {
-    analytics.logPlaylistHorizontalScroll(fromOfferId)
+    void analytics.logPlaylistHorizontalScroll(fromOfferId)
   }, [fromOfferId])
 
   const logSameCategoryPlaylistVerticalScroll = useFunctionOnce(() => {
-    analytics.logPlaylistVerticalScroll({
+    void analytics.logPlaylistVerticalScroll({
       ...apiRecoParamsSameCategory,
       fromOfferId,
       offerId,
@@ -43,7 +48,7 @@ export const useLogPlaylist = ({
   })
 
   const logOtherCategoriesPlaylistVerticalScroll = useFunctionOnce(() => {
-    analytics.logPlaylistVerticalScroll({
+    void analytics.logPlaylistVerticalScroll({
       ...apiRecoParamsOtherCategories,
       fromOfferId,
       offerId,
@@ -52,9 +57,20 @@ export const useLogPlaylist = ({
     })
   })
 
+  const logBooksSameCategoryPlaylistVerticalScroll = useFunctionOnce(() => {
+    void analytics.logPlaylistVerticalScroll({
+      ...apiRecoParamsBooksSameCategory,
+      fromOfferId,
+      offerId,
+      playlistType: PlaylistType.BOOKS_SAME_CATEGORY_SIMILAR_OFFERS,
+      nbResults: nbBooksSameCategorySimilarOffers,
+    })
+  })
+
   return {
     logPlaylistHorizontalScroll,
     logSameCategoryPlaylistVerticalScroll,
+    logBooksSameCategoryPlaylistVerticalScroll,
     logOtherCategoriesPlaylistVerticalScroll,
   }
 }

--- a/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.test.ts
+++ b/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.test.ts
@@ -1,4 +1,9 @@
-import { RecommendationApiParams, SearchGroupNameEnumv2 } from 'api/gen'
+import {
+  CategoryIdEnum,
+  RecommendationApiParams,
+  SearchGroupNameEnumv2,
+  SimilarOffersRequestQuery,
+} from 'api/gen'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { useOfferPlaylist } from 'features/offer/helpers/useOfferPlaylist/useOfferPlaylist'
 import * as useSimilarOffersAPI from 'features/offer/queries/useSimilarOffersQuery'
@@ -41,6 +46,7 @@ describe('useOfferPlaylist', () => {
       const { result } = renderHook(() =>
         useOfferPlaylist({
           offer,
+          offerCategory: CategoryIdEnum.CINEMA,
           offerSearchGroup,
           searchGroupList,
         })
@@ -53,6 +59,7 @@ describe('useOfferPlaylist', () => {
       const { result } = renderHook(() =>
         useOfferPlaylist({
           offer,
+          offerCategory: CategoryIdEnum.CINEMA,
           offerSearchGroup,
           searchGroupList,
         })
@@ -65,6 +72,7 @@ describe('useOfferPlaylist', () => {
       const { result } = renderHook(() =>
         useOfferPlaylist({
           offer,
+          offerCategory: CategoryIdEnum.CINEMA,
           offerSearchGroup,
           searchGroupList,
         })
@@ -77,6 +85,7 @@ describe('useOfferPlaylist', () => {
       const { result } = renderHook(() =>
         useOfferPlaylist({
           offer,
+          offerCategory: CategoryIdEnum.CINEMA,
           offerSearchGroup,
           searchGroupList,
         })
@@ -89,6 +98,7 @@ describe('useOfferPlaylist', () => {
       renderHook(() =>
         useOfferPlaylist({
           offer,
+          offerCategory: CategoryIdEnum.CINEMA,
           offerSearchGroup,
           searchGroupList,
         })
@@ -107,6 +117,33 @@ describe('useOfferPlaylist', () => {
           categoryExcluded: SearchGroupNameEnumv2.CINEMA,
           offerId: offer.id,
           position: { longitude: 90.477, latitude: 90.477 },
+        })
+      )
+    })
+
+    it('should fetch books same category playlist with graph retrieval model for book offers', async () => {
+      renderHook(() =>
+        useOfferPlaylist({
+          offer,
+          offerCategory: CategoryIdEnum.LIVRE,
+          offerSearchGroup: SearchGroupNameEnumv2.LIVRES,
+          searchGroupList,
+        })
+      )
+
+      expect(useSimilarOffersSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          categoryIncluded: SearchGroupNameEnumv2.LIVRES,
+          offerId: offer.id,
+          retrievalModel: SimilarOffersRequestQuery.RetrievalModelEnum.Graph,
+          shouldFetch: true,
+        })
+      )
+      expect(useSimilarOffersSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          categoryExcluded: SearchGroupNameEnumv2.LIVRES,
+          offerId: offer.id,
+          shouldFetch: false,
         })
       )
     })

--- a/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.ts
+++ b/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.ts
@@ -2,10 +2,12 @@ import { useIsFocused } from '@react-navigation/native'
 import { useMemo } from 'react'
 
 import {
+  CategoryIdEnum,
   OfferResponse,
   RecommendationApiParams,
   SearchGroupNameEnumv2,
   SearchGroupResponseModelv2,
+  SimilarOffersRequestQuery,
 } from 'api/gen'
 import { useSimilarOffersQuery } from 'features/offer/queries/useSimilarOffersQuery'
 import { Position, useLocation } from 'libs/location/location'
@@ -13,6 +15,7 @@ import { Offer } from 'shared/offer/types'
 
 type OfferPlaylistProps = {
   offer: OfferResponse
+  offerCategory: CategoryIdEnum
   offerSearchGroup: SearchGroupNameEnumv2
   searchGroupList: SearchGroupResponseModelv2[]
 }
@@ -22,10 +25,13 @@ type UseOfferPlaylistType = {
   apiRecoParamsSameCategory?: RecommendationApiParams
   otherCategoriesSimilarOffers?: Offer[]
   apiRecoParamsOtherCategories?: RecommendationApiParams
+  booksSameCategorySimilarOffers?: Offer[]
+  apiRecoParamsBooksSameCategory?: RecommendationApiParams
 }
 
 export const useOfferPlaylist = ({
   offer,
+  offerCategory,
   offerSearchGroup,
   searchGroupList,
 }: OfferPlaylistProps): UseOfferPlaylistType => {
@@ -42,6 +48,7 @@ export const useOfferPlaylist = ({
   )
 
   const position = userLocation ? roundedPosition : undefined
+  const isBookOffer = offerCategory === CategoryIdEnum.LIVRE
 
   const { similarOffers: sameCategorySimilarOffers, apiRecoParams: apiRecoParamsSameCategory } =
     useSimilarOffersQuery({
@@ -56,10 +63,21 @@ export const useOfferPlaylist = ({
     apiRecoParams: apiRecoParamsOtherCategories,
   } = useSimilarOffersQuery({
     offerId: offer.id,
-    shouldFetch: isFocused,
+    shouldFetch: isFocused && !isBookOffer,
     position,
     categoryExcluded: offerSearchGroup,
     searchGroupList,
+  })
+
+  const {
+    similarOffers: booksSameCategorySimilarOffers,
+    apiRecoParams: apiRecoParamsBooksSameCategory,
+  } = useSimilarOffersQuery({
+    offerId: offer.id,
+    shouldFetch: isFocused && isBookOffer,
+    position,
+    categoryIncluded: SearchGroupNameEnumv2.LIVRES,
+    retrievalModel: SimilarOffersRequestQuery.RetrievalModelEnum.Graph,
   })
 
   return {
@@ -67,5 +85,7 @@ export const useOfferPlaylist = ({
     apiRecoParamsSameCategory,
     otherCategoriesSimilarOffers,
     apiRecoParamsOtherCategories,
+    booksSameCategorySimilarOffers,
+    apiRecoParamsBooksSameCategory,
   }
 }

--- a/src/features/offer/queries/useSimilarOffersQuery.native.test.ts
+++ b/src/features/offer/queries/useSimilarOffersQuery.native.test.ts
@@ -1,6 +1,6 @@
 import { onlineManager } from '@tanstack/react-query'
 
-import { SearchGroupNameEnumv2, SimilarOffersResponse } from 'api/gen'
+import { SearchGroupNameEnumv2, SimilarOffersRequestQuery, SimilarOffersResponse } from 'api/gen'
 import { getCategories, useSimilarOffersQuery } from 'features/offer/queries/useSimilarOffersQuery'
 import { env } from 'libs/environment/fixtures'
 import { EmptyResponse } from 'libs/fetch'
@@ -140,6 +140,30 @@ describe('useSimilarOffersQuery', () => {
       })
     })
 
+    it('should call similar offers API with retrieval model when provided', async () => {
+      renderHook(
+        () =>
+          useSimilarOffersQuery({
+            offerId: mockOfferId,
+            shouldFetch: true,
+            categoryIncluded: SearchGroupNameEnumv2.LIVRES,
+            retrievalModel: SimilarOffersRequestQuery.RetrievalModelEnum.Graph,
+            position: null,
+          }),
+        {
+          wrapper: ({ children }) => reactQueryProviderHOC(children),
+        }
+      )
+
+      await waitFor(() => {
+        expect(fetchApiRecoSpy).toHaveBeenNthCalledWith(
+          1,
+          `${env.API_BASE_URL}/native/v1/recommendation/similar_offers/1?search_group_names=LIVRES&retrievalModel=graph`,
+          expect.objectContaining({ method: 'GET' })
+        )
+      })
+    })
+
     it('should not call similar offers API when offer id provided, user share his position and shouldFetch is false', () => {
       renderHook(
         () =>
@@ -208,6 +232,7 @@ describe('useSimilarOffersQuery', () => {
             latitude: undefined,
             longitude: undefined,
             offerId: 1,
+            retrievalModel: undefined,
             statusCode: 400,
             errorMessage:
               'Échec de la requête https://localhost/native/v1/recommendation/similar_offers/1?search_group_names=CINEMA, code: 400',

--- a/src/features/offer/queries/useSimilarOffersQuery.ts
+++ b/src/features/offer/queries/useSimilarOffersQuery.ts
@@ -4,7 +4,11 @@ import { useMemo } from 'react'
 import { api } from 'api/api'
 import { ApiError } from 'api/ApiError'
 import { isAPIExceptionNotCaptured } from 'api/apiHelpers'
-import { SearchGroupNameEnumv2, SearchGroupResponseModelv2 } from 'api/gen'
+import {
+  SearchGroupNameEnumv2,
+  SearchGroupResponseModelv2,
+  SimilarOffersRequestQuery,
+} from 'api/gen'
 import { Position } from 'libs/location/location'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { QueryKeys } from 'libs/queryKeys'
@@ -25,6 +29,7 @@ type Props = (WithIncludeCategoryProps | WithExcludeCategoryProps) & {
   shouldFetch: boolean
   position?: Position
   searchGroupList?: SearchGroupResponseModelv2[]
+  retrievalModel?: SimilarOffersRequestQuery.RetrievalModelEnum
 }
 
 export const getCategories = (
@@ -55,6 +60,7 @@ export const useSimilarOffersQuery = ({
   categoryIncluded,
   categoryExcluded,
   searchGroupList,
+  retrievalModel,
 }: Props) => {
   const searchGroupNames: SearchGroupNameEnumv2[] = useMemo(
     () => getCategories(searchGroupList, categoryIncluded, categoryExcluded),
@@ -62,7 +68,7 @@ export const useSimilarOffersQuery = ({
   )
 
   const { data: apiRecoResponse } = useQuery({
-    queryKey: [QueryKeys.SIMILAR_OFFERS_IDS, offerId, position, searchGroupNames],
+    queryKey: [QueryKeys.SIMILAR_OFFERS_IDS, offerId, position, searchGroupNames, retrievalModel],
     queryFn: async () => {
       try {
         return await api.getNativeV1RecommendationSimilarOffersofferId(
@@ -71,7 +77,8 @@ export const useSimilarOffersQuery = ({
           position?.latitude,
           undefined,
           undefined,
-          searchGroupNames
+          searchGroupNames,
+          retrievalModel
         )
       } catch (err) {
         const statusCode = err instanceof ApiError ? err.statusCode : 'unknown'
@@ -89,6 +96,7 @@ export const useSimilarOffersQuery = ({
                 longitude: position?.longitude,
                 latitude: position?.latitude,
                 searchGroupNames: JSON.stringify(searchGroupNames),
+                retrievalModel,
                 statusCode,
                 errorMessage,
               },

--- a/src/shared/verticalPlaylist/helpers/useGetOffersSimilarsFromPlaylist.native.test.ts
+++ b/src/shared/verticalPlaylist/helpers/useGetOffersSimilarsFromPlaylist.native.test.ts
@@ -1,4 +1,4 @@
-import { SearchGroupNameEnumv2 } from 'api/gen'
+import { CategoryIdEnum, SearchGroupNameEnumv2 } from 'api/gen'
 import { mockOffer } from 'features/bookOffer/fixtures/offer'
 import { PlaylistType } from 'features/offer/enums'
 import { useOfferPlaylist } from 'features/offer/helpers/useOfferPlaylist/useOfferPlaylist'
@@ -11,6 +11,7 @@ const mockUseOfferPlaylist = useOfferPlaylist as jest.Mock
 
 const baseParams = {
   offer: mockOffer,
+  offerCategory: CategoryIdEnum.CINEMA,
   offerSearchGroup: SearchGroupNameEnumv2.CINEMA,
   searchGroupList: [],
 }
@@ -26,6 +27,25 @@ describe('useGetOffersSimilarsFromPlaylist', () => {
       useGetOffersSimilarsFromPlaylist({
         ...baseParams,
         type: PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS,
+      })
+    )
+
+    expect(result.current.items).toEqual([mockOffer, mockOffer])
+    expect(result.current.title).toBe('Les fans aiment aussi')
+  })
+
+  it('should return books same category playlist', () => {
+    mockUseOfferPlaylist.mockReturnValueOnce({
+      sameCategorySimilarOffers: [mockOffer],
+      booksSameCategorySimilarOffers: [mockOffer, mockOffer],
+      otherCategoriesSimilarOffers: [mockOffer],
+    })
+
+    const { result } = renderHook(() =>
+      useGetOffersSimilarsFromPlaylist({
+        ...baseParams,
+        offerCategory: CategoryIdEnum.LIVRE,
+        type: PlaylistType.BOOKS_SAME_CATEGORY_SIMILAR_OFFERS,
       })
     )
 

--- a/src/shared/verticalPlaylist/helpers/useGetOffersSimilarsFromPlaylist.ts
+++ b/src/shared/verticalPlaylist/helpers/useGetOffersSimilarsFromPlaylist.ts
@@ -1,3 +1,4 @@
+import { OFFER_SIMILAR_PLAYLIST_TITLES } from 'features/offer/constant'
 import { PlaylistType } from 'features/offer/enums'
 import { useOfferPlaylist } from 'features/offer/helpers/useOfferPlaylist/useOfferPlaylist'
 import { SimilarOfferPlaylist } from 'shared/offer/types'
@@ -27,21 +28,21 @@ export const useGetOffersSimilarsFromPlaylist = ({
 
   const sameCategorySimilarOffersPlaylist: SimilarOfferPlaylistWithHits = {
     type: PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS,
-    title: 'Les fans aiment aussi',
+    title: OFFER_SIMILAR_PLAYLIST_TITLES[PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS] ?? '',
     offers: sameCategorySimilarOffers,
     nbHits: sameCategorySimilarOffers?.length,
   }
 
   const booksSameCategorySimilarOffersPlaylist: SimilarOfferPlaylistWithHits = {
     type: PlaylistType.BOOKS_SAME_CATEGORY_SIMILAR_OFFERS,
-    title: 'Dans la même catégorie',
+    title: OFFER_SIMILAR_PLAYLIST_TITLES[PlaylistType.BOOKS_SAME_CATEGORY_SIMILAR_OFFERS] ?? '',
     offers: booksSameCategorySimilarOffers,
     nbHits: booksSameCategorySimilarOffers?.length,
   }
 
   const otherCategoriesSimilarOffersPlaylist: SimilarOfferPlaylistWithHits = {
     type: PlaylistType.OTHER_CATEGORIES_SIMILAR_OFFERS,
-    title: 'Ça peut aussi te plaire',
+    title: OFFER_SIMILAR_PLAYLIST_TITLES[PlaylistType.OTHER_CATEGORIES_SIMILAR_OFFERS] ?? '',
     offers: otherCategoriesSimilarOffers,
     nbHits: otherCategoriesSimilarOffers?.length,
   }

--- a/src/shared/verticalPlaylist/helpers/useGetOffersSimilarsFromPlaylist.ts
+++ b/src/shared/verticalPlaylist/helpers/useGetOffersSimilarsFromPlaylist.ts
@@ -9,21 +9,34 @@ type SimilarOfferPlaylistWithHits = Omit<SimilarOfferPlaylist, 'handleChangePlay
 
 export const useGetOffersSimilarsFromPlaylist = ({
   offer,
+  offerCategory,
   offerSearchGroup,
   searchGroupList,
   type,
 }: OffersSimilars): VerticalPlaylistOffersData => {
-  const { sameCategorySimilarOffers, otherCategoriesSimilarOffers } = useOfferPlaylist({
+  const {
+    sameCategorySimilarOffers,
+    otherCategoriesSimilarOffers,
+    booksSameCategorySimilarOffers,
+  } = useOfferPlaylist({
     offer,
+    offerCategory,
     offerSearchGroup,
     searchGroupList,
   })
 
   const sameCategorySimilarOffersPlaylist: SimilarOfferPlaylistWithHits = {
     type: PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS,
-    title: 'Dans la même catégorie',
+    title: 'Les fans aiment aussi',
     offers: sameCategorySimilarOffers,
     nbHits: sameCategorySimilarOffers?.length,
+  }
+
+  const booksSameCategorySimilarOffersPlaylist: SimilarOfferPlaylistWithHits = {
+    type: PlaylistType.BOOKS_SAME_CATEGORY_SIMILAR_OFFERS,
+    title: 'Dans la même catégorie',
+    offers: booksSameCategorySimilarOffers,
+    nbHits: booksSameCategorySimilarOffers?.length,
   }
 
   const otherCategoriesSimilarOffersPlaylist: SimilarOfferPlaylistWithHits = {
@@ -35,6 +48,7 @@ export const useGetOffersSimilarsFromPlaylist = ({
 
   const similarOffersPlaylist: SimilarOfferPlaylistWithHits[] = [
     sameCategorySimilarOffersPlaylist,
+    booksSameCategorySimilarOffersPlaylist,
     otherCategoriesSimilarOffersPlaylist,
   ]
 

--- a/src/shared/verticalPlaylist/types.ts
+++ b/src/shared/verticalPlaylist/types.ts
@@ -1,4 +1,9 @@
-import { OfferResponse, SearchGroupNameEnumv2, SearchGroupResponseModelv2 } from 'api/gen'
+import {
+  CategoryIdEnum,
+  OfferResponse,
+  SearchGroupNameEnumv2,
+  SearchGroupResponseModelv2,
+} from 'api/gen'
 import { OffersModule } from 'features/home/types'
 import { PlaylistType } from 'features/offer/enums'
 import { ThematicSearchPlaylistData } from 'features/search/pages/ThematicSearch/types'
@@ -9,6 +14,7 @@ import { VerticalPlaylist } from 'shared/verticalPlaylist/enums'
 
 export type OffersSimilars = {
   offer: OfferResponse
+  offerCategory: CategoryIdEnum
   offerSearchGroup: SearchGroupNameEnumv2
   searchGroupList: SearchGroupResponseModelv2[]
   type: PlaylistType


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41498

J'ai pu tester que en loggant je n'ai pas de screenshots qui accompagne cette PR mais ce qui remonte correspond bien à ce que Laurent m'as dit c'est à dire : "En gros en mode graph, ça doit rien te renvoyer, et en mode normal ça doit renvoyer des offres"

Test effectué sur staging avec l’offre Livre `15502901`.

Pour la playlist **“Les fans aiment aussi”** :
```json
{
  "playlistDebugName": "sameCategorySimilarOffers",
  "offerId": 15502901,
  "searchGroupNames": ["LIVRES"],
  "nbRecoIds": 60,
  "firstRecoIds": [
    "104563811",
    "15580378",
    "15543975",
    "87397236",
    "78543851"
  ],
  "params": {
    "modelOrigin": "default",
    "recoOrigin": "algo"
  }
}
```

Pour la nouvelle playlist Livre “Dans la même catégorie” avec retrievalModel: "graph" :
```json
{
  "playlistDebugName": "booksSameCategorySimilarOffers",
  "offerId": 15502901,
  "searchGroupNames": ["LIVRES"],
  "retrievalModel": "graph",
  "nbRecoIds": 0,
  "firstRecoIds": [],
  "params": {
    "modelOrigin": "graph",
    "recoOrigin": "algo"
  }
}
```

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
