### PR TITLE
(PC-41946) feat(bonification): display handicap bonification coming s…

### DIFF
--- a/src/features/bonification/pages/BonificationExplanations.native.test.tsx
+++ b/src/features/bonification/pages/BonificationExplanations.native.test.tsx
@@ -89,7 +89,7 @@ describe('BonificationExplanations', () => {
   it('should not show handicap information text when qf bonification and handicap bonification are enabled', async () => {
     setFeatureFlags([
       RemoteStoreFeatureFlags.ENABLE_BONIFICATION,
-      RemoteStoreFeatureFlags.ENABLE_HANDICAP_BONIFICIATION,
+      RemoteStoreFeatureFlags.ENABLE_HANDICAP_BONIFICATION,
     ])
 
     render(<BonificationExplanations />)

--- a/src/features/bonification/pages/BonificationExplanations.native.test.tsx
+++ b/src/features/bonification/pages/BonificationExplanations.native.test.tsx
@@ -6,6 +6,7 @@ import { BonificationExplanations } from 'features/bonification/pages/Bonificati
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { beneficiaryUser } from 'fixtures/user'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { render, screen, userEvent } from 'tests/utils'
 
@@ -70,6 +71,33 @@ describe('BonificationExplanations', () => {
       screen.getByText(
         'Si tu habites en Nouvelle-Calédonie, tu ne pourras malheureusement pas bénéficier du bonus.'
       )
-    ).toBeTruthy()
+    ).toBeOnTheScreen()
+  })
+
+  it('should show handicap information text when qf bonification is enabled and handicap bonification is disabled', async () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_BONIFICATION])
+
+    render(<BonificationExplanations />)
+
+    expect(
+      screen.getByText(
+        'Si tu es en situation de handicap, un peu de patience, ton cas sera pris en compte prochainement.'
+      )
+    ).toBeOnTheScreen()
+  })
+
+  it('should not show handicap information text when qf bonification and handicap bonification are enabled', async () => {
+    setFeatureFlags([
+      RemoteStoreFeatureFlags.ENABLE_BONIFICATION,
+      RemoteStoreFeatureFlags.ENABLE_HANDICAP_BONIFICIATION,
+    ])
+
+    render(<BonificationExplanations />)
+
+    expect(
+      screen.queryByText(
+        'Si tu es en situation de handicap, un peu de patience, ton cas sera pris en compte prochainement.'
+      )
+    ).not.toBeOnTheScreen()
   })
 })

--- a/src/features/bonification/pages/BonificationExplanations.tsx
+++ b/src/features/bonification/pages/BonificationExplanations.tsx
@@ -42,7 +42,7 @@ export const BonificationExplanations = () => {
     euroToPacificFrancRate
   )
   const enableHandicapBonification = useFeatureFlag(
-    RemoteStoreFeatureFlags.ENABLE_HANDICAP_BONIFICIATION
+    RemoteStoreFeatureFlags.ENABLE_HANDICAP_BONIFICATION
   )
   const { data: bonificationQfThreshold } = useBonificationQfThreshold()
   const qfThresholdInCents = (bonificationQfThreshold || 700) * 100

