### PR TITLE
(PC-37478) feat(a11y): screen reader reads tooltips and security rules are read only one time

### DIFF
--- a/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
@@ -445,7 +445,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
                     testID="styled-input-container"
                   >
                     <TextInput
-                      accessibilityLabel="Champs de texte - Mot de passe - Obligatoire - Le mot de passe doit contenir au moins 12 caractères, 1 majuscule, 1 minuscule, 1 chiffre et un caractère spécial"
+                      accessibilityLabel="Champs de texte - Mot de passe - Obligatoire - 12 caractères - au minimum, 1 majuscule - au minimum, 1 minuscule - au minimum, 1 chiffre - au minimum, 1 caractère spécial (!@#$%^&*...) - au minimum"
                       accessibilityRequired={true}
                       autoCapitalize="none"
                       autoComplete="new-password"
@@ -552,9 +552,10 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
                   Le mot de passe doit contenir au moins 12 caractères, 1 majuscule, 1 minuscule, 1 chiffre et un caractère spécial
                 </Text>
                 <View
-                  accessibilityAtomic={false}
-                  accessibilityRole="none"
+                  accessibilityElementsHidden={true}
+                  accessible={false}
                   gap={1}
+                  importantForAccessibility="no-hide-descendants"
                   isVisible={true}
                   style={
                     {
@@ -899,7 +900,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
                     testID="styled-input-container"
                   >
                     <TextInput
-                      accessibilityLabel="Champs de texte - Confirmer le mot de passe - Obligatoire - La confirmation de mot de passe est obligatoire"
+                      accessibilityLabel="Champs de texte - Confirmer le mot de passe - Obligatoire - erreur  La confirmation de mot de passe est obligatoire"
                       accessibilityRequired={true}
                       autoCapitalize="none"
                       autoComplete="new-password"

--- a/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
@@ -104,7 +104,7 @@ exports[`SetPassword Page should render correctly 1`] = `
           testID="styled-input-container"
         >
           <TextInput
-            accessibilityLabel="Champs de texte - Mot de passe - Le mot de passe doit contenir au moins 12 caractères, 1 majuscule, 1 minuscule, 1 chiffre et un caractère spécial"
+            accessibilityLabel="Champs de texte - Mot de passe - 12 caractères - au minimum, 1 majuscule - au minimum, 1 minuscule - au minimum, 1 chiffre - au minimum, 1 caractère spécial (!@#$%^&*...) - au minimum"
             accessibilityRequired={false}
             autoCapitalize="none"
             autoComplete="current-password"
@@ -210,9 +210,10 @@ exports[`SetPassword Page should render correctly 1`] = `
         Le mot de passe doit contenir au moins 12 caractères, 1 majuscule, 1 minuscule, 1 chiffre et un caractère spécial
       </Text>
       <View
-        accessibilityAtomic={false}
-        accessibilityRole="none"
+        accessibilityElementsHidden={true}
+        accessible={false}
         gap={1}
+        importantForAccessibility="no-hide-descendants"
         isVisible={true}
         style={
           {

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -1389,7 +1389,7 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
                 testID="styled-input-container"
               >
                 <TextInput
-                  accessibilityLabel="Champs de texte - Mot de passe - Le mot de passe doit contenir au moins 12 caractères, 1 majuscule, 1 minuscule, 1 chiffre et un caractère spécial"
+                  accessibilityLabel="Champs de texte - Mot de passe - 12 caractères - au minimum, 1 majuscule - au minimum, 1 minuscule - au minimum, 1 chiffre - au minimum, 1 caractère spécial (!@#$%^&*...) - au minimum"
                   accessibilityRequired={false}
                   autoCapitalize="none"
                   autoComplete="current-password"
@@ -1495,9 +1495,10 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
               Le mot de passe doit contenir au moins 12 caractères, 1 majuscule, 1 minuscule, 1 chiffre et un caractère spécial
             </Text>
             <View
-              accessibilityAtomic={false}
-              accessibilityRole="none"
+              accessibilityElementsHidden={true}
+              accessible={false}
               gap={1}
+              importantForAccessibility="no-hide-descendants"
               isVisible={true}
               style={
                 {

--- a/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
@@ -428,7 +428,7 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
                       testID="styled-input-container"
                     >
                       <TextInput
-                        accessibilityLabel="Champs de texte - Mot de passe - Obligatoire - Le mot de passe doit contenir au moins 12 caractères, 1 majuscule, 1 minuscule, 1 chiffre et un caractère spécial"
+                        accessibilityLabel="Champs de texte - Mot de passe - Obligatoire - 12 caractères - au minimum, 1 majuscule - au minimum, 1 minuscule - au minimum, 1 chiffre - au minimum, 1 caractère spécial (!@#$%^&*...) - au minimum"
                         accessibilityRequired={true}
                         autoCapitalize="none"
                         autoComplete="new-password"
@@ -534,9 +534,10 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
                     Le mot de passe doit contenir au moins 12 caractères, 1 majuscule, 1 minuscule, 1 chiffre et un caractère spécial
                   </Text>
                   <View
-                    accessibilityAtomic={false}
-                    accessibilityRole="none"
+                    accessibilityElementsHidden={true}
+                    accessible={false}
                     gap={1}
+                    importantForAccessibility="no-hide-descendants"
                     isVisible={true}
                     style={
                       {

--- a/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
@@ -560,7 +560,7 @@ exports[`ChangePassword should render correctly 1`] = `
                     testID="styled-input-container"
                   >
                     <TextInput
-                      accessibilityLabel="Champs de texte - Nouveau mot de passe - Obligatoire - Le mot de passe doit contenir au moins 12 caractères, 1 majuscule, 1 minuscule, 1 chiffre et un caractère spécial"
+                      accessibilityLabel="Champs de texte - Nouveau mot de passe - Obligatoire - 12 caractères - au minimum, 1 majuscule - au minimum, 1 minuscule - au minimum, 1 chiffre - au minimum, 1 caractère spécial (!@#$%^&*...) - au minimum"
                       accessibilityRequired={true}
                       autoCapitalize="none"
                       autoComplete="new-password"

--- a/doc/accessibility/audits/2026_06_15.md
+++ b/doc/accessibility/audits/2026_06_15.md
@@ -68,6 +68,29 @@ Texte
 
 <details>
 
+<summary> 🟠 Critère 5.4 - Dans chaque écran, les messages de statut sont-ils correctement restitués par les technologies d’assistance ? </summary>
+
+**RAAM** : [Critère 5.4](https://accessibilite.public.lu/fr/raam1.1/referentiel-technique.html#crit-5_4)  
+**Ticket** : [PC-37478](https://passculture.atlassian.net/browse/PC-37478)  
+**PRs** : [#9730](https://github.com/pass-culture/pass-culture-app-native/pull/9730)  
+
+**Problème** 😱  
+- E09 : Activer le bouton « Suivre le thème » affiche un message en haut de l’écran, mais celui-ci n’est pas restitué aux technologies d’assistance.
+- E11 : La validation des critères requis pour le mot de passe n’est pas correctement restituée aux technologies d’assistance.
+
+**Correction** 💡  
+- E09 : Le tooltip (message affiché dans une bulle à côté du bouton et apparaissant au clic) est correctement lu lors de son apparition.
+- E11 : Les critères requis pour le mot de passe, ainsi que leur état de validation, sont correctement restitués aux technologies d’assistance.
+
+**Retours audit** 🔥  
+Texte
+
+</details>
+
+<br>
+
+<details>
+
 <summary> 🟠 Critère  8.2  - Dans chaque écran, l’utilisateur peut-il augmenter la taille des caractères de 200% au moins ? </summary>
 
 **RAAM** : [Critère 8.2](https://accessibilite.public.lu/fr/raam1.1/referentiel-technique.html#crit-8_2)  

--- a/src/features/auth/components/PasswordSecurityRules.native.test.tsx
+++ b/src/features/auth/components/PasswordSecurityRules.native.test.tsx
@@ -10,67 +10,69 @@ describe('<PasswordSecurityRules />', () => {
   it('should display 5 rules', async () => {
     render(<PasswordSecurityRules password="" />)
 
-    expect(screen.getByText('12 caractères')).toBeOnTheScreen()
-    expect(screen.getByText('1 majuscule')).toBeOnTheScreen()
-    expect(screen.getByText('1 minuscule')).toBeOnTheScreen()
-    expect(screen.getByText('1 chiffre')).toBeOnTheScreen()
-    expect(screen.getByText('1 caractère spécial (!@#$%^&*...)')).toBeOnTheScreen()
+    expect(screen.getByText('12 caractères', { includeHiddenElements: true })).toBeOnTheScreen()
+    expect(screen.getByText('1 majuscule', { includeHiddenElements: true })).toBeOnTheScreen()
+    expect(screen.getByText('1 minuscule', { includeHiddenElements: true })).toBeOnTheScreen()
+    expect(screen.getByText('1 chiffre', { includeHiddenElements: true })).toBeOnTheScreen()
+    expect(
+      screen.getByText('1 caractère spécial (!@#$%^&*...)', { includeHiddenElements: true })
+    ).toBeOnTheScreen()
   })
 
   it('should not validate any rules if input is empty', () => {
     render(<PasswordSecurityRules password="" />)
-    const closeIcons = screen.getAllByTestId('rule-icon-close')
+    const closeIcons = screen.getAllByTestId('rule-icon-close', { includeHiddenElements: true })
 
     expect(closeIcons).toHaveLength(5)
   })
 
   it('should validate capital rule', () => {
     render(<PasswordSecurityRules password="A" />)
-    const checkIcons = screen.getAllByTestId('rule-icon-check')
+    const checkIcons = screen.getAllByTestId('rule-icon-check', { includeHiddenElements: true })
 
     expect(checkIcons).toHaveLength(1)
 
-    const closeIcons = screen.getAllByTestId('rule-icon-close')
+    const closeIcons = screen.getAllByTestId('rule-icon-close', { includeHiddenElements: true })
 
     expect(closeIcons).toHaveLength(4)
   })
 
   it('should validate lowercase rule', () => {
     render(<PasswordSecurityRules password="a" />)
-    const checkIcons = screen.getAllByTestId('rule-icon-check')
+    const checkIcons = screen.getAllByTestId('rule-icon-check', { includeHiddenElements: true })
 
     expect(checkIcons).toHaveLength(1)
 
-    const closeIcons = screen.getAllByTestId('rule-icon-close')
+    const closeIcons = screen.getAllByTestId('rule-icon-close', { includeHiddenElements: true })
 
     expect(closeIcons).toHaveLength(4)
   })
 
   it('should validate number rule', () => {
     render(<PasswordSecurityRules password="1" />)
-    const checkIcons = screen.getAllByTestId('rule-icon-check')
+    const checkIcons = screen.getAllByTestId('rule-icon-check', { includeHiddenElements: true })
 
     expect(checkIcons).toHaveLength(1)
 
-    const closeIcons = screen.getAllByTestId('rule-icon-close')
+    const closeIcons = screen.getAllByTestId('rule-icon-close', { includeHiddenElements: true })
 
     expect(closeIcons).toHaveLength(4)
   })
 
   it('should validate special character rule', () => {
     render(<PasswordSecurityRules password="!" />)
-    const checkIcons = screen.getAllByTestId('rule-icon-check')
+    const checkIcons = screen.getAllByTestId('rule-icon-check', { includeHiddenElements: true })
 
     expect(checkIcons).toHaveLength(1)
 
-    const closeIcons = screen.getAllByTestId('rule-icon-close')
+    const closeIcons = screen.getAllByTestId('rule-icon-close', { includeHiddenElements: true })
 
     expect(closeIcons).toHaveLength(4)
   })
 
   it('should validate every rule if password is correct', () => {
     render(<PasswordSecurityRules password="ABCDefgh1234!!!!" />)
-    const checkIcons = screen.getAllByTestId('rule-icon-check')
+    const checkIcons = screen.getAllByTestId('rule-icon-check', { includeHiddenElements: true })
 
     expect(checkIcons).toHaveLength(5)
   })

--- a/src/features/auth/components/PasswordSecurityRules.tsx
+++ b/src/features/auth/components/PasswordSecurityRules.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { HiddenAccessibleText } from 'ui/components/HiddenAccessibleText'
 import { PasswordRule } from 'ui/components/inputs/rules/PasswordRule'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -49,8 +48,22 @@ function containsSpecialCharacter(password: string): boolean {
   return SPECIAL_CHARACTER_REGEX.test(password)
 }
 
-export const PASSWORD_SECURITY_RULES_ACCESSIBILITY_LABEL =
+const PASSWORD_SECURITY_RULES_ACCESSIBILITY_LABEL =
   'Le mot de passe doit contenir au moins 12 caractères, 1 majuscule, 1 minuscule, 1 chiffre et un caractère spécial'
+
+function getRuleLabel(title: string, isValidated: boolean) {
+  return `${title} ${isValidated ? '- critère validé' : '- au minimum'}`
+}
+
+export function getPasswordRulesAccessibilityLabel(password: string): string {
+  return [
+    getRuleLabel('12 caractères', isLongEnough(password)),
+    getRuleLabel('1 majuscule', containsCapital(password)),
+    getRuleLabel('1 minuscule', containsLowercase(password)),
+    getRuleLabel('1 chiffre', containsNumber(password)),
+    getRuleLabel('1 caractère spécial (!@#$%^&*...)', containsSpecialCharacter(password)),
+  ].join(', ')
+}
 
 export const PasswordSecurityRules: FunctionComponent<Props> = ({
   password,
@@ -65,8 +78,9 @@ export const PasswordSecurityRules: FunctionComponent<Props> = ({
       {visible ? (
         <RulesContainer
           isVisible={visible}
-          accessibilityRole={AccessibilityRole.STATUS}
-          accessibilityAtomic={false}
+          accessible={false}
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
           gap={1}>
           <PasswordRule title="12 caractères" isValidated={isLongEnough(password)} />
           <PasswordRule title="1 majuscule" isValidated={containsCapital(password)} />

--- a/src/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx
+++ b/src/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx
@@ -36,7 +36,7 @@ describe('SetPassword Page', () => {
   it('should display security rules', () => {
     render(<SetPassword {...props} />)
 
-    expect(screen.getByText('12 caractères')).toBeOnTheScreen()
+    expect(screen.getByText('12 caractères', { includeHiddenElements: true })).toBeOnTheScreen()
   })
 
   it('should not display "Obligatoire"', () => {

--- a/src/shared/forms/controllers/PasswordInputController.native.test.tsx
+++ b/src/shared/forms/controllers/PasswordInputController.native.test.tsx
@@ -62,7 +62,7 @@ describe('<PasswordInputController />', () => {
       const input = screen.getByTestId('Mot de passe')
       fireEvent.changeText(input, 'a')
 
-      expect(screen.getByText(rules)).toBeOnTheScreen()
+      expect(screen.getByText(rules, { includeHiddenElements: true })).toBeOnTheScreen()
     })
   })
 
@@ -74,9 +74,12 @@ describe('<PasswordInputController />', () => {
       '1 chiffre',
       '1 caractère spécial (!@#$%^&*...)',
     ])('should show password validation rules', (rules) => {
-      renderPasswordInputController({ withSecurityRules: true, securityRulesAlwaysVisible: true })
+      renderPasswordInputController({
+        withSecurityRules: true,
+        securityRulesAlwaysVisible: true,
+      })
 
-      expect(screen.getByText(rules)).toBeOnTheScreen()
+      expect(screen.getByText(rules, { includeHiddenElements: true })).toBeOnTheScreen()
     })
   })
 })

--- a/src/shared/forms/controllers/PasswordInputController.tsx
+++ b/src/shared/forms/controllers/PasswordInputController.tsx
@@ -3,8 +3,8 @@ import { Control, Controller, FieldPath, FieldValues } from 'react-hook-form'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
-  PASSWORD_SECURITY_RULES_ACCESSIBILITY_LABEL,
   PasswordSecurityRules,
+  getPasswordRulesAccessibilityLabel,
 } from 'features/auth/components/PasswordSecurityRules'
 import { getComputedAccessibilityLabel } from 'shared/accessibility/helpers/getComputedAccessibilityLabel'
 import { PasswordInput, Props as PasswordInputProps } from 'ui/components/inputs/PasswordInput'
@@ -30,18 +30,18 @@ export const PasswordInputController = <
 }: PropsWithChildren<Props<TFieldValues, TName>>): ReactElement => {
   const passwordInputErrorId = uuidv4()
 
-  const securityRulesAccessibilityLabel = withSecurityRules
-    ? PASSWORD_SECURITY_RULES_ACCESSIBILITY_LABEL
-    : undefined
-
   return (
     <Controller
       control={control}
       name={name}
       render={({ field: { onChange, onBlur, value, ref }, fieldState: { error } }) => {
+        const securityRulesAccessibilityLabel = withSecurityRules
+          ? getPasswordRulesAccessibilityLabel(value)
+          : undefined
+
         const computedAccessibilityHint = getComputedAccessibilityLabel(
           securityRulesAccessibilityLabel,
-          error?.message
+          error?.message ? `erreur\u00a0 ${error.message}` : undefined
         )
 
         return (

--- a/src/ui/components/Tooltip.tsx
+++ b/src/ui/components/Tooltip.tsx
@@ -1,5 +1,6 @@
 import { useFocusEffect } from '@react-navigation/native'
 import React, { ComponentProps, FunctionComponent, useCallback, useEffect, useRef } from 'react'
+import { AccessibilityInfo, findNodeHandle } from 'react-native'
 import { Path, Svg } from 'react-native-svg'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -32,10 +33,20 @@ export const Tooltip: FunctionComponent<Props> = ({
 }) => {
   const containerRef = useRef<AnimatedViewRefType>(null)
   useEffect(() => {
-    if (isVisible) {
-      containerRef.current?.fadeIn?.()
-    }
-  }, [isVisible])
+    if (!isVisible) return
+
+    void containerRef.current?.fadeIn?.()
+    AccessibilityInfo.announceForAccessibility(label)
+
+    const timeout = setTimeout(() => {
+      const node = findNodeHandle(containerRef.current)
+      if (node) {
+        AccessibilityInfo.setAccessibilityFocus(node)
+      }
+    }, FADE_IN_DURATION)
+
+    return () => clearTimeout(timeout)
+  }, [isVisible, label])
 
   // Hide tooltip when navigating away
   useFocusEffect(
@@ -55,6 +66,7 @@ export const Tooltip: FunctionComponent<Props> = ({
       style={style}
       ref={containerRef}
       accessibilityRole={AccessibilityRole.TOOLTIP}
+      accessibilityLiveRegion="assertive"
       pointerDirection={pointerDirection}>
       <StyledPointer pointerDirection={pointerDirection} />
       <Background>


### PR DESCRIPTION

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-37478

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
