### PR TITLE
(PC-41976) feat(a11y): fix 200% zoom display issues

### DIFF
--- a/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
@@ -145,6 +145,7 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
     swipeThreshold={100}
   >
     <View
+      height={432}
       isLandscape={false}
       leftNootch={16}
       maxHeight={1318}
@@ -159,6 +160,7 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
           "borderTopLeftRadius": 16,
           "borderTopRightRadius": 16,
           "flexDirection": "column",
+          "height": 432,
           "justifyContent": "flex-start",
           "maxHeight": 1318,
           "maxWidth": 960,

--- a/doc/accessibility/audits/2026_06_15.md
+++ b/doc/accessibility/audits/2026_06_15.md
@@ -71,8 +71,8 @@ Texte
 <summary> 🟠 Critère  8.2  - Dans chaque écran, l’utilisateur peut-il augmenter la taille des caractères de 200% au moins ? </summary>
 
 **RAAM** : [Critère 8.2](https://accessibilite.public.lu/fr/raam1.1/referentiel-technique.html#crit-8_2)  
-**Ticket** : [PC-41360](https://passculture.atlassian.net/browse/PC-41360)  
-**PRs** : [#9665](https://github.com/pass-culture/pass-culture-app-native/pull/9665)  
+**Ticket** : [PC-41360](https://passculture.atlassian.net/browse/PC-41360) & [PC-41976](https://passculture.atlassian.net/browse/PC-41976)
+**PRs** : [#9665](https://github.com/pass-culture/pass-culture-app-native/pull/9665) &[#9707] (https://github.com/pass-culture/pass-culture-app-native/pull/9707)
 
 **Problème** 😱  
 - E02 : - certaines sous pages de la homme avait un titre qui débordait sur la page
@@ -80,8 +80,11 @@ Texte
         - la modale paramètre de localisation n'est pas scrollabe donc il manque des informations et surtout l'accès au cta
 - E03&E09 : les titres trops long sont coupés
 - E11 : le liens sont coupés
-- E14 : le header prend trop de place, déteriorant la lisibilité du reste de la page 
-- E15 : certains titres de playlists étaient coupés
+- E14 : - le header prend trop de place, déteriorant la lisibilité du reste de la page 
+        - les suggestions de recherche ont des points de suspension
+        - les titres des playlists de lieu ont des points de suspension
+- E15 : - certains titres de playlists étaient coupés
+        - le titre dans le header ne s'affiche pas en entier
 
 
 **Correction** 💡  
@@ -90,8 +93,11 @@ Texte
         - la modale paramètre de localisation est scrollabe
 - E03&E09 : les titres s'affichent en entier
 - E11 : les liens sont entiers
-- E14 : le header est scrollable comme le reste du contenu
-- E15 : les titres s'affichent en entier
+- E14 : - le header est scrollable comme le reste du contenu
+        - les suggestions s'affichent en entier
+        - les titres de playlist s'affichent en entier
+- E15 : - les titres s'affichent en entier
+        - le titre dans le header s'affiche en entier
 
 **Retours audit** 🔥  
 Texte

--- a/src/features/achievements/components/Achievement.tsx
+++ b/src/features/achievements/components/Achievement.tsx
@@ -3,6 +3,10 @@ import styled, { useTheme } from 'styled-components/native'
 
 import { AchievementEnum } from 'api/gen'
 import { AchievementDetailsModal } from 'features/achievements/pages/AchievementDetailsModal'
+import {
+  useMobileFontScaleToDisplay,
+  useNumberOfLine,
+} from 'shared/accessibility/helpers/zoomHelpers'
 import { useModal } from 'ui/components/modals/useModal'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { AccessibleIcon } from 'ui/svg/icons/types'
@@ -18,15 +22,19 @@ type AchievementProps = {
 export const Achievement: FC<AchievementProps> = ({ Illustration, name, title, isCompleted }) => {
   const { visible, showModal, hideModal } = useModal(false)
   const { illustrations } = useTheme()
-
+  const numberOfLines = useNumberOfLine(2)
+  const height = useMobileFontScaleToDisplay({
+    default: getSpacing(55),
+    at200PercentZoom: undefined,
+  })
   return (
     <React.Fragment>
-      <StyledTouchableOpacity onPress={showModal}>
+      <StyledTouchableOpacity onPress={showModal} height={height}>
         <AchievementContainer isCompleted={!!isCompleted}>
           <IllustrationContainer>
             <Illustration size={illustrations.sizes.small} />
           </IllustrationContainer>
-          <TypoAchievementName numberOfLines={2} isCompleted={!!isCompleted}>
+          <TypoAchievementName numberOfLines={numberOfLines} isCompleted={!!isCompleted}>
             {title}
           </TypoAchievementName>
         </AchievementContainer>
@@ -36,10 +44,10 @@ export const Achievement: FC<AchievementProps> = ({ Illustration, name, title, i
   )
 }
 
-const StyledTouchableOpacity = styled(TouchableOpacity)({
+const StyledTouchableOpacity = styled(TouchableOpacity)<{ height?: number }>(({ height }) => ({
   flex: 0.5,
-  height: getSpacing(55),
-})
+  height,
+}))
 
 const AchievementContainer = styled.View<{ isCompleted: boolean }>(({ theme, isCompleted }) => ({
   paddingVertical: theme.designSystem.size.spacing.xl,

--- a/src/features/auth/pages/signup/AcceptCgu/AcceptCgu.tsx
+++ b/src/features/auth/pages/signup/AcceptCgu/AcceptCgu.tsx
@@ -10,7 +10,7 @@ import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { ReCaptcha } from 'libs/recaptcha/ReCaptcha'
 import { useIsRecaptchaEnabled } from 'queries/settings/useSettings'
 import { hiddenFromScreenReader } from 'shared/accessibility/helpers/hiddenFromScreenReader'
-import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
+import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
 import { Form } from 'ui/components/Form'
 import { InputError } from 'ui/components/inputs/InputError'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
@@ -124,10 +124,7 @@ export const AcceptCgu: FunctionComponent<PreValidationSignupLastStepProps> = ({
     !isChecked.acceptCgu ||
     !isChecked.acceptDataCharter
 
-  const numberOfLines = useMobileFontScaleToDisplay({
-    default: 2,
-    at200PercentZoom: undefined,
-  })
+  const numberOfLines = useNumberOfLine(2)
 
   return (
     <SetContainer>

--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
@@ -24,6 +24,7 @@ import { AlgoliaSuggestionHit } from 'libs/algolia/types'
 import { env } from 'libs/environment/env'
 import { useSearchGroupLabel } from 'libs/subcategories'
 import { useSubcategoriesQuery } from 'queries/subcategories/useSubcategoriesQuery'
+import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
 import { MagnifyingGlassFilled } from 'ui/svg/icons/MagnifyingGlassFilled'
 import { Typo } from 'ui/theme'
 
@@ -206,8 +207,9 @@ export function AutocompleteOfferItem({
 
   const testID = `autocompleteOfferItem_${hit.objectID}`
 
+  const numberOfLines = useNumberOfLine(1)
   return (
-    <SuggestionContainer hit={hit} onPress={onPress} testID={testID}>
+    <SuggestionContainer hit={hit} onPress={onPress} testID={testID} numberOfLines={numberOfLines}>
       {shouldDisplayCategorySuggestion && categoryToDisplay ? (
         <Suggestion categoryToDisplay={categoryToDisplay} />
       ) : undefined}
@@ -220,7 +222,8 @@ const SuggestionContainer: FunctionComponent<{
   onPress: () => void
   testID: string
   children: ReactNode
-}> = ({ hit, onPress, testID, children }) => (
+  numberOfLines?: number
+}> = ({ hit, onPress, testID, children, numberOfLines }) => (
   <AutocompleteItemTouchable
     testID={testID}
     onPress={onPress}
@@ -228,7 +231,7 @@ const SuggestionContainer: FunctionComponent<{
     <MagnifyingGlassIconContainer>
       <MagnifyingGlassFilledIcon />
     </MagnifyingGlassIconContainer>
-    <StyledText numberOfLines={1} ellipsizeMode="tail">
+    <StyledText numberOfLines={numberOfLines} ellipsizeMode="tail">
       <SuggestionHitHighlight suggestionHit={hit} attribute="query" />
       {children}
     </StyledText>

--- a/src/features/search/components/SearchHistoryItem/SearchHistoryItem.tsx
+++ b/src/features/search/components/SearchHistoryItem/SearchHistoryItem.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 import { HistoryItemHighlight } from 'features/search/components/Highlight/Highlight'
 import { Highlighted, HistoryItem } from 'features/search/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
 import { ClockFilled } from 'ui/svg/icons/ClockFilled'
 import { Typo } from 'ui/theme'
 
@@ -22,13 +23,15 @@ export function SearchHistoryItem({ item, queryHistory, onPress }: Props) {
     onPress(item)
   }, [item, onPress])
 
+  const numberOfLines = useNumberOfLine(1)
+
   return (
     <Container>
       <HistoryItemTouchable onPress={handlePress} accessibilityRole={AccessibilityRole.BUTTON}>
         <ClockIconContainer>
           <ClockFilledIcon />
         </ClockIconContainer>
-        <StyledText numberOfLines={1}>
+        <StyledText numberOfLines={numberOfLines}>
           {queryHistory === '' ? (
             <Typo.BodyItalic testID="withoutUsingHighlight">{item.query}</Typo.BodyItalic>
           ) : (

--- a/src/features/search/components/SearchVenueItemsDetails/SearchVenueItemDetails.tsx
+++ b/src/features/search/components/SearchVenueItemsDetails/SearchVenueItemDetails.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { PixelRatio } from 'react-native'
 import styled from 'styled-components/native'
 
+import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
 import { GUTTER_DP, Typo } from 'ui/theme'
 
 interface SearchVenueItemDetailsProps {
@@ -15,10 +16,12 @@ export const SearchVenueItemDetails = ({
   name,
   shortAddress,
 }: SearchVenueItemDetailsProps) => {
+  const numberOfLines = useNumberOfLine(2)
+
   return (
     <Container maxWidth={width}>
-      <VenueName>{name}</VenueName>
-      <ShortAddressLabel>{shortAddress}</ShortAddressLabel>
+      <VenueName numberOfLines={numberOfLines}>{name}</VenueName>
+      <ShortAddressLabel numberOfLines={numberOfLines}>{shortAddress}</ShortAddressLabel>
     </Container>
   )
 }
@@ -28,10 +31,10 @@ const Container = styled.View<{ maxWidth: number }>(({ maxWidth }) => ({
   marginTop: PixelRatio.roundToNearestPixel(GUTTER_DP / 2),
 }))
 
-const VenueName = styled(Typo.BodyAccent).attrs({
-  numberOfLines: 2,
-})({})
+const VenueName = styled(Typo.BodyAccent).attrs(({ numberOfLines }) => ({
+  numberOfLines,
+}))({})
 
-const ShortAddressLabel = styled(Typo.BodyAccentXs).attrs({
-  numberOfLines: 2,
-})(({ theme }) => ({ flexShrink: 1, color: theme.designSystem.color.text.subtle }))
+const ShortAddressLabel = styled(Typo.BodyAccentXs).attrs(({ numberOfLines }) => ({
+  numberOfLines,
+}))(({ theme }) => ({ flexShrink: 1, color: theme.designSystem.color.text.subtle }))

--- a/src/features/search/pages/SearchFilter/SearchFilter.tsx
+++ b/src/features/search/pages/SearchFilter/SearchFilter.tsx
@@ -24,6 +24,7 @@ import { useLocation } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
 import { SuggestedPlace } from 'libs/place/types'
 import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
+import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { Li } from 'ui/components/Li'
 import { VerticalUl } from 'ui/components/Ul'
@@ -41,7 +42,7 @@ export const SearchFilter: React.FC = () => {
   const { searchState, dispatch } = useSearch()
   const { navigateToSearch } = useNavigateToSearch('SearchResults')
   const logReinitializeFilters = useFunctionOnce(() => {
-    analytics.logReinitializeFilters(searchState.searchId)
+    void analytics.logReinitializeFilters(searchState.searchId)
   })
   const { place, selectedLocationMode, aroundMeRadius, aroundPlaceRadius } = useLocation()
   const { user } = useAuthContext()
@@ -107,6 +108,11 @@ export const SearchFilter: React.FC = () => {
     return isBeneficiary && hasRemainingCredit
   }, [user])
 
+  const shouldRenderInlineActions = useMobileFontScaleToDisplay({
+    default: false,
+    at200PercentZoom: true,
+  })
+
   const onClose = isMobileViewport ? onGoBack : undefined
   return (
     <PageWithHeader
@@ -139,16 +145,29 @@ export const SearchFilter: React.FC = () => {
           <SectionWrapper>
             <Section.Accessibility onClose={onClose} />
           </SectionWrapper>
+          {shouldRenderInlineActions ? (
+            <SectionWrapper>
+              <FilterPageButtons
+                onResetPress={onResetPress}
+                onSearchPress={onSearchPress}
+                isModal
+                filterBehaviour={FilterBehaviour.SEARCH}
+                isResetDisabled={hasDefaultValues}
+              />
+            </SectionWrapper>
+          ) : null}
         </VerticalUl>
       }
       fixedBottomChildren={
-        <FilterPageButtons
-          onResetPress={onResetPress}
-          onSearchPress={onSearchPress}
-          isModal
-          filterBehaviour={FilterBehaviour.SEARCH}
-          isResetDisabled={hasDefaultValues}
-        />
+        shouldRenderInlineActions ? null : (
+          <FilterPageButtons
+            onResetPress={onResetPress}
+            onSearchPress={onSearchPress}
+            isModal
+            filterBehaviour={FilterBehaviour.SEARCH}
+            isResetDisabled={hasDefaultValues}
+          />
+        )
       }
     />
   )

--- a/src/ui/components/headers/ContentHeader.tsx
+++ b/src/ui/components/headers/ContentHeader.tsx
@@ -3,7 +3,10 @@ import { Animated, Platform } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled, { useTheme } from 'styled-components/native'
 
-import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
+import {
+  useMobileFontScaleToDisplay,
+  useNumberOfLine,
+} from 'shared/accessibility/helpers/zoomHelpers'
 import { getAnimationState } from 'ui/animations/helpers/getAnimationState'
 import { BlurryWrapper } from 'ui/components/BlurryWrapper/BlurryWrapper'
 import { Button } from 'ui/designSystem/Button/Button'
@@ -40,13 +43,18 @@ export const ContentHeader = ({
 
   const marginTopHeader = Platform.OS === 'ios' ? top : top + theme.designSystem.size.spacing.s
 
+  const height = useMobileFontScaleToDisplay({
+    default: headerHeight,
+    at200PercentZoom: undefined,
+  })
+
   return (
-    <HeaderContainer style={containerStyle} height={headerHeight}>
+    <HeaderContainer style={containerStyle} height={height}>
       {
         // There is an issue with the blur on Android: we chose not to render it and use a white background
         // https://github.com/Kureev/react-native-blur/issues/511
         Platform.OS === 'android' ? null : (
-          <BlurNativeContainer height={headerHeight} style={blurContainerNative}>
+          <BlurNativeContainer height={height} style={blurContainerNative}>
             <BlurryWrapper />
           </BlurNativeContainer>
         )
@@ -81,7 +89,7 @@ export const ContentHeader = ({
   )
 }
 
-const BlurNativeContainer = styled(Animated.View)<{ height: number }>(({ height }) => ({
+const BlurNativeContainer = styled(Animated.View)<{ height?: number }>(({ height }) => ({
   position: 'absolute',
   top: 0,
   left: 0,
@@ -90,7 +98,7 @@ const BlurNativeContainer = styled(Animated.View)<{ height: number }>(({ height 
   overflow: 'hidden',
 }))
 
-const HeaderContainer = styled(Animated.View)<{ height: number }>(({ theme, height }) => ({
+const HeaderContainer = styled(Animated.View)<{ height?: number }>(({ theme, height }) => ({
   position: 'absolute',
   top: 0,
   left: 0,

--- a/src/ui/components/modals/AppModal.tsx
+++ b/src/ui/components/modals/AppModal.tsx
@@ -197,11 +197,17 @@ export const AppModal: FunctionComponent<Props> = ({
 
   useEscapeKeyAction(visible ? onRightIconPress : undefined)
 
+  const isFullscreenAtZoom = useMobileFontScaleToDisplay({
+    default: false,
+    at200PercentZoom: !maxHeight,
+  })
+  const effectiveIsFullscreen = isFullscreen || isFullscreenAtZoom
+
   let maxContainerHeight = maxHeight
   let modalContainerHeight = isSmallScreen ? windowHeight : modalHeight
 
   // no fullscreen in desktop view
-  if (isFullscreen || isUpToStatusBar) {
+  if (effectiveIsFullscreen || isUpToStatusBar) {
     maxContainerHeight = windowHeight
     modalContainerHeight = isUpToStatusBar ? windowHeight - top : windowHeight
   }
@@ -259,7 +265,7 @@ export const AppModal: FunctionComponent<Props> = ({
       propagateSwipe={propagateSwipe}>
       <KeyboardAvoidingViewWrapper>
         <ModalContainer
-          height={maxHeight ? undefined : modalContainerHeight}
+          height={modalContainerHeight}
           testID="modalContainer"
           maxHeight={maxContainerHeight}
           desktopConstraints={containerDesktopConstraints}
@@ -283,7 +289,7 @@ export const AppModal: FunctionComponent<Props> = ({
               {...iconProps}
             />
           )}
-          {isFullscreen || maxHeight || isUpToStatusBar ? (
+          {effectiveIsFullscreen || maxHeight || isUpToStatusBar ? (
             fullscreenModalBody
           ) : (
             <React.Fragment>
@@ -363,6 +369,7 @@ const StyledModal = styled(ReactNativeModal as any)(({ theme }) => {
 export type ModalContainerProps = {
   theme: DefaultTheme
   height?: number
+  fullscreen?: boolean
   maxHeight?: number
   noPadding?: boolean
   noPaddingBottom?: boolean
@@ -375,6 +382,7 @@ export type ModalContainerProps = {
 const ModalContainer = styled.View<ModalContainerProps>(
   ({
     height,
+    fullscreen,
     desktopConstraints,
     maxHeight,
     noPadding,
@@ -384,17 +392,20 @@ const ModalContainer = styled.View<ModalContainerProps>(
     rightNootch,
     leftNootch,
   }) => {
-    return appModalContainerStyle({
-      theme,
-      height,
-      desktopConstraints,
-      maxHeight,
-      noPadding,
-      noPaddingBottom,
-      isLandscape,
-      rightNootch,
-      leftNootch,
-    })
+    return {
+      ...appModalContainerStyle({
+        theme,
+        height,
+        desktopConstraints,
+        maxHeight,
+        noPadding,
+        noPaddingBottom,
+        isLandscape,
+        rightNootch,
+        leftNootch,
+      }),
+      ...(fullscreen ? { height: '100%', maxHeight: '100%' } : {}),
+    }
   }
 )
 

--- a/src/ui/components/tiles/HorizontalOfferTile.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.tsx
@@ -19,6 +19,7 @@ import { formatPrice, getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
 import { useSubcategory } from 'libs/subcategories'
 import { tileAccessibilityLabel, TileContentType } from 'libs/tileAccessibilityLabel'
 import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
+import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { getOfferDates } from 'shared/date/getOfferDates'
 import { Offer } from 'shared/offer/types'
@@ -160,6 +161,8 @@ export const HorizontalOfferTile = ({
     interactionTagLabel,
   })
 
+  const numberOfLine = useNumberOfLine(1)
+
   return (
     <Container
       navigateTo={{
@@ -189,7 +192,7 @@ export const HorizontalOfferTile = ({
               generatedSubtitles?.map((subtitle, index) => (
                 <Body
                   ellipsizeMode="tail"
-                  numberOfLines={1}
+                  numberOfLines={numberOfLine}
                   testID="native-category-value"
                   key={subtitle ? `${subtitle}_${index}` : index}>
                   {subtitle}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41976
## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Mockup/Before | 200 | 100 | web
| :--------------- | :-----------: | :---: | :---: |
|  <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 52 58" src="https://github.com/user-attachments/assets/fea37585-dd8f-4096-b875-21dabe7b4ec2" />|   https://github.com/user-attachments/assets/14caeb78-aee7-4d2c-acbc-68d084c6073e | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 54 48" src="https://github.com/user-attachments/assets/eefc5e1c-f7c4-4c46-a7a6-35811d42a152" />      |<img width="1440" height="777" alt="Capture d’écran 2026-05-28 à 15 57 01" src="https://github.com/user-attachments/assets/cf95b923-9a90-4221-9983-8fddfa14c4f2" />|
| <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 41 10" src="https://github.com/user-attachments/assets/2bba2422-c8db-4d84-8d17-100c4e491c72" />  | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 34 39" src="https://github.com/user-attachments/assets/d399b3ad-1276-46e2-b867-07140a93085b" /> |  <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 56 32" src="https://github.com/user-attachments/assets/59ef32b1-4284-4982-89f8-b6db7665f6aa" />|<img width="1434" height="777" alt="Capture d’écran 2026-05-28 à 15 56 25" src="https://github.com/user-attachments/assets/2066c6b9-95bf-4698-971d-debec5d1617f" />|
|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 42 09" src="https://github.com/user-attachments/assets/9148b898-2312-4dfe-95e0-64708420dbb0" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 26 07" src="https://github.com/user-attachments/assets/8b57fce2-2e5f-481c-a2bb-d7a22323f74f" />       | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 57 41" src="https://github.com/user-attachments/assets/1933ed9d-255b-41c9-bada-41b6b0356232" />      |   <img width="1433" height="777" alt="Capture d’écran 2026-05-28 à 15 57 55" src="https://github.com/user-attachments/assets/dd51f2a0-ac1f-45b9-839d-b3a93decf99a" /> |
|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 51 00" src="https://github.com/user-attachments/assets/f854dad6-7b0a-4c81-be49-b2f2a1cf9dbc" /> |       https://github.com/user-attachments/assets/ac156a3e-7767-4a05-8198-551fc0ba6e23 |<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 55 22" src="https://github.com/user-attachments/assets/0a883e3c-533a-45af-8207-9d7ac52dae29" />       | <img width="1435" height="773" alt="Capture d’écran 2026-05-28 à 15 55 09" src="https://github.com/user-attachments/assets/571c930b-d0b2-4d22-8dbf-1e62b8ae0a5e" />|
|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 41 41" src="https://github.com/user-attachments/assets/fdb872ae-6e3b-4812-a95b-c203a90ebb0f" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 12 35 38" src="https://github.com/user-attachments/assets/a0bf3547-06a3-42aa-859e-94c30be10d74" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 16 01 13" src="https://github.com/user-attachments/assets/430a8f59-e556-4b8b-8561-86762e75962d" />|<img width="1440" height="777" alt="Capture d’écran 2026-05-28 à 16 01 29" src="https://github.com/user-attachments/assets/af9b747e-8e5c-4e2b-b436-9054c5cba5ad" />|
|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 09 38 14" src="https://github.com/user-attachments/assets/50268706-15cd-49e7-a7cb-dff3f6a41996" />|https://github.com/user-attachments/assets/5238edd8-8190-4785-8696-92ca8aa355e1|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 58 32" src="https://github.com/user-attachments/assets/1bcbad6c-a135-4a41-b7eb-be40a69af37a" />|<img width="1432" height="776" alt="Capture d’écran 2026-05-28 à 15 58 49" src="https://github.com/user-attachments/assets/8ae6a038-6670-4f83-a606-854830fea3ba" />|
|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 42 28" src="https://github.com/user-attachments/assets/00329a45-55b5-4af6-87b7-95592a3696c3" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 08 31" src="https://github.com/user-attachments/assets/910a35d6-7dfe-4b95-91c0-6151aefc4ede" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 15 59 33" src="https://github.com/user-attachments/assets/928bef97-ca7f-492d-80c6-2ba6fae7fb52" />|<img width="1440" height="779" alt="Capture d’écran 2026-05-28 à 15 59 54" src="https://github.com/user-attachments/assets/96109fa7-2b99-4d69-85f0-ec982fb56eb1" />|
|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 09 40 16" src="https://github.com/user-attachments/assets/51548c3a-b658-45e6-8614-e4776ca01dae" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 09 06 38" src="https://github.com/user-attachments/assets/5886fff1-495c-43ab-8e5e-88133d5844a5" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-05-28 at 16 00 31" src="https://github.com/user-attachments/assets/b9a13b7a-134c-4832-9b2b-e1f41043777f" />|<img width="1440" height="782" alt="Capture d’écran 2026-05-28 à 16 00 49" src="https://github.com/user-attachments/assets/93189a1b-43c5-44f3-bcb0-8e2132675620" />|



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