--- a/src/features/bonification/pages/BonificationExplanations.tsx
+++ b/src/features/bonification/pages/BonificationExplanations.tsx
@@ -7,6 +7,8 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
 import { getSubscriptionHookConfig } from 'features/navigation/navigators/SubscriptionStackNavigator/getSubscriptionHookConfig'
 import { env } from 'libs/environment/env'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import {
   useBonificationBonusAmount,
   useBonificationQfThreshold,
@@ -38,6 +40,9 @@ export const BonificationExplanations = () => {
     bonificationBonusAmount,
     currency,
     euroToPacificFrancRate
+  )
+  const enableHandicapBonification = useFeatureFlag(
+    RemoteStoreFeatureFlags.ENABLE_HANDICAP_BONIFICIATION
   )
   const { data: bonificationQfThreshold } = useBonificationQfThreshold()
   const qfThresholdInCents = (bonificationQfThreshold || 700) * 100
@@ -100,10 +105,12 @@ export const BonificationExplanations = () => {
             externalNav={{ url: env.FAQ_LINK_CAF_QUOTIEN_FAMILIAL }}
             icon={ExternalSiteFilled}
           />
-          <StyledBodyS>
-            Si tu es en <Typo.BodyAccentS>situation de handicap</Typo.BodyAccentS>, un peu de
-            patience, ton cas sera pris en compte prochainement.
-          </StyledBodyS>
+          {enableHandicapBonification ? null : (
+            <StyledBodyS>
+              Si tu es en <Typo.BodyAccentS>situation de handicap</Typo.BodyAccentS>, un peu de
+              patience, ton cas sera pris en compte prochainement.
+            </StyledBodyS>
+          )}
         </ViewGap>
       }
     />

--- a/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx
+++ b/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx
@@ -22,7 +22,7 @@ describe('<ProfileTutorialAgeInformationCredit />', () => {
     beforeEach(() => {
       setFeatureFlags([
         RemoteStoreFeatureFlags.ENABLE_BONIFICATION,
-        RemoteStoreFeatureFlags.ENABLE_HANDICAP_BONIFICIATION,
+        RemoteStoreFeatureFlags.ENABLE_HANDICAP_BONIFICATION,
       ])
     })
 

--- a/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.tsx
+++ b/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.tsx
@@ -28,7 +28,7 @@ const headerTitle = 'Comment ça marche\u00a0?'
 
 export const ProfileTutorialAgeInformationCredit = () => {
   const enableHandicapBonification = useFeatureFlag(
-    RemoteStoreFeatureFlags.ENABLE_HANDICAP_BONIFICIATION
+    RemoteStoreFeatureFlags.ENABLE_HANDICAP_BONIFICATION
   )
   const enableFamilyQuotientBonification = useFeatureFlag(
     RemoteStoreFeatureFlags.ENABLE_BONIFICATION

--- a/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.web.test.tsx
+++ b/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.web.test.tsx
@@ -26,7 +26,7 @@ describe('<ProfileTutorialAgeInformationCredit/>', () => {
       it('should not have basic accessibility issues', async () => {
         setFeatureFlags([
           RemoteStoreFeatureFlags.ENABLE_BONIFICATION,
-          RemoteStoreFeatureFlags.ENABLE_HANDICAP_BONIFICIATION,
+          RemoteStoreFeatureFlags.ENABLE_HANDICAP_BONIFICATION,
         ])
         const { container } = render(<ProfileTutorialAgeInformationCredit />)
 

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -45,7 +45,7 @@ export enum RemoteStoreFeatureFlags {
   DISABLE_ACTIVATION = 'disableActivation',
   ENABLE_AI_FAKE_DOOR = 'enableAIFakeDoor',
   ENABLE_BONIFICATION = 'enableBonification',
-  ENABLE_HANDICAP_BONIFICIATION = 'enableHandicapBonification',
+  ENABLE_HANDICAP_BONIFICATION = 'enableHandicapBonification',
   ENABLE_CHATBOT = 'enableChatbot',
   ENABLE_HIDE_TICKET = 'enableHideTicket',
   ENABLE_MANDATORY_UPDATE_PERSONAL_DATA = 'enableMandatoryUpdatePersonalData',


### PR DESCRIPTION
…oon only when qf bonification is enabled and handicap bonification disabled

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41946

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

FF ENABLE_HANDICAP_BONIFICIATION == true
<img width="1439" height="769" alt="Capture d’écran 2026-05-29 à 11 21 40" src="https://github.com/user-attachments/assets/864b4c21-00b4-497f-8fe4-5444fe7a52fb" />

FF ENABLE_HANDICAP_BONIFICIATION ===. false
<img width="1440" height="778" alt="Capture d’écran 2026-05-29 à 11 23 05" src="https://github.com/user-attachments/assets/982dfbad-2289-4c0e-9b82-a1cfb58b01b3" />

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
