### PR TITLE
(PC-42058) fix(cheatcodes): fix AB test screen navigation key mismatch

### DIFF
--- a/src/cheatcodes/pages/CheatcodesMenu.tsx
+++ b/src/cheatcodes/pages/CheatcodesMenu.tsx
@@ -122,7 +122,7 @@ export function CheatcodesMenu(): React.JSX.Element {
       id: uuidv4(),
       title: 'AB Tests 🧪',
       navigationTarget: {
-        screen: 'CheatcodesABTest',
+        screen: 'CheatcodesScreenABTest',
       },
       subscreens: [],
     },

--- a/src/features/navigation/navigators/CheatcodesStackNavigator/types.ts
+++ b/src/features/navigation/navigators/CheatcodesStackNavigator/types.ts
@@ -30,7 +30,7 @@ export type CheatcodesStackParamList = {
   CheatcodesScreenRemoteBanners: undefined
   CheatcodesScreenTrustedDeviceInfos: undefined
   // Others
-  CheatcodesABTest: undefined
+  CheatcodesScreenABTest: undefined
   CheatcodeScreenLoadingPage: undefined
   CheatcodesNavigationAccountManagement: undefined
   CheatcodesNavigationErrors: undefined


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42058

## But de la PR

Le bouton **AB Tests 🧪** du menu cheatcodes ne faisait rien au clic, alors que tous les autres boutons fonctionnaient.

## Cause

La PR #9059 (*rework navigation stack declaration*) a renommé la clé du screen dans le navigator en `CheatcodesScreenABTest` (pour suivre la convention `CheatcodesScreenXxx` de la section *Others*), mais le menu et le fichier de types pointaient toujours vers l'ancienne clé `CheatcodesABTest`.

Comme le type `CheatcodesStackParamList` déclarait encore `CheatcodesABTest`, TypeScript ne détectait pas l'incohérence. À l'exécution, React Navigation cherchait une route inexistante dans le registry du stack → navigation ignorée silencieusement.

## Changements

- `types.ts` : clé de route `CheatcodesABTest` → `CheatcodesScreenABTest`
- `CheatcodesMenu.tsx` : cible de navigation `'CheatcodesABTest'` → `'CheatcodesScreenABTest'`