### PR TITLE
(PC-42172) fix(AppModal): modals are correctly displayed on web, mobi…

### DIFF
--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -1057,6 +1057,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
               <View
                 gap={4}
                 isModal={true}
+                isZoomed={false}
                 style={
                   {
                     "alignItems": "center",
@@ -1208,6 +1209,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                   </View>
                 </View>
                 <View
+                  isZoomed={false}
                   style={
                     {
                       "flexBasis": 0,

--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -206,9 +206,10 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
       swipeThreshold={100}
     >
       <View
+        height={1318}
         isLandscape={false}
         leftNootch={16}
-        maxHeight={1318}
+        maxHeight={1334}
         noPadding={true}
         rightNootch={16}
         style={
@@ -220,8 +221,9 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
             "borderTopLeftRadius": 16,
             "borderTopRightRadius": 16,
             "flexDirection": "column",
+            "height": 1318,
             "justifyContent": "flex-start",
-            "maxHeight": 1318,
+            "maxHeight": 1334,
             "maxWidth": 960,
             "paddingBottom": 32,
             "paddingLeft": 0,

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
@@ -197,6 +197,7 @@ exports[`<EmailResendModal /> should render correctly 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -361,7 +362,6 @@ exports[`<EmailResendModal /> should render correctly 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
@@ -216,6 +216,7 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
               }
             />
             <View
+              isZoomed={false}
               style={
                 {
                   "flexBasis": 0,

--- a/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
@@ -197,6 +197,7 @@ exports[`<DMSModal/> should render correctly 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -361,7 +362,6 @@ exports[`<DMSModal/> should render correctly 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
@@ -303,6 +303,7 @@ exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
           </View>
         </View>
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -360,7 +361,6 @@ exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
@@ -145,9 +145,10 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
     swipeThreshold={100}
   >
     <View
+      height={1318}
       isLandscape={false}
       leftNootch={16}
-      maxHeight={1318}
+      maxHeight={1334}
       noPadding={true}
       rightNootch={16}
       style={
@@ -159,8 +160,9 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
           "borderTopLeftRadius": 16,
           "borderTopRightRadius": 16,
           "flexDirection": "column",
+          "height": 1318,
           "justifyContent": "flex-start",
-          "maxHeight": 1318,
+          "maxHeight": 1334,
           "maxWidth": 960,
           "paddingBottom": 32,
           "paddingLeft": 0,
@@ -217,6 +219,7 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
               }
             />
             <View
+              isZoomed={false}
               style={
                 {
                   "flexBasis": 0,

--- a/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
@@ -168,9 +168,10 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
       swipeThreshold={100}
     >
       <View
+        height={1318}
         isLandscape={false}
         leftNootch={16}
-        maxHeight={1318}
+        maxHeight={1334}
         noPadding={true}
         rightNootch={16}
         style={
@@ -182,8 +183,9 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
             "borderTopLeftRadius": 16,
             "borderTopRightRadius": 16,
             "flexDirection": "column",
+            "height": 1318,
             "justifyContent": "flex-start",
-            "maxHeight": 1318,
+            "maxHeight": 1334,
             "maxWidth": 960,
             "paddingBottom": 32,
             "paddingLeft": 0,
@@ -240,6 +242,7 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
                 }
               />
               <View
+                isZoomed={false}
                 style={
                   {
                     "flexBasis": 0,

--- a/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
@@ -206,9 +206,10 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
       swipeThreshold={100}
     >
       <View
+        height={1318}
         isLandscape={false}
         leftNootch={16}
-        maxHeight={1318}
+        maxHeight={1334}
         noPadding={true}
         rightNootch={16}
         style={
@@ -220,8 +221,9 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
             "borderTopLeftRadius": 16,
             "borderTopRightRadius": 16,
             "flexDirection": "column",
+            "height": 1318,
             "justifyContent": "flex-start",
-            "maxHeight": 1318,
+            "maxHeight": 1334,
             "maxWidth": 960,
             "paddingBottom": 32,
             "paddingLeft": 0,
@@ -278,6 +280,7 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
                 }
               />
               <View
+                isZoomed={false}
                 style={
                   {
                     "flexBasis": 0,

--- a/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
@@ -115,6 +115,7 @@ exports[`PushNotificationsModal should render properly 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,

--- a/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
@@ -197,6 +197,7 @@ exports[`FavoriteAuthModal should match previous snapshot 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -362,7 +363,6 @@ retrouver tes favoris
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/features/offer/components/NotificationAuthModal/NotificationAuthModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/NotificationAuthModal/NotificationAuthModal.native.test.tsx.native-snap
@@ -197,6 +197,7 @@ exports[`NotificationAuthModal should match previous snapshot 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -362,7 +363,6 @@ activer un rappel
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/features/profile/components/Modals/ExpiredCreditModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/Modals/ExpiredCreditModal.native.test.tsx.native-snap
@@ -115,6 +115,7 @@ exports[`<ExpiredCreditModal/> should render correctly 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -1032,6 +1032,7 @@ exports[`<SearchFilter/> should render correctly 1`] = `
             <View
               gap={4}
               isModal={true}
+              isZoomed={false}
               style={
                 {
                   "alignItems": "center",
@@ -1183,6 +1184,7 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                 </View>
               </View>
               <View
+                isZoomed={false}
                 style={
                   {
                     "flexBasis": 0,

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -145,9 +145,10 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
     swipeThreshold={100}
   >
     <View
+      height={1318}
       isLandscape={false}
       leftNootch={16}
-      maxHeight={1318}
+      maxHeight={1334}
       noPadding={true}
       rightNootch={16}
       style={
@@ -159,8 +160,9 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
           "borderTopLeftRadius": 16,
           "borderTopRightRadius": 16,
           "flexDirection": "column",
+          "height": 1318,
           "justifyContent": "flex-start",
-          "maxHeight": 1318,
+          "maxHeight": 1334,
           "maxWidth": 960,
           "paddingBottom": 32,
           "paddingLeft": 0,

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -2272,6 +2272,7 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
             <View
               gap={4}
               isModal={true}
+              isZoomed={false}
               style={
                 {
                   "alignItems": "center",
@@ -2423,6 +2424,7 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                 </View>
               </View>
               <View
+                isZoomed={false}
                 style={
                   {
                     "flexBasis": 0,

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -145,9 +145,10 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
     swipeThreshold={100}
   >
     <View
+      height={1318}
       isLandscape={false}
       leftNootch={16}
-      maxHeight={1318}
+      maxHeight={1334}
       noPadding={true}
       rightNootch={16}
       style={
@@ -159,8 +160,9 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
           "borderTopLeftRadius": 16,
           "borderTopRightRadius": 16,
           "flexDirection": "column",
+          "height": 1318,
           "justifyContent": "flex-start",
-          "maxHeight": 1318,
+          "maxHeight": 1334,
           "maxWidth": 960,
           "paddingBottom": 32,
           "paddingLeft": 0,

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -546,6 +546,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
             <View
               gap={4}
               isModal={true}
+              isZoomed={false}
               style={
                 {
                   "alignItems": "center",
@@ -697,6 +698,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                 </View>
               </View>
               <View
+                isZoomed={false}
                 style={
                   {
                     "flexBasis": 0,

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -145,9 +145,10 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
     swipeThreshold={100}
   >
     <View
+      height={1318}
       isLandscape={false}
       leftNootch={16}
-      maxHeight={1318}
+      maxHeight={1334}
       noPadding={true}
       rightNootch={16}
       style={
@@ -159,8 +160,9 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
           "borderTopLeftRadius": 16,
           "borderTopRightRadius": 16,
           "flexDirection": "column",
+          "height": 1318,
           "justifyContent": "flex-start",
-          "maxHeight": 1318,
+          "maxHeight": 1334,
           "maxWidth": 960,
           "paddingBottom": 32,
           "paddingLeft": 0,

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -1009,6 +1009,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
             <View
               gap={4}
               isModal={true}
+              isZoomed={false}
               style={
                 {
                   "alignItems": "center",
@@ -1160,6 +1161,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                 </View>
               </View>
               <View
+                isZoomed={false}
                 style={
                   {
                     "flexBasis": 0,

--- a/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
@@ -145,9 +145,10 @@ exports[`VenueModal should render correctly 1`] = `
     swipeThreshold={100}
   >
     <View
+      height={1318}
       isLandscape={false}
       leftNootch={16}
-      maxHeight={1318}
+      maxHeight={1334}
       noPadding={true}
       rightNootch={16}
       style={
@@ -159,8 +160,9 @@ exports[`VenueModal should render correctly 1`] = `
           "borderTopLeftRadius": 16,
           "borderTopRightRadius": 16,
           "flexDirection": "column",
+          "height": 1318,
           "justifyContent": "flex-start",
-          "maxHeight": 1318,
+          "maxHeight": 1334,
           "maxWidth": 960,
           "paddingBottom": 32,
           "paddingLeft": 0,
@@ -217,6 +219,7 @@ exports[`VenueModal should render correctly 1`] = `
               }
             />
             <View
+              isZoomed={false}
               style={
                 {
                   "flexBasis": 0,

--- a/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
@@ -621,6 +621,7 @@ exports[`VenueModal should render correctly 1`] = `
             <View
               gap={4}
               isModal={true}
+              isZoomed={false}
               style={
                 {
                   "alignItems": "center",
@@ -772,6 +773,7 @@ exports[`VenueModal should render correctly 1`] = `
                 </View>
               </View>
               <View
+                isZoomed={false}
                 style={
                   {
                     "flexBasis": 0,

--- a/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
@@ -159,6 +159,7 @@ exports[`ShareAppModalVersionA should match snapshot 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -316,7 +317,6 @@ exports[`ShareAppModalVersionA should match snapshot 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 5,
             "width": "100%",
           }

--- a/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
@@ -159,6 +159,7 @@ exports[`ShareAppModalVersionB should match snapshot 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -316,7 +317,6 @@ exports[`ShareAppModalVersionB should match snapshot 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 5,
             "width": "100%",
           }

--- a/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
+++ b/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
@@ -210,7 +210,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                   data-testid="spacerBetweenHeaderAndContent"
                 />
                 <div
-                  class="css-view-175oi2r r-height-1pi2tsx r-maxWidth-iz080l r-paddingBottom-xd6kpl r-width-13qz1uu"
+                  class="css-view-175oi2r r-height-1pi2tsx r-paddingBottom-xd6kpl r-width-13qz1uu"
                 >
                   <div
                     class="css-view-175oi2r r-WebkitOverflowScrolling-150rngu r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-11yh6sk r-overflowY-1rnoaur r-transform-agouwx"

--- a/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
@@ -197,6 +197,7 @@ exports[`<NotificationsLoggedOutModal /> should render correctly 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -361,7 +362,6 @@ exports[`<NotificationsLoggedOutModal /> should render correctly 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
@@ -197,6 +197,7 @@ exports[`<NotificationsSettingsModal /> should render correctly 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -361,7 +362,6 @@ exports[`<NotificationsSettingsModal /> should render correctly 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
@@ -197,6 +197,7 @@ exports[`<OnboardingSubscriptionModal /> should display correctly 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -361,7 +362,6 @@ exports[`<OnboardingSubscriptionModal /> should display correctly 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
@@ -197,6 +197,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for activites_crea
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -361,7 +362,6 @@ exports[`<SubscriptionSuccessModal /> should render correctly for activites_crea
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -876,6 +876,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for cinema 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -1040,7 +1041,6 @@ exports[`<SubscriptionSuccessModal /> should render correctly for cinema 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -1555,6 +1555,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for lecture 1`] = 
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -1719,7 +1720,6 @@ exports[`<SubscriptionSuccessModal /> should render correctly for lecture 1`] = 
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -2234,6 +2234,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for musique 1`] = 
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -2398,7 +2399,6 @@ exports[`<SubscriptionSuccessModal /> should render correctly for musique 1`] = 
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -2913,6 +2913,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for spectacles 1`]
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -3077,7 +3078,6 @@ exports[`<SubscriptionSuccessModal /> should render correctly for spectacles 1`]
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -3592,6 +3592,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for visites 1`] = 
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -3756,7 +3757,6 @@ exports[`<SubscriptionSuccessModal /> should render correctly for visites 1`] = 
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
@@ -197,6 +197,7 @@ exports[`<UnsubscribingConfirmationModal /> should render correctly 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -361,7 +362,6 @@ exports[`<UnsubscribingConfirmationModal /> should render correctly 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/libs/location/geolocation/components/GeolocationActivationModal.native.test.tsx.native-snap
+++ b/__snapshots__/libs/location/geolocation/components/GeolocationActivationModal.native.test.tsx.native-snap
@@ -115,6 +115,7 @@ exports[`GeolocationActivationModal should render properly 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,

--- a/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
@@ -197,6 +197,7 @@ exports[`<ApplicationProcessingModal /> should match previous snapshot 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -361,7 +362,6 @@ exports[`<ApplicationProcessingModal /> should match previous snapshot 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
@@ -197,6 +197,7 @@ exports[`<AuthenticationModal /> should render correctly 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -361,7 +362,6 @@ exports[`<AuthenticationModal /> should render correctly 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
@@ -197,6 +197,7 @@ exports[`<ErrorApplicationModal /> should match previous snapshot 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -362,7 +363,6 @@ ton crédit
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
@@ -197,6 +197,7 @@ exports[`<FinishSubscriptionModal /> should display correct body when user needs
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -362,7 +363,6 @@ pour réserver cette offre
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -753,6 +753,7 @@ exports[`<FinishSubscriptionModal /> should render correctly with eighteen years
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -918,7 +919,6 @@ pour réserver cette offre
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -1309,6 +1309,7 @@ exports[`<FinishSubscriptionModal /> should render correctly with undefined depo
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -1474,7 +1475,6 @@ pour réserver cette offre
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/__snapshots__/ui/components/modals/AppModal.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/modals/AppModal.native.test.tsx.native-snap
@@ -203,6 +203,7 @@ exports[`<AppModal /> on big screen 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -260,7 +261,6 @@ exports[`<AppModal /> on big screen 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -490,6 +490,7 @@ exports[`<AppModal /> on small screen 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -547,7 +548,6 @@ exports[`<AppModal /> on small screen 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -731,6 +731,7 @@ exports[`<AppModal /> with backdrop disabled 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -788,7 +789,6 @@ exports[`<AppModal /> with backdrop disabled 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -1018,6 +1018,7 @@ exports[`<AppModal /> with backdrop enabled by default 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -1075,7 +1076,6 @@ exports[`<AppModal /> with backdrop enabled by default 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -1305,6 +1305,7 @@ exports[`<AppModal /> with backdrop explicitly enabled 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -1362,7 +1363,6 @@ exports[`<AppModal /> with backdrop explicitly enabled 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -1698,6 +1698,7 @@ exports[`<AppModal /> with left icon render 1`] = `
           </View>
         </View>
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -1755,7 +1756,6 @@ exports[`<AppModal /> with left icon render 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -1985,6 +1985,7 @@ exports[`<AppModal /> with minimal props 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -2042,7 +2043,6 @@ exports[`<AppModal /> with minimal props 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -2272,6 +2272,7 @@ exports[`<AppModal /> with right icon render 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -2436,7 +2437,6 @@ exports[`<AppModal /> with right icon render 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }
@@ -2666,6 +2666,7 @@ exports[`<AppModal /> without children 1`] = `
           }
         />
         <View
+          isZoomed={false}
           style={
             {
               "flexBasis": 0,
@@ -2723,7 +2724,6 @@ exports[`<AppModal /> without children 1`] = `
         style={
           {
             "height": "100%",
-            "maxWidth": 480,
             "paddingBottom": 8,
             "width": "100%",
           }

--- a/src/features/profile/components/Modals/DeleteProfileReasonNewEmailModal.tsx
+++ b/src/features/profile/components/Modals/DeleteProfileReasonNewEmailModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
+import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Close } from 'ui/svg/icons/Close'
@@ -12,13 +13,15 @@ type Props = {
 }
 
 export const DeleteProfileReasonNewEmailModal: React.FC<Props> = ({ isVisible, hideModal }) => {
+  const isFullScreen = useMobileFontScaleToDisplay({ default: false, at200PercentZoom: true })
   return (
     <AppModal
       title="Modifie ton adresse e-mail sur ce compte"
       visible={isVisible}
       rightIcon={Close}
       onRightIconPress={hideModal}
-      rightIconAccessibilityLabel="Fermer la modale">
+      rightIconAccessibilityLabel="Fermer la modale"
+      isFullscreen={isFullScreen}>
       <StyledBody>Tu ne peux créer qu’un seul compte pass Culture à ton nom.</StyledBody>
       <StyledBody>
         Pour modifier ton adresse e-mail, suis les instructions sur cette page.

--- a/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
+++ b/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
@@ -21,6 +21,7 @@ import { haveCookieChoicesChanged } from 'features/profile/helpers/haveCookieCho
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
+import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
 import { AnchorProvider } from 'ui/components/anchor/AnchorContext'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { AppModal } from 'ui/components/modals/AppModal'
@@ -158,6 +159,8 @@ export const ConsentSettings = () => {
     return scrollYRef.current
   }).current
 
+  const isFullscreen = useMobileFontScaleToDisplay({ default: false, at200PercentZoom: true })
+
   return (
     <React.Fragment>
       <AnchorProvider scrollViewRef={scrollViewRef} handleCheckScrollY={handleCheckScrollY}>
@@ -210,6 +213,7 @@ export const ConsentSettings = () => {
       <AppModal
         title=""
         visible={visible}
+        isFullscreen={isFullscreen}
         customModalHeader={
           <ModalHeader
             title="Quitter sans enregistrer&nbsp;?"

--- a/src/features/search/components/FilterPageButtons/FilterPageButtons.tsx
+++ b/src/features/search/components/FilterPageButtons/FilterPageButtons.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
 import { FilterBehaviour } from 'features/search/enums'
+import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
 import { StickyBottomGradient } from 'ui/components/StickyBottomGradient/StickyBottomGradient'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
@@ -39,10 +40,12 @@ export const FilterPageButtons: FunctionComponent<Props> = ({
     }
   }
 
+  const isZoomed = useMobileFontScaleToDisplay({ default: false, at200PercentZoom: true })
+
   return (
     <Wrapper>
       {displayGradient ? <StickyBottomGradient /> : null}
-      <Container isModal={isModal} gap={4}>
+      <Container isModal={isModal} gap={4} isZoomed={isZoomed}>
         <ResetButtonWrapper>
           <Button
             wording="Réinitialiser"
@@ -54,13 +57,13 @@ export const FilterPageButtons: FunctionComponent<Props> = ({
             size="small"
           />
         </ResetButtonWrapper>
-        <SearchButtonWrapper>
+        <SearchButtonWrapper isZoomed={isZoomed}>
           <Button
             wording={searchButtonText}
             onPress={onSearchPress}
             disabled={isSearchDisabled}
             color="brand"
-            fullWidth
+            fullWidth={!isZoomed}
           />
         </SearchButtonWrapper>
       </Container>
@@ -72,9 +75,13 @@ const Wrapper = styled.View({
   position: 'relative',
 })
 
-const Container = styled(ViewGap)<{ isModal: boolean }>(({ isModal, theme }) => {
+const Container = styled(ViewGap)<{ isModal: boolean; isZoomed: boolean }>(({
+  isModal,
+  isZoomed,
+  theme,
+}) => {
   return {
-    flexDirection: 'row',
+    flexDirection: isZoomed ? 'column' : 'row',
     alignItems: 'center',
     width: '100%',
     alignSelf: 'stretch',
@@ -90,9 +97,18 @@ const ResetButtonWrapper = styled.View({
   flexShrink: 0,
 })
 
-const SearchButtonWrapper = styled.View({
-  flexGrow: 1,
-  flexShrink: 1,
-  flexBasis: 0,
-  minWidth: 0,
-})
+const SearchButtonWrapper = styled.View<{ isZoomed: boolean }>(({ isZoomed }) => ({
+  ...(isZoomed
+    ? {
+        width: 'auto',
+        flexGrow: 0,
+        flexShrink: 0,
+        flexBasis: 'auto',
+      }
+    : {
+        flexGrow: 1,
+        flexShrink: 1,
+        flexBasis: 0,
+        minWidth: 0,
+      }),
+}))

--- a/src/features/search/pages/modals/SearchInVenueModal/SearchInVenueModal.tsx
+++ b/src/features/search/pages/modals/SearchInVenueModal/SearchInVenueModal.tsx
@@ -53,15 +53,17 @@ export const SearchInVenueModal = ({
         </HeaderContainer>
       }
       fixedModalBottom={
-        <SearchFixedModalBottomContainer>
-          <Container>
-            <Button
-              wording="Lancer la recherche"
-              onPress={doApplySearch}
-              disabled={isSearchButtonDisabled}
-            />
-          </Container>
-        </SearchFixedModalBottomContainer>
+        theme.isDesktopViewport ? undefined : (
+          <SearchFixedModalBottomContainer>
+            <Container>
+              <Button
+                wording="Lancer la recherche"
+                onPress={doApplySearch}
+                disabled={isSearchButtonDisabled}
+              />
+            </Container>
+          </SearchFixedModalBottomContainer>
+        )
       }>
       <SearchInputContainer>
         <SearchInput
@@ -73,6 +75,15 @@ export const SearchInVenueModal = ({
           testID="searchInput"
         />
       </SearchInputContainer>
+      {theme.isDesktopViewport ? (
+        <Container>
+          <Button
+            wording="Lancer la recherche"
+            onPress={doApplySearch}
+            disabled={isSearchButtonDisabled}
+          />
+        </Container>
+      ) : null}
     </AppModal>
   )
 }

--- a/src/ui/components/modals/AppModal.tsx
+++ b/src/ui/components/modals/AppModal.tsx
@@ -23,12 +23,12 @@ import { useKeyboardEvents } from 'ui/components/keyboard/useKeyboardEvents'
 import { appModalContainerStyle } from 'ui/components/modals/appModalContainerStyle'
 // eslint-disable-next-line no-restricted-imports
 import { ModalSpacing } from 'ui/components/modals/enum'
+import { ModalHeader } from 'ui/components/modals/ModalHeader'
 import { useEscapeKeyAction } from 'ui/hooks/useEscapeKeyAction'
 import { KeyboardAvoidingViewWrapper } from 'ui/pages/components/KeyboardAvoidingViewWrapper'
 import { Spacer, getSpacing } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
-import { ModalHeader } from './ModalHeader'
 import { ModalIconProps, ModalSwipeDirection } from './types'
 
 type Props = {
@@ -197,23 +197,13 @@ export const AppModal: FunctionComponent<Props> = ({
 
   useEscapeKeyAction(visible ? onRightIconPress : undefined)
 
-  const isFullscreenAtZoom = useMobileFontScaleToDisplay({
-    default: false,
-    at200PercentZoom: !maxHeight,
-  })
-  const upToStatusBarTopOffset = useMobileFontScaleToDisplay({
-    default: top,
-    at200PercentZoom: top + designSystem.size.spacing.xxxxl,
-  })
-  const effectiveIsFullscreen = isFullscreen || isFullscreenAtZoom
-
   let maxContainerHeight = maxHeight
   let modalContainerHeight = isSmallScreen ? windowHeight : modalHeight
 
   // no fullscreen in desktop view
-  if (effectiveIsFullscreen || isUpToStatusBar) {
-    maxContainerHeight = isUpToStatusBar ? windowHeight - upToStatusBarTopOffset : windowHeight
-    modalContainerHeight = windowHeight
+  if (isFullscreen || isUpToStatusBar) {
+    maxContainerHeight = windowHeight
+    modalContainerHeight = isUpToStatusBar ? windowHeight - top : windowHeight
   }
 
   const fullscreenModalBody = useMemo(() => {
@@ -269,7 +259,7 @@ export const AppModal: FunctionComponent<Props> = ({
       propagateSwipe={propagateSwipe}>
       <KeyboardAvoidingViewWrapper>
         <ModalContainer
-          height={maxHeight || isUpToStatusBar ? undefined : modalContainerHeight}
+          height={maxHeight ? undefined : modalContainerHeight}
           testID="modalContainer"
           maxHeight={maxContainerHeight}
           desktopConstraints={containerDesktopConstraints}
@@ -293,7 +283,7 @@ export const AppModal: FunctionComponent<Props> = ({
               {...iconProps}
             />
           )}
-          {effectiveIsFullscreen || maxHeight || isUpToStatusBar ? (
+          {isFullscreen || maxHeight || isUpToStatusBar ? (
             fullscreenModalBody
           ) : (
             <React.Fragment>
@@ -349,7 +339,6 @@ const ScrollViewContainer = styled.View.attrs<{ backdropColor?: string }>(({ the
   marginBottom: theme.designSystem.size.spacing.xxxxl,
 }))<{ paddingBottom: number; modalSpacing?: ModalSpacing }>(({ paddingBottom, modalSpacing }) => ({
   width: '100%', // do not use `flex: 1` here if you want full width
-  maxWidth: getSpacing(120),
   height: '100%',
   paddingBottom,
   ...(modalSpacing ? { paddingHorizontal: modalSpacing } : {}),
@@ -373,7 +362,6 @@ const StyledModal = styled(ReactNativeModal as any)(({ theme }) => {
 export type ModalContainerProps = {
   theme: DefaultTheme
   height?: number
-  fullscreen?: boolean
   maxHeight?: number
   noPadding?: boolean
   noPaddingBottom?: boolean
@@ -386,7 +374,6 @@ export type ModalContainerProps = {
 const ModalContainer = styled.View<ModalContainerProps>(
   ({
     height,
-    fullscreen,
     desktopConstraints,
     maxHeight,
     noPadding,
@@ -396,20 +383,17 @@ const ModalContainer = styled.View<ModalContainerProps>(
     rightNootch,
     leftNootch,
   }) => {
-    return {
-      ...appModalContainerStyle({
-        theme,
-        height,
-        desktopConstraints,
-        maxHeight,
-        noPadding,
-        noPaddingBottom,
-        isLandscape,
-        rightNootch,
-        leftNootch,
-      }),
-      ...(fullscreen ? { height: '100%', maxHeight: '100%' } : {}),
-    }
+    return appModalContainerStyle({
+      theme,
+      height,
+      desktopConstraints,
+      maxHeight,
+      noPadding,
+      noPaddingBottom,
+      isLandscape,
+      rightNootch,
+      leftNootch,
+    })
   }
 )
 

--- a/src/ui/components/modals/AppModalWithIllustration.tsx
+++ b/src/ui/components/modals/AppModalWithIllustration.tsx
@@ -1,7 +1,10 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
+import {
+  useMobileFontScaleToDisplay,
+  useNumberOfLine,
+} from 'shared/accessibility/helpers/zoomHelpers'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { Close } from 'ui/svg/icons/Close'
 import { AccessibleIcon } from 'ui/svg/icons/types'
@@ -27,7 +30,7 @@ export const AppModalWithIllustration: FunctionComponent<Props> = ({
     <AppModal
       visible={visible}
       title={title}
-      titleNumberOfLines={useMobileFontScaleToDisplay({ default: 2, at200PercentZoom: undefined })}
+      titleNumberOfLines={useNumberOfLine(2)}
       isFullscreen={useMobileFontScaleToDisplay({ default: false, at200PercentZoom: true })}
       rightIconAccessibilityLabel="Fermer la modale"
       rightIcon={Close}

--- a/src/ui/components/modals/ModalHeader.tsx
+++ b/src/ui/components/modals/ModalHeader.tsx
@@ -44,8 +44,12 @@ export const ModalHeader: FunctionComponent<ModalHeaderProps> = ({
       testID: 'rightIcon',
     }))``
   const { top } = useSafeAreaInsets()
-  const statusBarMarginTop = useMobileFontScaleToDisplay({ default: 0, at200PercentZoom: top })
-  const marginTop = withStatusBarMargin ? statusBarMarginTop : 0
+  const marginTop = useMobileFontScaleToDisplay({
+    default: withStatusBarMargin ? top : 0,
+    at200PercentZoom: top,
+  })
+
+  const isZoomed = useMobileFontScaleToDisplay({ default: false, at200PercentZoom: true })
 
   const titleNumberOfLines = useNumberOfLine(numberOfLines)
 
@@ -67,7 +71,7 @@ export const ModalHeader: FunctionComponent<ModalHeaderProps> = ({
           />
         ) : null}
       </HeaderActionContainer>
-      <TitleContainer>
+      <TitleContainer isZoomed={isZoomed}>
         <Title numberOfLines={titleNumberOfLines} nativeID={titleID} testID="modalHeaderTitle">
           {title}
         </Title>
@@ -99,10 +103,10 @@ const Container = styled(View)<{ modalSpacing?: ModalSpacing; marginTop: number 
   })
 )
 
-const TitleContainer = styled.View(({ theme }) => ({
+const TitleContainer = styled.View<{ isZoomed: boolean }>(({ theme, isZoomed }) => ({
   justifyContent: 'center',
+  flex: isZoomed ? undefined : 1,
   paddingHorizontal: theme.designSystem.size.spacing.m,
-  flex: 1,
   zIndex: theme.zIndex.modalHeader,
 }))
 

--- a/src/ui/pages/helpers/useStickyFooterGradient.ts
+++ b/src/ui/pages/helpers/useStickyFooterGradient.ts
@@ -94,7 +94,7 @@ export function useStickyFooterGradient({
 
   return {
     gradientRef,
-    bottomChildrenViewHeight,
+    bottomChildrenViewHeight: hasFixedBottomChildren ? bottomChildrenViewHeight : 0,
     onFixedBottomChildrenViewLayout,
     onChildrenScrollViewLayout,
     onChildrenScrollViewContentSizeChange,


### PR DESCRIPTION
…le 100% and 200%

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42172

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| web | 100% | 200% |
| :-----------: | :---: |:---: |
 | <img width="1440" height="780" alt="Capture d’écran 2026-06-03 à 10 55 53" src="https://github.com/user-attachments/assets/b379a1d7-8ad6-42fd-8178-18fc41510f48" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 10 52 25" src="https://github.com/user-attachments/assets/2b30eafb-3d2d-4e50-bb77-f49f513dcd8c" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 10 34 27" src="https://github.com/user-attachments/assets/18dc9578-1ff5-41cc-90a2-ac04cbe1ed2d" />|
|   <img width="1440" height="778" alt="Capture d’écran 2026-06-03 à 10 57 28" src="https://github.com/user-attachments/assets/ab601f68-7df9-4f6c-b66f-40c0194b49d3" /> |    <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 10 49 24" src="https://github.com/user-attachments/assets/643cce64-74c3-42ae-9898-725cbfd26fce" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 10 34 36" src="https://github.com/user-attachments/assets/308c50b0-9498-436a-b234-0ea37abe973b" />      |
| <img width="1440" height="781" alt="Capture d’écran 2026-06-03 à 10 54 38" src="https://github.com/user-attachments/assets/209b57ea-bd3b-4aa7-84dd-9d517c0e7896" /> |  <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 10 52 39" src="https://github.com/user-attachments/assets/95645e26-aa14-4838-96c5-42f7b2279eda" /> |   <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 10 35 27" src="https://github.com/user-attachments/assets/b46c583d-f676-4e38-8a26-e9ee9d51655f" />|
| <img width="1438" height="774" alt="Capture d’écran 2026-06-03 à 10 55 00" src="https://github.com/user-attachments/assets/3bfa4886-fb70-4676-b231-07ab5ca62a26" />        |  <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 10 52 48" src="https://github.com/user-attachments/assets/6356a6c5-244c-4ed0-af74-e985c9d5d996" /> |   <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 10 36 12" src="https://github.com/user-attachments/assets/ef011a46-593f-46ac-ba3d-418e813be5cd" /> |
|<img width="1429" height="777" alt="Capture d’écran 2026-06-03 à 10 53 37" src="https://github.com/user-attachments/assets/5ccf2e58-2ea5-41cc-83f9-2b1197e90396" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 10 53 10" src="https://github.com/user-attachments/assets/55fe4b6a-2915-43eb-aa32-e7d1d499cfca" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 10 46 19" src="https://github.com/user-attachments/assets/96aac0df-df1b-4033-a895-20d4192fb008" />|
|<img width="1108" height="752" alt="Capture d’écran 2026-06-03 à 11 35 34" src="https://github.com/user-attachments/assets/81348770-1cf6-45ef-8ff4-f5c544e29e36" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 24 23" src="https://github.com/user-attachments/assets/a1982ea3-ee52-4065-abd8-443e9a060e07" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 23 53" src="https://github.com/user-attachments/assets/0dc726d0-f2a7-4d17-bd15-09722cc498a6" />|
|<img width="1107" height="743" alt="Capture d’écran 2026-06-03 à 11 34 08" src="https://github.com/user-attachments/assets/a7317958-8bc1-4eed-a833-b00e1ed9daa0" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 29 39" src="https://github.com/user-attachments/assets/d0f51514-60e1-45d3-be48-c4756d2633a0" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 20 40" src="https://github.com/user-attachments/assets/b43a960e-7270-4d86-ab1d-2f36440ddbc9" />|
|<img width="1060" height="739" alt="Capture d’écran 2026-06-03 à 11 56 44" src="https://github.com/user-attachments/assets/41f39b22-a086-4469-b278-0ff171298081" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 56 34" src="https://github.com/user-attachments/assets/25cb1217-320b-47cf-a575-09b45de0255b" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 54 25" src="https://github.com/user-attachments/assets/252170ab-c28d-4d06-a829-1096d4d32f7f" />|
|<img width="1109" height="744" alt="Capture d’écran 2026-06-03 à 11 33 54" src="https://github.com/user-attachments/assets/880db31b-31b1-4709-b166-0564a9ea120a" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 14 47" src="https://github.com/user-attachments/assets/103fe528-6063-4a4a-aada-6bb567df3066" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 20 48" src="https://github.com/user-attachments/assets/7df3944e-1e9c-4723-bfd4-0ad4f5b3d31d" />|
|<img width="1114" height="746" alt="Capture d’écran 2026-06-03 à 11 33 32" src="https://github.com/user-attachments/assets/e2cb4678-ac78-44f9-9729-5ffbbbaca06d" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 27 38" src="https://github.com/user-attachments/assets/920e2312-cced-4eeb-b95c-31843211ce1a" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 20 10" src="https://github.com/user-attachments/assets/28fe900e-b547-4707-8fb7-4e0f212905f6" />|
|<img width="1108" height="745" alt="Capture d’écran 2026-06-03 à 11 35 01" src="https://github.com/user-attachments/assets/4c18f095-c0c2-4d50-9a3b-5ed691c86acf" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 29 27" src="https://github.com/user-attachments/assets/58163d4d-12a9-4399-a27b-6ed79a37884f" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 20 18" src="https://github.com/user-attachments/assets/11eeca54-9947-4738-a4b7-9514a4b5561d" />|
|<img width="1106" height="745" alt="Capture d’écran 2026-06-03 à 11 35 18" src="https://github.com/user-attachments/assets/a190f72c-702f-47bc-a6bd-737c91a2a9f6" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 29 12" src="https://github.com/user-attachments/assets/b28a619c-8c97-43d5-9f30-48274460d74c" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 20 26" src="https://github.com/user-attachments/assets/c4b51639-c159-47c0-92e8-a36f9618ebe0" />|
| <img width="1065" height="739" alt="Capture d’écran 2026-06-03 à 12 05 18" src="https://github.com/user-attachments/assets/c430521c-9463-4380-9b2d-27f46d3d541e" />| <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 30 02" src="https://github.com/user-attachments/assets/df4d9279-0eff-4155-9db4-092d7653f815" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 11 21 23" src="https://github.com/user-attachments/assets/3f7fb5cc-7200-49f9-8cd8-4353baa2ed2e" />|



changement du sens des boutons sur les modales de filtre en zoom 200 
|web | 100|200|
| :-----------: | :---: |:---: |
|<img width="1439" height="781" alt="Capture d’écran 2026-06-03 à 16 47 13" src="https://github.com/user-attachments/assets/d9914b6d-ddff-427d-9fc7-7cee260dddc0" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 16 36 57" src="https://github.com/user-attachments/assets/dac87f1b-d040-4155-9cf4-b4801e83d950" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 16 35 18" src="https://github.com/user-attachments/assets/90f8ed9b-0498-4638-b71b-7ace946ac747" />|
|<img width="1440" height="776" alt="Capture d’écran 2026-06-03 à 16 46 59" src="https://github.com/user-attachments/assets/d804f714-622d-4cec-b01a-f0473e5c4a49" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 16 44 22" src="https://github.com/user-attachments/assets/9f9e1bea-50ad-47d1-8273-e11a7502149f" />|<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-03 at 16 42 44" src="https://github.com/user-attachments/assets/d3d5f640-9209-4017-b0e8-ca1124616f3f" />|





[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
