### PR TITLE
(PC-41885) feat(home): add thematicHomeEntryId and thematicHomeTitle in video module to manage thematic home redirection

### DIFF
--- a/src/features/home/components/modules/video/VideoModule.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoModule.native.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ComponentProps } from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { SubcategoriesResponseModelv2 } from 'api/gen'
@@ -28,14 +28,14 @@ describe('VideoModule', () => {
 
   it('should render properly', async () => {
     mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture] })
-    renderVideoModule()
+    renderVideoModule({})
 
     expect(await screen.findByText(offerFixture.offer.name)).toBeOnTheScreen()
   })
 
   it('should navigate to video module page when pressing video thumbnail', async () => {
     mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture] })
-    renderVideoModule()
+    renderVideoModule({})
 
     const button = screen.getByTestId('video-thumbnail')
 
@@ -66,7 +66,7 @@ describe('VideoModule', () => {
 
   it('should log ModuleDisplayedOnHomePage event when seeing the module', async () => {
     mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture] })
-    renderVideoModule()
+    renderVideoModule({})
 
     await screen.findByText(offerFixture.offer.name)
 
@@ -81,14 +81,14 @@ describe('VideoModule', () => {
 
   it('should not log ModuleDisplayedOnHomePage event when module is not rendered', async () => {
     mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [] })
-    renderVideoModule()
+    renderVideoModule({})
 
     expect(analytics.logModuleDisplayedOnHomepage).not.toHaveBeenCalled()
   })
 
   it('should render multi offer component if multiples offers', async () => {
     mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture, offerFixture2] })
-    renderVideoModule()
+    renderVideoModule({})
 
     const multiOfferList = screen.getByTestId('video-multi-offers-module-list')
 
@@ -99,14 +99,44 @@ describe('VideoModule', () => {
 
   it('should render one offer component when one offer', async () => {
     mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture] })
-    renderVideoModule()
+    renderVideoModule({})
 
     expect(await screen.findByTestId('videoMonoOfferTile')).toBeOnTheScreen()
   })
 
+  it('should render thematic home redirection button when data defined', async () => {
+    mockUseVideoOffersQuery.mockReturnValueOnce({
+      offers: [offerFixture],
+    })
+    renderVideoModule({
+      thematicHomeEntryId: 'homeEntryId',
+      thematicHomeTitle: 'Si tu veux en voir en plus',
+    })
+
+    expect(await screen.findByText('Si tu veux en voir en plus')).toBeOnTheScreen()
+  })
+
+  it('should redirect to thematic home when pressing redirection button and data defined', async () => {
+    mockUseVideoOffersQuery.mockReturnValueOnce({
+      offers: [offerFixture],
+    })
+    renderVideoModule({
+      thematicHomeEntryId: 'homeEntryId',
+      thematicHomeTitle: 'Si tu veux en voir en plus',
+    })
+
+    await user.press(screen.getByText('Si tu veux en voir en plus'))
+
+    expect(navigate).toHaveBeenCalledWith('ThematicHome', {
+      from: 'videoModule',
+      homeId: 'homeEntryId',
+      moduleId: '4ZzxHKDN7BvBAxVR6hFbU6',
+    })
+  })
+
   it('should render mobile design if mobile viewport', async () => {
     mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture] })
-    renderVideoModule()
+    renderVideoModule({})
 
     const multiOfferList = screen.getByTestId('mobile-video-module')
 
