### PR TITLE
(PC-40344) feat(OfferDescription): Voice over reads following part of the text on click on See more

### DIFF
--- a/doc/accessibility/audits/2026_06_15.md
+++ b/doc/accessibility/audits/2026_06_15.md
@@ -120,6 +120,27 @@ Texte
 
 <details>
 
+<summary> 🟠 Critère 10.2 - Dans chaque écran, l’ordre de restitution par les technologies d’assistance est-il cohérent ? </summary>
+
+**RAAM** : [Critère 10.2](https://accessibilite.public.lu/fr/raam1.1/referentiel-technique.html#crit-10.2)  
+**Ticket** : [PC-40344](https://passculture.atlassian.net/browse/PC-40344)  
+**PRs** : [#9696](https://github.com/pass-culture/pass-culture-app-native/pull/9696)  
+
+**Problème** 😱  
+- E15 : Avec Voice over, dans la description d'une offre avec un texte tronqué, au clique sur “voir plus” , le focus ne se fait pas sur la suite du texte qui était coupé mais reste sur le bouton devenu "voir moins". 
+
+**Correction** 💡  
+- E15 : Le focus passe sur la seconde partie du texte au clic sur "voir plus".
+
+**Retours audit** 🔥  
+Texte
+
+</details>
+
+<br>
+
+<details>
+
 <summary> 🟠 Critère 11.9 - Dans chaque écran, le contenu proposé est-il consultable quelle que soit l’orientation de l’écran (portrait ou paysage) ? </summary>
 
 **RAAM** : [Critère 11.9](https://accessibilite.public.lu/fr/raam1.1/referentiel-technique.html#crit-11-9)  
@@ -157,3 +178,4 @@ Texte
 Texte
 
 </details>
+

--- a/src/ui/components/CollapsibleText/CollapsibleText.native.test.tsx
+++ b/src/ui/components/CollapsibleText/CollapsibleText.native.test.tsx
@@ -7,6 +7,9 @@ import { CollapsibleText } from './CollapsibleText'
 
 const LONG_TEXT = 'LONG Lorem ipsum dolor sit amet.'.repeat(30)
 const SHORT_TEXT = 'SHORT Lorem ipsum dolor sit amet.'
+const CUT_INDEX = LONG_TEXT.slice(0, 100).lastIndexOf(' ')
+const FIRST_PART = LONG_TEXT.slice(0, CUT_INDEX)
+const SECOND_PART = LONG_TEXT.slice(CUT_INDEX).trim()
 
 const user = userEvent.setup()
 
@@ -44,8 +47,9 @@ describe('CollapsibleText', () => {
     const button = screen.getByText('Voir plus')
     await user.press(button)
 
-    expect(screen.getByText(LONG_TEXT)).toBeOnTheScreen()
     expect(screen.getByText('Voir moins')).toBeOnTheScreen()
+    expect(screen.getByText(FIRST_PART)).toBeOnTheScreen()
+    expect(screen.getByLabelText(SECOND_PART)).toBeOnTheScreen()
   })
 
   it('should collapse text again when clicking on "Voir moins"', async () => {

--- a/src/ui/components/CollapsibleText/CollapsibleText.tsx
+++ b/src/ui/components/CollapsibleText/CollapsibleText.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { View } from 'react-native'
+import React, { useEffect, useRef, useState } from 'react'
+import { AccessibilityInfo, findNodeHandle, View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { Markdown } from 'ui/components/Markdown/Markdown'
@@ -14,32 +14,70 @@ type Props = {
   children?: React.ReactNode
 }
 
-function truncateText(text: string, maxChars: number) {
-  if (text.length <= maxChars) return text
+function getCutIndex(text: string, maxChars: number) {
+  if (text.length <= maxChars) return text.length
   const truncated = text.slice(0, maxChars)
   const lastSpace = truncated.lastIndexOf(' ')
-  return truncated.slice(0, lastSpace) + '…'
+  return lastSpace > 0 ? lastSpace : maxChars
+}
+
+function getContinuationA11yLabel(text: string, cutIndex: number) {
+  const continuation = text.slice(cutIndex).trim()
+  if (!continuation) return text
+  return continuation
 }
 
 export function CollapsibleText({ text, maxChars = 250, onAdditionalPress, children }: Props) {
   const [expanded, setExpanded] = useState(false)
+  const continuationFocusRef = useRef<View>(null)
+
   const isTruncated = text.length > maxChars
-  const collapsedText = truncateText(text, maxChars)
+  const cutIndex = getCutIndex(text, maxChars)
+
+  const firstPart = text.slice(0, cutIndex)
+  const secondPart = text.slice(cutIndex)
+  const collapsedText = `${firstPart}…`
+
+  const continuationA11yLabel = getContinuationA11yLabel(text, cutIndex)
 
   const buttonIcon = expanded ? ArrowUp : ArrowDown
   const buttonText = expanded ? 'Voir moins' : 'Voir plus'
-  const buttonAccessibleHint = expanded
-    ? 'Réduire le texte'
-    : 'Une fois déplié, revenir en arrière pour lire tout le texte'
+  const buttonAccessibleHint = expanded ? 'Réduire le texte' : 'Déplier le texte'
 
   const onPress = () => {
     setExpanded((prev) => !prev)
     if (onAdditionalPress) onAdditionalPress()
   }
 
+  useEffect(() => {
+    if (!expanded || !isTruncated) return
+
+    const timer = setTimeout(() => {
+      const reactTag = findNodeHandle(continuationFocusRef.current)
+      if (reactTag) {
+        AccessibilityInfo.setAccessibilityFocus(reactTag)
+      }
+    }, 150)
+
+    return () => clearTimeout(timer)
+  }, [expanded, isTruncated])
+
   return (
     <View>
-      {expanded ? <Markdown>{text}</Markdown> : <Markdown>{collapsedText}</Markdown>}
+      {expanded ? (
+        <View>
+          <Markdown>{firstPart}</Markdown>
+          <View
+            ref={continuationFocusRef}
+            accessible
+            accessibilityRole="text"
+            accessibilityLabel={continuationA11yLabel}>
+            <Markdown>{secondPart}</Markdown>
+          </View>
+        </View>
+      ) : (
+        <Markdown>{isTruncated ? collapsedText : text}</Markdown>
+      )}
 
       {expanded && children ? children : null}
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-40344

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

<img width="1027" height="621" alt="Capture d’écran 2026-05-28 à 10 20 04" src="https://github.com/user-attachments/assets/6afdb18f-ff2b-43bc-95c6-a3d168ce3e8b" />
<img width="1028" height="628" alt="Capture d’écran 2026-05-28 à 10 20 22" src="https://github.com/user-attachments/assets/3c5ddf17-3cba-4364-acc3-1dace3c3c94f" />

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
