### PR TITLE
(IC-1059) ci(workflow): Destroy key only when it is created

### DIFF
--- a/.github/workflows/dev_on_workflow_environment_android_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_android_deploy.yml
@@ -160,7 +160,7 @@ jobs:
           fi
 
       - name: Delete service account key
-        if: always()
+        if: always() && steps.create-sa-key.conclusion != 'skipped'
         env:
           KEY_ID: ${{ steps.create-sa-key.outputs.SA_KEY_ID }}
           SERVICE_ACCOUNT: ${{ vars.NATIVE_DEPLOYER_SERVICE_ACCOUNT }}

--- a/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
@@ -140,7 +140,7 @@ jobs:
           fi
 
       - name: Delete service account key
-        if: always()
+        if: always() && steps.create-sa-key.conclusion != 'skipped'
         env:
           KEY_ID: ${{ steps.create-sa-key.outputs.SA_KEY_ID }}
           SERVICE_ACCOUNT: ${{ vars.NATIVE_DEPLOYER_SERVICE_ACCOUNT }}

--- a/.github/workflows/dev_on_workflow_environment_soft_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_soft_deploy.yml
@@ -109,7 +109,7 @@ jobs:
           bundle exec fastlane ios deploy ota: --env "${ENV}"
 
       - name: Delete service account key
-        if: always()
+        if: always() && steps.create-sa-key.conclusion != 'skipped'
         env:
           KEY_ID: ${{ steps.create-sa-key.outputs.SA_KEY_ID }}
           SERVICE_ACCOUNT: ${{ vars.NATIVE_DEPLOYER_SERVICE_ACCOUNT }}

--- a/.github/workflows/dev_on_workflow_pr_preview.yml
+++ b/.github/workflows/dev_on_workflow_pr_preview.yml
@@ -121,7 +121,7 @@ jobs:
           channelId: ${{ inputs.CHANNEL }}
 
       - name: Delete service account key
-        if: always()
+        if: always() && steps.create-sa-key.conclusion != 'skipped'
         env:
           KEY_ID: ${{ steps.create-sa-key.outputs.SA_KEY_ID }}
           SERVICE_ACCOUNT: ${{ vars.NATIVE_DEPLOYER_SERVICE_ACCOUNT }}


### PR DESCRIPTION
Signed-off-by: Lamine BA <lamine.ba@passculture.app>

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
