### PR TITLE
(PC-42006) fix(offer): display correctly artist playlist with role on 2 lines

### DIFF
--- a/src/ui/components/Avatar/AvatarListItem.tsx
+++ b/src/ui/components/Avatar/AvatarListItem.tsx
@@ -46,7 +46,11 @@ export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
           <ArtistName numberOfLines={2} maxWidth={size ?? 0} isFullWidth={isFullWidth}>
             {name}
           </ArtistName>
-          {role ? <ArtistRole numberOfLines={2}>{role}</ArtistRole> : null}
+          {role ? (
+            <ArtistRole numberOfLines={2} maxWidth={size ?? 0} isFullWidth={isFullWidth}>
+              {role}
+            </ArtistRole>
+          ) : null}
         </View>
       </StyledView>
     </InternalTouchableLink>
@@ -61,11 +65,14 @@ const ArtistName = styled(Typo.BodyAccentS)<{ maxWidth: number; isFullWidth: boo
   })
 )
 
-const ArtistRole = styled(Typo.BodyAccentXs)(({ theme }) => ({
-  textAlign: 'center',
-  alignSelf: 'center',
-  color: theme.designSystem.color.text.subtle,
-}))
+const ArtistRole = styled(Typo.BodyAccentXs)<{ maxWidth: number; isFullWidth: boolean }>(
+  ({ theme, maxWidth, isFullWidth }) => ({
+    textAlign: 'center',
+    maxWidth: isFullWidth ? '100%' : maxWidth,
+    alignSelf: 'center',
+    color: theme.designSystem.color.text.subtle,
+  })
+)
 
 const StyledView = styled(ViewGap)<{ isFullWidth: boolean }>(({ isFullWidth }) => ({
   flexDirection: isFullWidth ? 'row' : 'column',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42006

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-02 at 15 17 05" src="https://github.com/user-attachments/assets/ad4de478-b8fc-49f8-9cd1-7b31d36a76ac" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-02 at 15 20 39" src="https://github.com/user-attachments/assets/9e964cb2-20a5-46fd-b989-3e99626a5060" />|
| Android          |<img width="1080" height="2400" alt="Screenshot_1780406376" src="https://github.com/user-attachments/assets/ea7885df-ab07-4b88-8204-d18be3740951" />|<img width="1080" height="2400" alt="Screenshot_1780406406" src="https://github.com/user-attachments/assets/2e432156-4c00-4460-be4d-9ebcbc75c246" />|
| Phone - Chrome   |<img width="391" height="686" alt="Capture d’écran 2026-06-02 à 15 17 19" src="https://github.com/user-attachments/assets/789bfcdc-021c-4e41-b8cd-bf20c82535fe" />|<img width="391" height="686" alt="Capture d’écran 2026-06-02 à 15 20 51" src="https://github.com/user-attachments/assets/9dfaec73-c44f-4694-8570-c38b33888cb3" />|
| Desktop - Chrome |<img width="1916" height="925" alt="Capture d’écran 2026-06-02 à 15 17 11" src="https://github.com/user-attachments/assets/3105fada-8de1-44d7-938b-794f99b07e84" />|<img width="1915" height="932" alt="Capture d’écran 2026-06-02 à 15 21 04" src="https://github.com/user-attachments/assets/7287d91d-156e-4e15-88df-715dadbaf08f" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
