### PR TITLE
(PC-42093) build(workflows): update action for node 24

### DIFF
--- a/.github/workflows/dev_on_pull_request_title_checker.yml
+++ b/.github/workflows/dev_on_pull_request_title_checker.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: Slashgear/action-check-pr-title@v4.3.0
+      - uses: Slashgear/action-check-pr-title@action-check-pr-title-v6.0.0
         with:
           regexp: '^(\((PC-[0-9]+|BSR|IC-[0-9]+)\) )?(build|ci|docs|feat|fix|perf|refactor|test|chore)\(\w+\): \w+'

--- a/.github/workflows/dev_on_schedule_flashlight_android.yml
+++ b/.github/workflows/dev_on_schedule_flashlight_android.yml
@@ -27,7 +27,7 @@ jobs:
           node-version-file: '.nvmrc'
       - uses: pass-culture/common-workflows/actions/setup-safe-chain@9a5f036470496551365fe9c26afbd4febe20a8cb
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -46,7 +46,7 @@ jobs:
           echo 'Enabling KVM...'
           sudo chmod 777 /dev/kvm
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Authenticate to Google
         uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # v3.0.0
@@ -93,7 +93,7 @@ jobs:
       - name: Run the full test script
         id: run_test
         env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
           set +e
           ./scripts/run_flashlight_on_android.sh 2>&1 | tee test_output.log

--- a/.github/workflows/dev_on_workflow_call_e2e_android.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_android.yml
@@ -51,13 +51,13 @@ jobs:
       - uses: pass-culture/common-workflows/actions/setup-safe-chain@9a5f036470496551365fe9c26afbd4febe20a8cb
 
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
         with:
           cmdline-tools-version: 11076708 # correspond to cmdline-tools version 12.0
 

--- a/.github/workflows/dev_on_workflow_check_folder_change.yml
+++ b/.github/workflows/dev_on_workflow_check_folder_change.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: ${{ inputs.fetch-tags }}
       - id: folder-check-changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           base_sha: ${{ inputs.base_sha }}
           files: |

--- a/.github/workflows/dev_on_workflow_environment_android_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_android_deploy.yml
@@ -55,12 +55,12 @@ jobs:
           node-version-file: '.nvmrc'
       - uses: pass-culture/common-workflows/actions/setup-safe-chain@9a5f036470496551365fe9c26afbd4febe20a8cb
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
         with:
           cmdline-tools-version: 11076708 # correspond to cmdline-tools version 12.0
       - uses: pass-culture-github-actions/cache@v1.0.0

--- a/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/dev_on_workflow_environment_soft_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_soft_deploy.yml
@@ -31,7 +31,7 @@ jobs:
           node-version-file: '.nvmrc'
       - uses: pass-culture/common-workflows/actions/setup-safe-chain@9a5f036470496551365fe9c26afbd4febe20a8cb
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/dev_on_workflow_install.yml
+++ b/.github/workflows/dev_on_workflow_install.yml
@@ -26,12 +26,12 @@ jobs:
           node-version-file: '.nvmrc'
       - uses: pass-culture/common-workflows/actions/setup-safe-chain@9a5f036470496551365fe9c26afbd4febe20a8cb
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
         with:
           cmdline-tools-version: 11076708 # correspond to cmdline-tools version 12.0
       - id: gcloud-auth


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42093

## Context
We want to migrate all actions to node 24, latest node version, node 20 support being deprecated as of september 2026. 

## Tasks
 - use new versions of action to migrate to node 24

## Caveat
Only actions that cannot be migrated for now are gcs-cache and cache, will be done in a second part.