### PR TITLE
(PC-42109) feat(analytics): add displayAdvice param to ConsultVenue and ConsultOffer logs following pro advices AB testing

### DIFF
--- a/src/features/bookOffer/components/BookingImpossible.tsx
+++ b/src/features/bookOffer/components/BookingImpossible.tsx
@@ -10,6 +10,8 @@ import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/
 import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog'
 import { analytics } from 'libs/analytics/provider'
 import { useAddFavoriteMutation } from 'queries/favorites/useAddFavoriteMutation'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
@@ -22,6 +24,7 @@ export const BookingImpossible: React.FC = () => {
   const favorite = useFavorite({ offerId })
   const { navigate } = useNavigation<UseNavigationType>()
   const { mutate: notifyWebappLinkSent } = useNotifyWebappLinkSentMutation()
+  const proAdvicesOnOfferSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
 
   useEffect(() => {
     if (offerId === undefined) return
@@ -54,7 +57,7 @@ export const BookingImpossible: React.FC = () => {
     dismissModal()
 
     const from = 'bookingimpossible'
-    triggerConsultOfferLog({ offerId, from })
+    triggerConsultOfferLog({ offerId, from, displayAdvice: proAdvicesOnOfferSegment === 'A' })
     navigate('Offer', { id: offerId, from })
   }
 

--- a/src/features/bookings/components/BookingDetailsContent.native.test.tsx
+++ b/src/features/bookings/components/BookingDetailsContent.native.test.tsx
@@ -94,7 +94,11 @@ describe('<BookingDetailsContent />', () => {
     const venueBlock = screen.getByText('Maison de la Brique')
     await user.press(venueBlock)
 
-    expect(analytics.logConsultVenue).toHaveBeenCalledWith({ venueId: '2185', from: 'bookings' })
+    expect(analytics.logConsultVenue).toHaveBeenCalledWith({
+      venueId: '2185',
+      from: 'bookings',
+      displayAdvice: false,
+    })
   })
 
   it('should not navigate to Venue page when venue is not OpenToPublic', async () => {

--- a/src/features/bookings/components/EndedBookingItem.native.test.tsx
+++ b/src/features/bookings/components/EndedBookingItem.native.test.tsx
@@ -117,6 +117,7 @@ describe('EndedBookingItem', () => {
       offerId: '147874',
       from: 'endedbookings',
       isHeadline: false,
+      displayAdvice: false,
     })
   })
 

--- a/src/features/bookings/components/EndedBookingItem.tsx
+++ b/src/features/bookings/components/EndedBookingItem.tsx
@@ -13,6 +13,8 @@ import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { ShareContent } from 'libs/share/types'
 import { useSubcategoriesMapping } from 'libs/subcategories'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { OfferImage } from 'ui/components/tiles/OfferImage'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -35,6 +37,7 @@ export const EndedBookingItem = ({
   const subcategory = subcategoriesMapping[stock.offer.subcategoryId]
   const prePopulateOffer = usePrePopulateOffer()
   const netInfo = useNetInfoContext()
+  const proAdvicesOnOfferSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
 
   const endedBookingDateLabel = getEndedBookingDateLabel(cancellationDate, dateUsed)
 
@@ -44,6 +47,7 @@ export const EndedBookingItem = ({
       categoryId: subcategory.categoryId,
       netInfo,
       prePopulateOffer,
+      proAdvicesOnOfferSegment,
     })
 
   const { share: shareOffer, shareContent } = getShareOffer({

--- a/src/features/bookings/components/EndedBookingListItemWrapper.tsx
+++ b/src/features/bookings/components/EndedBookingListItemWrapper.tsx
@@ -11,6 +11,8 @@ import { getEndedBookingItemProperties } from 'features/bookings/helpers/v2/getE
 import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { useSubcategory } from 'libs/subcategories'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Button } from 'ui/designSystem/Button/Button'
 import { ThumbUp } from 'ui/svg/icons/ThumbUp'
@@ -36,6 +38,7 @@ export const EndedBookingListItemWrapper: FunctionComponent<EndedBookingProps> =
   const prePopulateOffer = usePrePopulateOffer()
   const netInfo = useNetInfoContext()
   const { isEvent, categoryId } = useSubcategory(subcategoryId)
+  const proAdvicesOnOfferSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
 
   const { accessibilityLabel, isBookingEligibleForArchive, handlePressOffer, navigateTo } =
     getEndedBookingItemProperties({
@@ -43,6 +46,7 @@ export const EndedBookingListItemWrapper: FunctionComponent<EndedBookingProps> =
       categoryId,
       netInfo,
       prePopulateOffer,
+      proAdvicesOnOfferSegment,
     })
 
   const shouldShowReactionButton =

--- a/src/features/bookings/components/LinkToOffer.tsx
+++ b/src/features/bookings/components/LinkToOffer.tsx
@@ -5,6 +5,8 @@ import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsult
 import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { SubcategoriesMapping } from 'libs/subcategories/types'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Button } from 'ui/designSystem/Button/Button'
 import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
@@ -18,6 +20,7 @@ export const LinkToOffer = ({
 }) => {
   const netInfo = useNetInfoContext()
   const prePopulateOffer = usePrePopulateOffer()
+  const proAdvicesOnOfferSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
 
   const onNavigateToOfferPress = () => {
     if (netInfo.isConnected) {
@@ -29,7 +32,11 @@ export const LinkToOffer = ({
         offerId: offer.id,
       })
 
-      triggerConsultOfferLog({ offerId: offer.id, from: 'bookings' })
+      triggerConsultOfferLog({
+        offerId: offer.id,
+        from: 'bookings',
+        displayAdvice: proAdvicesOnOfferSegment === 'A',
+      })
     } else {
       showErrorSnackBar(
         'Impossible d’afficher le détail de l’offre. Connecte-toi à internet avant de réessayer.'

--- a/src/features/bookings/components/Ticket/Ticket.tsx
+++ b/src/features/bookings/components/Ticket/Ticket.tsx
@@ -17,6 +17,8 @@ import { UserProfile } from 'features/share/types'
 import { analytics } from 'libs/analytics/provider'
 import { SubcategoriesMapping } from 'libs/subcategories/types'
 import { formatFullAddress } from 'shared/address/addressFormatter'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { Banner } from 'ui/designSystem/Banner/Banner'
 import { showErrorSnackBar, showSuccessSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { IdCard } from 'ui/svg/icons/IdCard'
@@ -43,6 +45,7 @@ export const Ticket = ({
   ticket,
 }: TicketProps) => {
   const { navigate, goBack } = useNavigation<UseNavigationType>()
+  const proAdvicesOnVenueSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_VENUE)
 
   const { mutate: archiveBooking } = useArchiveBookingMutation({
     bookingId: booking.id,
@@ -79,7 +82,11 @@ export const Ticket = ({
   const venueBlockAddress = getAddress(offer.address)
 
   const handleOnSeeVenuePress = async () => {
-    await analytics.logConsultVenue({ venueId: offer.venue.id.toString(), from: 'bookings' })
+    await analytics.logConsultVenue({
+      venueId: offer.venue.id.toString(),
+      from: 'bookings',
+      displayAdvice: proAdvicesOnVenueSegment === 'A',
+    })
     navigate('Venue', { id: offer.venue.id })
   }
   const expirationDateFormated = ({ prefix }: { prefix: string }) => {

--- a/src/features/bookings/helpers/v2/getEndedBookingItemProperties.test.ts
+++ b/src/features/bookings/helpers/v2/getEndedBookingItemProperties.test.ts
@@ -142,6 +142,7 @@ describe('getEndedBookingItemProperties', () => {
       expect(triggerConsultOfferLog).toHaveBeenCalledWith({
         offerId: initialBooking.stock.offer.id,
         from: 'endedbookings',
+        displayAdvice: false,
       })
     })
 

--- a/src/features/bookings/helpers/v2/getEndedBookingItemProperties.ts
+++ b/src/features/bookings/helpers/v2/getEndedBookingItemProperties.ts
@@ -15,6 +15,7 @@ type EndedBookingItem = {
   categoryId: CategoryIdEnum
   netInfo: NetInfoState
   prePopulateOffer: (offer: PartialOffer) => void
+  proAdvicesOnOfferSegment?: string
 }
 
 export const getEndedBookingItemProperties = ({
@@ -22,6 +23,7 @@ export const getEndedBookingItemProperties = ({
   categoryId,
   netInfo,
   prePopulateOffer,
+  proAdvicesOnOfferSegment,
 }: EndedBookingItem) => {
   const { dateUsed, cancellationDate, cancellationReason, stock } = booking
   const { offer } = stock
@@ -56,6 +58,7 @@ export const getEndedBookingItemProperties = ({
       triggerConsultOfferLog({
         offerId: offer.id,
         from: 'endedbookings',
+        displayAdvice: proAdvicesOnOfferSegment === 'A',
       })
     } else {
       showErrorSnackBar(

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
@@ -19,6 +19,7 @@ import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import * as useNetInfoContextDefault from 'libs/network/NetInfoWrapper'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
 import * as useBookingByIdQueryAPI from 'queries/bookings/useBookingByIdQuery'
+import * as ABSegmentModule from 'shared/useABSegment/useABSegment'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, render, screen, userEvent } from 'tests/utils'
@@ -48,6 +49,8 @@ jest.mock('queries/bookings/useBookingsQuery', () => ({
 }))
 
 jest.mock('libs/firebase/analytics/analytics')
+
+const useABSegmentSpy = jest.spyOn(ABSegmentModule, 'useABSegment')
 
 const user = userEvent.setup()
 
@@ -197,6 +200,7 @@ describe('BookingDetails', () => {
 
     it('should redirect to the Offer page and log event', async () => {
       const booking = ongoingBookingV2
+      useABSegmentSpy.mockReturnValueOnce('B')
       renderBookingDetailsWithBookingById(booking)
 
       const text = screen.getByText('Voir l’offre')
@@ -213,6 +217,7 @@ describe('BookingDetails', () => {
         offerId: String(offerId),
         from: 'bookings',
         isHeadline: false,
+        displayAdvice: false,
       })
     })
 

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
@@ -62,6 +62,7 @@ describe('BookingDetails', () => {
 
     mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', subcategoriesDataTest)
     mockUseNetInfoContext.mockReturnValue({ isConnected: true })
+    useABSegmentSpy.mockReturnValue('B')
   })
 
   describe('BookingDetails : when FF WIP_NEW_BOOKINGS_ENDED_ONGOING is on', () => {
@@ -200,7 +201,7 @@ describe('BookingDetails', () => {
 
     it('should redirect to the Offer page and log event', async () => {
       const booking = ongoingBookingV2
-      useABSegmentSpy.mockReturnValueOnce('B')
+
       renderBookingDetailsWithBookingById(booking)
 
       const text = screen.getByText('Voir l’offre')

--- a/src/features/favorites/components/Favorite.tsx
+++ b/src/features/favorites/components/Favorite.tsx
@@ -22,6 +22,8 @@ import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { useBookOfferModal } from 'shared/offer/helpers/useBookOfferModal'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { ANIMATION_USE_NATIVE_DRIVER } from 'ui/components/animationUseNativeDriver'
 import { LineSeparator } from 'ui/components/LineSeparator'
 import { useModal } from 'ui/components/modals/useModal'
@@ -62,6 +64,7 @@ export const Favorite: React.FC<Props> = (props) => {
   )
   const currency = useGetCurrencyToDisplay()
   const { data: euroToPacificFrancRate } = usePacificFrancToEuroRate()
+  const proAdvicesOnOfferSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
 
   const displayPrice = getFavoriteDisplayPrice({
     currency,
@@ -109,7 +112,11 @@ export const Favorite: React.FC<Props> = (props) => {
       offerId: offer.id,
     })
 
-    triggerConsultOfferLog({ offerId: offer.id, from: 'favorites' })
+    triggerConsultOfferLog({
+      offerId: offer.id,
+      from: 'favorites',
+      displayAdvice: proAdvicesOnOfferSegment === 'A',
+    })
   }
 
   function onRemove() {

--- a/src/features/home/components/modules/marketing/MarketingBlockExclusivity.native.test.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockExclusivity.native.test.tsx
@@ -68,6 +68,7 @@ describe('MarketingBlockExclusivity', () => {
       moduleName: 'La nuit des temps',
       offerId: '102280',
       isHeadline: false,
+      displayAdvice: false,
     })
   })
 

--- a/src/features/home/components/modules/marketing/MarketingBlockExclusivity.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockExclusivity.tsx
@@ -5,6 +5,8 @@ import { MarketingBlock } from 'features/home/components/modules/marketing/Marke
 import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog'
 import { formatBookingAllowedDatetime } from 'libs/parsers/formatDates'
 import { Offer } from 'shared/offer/types'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { ShadowWrapper } from 'ui/components/ShadowWrapper'
 
 type AttachedOfferCardProps = {
@@ -22,6 +24,7 @@ const UnmemoizedMarketingBlockExclusivity = ({
   backgroundImageUrl,
   shouldDisplayBookingAllowedDatetime,
 }: AttachedOfferCardProps) => {
+  const proAdvicesOnOfferSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
   const logConsultOffer = () => {
     triggerConsultOfferLog({
       offerId: Number.parseInt(offer.objectID),
@@ -29,6 +32,7 @@ const UnmemoizedMarketingBlockExclusivity = ({
       homeEntryId,
       moduleName: offer.offer.name,
       moduleId,
+      displayAdvice: proAdvicesOnOfferSegment === 'A',
     })
   }
   const bookingAllowedDatetime = offer.offer.bookingAllowedDatetime

--- a/src/features/home/components/modules/venues/VenueTile.native.test.tsx
+++ b/src/features/home/components/modules/venues/VenueTile.native.test.tsx
@@ -4,6 +4,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { venuesSearchFixture } from 'libs/algolia/fixtures/venuesSearchFixture'
 import { analytics } from 'libs/analytics/provider'
 import { ILocationContext, LocationMode } from 'libs/location/types'
+import * as ABSegmentModule from 'shared/useABSegment/useABSegment'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent } from 'tests/utils'
 
@@ -39,6 +40,8 @@ jest.mock('libs/location/LocationWrapper', () => ({
   useLocation: () => mockUseLocation(),
 }))
 
+const useABSegmentSpy = jest.spyOn(ABSegmentModule, 'useABSegment')
+
 const user = userEvent.setup()
 jest.useFakeTimers()
 
@@ -61,6 +64,7 @@ describe('VenueTile component', () => {
       from: 'home',
       moduleName: 'le nom du module',
       moduleId: 'module-id',
+      displayAdvice: false,
     })
   })
 
@@ -75,6 +79,22 @@ describe('VenueTile component', () => {
       moduleName: 'le nom du module',
       moduleId: 'module-id',
       homeEntryId: 'abcd',
+      displayAdvice: false,
+    })
+  })
+
+  it('should log analytics event ConsultVenue when pressing on the venue tile with pro advice AB testing segment A', async () => {
+    useABSegmentSpy.mockReturnValueOnce('A')
+    renderVenueTile()
+
+    await user.press(screen.getByLabelText('Le Petit Rintintin 1 - Paris - 75000 - Cinéma'))
+
+    expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
+      venueId: venue.id.toString(),
+      from: 'home',
+      moduleName: 'le nom du module',
+      moduleId: 'module-id',
+      displayAdvice: true,
     })
   })
 

--- a/src/features/home/components/modules/venues/VenueTile.tsx
+++ b/src/features/home/components/modules/venues/VenueTile.tsx
@@ -15,6 +15,8 @@ import { useLocation } from 'libs/location/location'
 import { mapActivityToIcon } from 'libs/parsers/activity'
 import { QueryKeys } from 'libs/queryKeys'
 import { tileAccessibilityLabel, TileContentType } from 'libs/tileAccessibilityLabel'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { ImageTile } from 'ui/components/ImageTile'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Tag } from 'ui/designSystem/Tag/Tag'
@@ -45,6 +47,7 @@ const UnmemoizedVenueTile = (props: VenueTileProps) => {
   const queryClient = useQueryClient()
   const { designSystem } = useTheme()
   const { userLocation, selectedPlace, selectedLocationMode } = useLocation()
+  const proAdvicesOnVenueSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_VENUE)
 
   const distance = getDistance(
     { lat: venue.latitude, lng: venue.longitude },
@@ -63,6 +66,7 @@ const UnmemoizedVenueTile = (props: VenueTileProps) => {
       from: 'home',
       homeEntryId: props.homeEntryId,
       originDetails: props.originDetails,
+      displayAdvice: proAdvicesOnVenueSegment === 'A',
     })
   }
 

--- a/src/features/home/components/modules/venues/VenuesModule.native.test.tsx
+++ b/src/features/home/components/modules/venues/VenuesModule.native.test.tsx
@@ -144,6 +144,7 @@ describe('VenuesModule component', () => {
           moduleId: props.moduleId,
           homeEntryId: props.homeEntryId,
           originDetails: 'volunteeringPlaylist',
+          displayAdvice: false,
         })
       })
     })
@@ -179,6 +180,7 @@ describe('VenuesModule component', () => {
           moduleName: props.displayParameters.title,
           moduleId: props.moduleId,
           homeEntryId: props.homeEntryId,
+          displayAdvice: false,
         })
       })
     })

--- a/src/features/home/components/modules/video/VideoEndView.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoEndView.native.test.tsx
@@ -44,6 +44,7 @@ describe('VideoEndView', () => {
         moduleName: 'salut à tous c’est lujipeka',
         homeEntryId: 'xyz',
         isHeadline: false,
+        displayAdvice: false,
       })
     )
   })

--- a/src/features/home/components/modules/video/VideoEndView.tsx
+++ b/src/features/home/components/modules/video/VideoEndView.tsx
@@ -8,6 +8,8 @@ import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsult
 import { useCategoryIdMapping } from 'libs/subcategories'
 import { Offer } from 'shared/offer/types'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { ArrowAgain } from 'ui/svg/icons/ArrowAgain'
 import { Offers } from 'ui/svg/icons/Offers'
 
@@ -22,6 +24,7 @@ export const VideoEndView: React.FC<{
 }> = ({ onPressReplay, offer, onPressSeeOffer, style, moduleId, moduleName, homeEntryId }) => {
   const prePopulateOffer = usePrePopulateOffer()
   const mapping = useCategoryIdMapping()
+  const proAdvicesOnOfferSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
 
   return (
     <VideoEndViewContainer style={style}>
@@ -49,6 +52,7 @@ export const VideoEndView: React.FC<{
                     moduleId,
                     moduleName,
                     homeEntryId,
+                    displayAdvice: proAdvicesOnOfferSegment === 'A',
                   })
                 }}
                 navigateTo={{

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.native.test.tsx
@@ -66,6 +66,7 @@ describe('VideoMonoOfferTile', () => {
 
     expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
       offerId: mockOffer.objectID,
+      displayAdvice: false,
       ...mockAnalyticsParams,
     })
   })

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
@@ -10,6 +10,8 @@ import { OfferAnalyticsParams } from 'libs/analytics/types'
 import { useCategoryIdMapping } from 'libs/subcategories'
 import { Offer } from 'shared/offer/types'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { getSpacing } from 'ui/theme'
 
@@ -30,6 +32,7 @@ export const VideoMonoOfferTile: FunctionComponent<Props> = ({
   const mapping = useCategoryIdMapping()
   const prePopulateOffer = usePrePopulateOffer()
   const { isDesktopViewport } = useTheme()
+  const proAdvicesOnOfferSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
 
   const offerHeight = isDesktopViewport ? getSpacing(45) : getSpacing(35)
 
@@ -42,7 +45,11 @@ export const VideoMonoOfferTile: FunctionComponent<Props> = ({
     onBeforeNavigate: () => {
       onPressOffer?.()
       prePopulateOffer({ ...offer.offer, offerId: +offer.objectID, categoryId })
-      triggerConsultOfferLog({ offerId: +offer.objectID, ...analyticsParams })
+      triggerConsultOfferLog({
+        offerId: +offer.objectID,
+        displayAdvice: proAdvicesOnOfferSegment === 'A',
+        ...analyticsParams,
+      })
     },
   }
 

--- a/src/features/home/components/modules/video/VideoMultiOfferTile.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoMultiOfferTile.native.test.tsx
@@ -51,6 +51,7 @@ describe('VideoMultiOfferTile', () => {
 
     expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
       offerId: mockOffer.objectID,
+      displayAdvice: false,
       ...mockAnalyticsParams,
     })
   })

--- a/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
@@ -18,6 +18,8 @@ import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay
 import { getOfferDates } from 'shared/date/getOfferDates'
 import { Offer } from 'shared/offer/types'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { getSpacing } from 'ui/theme'
 
@@ -35,6 +37,7 @@ export const VideoMultiOfferTile: FunctionComponent<Props> = ({ offer, analytics
   const prePopulateOffer = usePrePopulateOffer()
   const mapping = useCategoryIdMapping()
   const { subcategoryId, dates, releaseDate, isDuo, thumbUrl, name } = offer.offer
+  const proAdvicesOnOfferSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
 
   const displayPrice = getDisplayedPrice(
     offer?.offer?.prices,
@@ -71,7 +74,11 @@ export const VideoMultiOfferTile: FunctionComponent<Props> = ({ offer, analytics
         accessibilityLabel={accessibilityLabel}
         onBeforeNavigate={() => {
           prePopulateOffer({ ...offer.offer, offerId: +offer.objectID, categoryId })
-          triggerConsultOfferLog({ offerId: +offer.objectID, ...analyticsParams })
+          triggerConsultOfferLog({
+            offerId: +offer.objectID,
+            displayAdvice: proAdvicesOnOfferSegment === 'A',
+            ...analyticsParams,
+          })
         }}
         testId="multi-offer-tile">
         <PlaylistCardOffer

--- a/src/features/offer/components/MoviesScreeningCalendar/MovieOfferTile.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendar/MovieOfferTile.tsx
@@ -17,6 +17,8 @@ import { formatDuration } from 'features/offer/helpers/formatDuration/formatDura
 import { VenueOffers } from 'features/venue/types'
 import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog'
 import { useSubcategoriesMapping } from 'libs/subcategories'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { EventCardList } from 'ui/components/eventCard/EventCardList'
 import { HorizontalOfferTile } from 'ui/components/tiles/HorizontalOfferTile'
 
@@ -51,6 +53,8 @@ export const MovieOfferTile: FC<MovieOfferTileProps> = ({
     movieScreeningUserData,
   } = useOfferCTAButton(offer, subcategoriesMapping[offer.subcategoryId], bookingData)
 
+  const proAdvicesOnOfferSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
+
   const eventCardData = selectedDateScreenings(
     offer.venue.id,
     () => {
@@ -59,6 +63,7 @@ export const MovieOfferTile: FC<MovieOfferTileProps> = ({
         offerId: Number(offerScreeningOnSelectedDates?.objectID),
         from: 'venue',
         venueId: offer.venue.id,
+        displayAdvice: proAdvicesOnOfferSegment === 'A',
       })
     },
     movieScreeningUserData

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -55,6 +55,7 @@ type Props = {
   proAdvices?: AdviceCardData[]
   hasVideoCookiesConsent?: boolean
   isMultiArtistsEnabled?: boolean
+  proAdvicesSegment?: string
 }
 
 export const OfferBody: FunctionComponent<Props> = ({
@@ -71,6 +72,7 @@ export const OfferBody: FunctionComponent<Props> = ({
   proAdvices,
   hasVideoCookiesConsent,
   isMultiArtistsEnabled,
+  proAdvicesSegment,
   onVideoConsentPress,
   onShowOfferArtistsModal,
 }) => {
@@ -272,6 +274,7 @@ export const OfferBody: FunctionComponent<Props> = ({
         subcategory={subcategory}
         distance={distance}
         isOfferAtSameAddressAsVenue={isOfferAtSameAddressAsVenue}
+        proAdvicesSegment={proAdvicesSegment}
       />
     </Container>
   )

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -33,6 +33,8 @@ import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
 import { formatFullAddress } from 'shared/address/addressFormatter'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { isNullOrUndefined } from 'shared/isNullOrUndefined/isNullOrUndefined'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GroupTags } from 'ui/GroupTags/GroupTags'
@@ -94,6 +96,7 @@ export const OfferBody: FunctionComponent<Props> = ({
   const { user } = useAuthContext()
   const currency = useGetCurrencyToDisplay()
   const { data: euroToPacificFrancRate } = usePacificFrancToEuroRate()
+  const proAdvicesOnVenueSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_VENUE)
 
   const extraData = offer.extraData ?? undefined
   const tags = getOfferTags(subcategory.appLabel, extraData)
@@ -213,7 +216,10 @@ export const OfferBody: FunctionComponent<Props> = ({
           showTopComponent={hasVenuePage}
           TopComponent={
             isCinemaOffer || !isOfferAtSameAddressAsVenue ? null : (
-              <OfferVenueButton venue={offer.venue} />
+              <OfferVenueButton
+                venue={offer.venue}
+                proAdvicesOnVenueSegment={proAdvicesOnVenueSegment}
+              />
             )
           }
           showBottomComponent={summaryInfoItems.length > 0}
@@ -274,7 +280,8 @@ export const OfferBody: FunctionComponent<Props> = ({
         subcategory={subcategory}
         distance={distance}
         isOfferAtSameAddressAsVenue={isOfferAtSameAddressAsVenue}
-        proAdvicesSegment={proAdvicesSegment}
+        proAdvicesOnOfferSegment={proAdvicesSegment}
+        proAdvicesOnVenueSegment={proAdvicesOnVenueSegment}
       />
     </Container>
   )

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -446,7 +446,8 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
               isMultiArtistsEnabled={isMultiArtistsEnabled}
               onShowOfferArtistsModal={onShowOfferArtistsModal}
               proAdvicesCount={proAdvicesCount}
-              proAdvices={proAdvices}>
+              proAdvices={proAdvices}
+              proAdvicesSegment={proAdvicesSegment}>
               {theme.isDesktopViewport ? OfferCTAsComponent : null}
             </OfferBody>
           </BodyWrapper>

--- a/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
@@ -408,6 +408,7 @@ describe('<OfferPlace />', () => {
       expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
         venueId: mockOffer.venue.id.toString(),
         from: 'offer',
+        displayAdvice: false,
       })
     })
   })

--- a/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
@@ -316,6 +316,7 @@ describe('<OfferPlace />', () => {
       fromMultivenueOfferId: '146112',
       offerId: '2',
       isHeadline: false,
+      displayAdvice: false,
     })
   })
 

--- a/src/features/offer/components/OfferPlace/OfferPlace.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.tsx
@@ -19,6 +19,7 @@ export type OfferPlaceProps = {
   subcategory: Subcategory
   isOfferAtSameAddressAsVenue: boolean
   distance?: string | null
+  proAdvicesSegment?: string
 }
 
 type PartialVenue = Pick<
@@ -46,6 +47,7 @@ export const OfferPlace: FC<OfferPlaceProps> = ({
   subcategory,
   distance,
   isOfferAtSameAddressAsVenue,
+  proAdvicesSegment,
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
   const queryClient = useQueryClient()
@@ -79,6 +81,7 @@ export const OfferPlace: FC<OfferPlaceProps> = ({
           subcategory={subcategory}
           handleOnSeeVenuePress={handleOnSeeVenuePress}
           isOfferAtSameAddressAsVenue={isOfferAtSameAddressAsVenue}
+          proAdvicesSegment={proAdvicesSegment}
         />
       )}
     </OfferPlaceWrapper>

--- a/src/features/offer/components/OfferPlace/OfferPlace.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.tsx
@@ -19,7 +19,8 @@ export type OfferPlaceProps = {
   subcategory: Subcategory
   isOfferAtSameAddressAsVenue: boolean
   distance?: string | null
-  proAdvicesSegment?: string
+  proAdvicesOnOfferSegment?: string
+  proAdvicesOnVenueSegment?: string
 }
 
 type PartialVenue = Pick<
@@ -47,7 +48,8 @@ export const OfferPlace: FC<OfferPlaceProps> = ({
   subcategory,
   distance,
   isOfferAtSameAddressAsVenue,
-  proAdvicesSegment,
+  proAdvicesOnOfferSegment,
+  proAdvicesOnVenueSegment,
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
   const queryClient = useQueryClient()
@@ -61,7 +63,11 @@ export const OfferPlace: FC<OfferPlaceProps> = ({
     ? async () => {
         // We pre-populate the query-cache with the data from the search result for a smooth transition
         queryClient.setQueryData([QueryKeys.VENUE, offer.venue.id], mergeVenueData(offer.venue))
-        await analytics.logConsultVenue({ venueId: offer.venue.id.toString(), from: 'offer' })
+        await analytics.logConsultVenue({
+          venueId: offer.venue.id.toString(),
+          from: 'offer',
+          displayAdvice: proAdvicesOnVenueSegment === 'A',
+        })
         navigate('Venue', { id: offer.venue.id })
       }
     : undefined
@@ -81,7 +87,7 @@ export const OfferPlace: FC<OfferPlaceProps> = ({
           subcategory={subcategory}
           handleOnSeeVenuePress={handleOnSeeVenuePress}
           isOfferAtSameAddressAsVenue={isOfferAtSameAddressAsVenue}
-          proAdvicesSegment={proAdvicesSegment}
+          proAdvicesSegment={proAdvicesOnOfferSegment}
         />
       )}
     </OfferPlaceWrapper>

--- a/src/features/offer/components/OfferTile/OfferTile.native.test.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.native.test.tsx
@@ -8,6 +8,7 @@ import { PlaylistType } from 'features/offer/enums'
 import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
 import { analytics } from 'libs/analytics/provider'
 import { NAVIGATION_METHOD } from 'shared/constants'
+import * as ABSegmentModule from 'shared/useABSegment/useABSegment'
 import { queryCache, reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent } from 'tests/utils'
 
@@ -21,6 +22,8 @@ mockUseNavigation.mockReturnValue({
   navigate: mockNavigate,
   push: mockPush,
 })
+
+const useABSegmentSpy = jest.spyOn(ABSegmentModule, 'useABSegment')
 
 const OFFER = mockedAlgoliaResponse.hits[0].offer
 const OFFER_LOCATION = mockedAlgoliaResponse.hits[0]._geoloc
@@ -133,6 +136,21 @@ describe('OfferTile component', () => {
         from: 'home',
         moduleName: props.moduleName,
         isHeadline: false,
+        displayAdvice: false,
+      })
+    })
+
+    it('should log ConsultOffer that user opened the offer and pro advices AB testing segment is A', async () => {
+      useABSegmentSpy.mockReturnValueOnce('A')
+      render(reactQueryProviderHOC(<OfferTile {...props} />))
+      await user.press(screen.getByTestId('tileImage'))
+
+      expect(analytics.logConsultOffer).toHaveBeenCalledWith({
+        offerId: String(OFFER_ID),
+        from: 'home',
+        moduleName: props.moduleName,
+        isHeadline: false,
+        displayAdvice: true,
       })
     })
 
@@ -159,6 +177,7 @@ describe('OfferTile component', () => {
         fromOfferId: '1',
         playlistType: PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS,
         isHeadline: false,
+        displayAdvice: false,
       })
     })
 
@@ -172,6 +191,7 @@ describe('OfferTile component', () => {
         moduleName: props.moduleName,
         homeEntryId: 'abcd',
         isHeadline: false,
+        displayAdvice: false,
       })
     })
 
@@ -203,6 +223,7 @@ describe('OfferTile component', () => {
         venueId: 1,
         searchId,
         isHeadline: false,
+        displayAdvice: false,
       })
     })
 
@@ -232,6 +253,7 @@ describe('OfferTile component', () => {
         playlistType: undefined,
         venueId: undefined,
         isHeadline: false,
+        displayAdvice: false,
       })
     })
 
@@ -262,6 +284,7 @@ describe('OfferTile component', () => {
         moduleId: undefined,
         venueId: undefined,
         isHeadline: false,
+        displayAdvice: false,
       })
     })
   })

--- a/src/features/offer/components/OfferTile/OfferTile.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.tsx
@@ -11,6 +11,8 @@ import { useLocation } from 'libs/location/location'
 import { tileAccessibilityLabel, TileContentType } from 'libs/tileAccessibilityLabel'
 import { NAVIGATION_METHOD } from 'shared/constants'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
@@ -43,6 +45,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
   const { onFocus, onBlur, isFocus } = useHandleFocus()
   const prePopulateOffer = usePrePopulateOffer()
   const { userLocation, selectedPlace, selectedLocationMode } = useLocation()
+  const proAdvicesOnOfferSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
 
   const { offerId, name, date, price, categoryId, thumbUrl, offerLocation, subcategoryId } = props
 
@@ -85,6 +88,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
       searchId,
       index,
       artistName,
+      displayAdvice: proAdvicesOnOfferSegment === 'A',
     })
   }
 

--- a/src/features/offer/components/OfferVenueButton/OfferVenueButton.native.test.tsx
+++ b/src/features/offer/components/OfferVenueButton/OfferVenueButton.native.test.tsx
@@ -44,6 +44,7 @@ describe('<OfferVenueButton />', () => {
     expect(analytics.logConsultVenue).toHaveBeenCalledWith({
       venueId: offerResponseSnap.venue.id.toString(),
       from: 'offer',
+      displayAdvice: false,
     })
   })
 })

--- a/src/features/offer/components/OfferVenueButton/OfferVenueButton.tsx
+++ b/src/features/offer/components/OfferVenueButton/OfferVenueButton.tsx
@@ -10,9 +10,10 @@ import { Typo } from 'ui/theme'
 
 interface Props {
   venue: OfferVenueResponse
+  proAdvicesOnVenueSegment?: string
 }
 
-export function OfferVenueButton({ venue }: Readonly<Props>) {
+export function OfferVenueButton({ venue, proAdvicesOnVenueSegment }: Readonly<Props>) {
   const { designSystem, icons } = useTheme()
 
   return (
@@ -26,7 +27,11 @@ export function OfferVenueButton({ venue }: Readonly<Props>) {
       }
       navigateTo={{ screen: 'Venue', params: { id: venue.id } }}
       onBeforeNavigate={() =>
-        analytics.logConsultVenue({ venueId: venue.id.toString(), from: 'offer' })
+        analytics.logConsultVenue({
+          venueId: venue.id.toString(),
+          from: 'offer',
+          displayAdvice: proAdvicesOnVenueSegment === 'A',
+        })
       }
       accessibilityLabel={`Accéder à la page du lieu ${venue.name}`}
     />

--- a/src/features/offer/components/OfferVenueContainer/OfferVenueContainer.tsx
+++ b/src/features/offer/components/OfferVenueContainer/OfferVenueContainer.tsx
@@ -25,6 +25,7 @@ type Props = {
   handleOnSeeVenuePress?: VoidFunction
   isOfferAtSameAddressAsVenue: boolean
   distance?: string | null
+  proAdvicesSegment?: string
 }
 
 export const OfferVenueContainer: FC<Props> = ({
@@ -33,6 +34,7 @@ export const OfferVenueContainer: FC<Props> = ({
   subcategory,
   handleOnSeeVenuePress,
   isOfferAtSameAddressAsVenue,
+  proAdvicesSegment,
 }) => {
   const venueSectionTitle = getVenueSectionTitle(offer.subcategoryId, subcategory.isEvent)
 
@@ -104,6 +106,7 @@ export const OfferVenueContainer: FC<Props> = ({
       offerId: nextOfferId,
       from: 'offer',
       fromMultivenueOfferId: offer.id,
+      displayAdvice: proAdvicesSegment === 'A',
     })
     navigate('Offer', {
       fromOfferId: offer.id,

--- a/src/features/search/components/SearchSuggestions/SearchSuggestions.tsx
+++ b/src/features/search/components/SearchSuggestions/SearchSuggestions.tsx
@@ -22,6 +22,8 @@ import { env } from 'libs/environment/env'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useLocation } from 'libs/location/location'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { Button } from 'ui/designSystem/Button/Button'
 import { AISearch } from 'ui/svg/icons/AISearch'
 
@@ -56,6 +58,7 @@ export const SearchSuggestions = ({
   const shouldDisplayArtistsSuggestions = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_ARTISTS_SUGGESTIONS_IN_SEARCH
   )
+  const proAdvicesOnVenueSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_VENUE)
 
   useEffect(() => {
     setOptions({
@@ -121,7 +124,11 @@ export const SearchSuggestions = ({
 
   const onVenuePress = async (venueId: number) => {
     hideSuggestions()
-    await analytics.logConsultVenue({ venueId: venueId.toString(), from: 'searchAutoComplete' })
+    await analytics.logConsultVenue({
+      venueId: venueId.toString(),
+      from: 'searchAutoComplete',
+      displayAdvice: proAdvicesOnVenueSegment === 'A',
+    })
     navigate('Venue', { id: venueId })
   }
 

--- a/src/features/search/components/SearchVenueItems/SearchVenueItem.native.test.tsx
+++ b/src/features/search/components/SearchVenueItems/SearchVenueItem.native.test.tsx
@@ -101,6 +101,7 @@ describe('<SearchVenueItem />', () => {
       venueId: mockAlgoliaVenue.objectID,
       searchId,
       from: 'searchVenuePlaylist',
+      displayAdvice: false,
     })
   })
 

--- a/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
+++ b/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
@@ -17,6 +17,8 @@ import { mapActivityToIcon } from 'libs/parsers/activity'
 import { QueryKeys } from 'libs/queryKeys'
 import { queryClient } from 'libs/react-query/queryClient'
 import { tileAccessibilityLabel, TileContentType } from 'libs/tileAccessibilityLabel'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { ImageTile } from 'ui/components/ImageTile'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Tag } from 'ui/designSystem/Tag/Tag'
@@ -51,6 +53,7 @@ const UnmemoizedSearchVenueItem = ({
   const { designSystem } = useTheme()
   const { lat, lng } = venue._geoloc
   const distance = getDistance({ lat, lng }, { userLocation, selectedPlace, selectedLocationMode })
+  const proAdvicesOnVenueSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_VENUE)
 
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.VENUE, {
     ...venue,
@@ -65,6 +68,7 @@ const UnmemoizedSearchVenueItem = ({
       venueId: venue.objectID,
       searchId,
       from: 'searchVenuePlaylist',
+      displayAdvice: proAdvicesOnVenueSegment === 'A',
     })
 
     const currentQueryID = algoliaAnalyticsSelectors.selectCurrentQueryID()

--- a/src/features/search/pages/SearchLanding/SearchLanding.native.test.tsx
+++ b/src/features/search/pages/SearchLanding/SearchLanding.native.test.tsx
@@ -318,6 +318,7 @@ describe('<SearchLanding />', () => {
       expect(analytics.logConsultVenue).toHaveBeenCalledWith({
         from: 'searchAutoComplete',
         venueId: '1',
+        displayAdvice: false,
       })
     })
 

--- a/src/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx
+++ b/src/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx
@@ -352,6 +352,7 @@ describe('<SearchResults/>', () => {
       expect(analytics.logConsultVenue).toHaveBeenCalledWith({
         from: 'searchAutoComplete',
         venueId: '1',
+        displayAdvice: false,
       })
     })
 

--- a/src/features/search/pages/ThematicSearch/ThematicSearchPlaylist.native.test.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearchPlaylist.native.test.tsx
@@ -32,6 +32,7 @@ describe('ThematicSearchPlaylist', () => {
       index: 0,
       offerId: '1',
       isHeadline: false,
+      displayAdvice: false,
     })
   })
 })

--- a/src/features/venue/pages/Venue/Venue.native.test.tsx
+++ b/src/features/venue/pages/Venue/Venue.native.test.tsx
@@ -303,12 +303,30 @@ describe('<Venue />', () => {
     it.each([['deeplink'], ['venueMap']])(
       'should log consult venue when URL from param equal to %s',
       async (from) => {
+        abTestOverridesActions.setOverride(AB_TESTS.PRO_REVIEWS_ON_VENUE, 'B')
         renderVenue(venueId, from as Referrals)
 
         await waitFor(() => {
           expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
             venueId: venueId.toString(),
             from,
+            displayAdvice: false,
+          })
+        })
+      }
+    )
+
+    it.each([['deeplink'], ['venueMap']])(
+      'should log consult venue when URL from param equal to %s and pro advices segment AB Testing is A',
+      async (from) => {
+        abTestOverridesActions.setOverride(AB_TESTS.PRO_REVIEWS_ON_VENUE, 'A')
+        renderVenue(venueId, from as Referrals)
+
+        await waitFor(() => {
+          expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
+            venueId: venueId.toString(),
+            from,
+            displayAdvice: true,
           })
         })
       }

--- a/src/features/venue/pages/Venue/Venue.tsx
+++ b/src/features/venue/pages/Venue/Venue.tsx
@@ -166,9 +166,13 @@ export const Venue: FunctionComponent = () => {
 
   useEffect(() => {
     if ((params.from === 'deeplink' || params.from === 'venueMap') && venue?.id) {
-      void analytics.logConsultVenue({ venueId: venue.id.toString(), from: params.from })
+      void analytics.logConsultVenue({
+        venueId: venue.id.toString(),
+        from: params.from,
+        displayAdvice: proAdvicesSegment === 'A',
+      })
     }
-  }, [params.from, venue?.id])
+  }, [params.from, proAdvicesSegment, venue?.id])
 
   const isCTADisplayed =
     venue?.activity !== Activity.CINEMA &&

--- a/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.native.test.tsx
@@ -317,6 +317,7 @@ describe('VenueMapViewContainer', () => {
     expect(analytics.logConsultVenue).toHaveBeenCalledWith({
       venueId: venuesFixture[0].venueId.toString(),
       from: 'venueMap',
+      displayAdvice: false,
     })
   })
 

--- a/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.tsx
@@ -41,6 +41,8 @@ import { useLocation } from 'libs/location/location'
 import { Map, MarkerPressEvent, Region } from 'libs/maps/maps'
 import { useVenueOffersQuery } from 'queries/venue/useVenueOffersQuery'
 import { usePageTracking } from 'shared/tracking/usePageTracking'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { LENGTH_L } from 'ui/theme'
 
 import { VenueMapView } from './VenueMapView'
@@ -106,6 +108,7 @@ export const VenueMapViewContainer: FunctionComponent = () => {
     transformHits,
     venue,
   })
+  const proAdvicesOnVenueSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_VENUE)
 
   const hasOffers = !!selectedVenueOffers && selectedVenueOffers.hits?.length
   const contentViewHeight = useMemo(() => {
@@ -195,6 +198,7 @@ export const VenueMapViewContainer: FunctionComponent = () => {
     analytics.logConsultVenue({
       venueId: venueId.toString(),
       from: camelCase(routeName) as Referrals,
+      displayAdvice: proAdvicesOnVenueSegment === 'A',
     })
   }
 

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -321,6 +321,7 @@ export const logEventAnalytics = {
     originDetails?: string
     adviceType?: 'book_club' | 'cine_club' | 'pro'
     offerId?: string
+    displayAdvice?: boolean
   }) => analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_VENUE }, params),
   logConsultVenueMap: ({ from, searchId }: { from: Referrals; searchId?: string }) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_VENUE_MAP }, { from, searchId }),

--- a/src/libs/analytics/types.ts
+++ b/src/libs/analytics/types.ts
@@ -46,4 +46,5 @@ export type ConsultOfferLogParams = {
   isHeadline?: boolean
   adviceType?: 'book_club' | 'cine_club' | 'pro'
   originDetails?: string
+  displayAdvice?: boolean
 }

--- a/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
@@ -122,6 +122,7 @@ describe('HorizontalOfferTile component', () => {
       index: 0,
       searchId: '539b285e',
       isHeadline: false,
+      displayAdvice: false,
     })
   })
 

--- a/src/ui/components/tiles/HorizontalOfferTile.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.tsx
@@ -24,6 +24,8 @@ import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay
 import { getOfferDates } from 'shared/date/getOfferDates'
 import { Offer } from 'shared/offer/types'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
+import { AB_TESTS } from 'shared/useABSegment/abTests'
+import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { OfferName } from 'ui/components/tiles/OfferName'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -73,6 +75,7 @@ export const HorizontalOfferTile = ({
   const currency = useGetCurrencyToDisplay()
   const { data: euroToPacificFrancRate } = usePacificFrancToEuroRate()
   const prePopulateOffer = usePrePopulateOffer()
+  const proAdvicesOnOfferSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
 
   const userPosition =
     currentRoute === 'SearchResults' &&
@@ -128,7 +131,7 @@ export const HorizontalOfferTile = ({
 
     triggerConsultOfferLog({
       offerId,
-
+      displayAdvice: proAdvicesOnOfferSegment === 'A',
       ...analyticsParams,
     })
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42109

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
