### PR TITLE
(PC-42033) feat(offer): use InfoHeader when single artist rather than playlist

### DIFF
--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.native.test.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.native.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 
-import { CategoryIdEnum, SubcategoryIdEnum } from 'api/gen'
+import { navigate } from '__mocks__/@react-navigation/native'
+import { ArtistType, CategoryIdEnum, SubcategoryIdEnum } from 'api/gen'
 import { OfferArtistsSection } from 'features/offer/components/OfferArtistsSection/OfferArtistsSection'
-import { render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 const mockArtist = { id: '1', name: 'Edith Piaf' }
 const mockMultiArtists = [
@@ -11,58 +12,121 @@ const mockMultiArtists = [
   { id: '3', name: 'Sigourney Weaver' },
 ]
 
+const user = userEvent.setup()
+
+jest.useFakeTimers()
+
 describe('<OfferArtistsSection />', () => {
-  it('should display single artist', () => {
-    render(
-      <OfferArtistsSection
-        artists={[mockArtist]}
-        offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-        offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-        onPlaylistItemPress={jest.fn()}
-      />
-    )
+  describe('When single artist', () => {
+    it('should display correctly', () => {
+      render(
+        <OfferArtistsSection
+          artists={[mockArtist]}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
 
-    expect(screen.getByText('Edith Piaf')).toBeOnTheScreen()
+      expect(screen.getByText('Edith Piaf')).toBeOnTheScreen()
+    })
+
+    it('should display default avatar when image not defined', () => {
+      render(
+        <OfferArtistsSection
+          artists={[mockArtist]}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
+
+      expect(screen.getByTestId('defaultArtistAvatar')).toBeOnTheScreen()
+    })
+
+    it('should display artist image when image defined', () => {
+      render(
+        <OfferArtistsSection
+          artists={[{ ...mockArtist, image: 'url' }]}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
+
+      expect(screen.getByTestId('ArtistImage')).toBeOnTheScreen()
+    })
+
+    it('should display role as subtitle when role defined', () => {
+      render(
+        <OfferArtistsSection
+          artists={[{ ...mockArtist, role: ArtistType.author }]}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
+
+      expect(screen.getByText('Auteur')).toBeOnTheScreen()
+      expect(screen.getByTestId('subtitleWithTitle')).toBeOnTheScreen()
+    })
+
+    it('should redirect to artist page when pressing button', async () => {
+      render(
+        <OfferArtistsSection
+          artists={[mockArtist]}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
+
+      await user.press(screen.getByLabelText('Accéder à la page artiste de Edith Piaf'))
+
+      expect(navigate).toHaveBeenCalledWith('Artist', { id: '1' })
+    })
+
+    it('should display singular section title', () => {
+      render(
+        <OfferArtistsSection
+          artists={[mockArtist]}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
+
+      expect(screen.getAllByText('Artiste')[0]).toBeOnTheScreen()
+    })
   })
 
-  it('should display singular section title when single artist', () => {
-    render(
-      <OfferArtistsSection
-        artists={[mockArtist]}
-        offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-        offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-        onPlaylistItemPress={jest.fn()}
-      />
-    )
+  describe('When multi artists', () => {
+    it('should display correctly', () => {
+      render(
+        <OfferArtistsSection
+          artists={mockMultiArtists}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
 
-    expect(screen.getAllByText('Artiste')[0]).toBeOnTheScreen()
-  })
+      expect(screen.getByText('Sam Worthington')).toBeOnTheScreen()
+      expect(screen.getByText('Zoe Saldana')).toBeOnTheScreen()
+      expect(screen.getByText('Sigourney Weaver')).toBeOnTheScreen()
+    })
 
-  it('should display multi artists', () => {
-    render(
-      <OfferArtistsSection
-        artists={mockMultiArtists}
-        offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-        offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-        onPlaylistItemPress={jest.fn()}
-      />
-    )
+    it('should display plural section title', () => {
+      render(
+        <OfferArtistsSection
+          artists={mockMultiArtists}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
 
-    expect(screen.getByText('Sam Worthington')).toBeOnTheScreen()
-    expect(screen.getByText('Zoe Saldana')).toBeOnTheScreen()
-    expect(screen.getByText('Sigourney Weaver')).toBeOnTheScreen()
-  })
-
-  it('should display plural section title when multi artists', () => {
-    render(
-      <OfferArtistsSection
-        artists={mockMultiArtists}
-        offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-        offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-        onPlaylistItemPress={jest.fn()}
-      />
-    )
-
-    expect(screen.getByText('Artistes')).toBeOnTheScreen()
+      expect(screen.getByText('Artistes')).toBeOnTheScreen()
+    })
   })
 })

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
@@ -1,10 +1,19 @@
 import React, { FunctionComponent } from 'react'
+import { styled, useTheme } from 'styled-components/native'
 
 import { CategoryIdEnum, OfferArtist, SubcategoryIdEnum } from 'api/gen'
 import { formatArtists } from 'features/artist/helpers/formatArtists'
+import { getArtistRole } from 'features/artist/helpers/getArtistRole'
 import { getArtistSectionTitle } from 'features/artist/helpers/getArtistSectionTitle'
+import { FastImage } from 'libs/resizing-image-on-demand/FastImage'
+import { accessibilityRoleInternalNavigation } from 'shared/accessibility/helpers/accessibilityRoleInternalNavigation'
+import { Avatar } from 'ui/components/Avatar/Avatar'
 import { AvatarList } from 'ui/components/Avatar/AvatarList'
+import { DefaultAvatar } from 'ui/components/Avatar/DefaultAvatar'
+import { InfoHeader } from 'ui/components/InfoHeader/InfoHeader'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { Typo } from 'ui/theme'
 import { AVATAR_MEDIUM } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
@@ -22,20 +31,60 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
   offerSubcategoryId,
   onPlaylistItemPress,
 }) => {
+  const { designSystem } = useTheme()
   const sectionTitle = getArtistSectionTitle(offerSubcategoryId)
   const formattedArtists = formatArtists(artists, offerCategoryId)
+
+  const soloArtist = artists[0]
 
   return (
     <ViewGap gap={4}>
       <Typo.Title4 {...getHeadingAttrs(2)}>
         {artists.length === 1 ? sectionTitle.singular : sectionTitle.plural}
       </Typo.Title4>
-      <AvatarList
-        data={formattedArtists}
-        avatarConfig={{ size: AVATAR_MEDIUM }}
-        onItemPress={onPlaylistItemPress}
-        withMargins={false}
-      />
+      {artists.length === 1 && soloArtist ? (
+        <InternalTouchableLink
+          navigateTo={{ screen: 'Artist', params: { id: soloArtist.id } }}
+          accessibilityLabel={`Accéder à la page artiste de ${soloArtist.name}`}
+          accessibilityRole={accessibilityRoleInternalNavigation()}
+          onBeforeNavigate={() => onPlaylistItemPress(soloArtist.id ?? '', soloArtist.name)}>
+          <InfoHeader
+            title={soloArtist.name}
+            subtitle={soloArtist.role ? getArtistRole(soloArtist.role, offerCategoryId) : undefined}
+            defaultThumbnailSize={AVATAR_MEDIUM}
+            thumbnailComponent={
+              <Avatar
+                size={AVATAR_MEDIUM}
+                rounded={false}
+                borderRadius={designSystem.size.borderRadius.pill}>
+                {soloArtist.image ? (
+                  <ArtistImage url={soloArtist.image} testID="ArtistImage" />
+                ) : (
+                  <DefaultAvatar testID="defaultArtistAvatar" />
+                )}
+              </Avatar>
+            }
+            rightComponent={<RightFilled size={designSystem.size.icon.s} testID="RightFilled" />}
+          />
+        </InternalTouchableLink>
+      ) : (
+        <AvatarList
+          data={formattedArtists}
+          avatarConfig={{ size: AVATAR_MEDIUM }}
+          onItemPress={onPlaylistItemPress}
+          withMargins={false}
+        />
+      )}
     </ViewGap>
   )
 }
+
+const ArtistImage = styled(FastImage)(({ theme }) => ({
+  width: '100%',
+  height: '100%',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: theme.designSystem.color.background.subtle,
+  borderWidth: 1,
+  borderColor: theme.designSystem.color.border.subtle,
+}))

--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -742,7 +742,7 @@ describe('<OfferBody />', () => {
       expect(screen.getByText('Écrivains')).toBeOnTheScreen()
     })
 
-    it('should trigger ConsultArtist log when pressing artist playlist item', async () => {
+    it('should trigger ConsultArtist log when pressing artist playlist item and offer has several artists', async () => {
       const offer: OfferResponse = {
         ...offerResponseSnap,
         subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
@@ -750,6 +750,28 @@ describe('<OfferBody />', () => {
           { id: '1', name: 'Stephen King' },
           { id: '2', name: 'Robert McCammon' },
         ],
+      }
+
+      renderOfferBody({
+        offer,
+        subcategory: mockSubcategoryBook,
+        isMultiArtistsEnabled: true,
+      })
+
+      await user.press(screen.getByLabelText('Accéder à la page artiste de Stephen King'))
+
+      expect(analytics.logConsultArtist).toHaveBeenCalledWith({
+        artistId: '1',
+        artistName: 'Stephen King',
+        from: 'offer',
+      })
+    })
+
+    it('should trigger ConsultArtist log when pressing artist playlist item and offer has single artist', async () => {
+      const offer: OfferResponse = {
+        ...offerResponseSnap,
+        subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
+        artists: [{ id: '1', name: 'Stephen King' }],
       }
 
       renderOfferBody({

--- a/src/ui/components/InfoHeader/InfoHeader.tsx
+++ b/src/ui/components/InfoHeader/InfoHeader.tsx
@@ -30,7 +30,7 @@ export const InfoHeader: FunctionComponent<InfoHeaderProps> = ({
 }) => {
   const numberOfLines = useNumberOfLine(2)
   const subtitleComponent = title ? (
-    <Subtitle testID="subtitileWithTitle" numberOfLines={numberOfLines}>
+    <Subtitle testID="subtitleWithTitle" numberOfLines={numberOfLines}>
       {subtitle}
     </Subtitle>
   ) : (


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42033

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="329" height="224" alt="Capture d’écran 2026-06-02 à 10 31 35" src="https://github.com/user-attachments/assets/7b0587ba-fa55-40e9-afbd-ff15727c1cec" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-02 at 10 36 50" src="https://github.com/user-attachments/assets/3093d5fc-902f-41d2-b564-8bed9503960f" />|
| Android          |               |<img width="1080" height="2400" alt="Screenshot_1780389690" src="https://github.com/user-attachments/assets/050930de-5974-4fff-a37e-cbb765274c51" />|
| Phone - Chrome   |               |<img width="420" height="695" alt="Capture d’écran 2026-06-02 à 10 32 33" src="https://github.com/user-attachments/assets/d6e490f6-af6e-4b5a-93c2-8aeb370e0408" />|
| Desktop - Chrome |               |<img width="1513" height="774" alt="Capture d’écran 2026-06-02 à 10 32 22" src="https://github.com/user-attachments/assets/7e29c463-17d4-47aa-b0c2-5b2ac5bb88eb" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
