### PR TITLE
(PC-42101) fix(web): guard against null document.body in reanimated M…

### DIFF
--- a/.yarn/patches/react-native-reanimated-npm-4.1.7-30a13d0d8a.patch
+++ b/.yarn/patches/react-native-reanimated-npm-4.1.7-30a13d0d8a.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/module/layoutReanimation/web/domUtils.js b/lib/module/layoutReanimation/web/domUtils.js
+index ee9e030a46abc67e6735cffe2ee08e2d234bf712..23177f6cb0c619534d22d17bdba4c1eff82d9eb6 100644
+--- a/lib/module/layoutReanimation/web/domUtils.js
++++ b/lib/module/layoutReanimation/web/domUtils.js
+@@ -135,7 +135,10 @@ function checkIfScreenWasChanged(mutationTarget) {
+   return mutationTarget[reactFiberKey]?.child?.memoizedProps?.navigation !== undefined;
+ }
+ export function addHTMLMutationObserver() {
+-  if (isObserverSet || !IS_WINDOW_AVAILABLE) {
++  // `document.body` can be null while `window` exists (e.g. during page teardown/unload),
++  // which makes `observer.observe(document.body, ...)` throw. Bail out before setting
++  // `isObserverSet` so the observer can still be installed on a later mount.
++  if (isObserverSet || !IS_WINDOW_AVAILABLE || !document.body) {
+     return;
+   }
+   isObserverSet = true;

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "react-native-performance": "^5.1.4",
     "react-native-permissions": "^5.4.1",
     "react-native-qrcode-svg": "^6.1.2",
-    "react-native-reanimated": "~4.1.7",
+    "react-native-reanimated": "patch:react-native-reanimated@npm%3A4.1.7#~/.yarn/patches/react-native-reanimated-npm-4.1.7-30a13d0d8a.patch",
     "react-native-reanimated-carousel": "^4.0.2",
     "react-native-safe-area-context": "^5.5.1",
     "react-native-screens": "^4.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11793,7 +11793,7 @@ __metadata:
     react-native-performance: "npm:^5.1.4"
     react-native-permissions: "npm:^5.4.1"
     react-native-qrcode-svg: "npm:^6.1.2"
-    react-native-reanimated: "npm:~4.1.7"
+    react-native-reanimated: "patch:react-native-reanimated@npm%3A4.1.7#~/.yarn/patches/react-native-reanimated-npm-4.1.7-30a13d0d8a.patch"
     react-native-reanimated-carousel: "npm:^4.0.2"
     react-native-safe-area-context: "npm:^5.5.1"
     react-native-screens: "npm:^4.11.1"
@@ -24216,7 +24216,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-reanimated@npm:~4.1.7":
+"react-native-reanimated@npm:4.1.7":
   version: 4.1.7
   resolution: "react-native-reanimated@npm:4.1.7"
   dependencies:
@@ -24227,6 +24227,20 @@ __metadata:
     react-native: 0.78 - 0.82
     react-native-worklets: 0.5 - 0.8
   checksum: 10/7635d929c138a8beb3411db54e9f8869fa3331c274cd50ef22289736f2b4a115292bc97ef13ea0e717764ab0470af50a38acd4cbb1371b44a56b2ecf449c5207
+  languageName: node
+  linkType: hard
+
+"react-native-reanimated@patch:react-native-reanimated@npm%3A4.1.7#~/.yarn/patches/react-native-reanimated-npm-4.1.7-30a13d0d8a.patch":
+  version: 4.1.7
+  resolution: "react-native-reanimated@patch:react-native-reanimated@npm%3A4.1.7#~/.yarn/patches/react-native-reanimated-npm-4.1.7-30a13d0d8a.patch::version=4.1.7&hash=a0785c"
+  dependencies:
+    react-native-is-edge-to-edge: "npm:^1.2.1"
+    semver: "npm:^7.7.2"
+  peerDependencies:
+    react: "*"
+    react-native: 0.78 - 0.82
+    react-native-worklets: 0.5 - 0.8
+  checksum: 10/f0fc21cf6d705b24180adc7677ceee60ac720246b3641df90ba443ed43ceb86874acd87ccd0c2bb0f78c1bbb617393e6d672348dbb12787b7600d4f9e7e2d10f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
…utationObserver

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42101

## Contexte

Erreur récurrente remontée en production sur le **web uniquement** :

> `TypeError: Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'.`

- **First seen** il y a ~2 mois (release `1.384.2-web`), **last seen** récemment (`1.392.0-web`) → bug ancien qui traverse de nombreuses releases.
- `handled: true` → non-fatal, mais génère un bruit constant dans Sentry.
- Déclenché lors de la navigation sur les **pages Offre** (breadcrumbs : `GET /native/v3/offer/...`, `recommendation/similar_offers`).

## Cause

L'erreur est **interne à `react-native-reanimated@4.1.7`** (et non à notre code — `useLaunchPerformanceObserver` utilise `PerformanceObserver`, `IntersectionObserver.web` utilise `globalThis.IntersectionObserver`, aucun rapport).

Au démontage d'un composant portant une animation `exiting`, `AnimatedComponent.componentWillUnmount()` appelle `addHTMLMutationObserver()` (`layoutReanimation/web/domUtils.js`). Cette fonction ne se protège que via `IS_WINDOW_AVAILABLE` (`typeof window !== 'undefined'`) puis exécute `observer.observe(document.body, …)` **sans vérifier que `document.body` existe**. Quand `document.body` est `null` (typiquement pendant un teardown/unload de page en transition de navigation), `observe()` lève le `TypeError`.

## Correctif

Patch défensif via **patch-package** (déjà en place dans le projet) : ajout de `!document.body` au early-return de `addHTMLMutationObserver`.

```diff
 export function addHTMLMutationObserver() {
-  if (isObserverSet || !IS_WINDOW_AVAILABLE) {
+  if (isObserverSet || !IS_WINDOW_AVAILABLE || !document.body) {
     return;
   }