@@ -117,7 +147,7 @@ describe('VideoModule', () => {
 
   it('should render desktop design if desktop viewport', async () => {
     mockUseVideoOffersQuery.mockReturnValueOnce({ offers: [offerFixture] })
-    renderVideoModule(true)
+    renderVideoModule({ isDesktopViewport: true })
 
     const multiOfferList = screen.getByTestId('desktop-video-module')
 
@@ -130,7 +160,7 @@ describe('VideoModule', () => {
     mockUseVideoOffersQuery.mockReturnValueOnce({
       offers: [offerFixture, offerFixture2, offerFixture3, offerFixture4],
     })
-    renderVideoModule(true)
+    renderVideoModule({ isDesktopViewport: true })
 
     const seeAllButton = screen.getByLabelText(
       'Voir tout pour la sélection Lujipeka répond à vos questions !'
@@ -145,7 +175,7 @@ describe('VideoModule', () => {
     mockUseVideoOffersQuery.mockReturnValueOnce({
       offers: [offerFixture, offerFixture2],
     })
-    renderVideoModule(true)
+    renderVideoModule({ isDesktopViewport: true })
 
     const seeAllButton = screen.queryByLabelText(
       'Voir tout pour la sélection Lujipeka répond à vos questions !'
@@ -200,10 +230,25 @@ const offerFixture4 = {
   },
 }
 
-function renderVideoModule(isDesktopViewport?: boolean) {
+type RenderVideoModuleType = Partial<ComponentProps<typeof VideoModule>> & {
+  isDesktopViewport?: boolean
+}
+
+function renderVideoModule({
+  isDesktopViewport,
+  thematicHomeEntryId,
+  thematicHomeTitle,
+}: RenderVideoModuleType) {
   render(
     reactQueryProviderHOC(
-      <VideoModule {...videoModuleFixture} index={1} homeEntryId="abcd" shouldShowModal={false} />
+      <VideoModule
+        {...videoModuleFixture}
+        index={1}
+        homeEntryId="abcd"
+        shouldShowModal={false}
+        thematicHomeEntryId={thematicHomeEntryId}
+        thematicHomeTitle={thematicHomeTitle}
+      />
     ),
     {
       theme: { isDesktopViewport: isDesktopViewport ?? false },

--- a/src/features/home/components/modules/video/VideoModule.tsx
+++ b/src/features/home/components/modules/video/VideoModule.tsx
@@ -83,6 +83,8 @@ export const VideoModule: FunctionComponent<VideoModuleBaseProps> = (props) => {
         offerIds: props.offerIds,
         eanList: props.eanList,
         transcription: props.transcription,
+        thematicHomeEntryId: props.thematicHomeEntryId,
+        thematicHomeTitle: props.thematicHomeTitle,
       })
     },
     offers,

--- a/src/features/home/components/modules/video/VideoModuleDesktop.tsx
+++ b/src/features/home/components/modules/video/VideoModuleDesktop.tsx
@@ -5,15 +5,19 @@ import { ImageBackground, View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
+import { AttachedThematicCard } from 'features/home/components/AttachedModuleCard/AttachedThematicCard'
 import { VideoMonoOfferTile } from 'features/home/components/modules/video/VideoMonoOfferTile'
 import { VideoModuleProps } from 'features/home/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { analytics } from 'libs/analytics/provider'
+import { accessibilityRoleInternalNavigation } from 'shared/accessibility/helpers/accessibilityRoleInternalNavigation'
+import { getComputedAccessibilityLabel } from 'shared/accessibility/helpers/getComputedAccessibilityLabel'
 import { Offer } from 'shared/offer/types'
 import { ColorsType } from 'theme/types'
 import { SeeAllInModalButton } from 'ui/components/SeeAllButton/SeeAllInModalButton'
 import { Separator } from 'ui/components/Separator'
 import { HorizontalOfferTile } from 'ui/components/tiles/HorizontalOfferTile'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Play } from 'ui/svg/icons/Play'
 import { getSpacing, Typo } from 'ui/theme'
 import { videoModuleColorsMapping } from 'ui/theme/videoModuleColorsMapping'
@@ -63,8 +67,25 @@ export const VideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) =
     ) : null
   }
 
+  function renderMultiOffer() {
+    return (
+      <StyledMultiOfferList hasOnlyTwoOffers={hasOnlyTwoOffers}>
+        {props.offers.slice(0, 3).map((offer: Offer, index) => (
+          <React.Fragment key={offer.objectID}>
+            <StyledHorizontalOfferTile offer={offer} analyticsParams={props.analyticsParams} />
+            {index < nbOfSeparators ? (
+              <StyledSeparator hasOnlyTwoOffers={hasOnlyTwoOffers} />
+            ) : null}
+          </React.Fragment>
+        ))}
+      </StyledMultiOfferList>
+    )
+  }
+
   const fillFromDesignSystem =
     designSystem.color.background[videoModuleColorsMapping[props.color] ?? 'default']
+
+  const hasThematicHomeEntry = !!(props.thematicHomeEntryId && props.thematicHomeTitle)
 
   return (
     <React.Fragment>
@@ -83,7 +104,9 @@ export const VideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) =
             isMultiOffer={props.isMultiOffer}
           />
         </ColorCategoryBackgroundWrapper>
-        <VideoOfferContainer isMultiOffer={props.isMultiOffer}>
+        <VideoOfferContainer
+          isMultiOffer={props.isMultiOffer}
+          hasThematicHomeEntry={hasThematicHomeEntry}>
           <StyledTouchableHighlight
             onPress={props.onVideoPlaceholderPress}
             testID="video-thumbnail"
@@ -101,25 +124,27 @@ export const VideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) =
               </PlayerContainer>
             </Thumbnail>
           </StyledTouchableHighlight>
-          <StyledView>
-            {props.isMultiOffer ? (
-              <StyledMultiOfferList hasOnlyTwoOffers={hasOnlyTwoOffers}>
-                {props.offers.slice(0, 3).map((offer: Offer, index) => (
-                  <React.Fragment key={offer.objectID}>
-                    <StyledHorizontalOfferTile
-                      offer={offer}
-                      analyticsParams={props.analyticsParams}
-                    />
-                    {index < nbOfSeparators ? (
-                      <StyledSeparator hasOnlyTwoOffers={hasOnlyTwoOffers} />
-                    ) : null}
-                  </React.Fragment>
-                ))}
-              </StyledMultiOfferList>
-            ) : (
-              renderSoloOffer()
-            )}
-          </StyledView>
+          {hasThematicHomeEntry ? (
+            <StyledView>
+              <VideoMonoOfferTileWrapper>
+                <InternalTouchableLink
+                  navigateTo={{
+                    screen: 'ThematicHome',
+                    params: {
+                      homeId: props.thematicHomeEntryId,
+                      from: 'videoModule',
+                      moduleId: props.id,
+                    },
+                  }}
+                  accessibilityLabel={getComputedAccessibilityLabel(props.thematicHomeTitle)}
+                  accessibilityRole={accessibilityRoleInternalNavigation()}>
+                  <AttachedThematicCard title={props.thematicHomeTitle ?? ''} />
+                </InternalTouchableLink>
+              </VideoMonoOfferTileWrapper>
+            </StyledView>
+          ) : (
+            <StyledView>{props.isMultiOffer ? renderMultiOffer() : renderSoloOffer()}</StyledView>
+          )}
         </VideoOfferContainer>
       </View>
     </React.Fragment>
@@ -144,8 +169,9 @@ const BlackView = styled.View(({ theme }) => ({
 
 const VideoOfferContainer = styled.View<{
   isMultiOffer: boolean
-}>(({ theme, isMultiOffer }) => ({
-  ...(isMultiOffer
+  hasThematicHomeEntry: boolean
+}>(({ theme, isMultiOffer, hasThematicHomeEntry }) => ({
+  ...(isMultiOffer && !hasThematicHomeEntry
     ? { marginHorizontal: theme.contentPage.marginHorizontal }
     : { marginLeft: theme.contentPage.marginHorizontal }),
   flexDirection: 'row',

--- a/src/features/home/components/modules/video/VideoModuleHeader.tsx
+++ b/src/features/home/components/modules/video/VideoModuleHeader.tsx
@@ -2,11 +2,15 @@ import { useRoute } from '@react-navigation/native'
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
+import { AttachedThematicCard } from 'features/home/components/AttachedModuleCard/AttachedThematicCard'
 import { VideoMonoOfferTile } from 'features/home/components/modules/video/VideoMonoOfferTile'
 import { UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
 import { OfferAnalyticsParams } from 'libs/analytics/types'
 import { formatToFrenchDate } from 'libs/parsers/formatDates'
+import { accessibilityRoleInternalNavigation } from 'shared/accessibility/helpers/accessibilityRoleInternalNavigation'
+import { getComputedAccessibilityLabel } from 'shared/accessibility/helpers/getComputedAccessibilityLabel'
 import { Offer } from 'shared/offer/types'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Tag } from 'ui/designSystem/Tag/Tag'
 import { TagVariant } from 'ui/designSystem/Tag/types'
 import { Typo } from 'ui/theme'
@@ -32,7 +36,12 @@ export const VideoModuleHeader: FunctionComponent<Props> = ({
     videoDescription,
     offerTitle,
     color,
+    thematicHomeEntryId,
+    thematicHomeTitle,
+    moduleId,
   } = params
+
+  const hasThematicHomeEntry = !!(thematicHomeEntryId && thematicHomeTitle)
 
   return (
     <React.Fragment>
@@ -56,7 +65,7 @@ export const VideoModuleHeader: FunctionComponent<Props> = ({
         <Typo.Title4 {...getHeadingAttrs(2)}>{offerTitle}</Typo.Title4>
       </OfferTitleContainer>
 
-      {!isMultiOffer && offers[0] ? (
+      {!isMultiOffer && offers[0] && !hasThematicHomeEntry ? (
         <VideoMonoOfferTileContainer>
           <VideoMonoOfferTile
             offer={offers[0]}
@@ -64,6 +73,24 @@ export const VideoModuleHeader: FunctionComponent<Props> = ({
             analyticsParams={analyticsParams}
             onPressOffer={handleLogHasDismissedModal}
           />
+        </VideoMonoOfferTileContainer>
+      ) : null}
+
+      {hasThematicHomeEntry ? (
+        <VideoMonoOfferTileContainer>
+          <InternalTouchableLink
+            navigateTo={{
+              screen: 'ThematicHome',
+              params: {
+                homeId: thematicHomeEntryId,
+                from: 'videoModule',
+                moduleId,
+              },
+            }}
+            accessibilityLabel={getComputedAccessibilityLabel(thematicHomeTitle)}
+            accessibilityRole={accessibilityRoleInternalNavigation()}>
+            <AttachedThematicCard title={thematicHomeTitle ?? ''} />
+          </InternalTouchableLink>
         </VideoMonoOfferTileContainer>
       ) : null}
     </React.Fragment>

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -4,12 +4,16 @@ import { LayoutChangeEvent, View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
+import { AttachedThematicCard } from 'features/home/components/AttachedModuleCard/AttachedThematicCard'
 import { VideoMonoOfferTile } from 'features/home/components/modules/video/VideoMonoOfferTile'
 import { VideoMultiOfferPlaylist } from 'features/home/components/modules/video/VideoMultiOfferPlaylist'
 import { VideoModuleProps } from 'features/home/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import { accessibilityRoleInternalNavigation } from 'shared/accessibility/helpers/accessibilityRoleInternalNavigation'
+import { getComputedAccessibilityLabel } from 'shared/accessibility/helpers/getComputedAccessibilityLabel'
 import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
 import { ColorsType } from 'theme/types'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Play } from 'ui/svg/icons/Play'
 import { getSpacing, Typo } from 'ui/theme'
 import { videoModuleColorsMapping } from 'ui/theme/videoModuleColorsMapping'
@@ -33,6 +37,34 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
 
   const fillFromDesignSystem =
     designSystem.color.background[videoModuleColorsMapping[props.color] ?? 'default']
+
+  const renderOfferPart = () => {
+    if (!props.isMultiOffer && props.offers[0]) {
+      return (
+        <VideoOfferContainer
+          onLayout={(event: LayoutChangeEvent) => {
+            const { height } = event.nativeEvent.layout
+            setMonoOfferCardHeight(height)
+          }}>
+          <VideoMonoOfferTileWrapper>
+            <VideoMonoOfferTile
+              offer={props.offers[0]}
+              color={props.color}
+              analyticsParams={props.analyticsParams}
+            />
+          </VideoMonoOfferTileWrapper>
+        </VideoOfferContainer>
+      )
+    }
+
+    return (
+      <VideoOfferContainer>
+        <VideoMultiOfferPlaylist offers={props.offers} analyticsParams={props.analyticsParams} />
+      </VideoOfferContainer>
+    )
+  }
+
+  const hasThematicHomeEntry = !!(props.thematicHomeEntryId && props.thematicHomeTitle)
 
   return (
     <Container>
@@ -66,32 +98,36 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
           </Thumbnail>
         </StyledTouchableHighlight>
         <ViewWithPaddingTop>
-          {!props.isMultiOffer && props.offers[0] ? (
+          {hasThematicHomeEntry ? (
             <VideoOfferContainer
               onLayout={(event: LayoutChangeEvent) => {
                 const { height } = event.nativeEvent.layout
                 setMonoOfferCardHeight(height)
               }}>
               <VideoMonoOfferTileWrapper>
-                <VideoMonoOfferTile
-                  offer={props.offers[0]}
-                  color={props.color}
-                  analyticsParams={props.analyticsParams}
-                />
+                <InternalTouchableLink
+                  navigateTo={{
+                    screen: 'ThematicHome',
+                    params: {
+                      homeId: props.thematicHomeEntryId,
+                      from: 'videoModule',
+                      moduleId: props.id,
+                    },
+                  }}
+                  accessibilityLabel={getComputedAccessibilityLabel(props.thematicHomeTitle)}
+                  accessibilityRole={accessibilityRoleInternalNavigation()}>
+                  <AttachedThematicCard title={props.thematicHomeTitle ?? ''} />
+                </InternalTouchableLink>
               </VideoMonoOfferTileWrapper>
             </VideoOfferContainer>
           ) : (
-            <VideoOfferContainer>
-              <VideoMultiOfferPlaylist
-                offers={props.offers}
-                analyticsParams={props.analyticsParams}
-              />
-            </VideoOfferContainer>
+            renderOfferPart()
           )}
           <ColorCategoryBackground
             colorCategoryBackgroundHeightUniqueOffer={COLOR_CATEGORY_BACKGROUND_HEIGHT_MONO_OFFER}
             backgroundColor={fillFromDesignSystem || videoModuleColorsMapping[props.color]}
             isMultiOffer={props.isMultiOffer}
+            hasThematicHomeEntry={hasThematicHomeEntry}
           />
         </ViewWithPaddingTop>
       </View>
@@ -161,15 +197,25 @@ const ColorCategoryBackground = styled.View<{
   colorCategoryBackgroundHeightUniqueOffer: number
   isMultiOffer: boolean
   backgroundColor: ColorsType
-}>(({ colorCategoryBackgroundHeightUniqueOffer, isMultiOffer, backgroundColor, theme }) => ({
-  height: isMultiOffer
-    ? COLOR_CATEGORY_BACKGROUND_HEIGHT_MULTI_OFFER
-    : colorCategoryBackgroundHeightUniqueOffer,
-  backgroundColor,
-  position: 'absolute',
-  width: '100%',
-  zIndex: theme.zIndex.background,
-}))
+  hasThematicHomeEntry: boolean
+}>(
+  ({
+    colorCategoryBackgroundHeightUniqueOffer,
+    isMultiOffer,
+    backgroundColor,
+    hasThematicHomeEntry,
+    theme,
+  }) => ({
+    height:
+      isMultiOffer && !hasThematicHomeEntry
+        ? COLOR_CATEGORY_BACKGROUND_HEIGHT_MULTI_OFFER
+        : colorCategoryBackgroundHeightUniqueOffer,
+    backgroundColor,
+    position: 'absolute',
+    width: '100%',
+    zIndex: theme.zIndex.background,
+  })
+)
 
 const VideoOfferContainer = styled.View(({ theme }) => ({
   overflow: 'visible',

--- a/src/features/home/pages/VideoModulePage.native.test.tsx
+++ b/src/features/home/pages/VideoModulePage.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useRoute } from '__mocks__/@react-navigation/native'
+import { navigate, useRoute } from '__mocks__/@react-navigation/native'
 import { SubcategoriesResponseModelv2 } from 'api/gen'
 import { VideoModulePage } from 'features/home/pages/VideoModulePage'
 import { useVideoOffersQuery } from 'features/home/queries/useVideoOffersQuery'
@@ -148,6 +148,38 @@ describe('VideoModulePage', () => {
         moduleId: 'module-123',
         seenDuration: 135,
         videoDuration: 267,
+      })
+    })
+  })
+
+  describe('When thematic home entry id and title defined', () => {
+    beforeEach(() => {
+      useRoute.mockReturnValue({
+        params: {
+          ...mockParams,
+          thematicHomeEntryId: 'homeEntryId',
+          thematicHomeTitle: 'Si tu veux en voir en plus',
+        },
+      })
+
+      mockUseVideoOffersQuery.mockReturnValue({ offers: [...offersFixture] })
+    })
+
+    it('should display thematic home redirection button', async () => {
+      render(reactQueryProviderHOC(<VideoModulePage />))
+
+      expect(screen.getByText('Si tu veux en voir en plus')).toBeOnTheScreen()
+    })
+
+    it('should redirect to thematic home when pressing redirection button', async () => {
+      render(reactQueryProviderHOC(<VideoModulePage />))
+
+      await user.press(screen.getByText('Si tu veux en voir en plus'))
+
+      expect(navigate).toHaveBeenCalledWith('ThematicHome', {
+        from: 'videoModule',
+        homeId: 'homeEntryId',
+        moduleId: 'module-123',
       })
     })
   })

--- a/src/features/home/pages/VideoModulePage.tsx
+++ b/src/features/home/pages/VideoModulePage.tsx
@@ -39,6 +39,8 @@ export const VideoModulePage: FunctionComponent = () => {
     isMultiOffer,
     videoTitle,
     transcription,
+    thematicHomeEntryId,
+    thematicHomeTitle,
   } = params
   const { goBack } = useGoBack(...homeNavigationConfig)
   const theme = useTheme()
@@ -58,6 +60,8 @@ export const VideoModulePage: FunctionComponent = () => {
     from: 'videoModal',
     homeEntryId,
   }
+
+  const hasThematicHomeEntry = !!(thematicHomeEntryId && thematicHomeTitle)
 
   const handleLogHasDismissedModal = async () => {
     const playerCurrentRef = playerRef.current
@@ -105,7 +109,7 @@ export const VideoModulePage: FunctionComponent = () => {
 
         <VideoPlayer
           youtubeVideoId={youtubeVideoId}
-          offer={isMultiOffer ? undefined : offers[0]}
+          offer={isMultiOffer && !hasThematicHomeEntry ? undefined : offers[0]}
           moduleId={moduleId}
           moduleName={moduleName}
           homeEntryId={homeEntryId}
@@ -130,7 +134,7 @@ export const VideoModulePage: FunctionComponent = () => {
 
         <FlatList
           ItemSeparatorComponent={ItemSeparatorComponent}
-          data={isMultiOffer ? offers : []}
+          data={isMultiOffer && !hasThematicHomeEntry ? offers : []}
           ListHeaderComponent={
             <VideoModuleHeader
               analyticsParams={analyticsParams}

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -313,6 +313,8 @@ export type VideoModule = {
   offerIds?: string[]
   eanList?: string[]
   transcription: string
+  thematicHomeEntryId?: string
+  thematicHomeTitle?: string
 }
 
 export interface VideoModuleProps extends VideoModule {

--- a/src/features/navigation/helpers/screenParamsUtils.ts
+++ b/src/features/navigation/helpers/screenParamsUtils.ts
@@ -208,6 +208,8 @@ export const screenParamsParser: ParamsParsers = {
     offerIds: identityFn,
     eanList: identityFn,
     transcription: identityFn,
+    thematicHomeEntryId: identityFn,
+    thematicHomeTitle: identityFn,
   },
 }
 

--- a/src/features/navigation/navigators/RootNavigator/types.ts
+++ b/src/features/navigation/navigators/RootNavigator/types.ts
@@ -226,6 +226,8 @@ type VideoModulePageParams = {
   offerIds?: string[]
   eanList?: string[]
   transcription: string
+  thematicHomeEntryId?: string
+  thematicHomeTitle?: string
 }
 
 type LoginParams = {

--- a/src/libs/contentful/adapters/modules/adaptVideoModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptVideoModule.ts
@@ -34,5 +34,7 @@ export const adaptVideoModule = (module: VideoContentModel): VideoModule | null 
     offerIds: module.fields.offerIds,
     eanList: module.fields.eanList,
     transcription: module.fields.transcription,
+    thematicHomeEntryId: module.fields.thematicHomeEntryId,
+    thematicHomeTitle: module.fields.thematicHomeTitle,
   }
 }

--- a/src/libs/contentful/types.ts
+++ b/src/libs/contentful/types.ts
@@ -198,6 +198,8 @@ type VideoFields = {
   eanList?: string[]
   additionalAlgoliaParameters?: AlgoliaParameters[]
   transcription: string
+  thematicHomeEntryId?: string
+  thematicHomeTitle?: string
 }
 
 type VenueMapBlockFields = {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41885

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-27 at 11 48 51" src="https://github.com/user-attachments/assets/9c1c71a4-66a4-4ca4-b8d8-be46cca5b43c" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-27 at 11 48 56" src="https://github.com/user-attachments/assets/c5f0f614-4381-4d3d-8441-3ad6a87d05d1" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-27 at 11 52 40" src="https://github.com/user-attachments/assets/62fffd33-e80a-4200-b070-192f5a1b1530" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-27 at 11 50 38" src="https://github.com/user-attachments/assets/eb6b2219-ee38-4477-9ed5-55e8f0aff80d" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-27 at 11 47 53" src="https://github.com/user-attachments/assets/8217c2e6-37e6-4e42-bb05-376d17732de1" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-27 at 14 49 24" src="https://github.com/user-attachments/assets/28d53d4c-a6eb-4355-9803-79c165d962e0" />|
| Android          |<img width="1080" height="2400" alt="Screenshot_1779888965" src="https://github.com/user-attachments/assets/d7d1828a-78cd-4014-ab8e-9b4730132def" /> <img width="1080" height="2400" alt="Screenshot_1779888975" src="https://github.com/user-attachments/assets/0e0aed5f-b182-4662-a3a8-8b799ed05a8c" />|<img width="1080" height="2400" alt="Screenshot_1779889634" src="https://github.com/user-attachments/assets/e65584b9-8329-4416-9866-7e1e46b385b2" /> <img width="1080" height="2400" alt="Screenshot_1779889618" src="https://github.com/user-attachments/assets/3247d04c-2f34-4fb3-a6df-a1e25de4c5c1" /> <img width="1080" height="2400" alt="Screenshot_1779876341" src="https://github.com/user-attachments/assets/143ff4b9-046e-4d77-b1d0-53791efa3dcc" /> <img width="1080" height="2400" alt="Screenshot_1779886180" src="https://github.com/user-attachments/assets/d21745af-1229-4495-8880-e1ab964c4278" />|
| Phone - Chrome   |<img width="386" height="684" alt="Capture d’écran 2026-05-27 à 11 49 10" src="https://github.com/user-attachments/assets/78a9f6a2-7f84-4443-a839-278cbcac5534" /> <img width="397" height="688" alt="Capture d’écran 2026-05-27 à 11 49 22" src="https://github.com/user-attachments/assets/f7a08554-27e1-41c8-97b4-fbfbb765d5ad" />|<img width="394" height="698" alt="Capture d’écran 2026-05-27 à 11 52 48" src="https://github.com/user-attachments/assets/c6d839cf-2e40-4039-b861-569a25d4eacb" /> <img width="421" height="701" alt="Capture d’écran 2026-05-27 à 11 50 48" src="https://github.com/user-attachments/assets/a9155c8c-c7c0-4433-9f7a-121a659e77ef" /> <img width="395" height="684" alt="Capture d’écran 2026-05-27 à 11 47 45" src="https://github.com/user-attachments/assets/c9943403-0ef2-4147-afd9-ed394a197613" /> <img width="400" height="688" alt="Capture d’écran 2026-05-27 à 14 47 24" src="https://github.com/user-attachments/assets/01b8b05c-3a68-43cd-9046-8c087fd9c23b" />|
| Desktop - Chrome |<img width="1914" height="927" alt="Capture d’écran 2026-05-27 à 15 34 50" src="https://github.com/user-attachments/assets/03d688f3-160e-4bed-ba9b-0c9ae8ef3e77" /> <img width="1919" height="930" alt="Capture d’écran 2026-05-27 à 15 35 09" src="https://github.com/user-attachments/assets/fa816da4-c3c7-403e-8135-a75a6562a4d5" />|<img width="1509" height="769" alt="Capture d’écran 2026-05-27 à 12 09 55" src="https://github.com/user-attachments/assets/9f9141a7-6bb5-4a7e-b250-f266d97a25dc" /> <img width="1918" height="927" alt="Capture d’écran 2026-05-27 à 15 40 54" src="https://github.com/user-attachments/assets/45564782-7e8b-43bc-8d74-8dee53186aa7" /> <img width="1918" height="926" alt="Capture d’écran 2026-05-27 à 15 40 08" src="https://github.com/user-attachments/assets/909ff430-a416-41a6-b56a-474a093d1cb1" /> <img width="1508" height="767" alt="Capture d’écran 2026-05-27 à 14 47 17" src="https://github.com/user-attachments/assets/12980a81-3410-4330-b4d3-8d38bbc681da" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
