### PR TITLE
(PC-42034) feat(offer): add artist role filters

### DIFF
--- a/src/features/artist/constants.ts
+++ b/src/features/artist/constants.ts
@@ -2,17 +2,37 @@ import { ArtistType, CategoryIdEnum, SubcategoryIdEnum } from 'api/gen'
 import { ArtistRoleLabelConfig, ArtistSectionTitle } from 'features/artist/types'
 
 export const artistRoleLabelMapping: Record<ArtistType, ArtistRoleLabelConfig> = {
-  [ArtistType.author]: 'Auteur',
-  [ArtistType.film_actor]: 'Acteur',
-  [ArtistType.film_director]: 'Réalisateur',
-  [ArtistType.performer]: {
-    [CategoryIdEnum.SPECTACLE]: 'Interprète',
-    [CategoryIdEnum.MUSIQUE_LIVE]: 'Artiste',
-    [CategoryIdEnum.MUSIQUE_ENREGISTREE]: 'Artiste',
+  [ArtistType.author]: {
+    singular: 'Auteur',
+    plural: 'Auteurs',
   },
-  [ArtistType.stage_director]: 'Metteur en scène',
+  [ArtistType.film_actor]: {
+    singular: 'Acteur',
+    plural: 'Acteurs',
+  },
+  [ArtistType.film_director]: {
+    singular: 'Réalisateur',
+    plural: 'Réalisateurs',
+  },
+  [ArtistType.stage_director]: {
+    singular: 'Metteur en scène',
+    plural: 'Metteurs en scène',
+  },
+  [ArtistType.performer]: {
+    [CategoryIdEnum.SPECTACLE]: {
+      singular: 'Interprète',
+      plural: 'Interprètes',
+    },
+    [CategoryIdEnum.MUSIQUE_LIVE]: {
+      singular: 'Artiste',
+      plural: 'Artistes',
+    },
+    [CategoryIdEnum.MUSIQUE_ENREGISTREE]: {
+      singular: 'Artiste',
+      plural: 'Artistes',
+    },
+  },
 }
-
 export const ARTIST_SECTION_TITLES = {
   artist: { singular: 'Artiste', plural: 'Artistes' },
   distribution: { singular: 'Distribution', plural: 'Distribution' },

--- a/src/features/artist/helpers/getArtistRole.native.test.ts
+++ b/src/features/artist/helpers/getArtistRole.native.test.ts
@@ -2,49 +2,61 @@ import { ArtistType, CategoryIdEnum } from 'api/gen'
 import { getArtistRole } from 'features/artist/helpers/getArtistRole'
 
 describe('getArtistRole', () => {
-  describe('when role config is a simple string', () => {
-    it('should return "Auteur" for author artist type', () => {
-      expect(getArtistRole(ArtistType.author)).toEqual('Auteur')
+  describe('Independent roles of the category', () => {
+    it('should return singular role by default', () => {
+      expect(getArtistRole(ArtistType.film_actor)).toEqual('Acteur')
     })
 
-    it('should return "Acteur" for film actor artist type even if a category is provided', () => {
-      expect(getArtistRole(ArtistType.film_actor, CategoryIdEnum.SPECTACLE)).toEqual('Acteur')
-    })
-
-    it('should return "Metteur en scène" for stage director artist type', () => {
-      expect(getArtistRole(ArtistType.stage_director)).toEqual('Metteur en scène')
+    it('should return plural role if specified', () => {
+      expect(getArtistRole(ArtistType.film_actor, undefined, true)).toEqual('Acteurs')
     })
   })
 
-  describe('when role config depends on the category (performer)', () => {
-    it('should return "Interprète" when category is SPECTACLE', () => {
-      const result = getArtistRole(ArtistType.performer, CategoryIdEnum.SPECTACLE)
+  describe('Roles dependent on the category', () => {
+    describe('Singular role', () => {
+      it('should return "Interprète" for a SPECTACLE performer', () => {
+        expect(getArtistRole(ArtistType.performer, CategoryIdEnum.SPECTACLE)).toEqual('Interprète')
+      })
 
-      expect(result).toEqual('Interprète')
+      it('should return "Artiste" for a MUSIQUE_LIVE performer', () => {
+        expect(getArtistRole(ArtistType.performer, CategoryIdEnum.MUSIQUE_LIVE)).toEqual('Artiste')
+      })
+
+      it('should return "Artiste" for a MUSIQUE_ENREGISTREE performer', () => {
+        expect(getArtistRole(ArtistType.performer, CategoryIdEnum.MUSIQUE_ENREGISTREE)).toEqual(
+          'Artiste'
+        )
+      })
     })
 
-    it('should return "Artiste" when category is MUSIQUE_LIVE', () => {
-      const result = getArtistRole(ArtistType.performer, CategoryIdEnum.MUSIQUE_LIVE)
+    describe('Plural role', () => {
+      it('should return "Interprètes" for a SPECTACLE performer', () => {
+        expect(getArtistRole(ArtistType.performer, CategoryIdEnum.SPECTACLE, true)).toEqual(
+          'Interprètes'
+        )
+      })
 
-      expect(result).toEqual('Artiste')
+      it('should return "Artistes" for a MUSIQUE_LIVE performer', () => {
+        expect(getArtistRole(ArtistType.performer, CategoryIdEnum.MUSIQUE_LIVE, true)).toEqual(
+          'Artistes'
+        )
+      })
+
+      it('should return "Artistes" for a MUSIQUE_ENREGISTREE performer', () => {
+        expect(
+          getArtistRole(ArtistType.performer, CategoryIdEnum.MUSIQUE_ENREGISTREE, true)
+        ).toEqual('Artistes')
+      })
     })
+  })
 
-    it('should return "Artiste" when category is MUSIQUE_ENREGISTREE', () => {
-      const result = getArtistRole(ArtistType.performer, CategoryIdEnum.MUSIQUE_ENREGISTREE)
+  it('should return "Artiste(s)" for a category not linked to a role', () => {
+    expect(getArtistRole(ArtistType.performer, CategoryIdEnum.CINEMA)).toBe('Artiste')
+    expect(getArtistRole(ArtistType.performer, CategoryIdEnum.CINEMA, true)).toBe('Artistes')
+  })
 
-      expect(result).toEqual('Artiste')
-    })
-
-    it('should return the fallback "Artiste" if the category is not defined in the mapping', () => {
-      const result = getArtistRole(ArtistType.performer, CategoryIdEnum.CONFERENCE)
-
-      expect(result).toEqual('Artiste')
-    })
-
-    it('should return the fallback "Artiste" if no category is provided', () => {
-      const result = getArtistRole(ArtistType.performer)
-
-      expect(result).toEqual('Artiste')
-    })
+  it('should return "Artiste(s)" for a category linked to a role but not specified', () => {
+    expect(getArtistRole(ArtistType.performer, undefined)).toBe('Artiste')
+    expect(getArtistRole(ArtistType.performer, undefined, true)).toBe('Artistes')
   })
 })

--- a/src/features/artist/helpers/getArtistRole.ts
+++ b/src/features/artist/helpers/getArtistRole.ts
@@ -1,16 +1,23 @@
 import { ArtistType, CategoryIdEnum } from 'api/gen'
 import { artistRoleLabelMapping } from 'features/artist/constants'
 
-export function getArtistRole(role: ArtistType, category?: CategoryIdEnum) {
+export function getArtistRole(role: ArtistType, category?: CategoryIdEnum, isPlural = false) {
   const config = artistRoleLabelMapping[role]
+  const defaultConfig = { singular: 'Artiste', plural: 'Artistes' }
 
-  if (typeof config === 'string') {
-    return config
+  let target = defaultConfig
+
+  if (config) {
+    if ('singular' in config) {
+      target = config
+    } else if (category) {
+      const categoryConfig = config[category]
+
+      if (categoryConfig) {
+        target = categoryConfig
+      }
+    }
   }
 
-  if (category && config[category]) {
-    return config[category] ?? 'Artiste'
-  }
-
-  return 'Artiste'
+  return isPlural ? target.plural : target.singular
 }

--- a/src/features/artist/types.ts
+++ b/src/features/artist/types.ts
@@ -1,6 +1,11 @@
 import { CategoryIdEnum } from 'api/gen'
 
-export type ArtistRoleLabelConfig = string | Partial<Record<CategoryIdEnum, string>>
+type RoleLabels = {
+  singular: string
+  plural: string
+}
+
+export type ArtistRoleLabelConfig = RoleLabels | Partial<Record<CategoryIdEnum, RoleLabels>>
 
 export type ArtistSectionTitle = {
   singular: string

--- a/src/features/offer/components/OfferAbout/OfferAbout.native.test.tsx
+++ b/src/features/offer/components/OfferAbout/OfferAbout.native.test.tsx
@@ -97,38 +97,4 @@ describe('<OfferAbout />', () => {
       expect(screen.queryByText('Description :')).not.toBeOnTheScreen()
     })
   })
-
-  describe('Accessibility section', () => {
-    it('should display accessibility when disabilities are defined', () => {
-      render(
-        <OfferAbout
-          offer={offerResponseSnap}
-          metadata={[]}
-          hasMetadata={false}
-          shouldDisplayAccessibilitySection
-        />
-      )
-
-      expect(screen.getByText('Handicap visuel')).toBeOnTheScreen()
-    })
-
-    it('should not display accessibility when disabilities are not defined', () => {
-      const offer: OfferResponse = {
-        ...offerResponseSnap,
-        accessibility: {},
-      }
-
-      render(
-        <OfferAbout
-          offer={offer}
-          metadata={[]}
-          hasMetadata={false}
-          shouldDisplayAccessibilitySection={false}
-        />
-      )
-
-      expect(screen.queryByText('Handicap visuel')).not.toBeOnTheScreen()
-      expect(screen.queryByText('Accessibilité de l’offre')).not.toBeOnTheScreen()
-    })
-  })
 })

--- a/src/features/offer/components/OfferAbout/OfferAbout.native.test.tsx
+++ b/src/features/offer/components/OfferAbout/OfferAbout.native.test.tsx
@@ -19,41 +19,20 @@ describe('<OfferAbout />', () => {
   ]
 
   it('should display about section', () => {
-    render(
-      <OfferAbout
-        offer={offerResponseSnap}
-        metadata={metadata}
-        hasMetadata
-        shouldDisplayAccessibilitySection
-      />
-    )
+    render(<OfferAbout offer={offerResponseSnap} metadata={metadata} hasMetadata />)
 
     expect(screen.getByText('À propos')).toBeOnTheScreen()
   })
 
   describe('Metadata', () => {
     it('should display metadata', () => {
-      render(
-        <OfferAbout
-          offer={offerResponseSnap}
-          metadata={metadata}
-          hasMetadata
-          shouldDisplayAccessibilitySection={false}
-        />
-      )
+      render(<OfferAbout offer={offerResponseSnap} metadata={metadata} hasMetadata />)
 
       expect(screen.getByText('Mickey')).toBeOnTheScreen()
     })
 
     it('should not display metadata', () => {
-      render(
-        <OfferAbout
-          offer={offerResponseSnap}
-          metadata={[]}
-          hasMetadata={false}
-          shouldDisplayAccessibilitySection={false}
-        />
-      )
+      render(<OfferAbout offer={offerResponseSnap} metadata={[]} hasMetadata={false} />)
 
       expect(screen.queryByText('Mickey')).not.toBeOnTheScreen()
     })
@@ -66,14 +45,7 @@ describe('<OfferAbout />', () => {
         description: 'Cette offre est super cool cool cool cool cool cool',
       }
 
-      render(
-        <OfferAbout
-          offer={offer}
-          metadata={metadata}
-          hasMetadata
-          shouldDisplayAccessibilitySection
-        />
-      )
+      render(<OfferAbout offer={offer} metadata={metadata} hasMetadata />)
 
       expect(
         screen.getByText('Cette offre est super cool cool cool cool cool cool')
@@ -85,14 +57,7 @@ describe('<OfferAbout />', () => {
         ...offerResponseSnap,
         description: null,
       }
-      render(
-        <OfferAbout
-          offer={offer}
-          metadata={metadata}
-          hasMetadata
-          shouldDisplayAccessibilitySection
-        />
-      )
+      render(<OfferAbout offer={offer} metadata={metadata} hasMetadata />)
 
       expect(screen.queryByText('Description :')).not.toBeOnTheScreen()
     })

--- a/src/features/offer/components/OfferAbout/OfferAbout.tsx
+++ b/src/features/offer/components/OfferAbout/OfferAbout.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent } from 'react'
 import { View } from 'react-native'
 
 import { OfferResponse } from 'api/gen'
-import { OfferAccessibility } from 'features/offer/components/OfferAccessibility/OfferAccessibility'
 import { OfferMetadataItemProps } from 'features/offer/components/OfferMetadataItem/OfferMetadataItem'
 import { OfferMetadataList } from 'features/offer/components/OfferMetadataList/OfferMetadataList'
 import { CollapsibleText } from 'ui/components/CollapsibleText/CollapsibleText'
@@ -17,12 +16,7 @@ type Props = {
   shouldDisplayAccessibilitySection: boolean
 }
 
-export const OfferAbout: FunctionComponent<Props> = ({
-  offer,
-  metadata,
-  hasMetadata,
-  shouldDisplayAccessibilitySection,
-}) => {
+export const OfferAbout: FunctionComponent<Props> = ({ offer, metadata, hasMetadata }) => {
   return (
     <ViewGap gap={2}>
       <Typo.Title3 {...getHeadingAttrs(2)}>À propos</Typo.Title3>
@@ -35,9 +29,6 @@ export const OfferAbout: FunctionComponent<Props> = ({
               <Typo.BodyAccent>Description&nbsp;:</Typo.BodyAccent>
               <CollapsibleText text={offer.description} />
             </View>
-          ) : null}
-          {shouldDisplayAccessibilitySection ? (
-            <OfferAccessibility accessibility={offer.accessibility} />
           ) : null}
         </ViewGap>
       </ViewGap>

--- a/src/features/offer/components/OfferAbout/OfferAbout.tsx
+++ b/src/features/offer/components/OfferAbout/OfferAbout.tsx
@@ -13,7 +13,6 @@ type Props = {
   offer: OfferResponse
   metadata: OfferMetadataItemProps[]
   hasMetadata: boolean
-  shouldDisplayAccessibilitySection: boolean
 }
 
 export const OfferAbout: FunctionComponent<Props> = ({ offer, metadata, hasMetadata }) => {

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.native.test.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.native.test.tsx
@@ -7,10 +7,11 @@ import { render, screen, userEvent } from 'tests/utils'
 
 const mockArtist = { id: '1', name: 'Edith Piaf' }
 const mockMultiArtists = [
-  { id: '1', name: 'Sam Worthington' },
-  { id: '2', name: 'Zoe Saldana' },
-  { id: '3', name: 'Sigourney Weaver' },
+  { id: '1', name: 'Sam Worthington', role: ArtistType.film_actor },
+  { id: '2', name: 'Zoe Saldana', role: ArtistType.film_actor },
+  { id: '3', name: 'Sigourney Weaver', role: ArtistType.film_actor },
 ]
+const mockFilmDirector = { id: '4', name: 'James Cameron', role: ArtistType.film_director }
 
 const user = userEvent.setup()
 
@@ -98,6 +99,19 @@ describe('<OfferArtistsSection />', () => {
 
       expect(screen.getAllByText('Artiste')[0]).toBeOnTheScreen()
     })
+
+    it('should not display filter buttons', () => {
+      render(
+        <OfferArtistsSection
+          artists={[mockArtist]}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
+
+      expect(screen.queryByTestId('filterButtons')).not.toBeOnTheScreen()
+    })
   })
 
   describe('When multi artists', () => {
@@ -127,6 +141,92 @@ describe('<OfferArtistsSection />', () => {
       )
 
       expect(screen.getByText('Artistes')).toBeOnTheScreen()
+    })
+
+    it('should not display filter buttons when there are only artists with the same role', () => {
+      render(
+        <OfferArtistsSection
+          artists={mockMultiArtists}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
+
+      expect(screen.queryByTestId('filterButtons')).not.toBeOnTheScreen()
+    })
+
+    it('should display filter buttons when there are artists with different roles', () => {
+      render(
+        <OfferArtistsSection
+          artists={[...mockMultiArtists, mockFilmDirector]}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
+
+      expect(screen.getByText('Acteurs (3)')).toBeOnTheScreen()
+      expect(screen.getByText('Réalisateur (1)')).toBeOnTheScreen()
+    })
+
+    it('should display all artists by default', () => {
+      render(
+        <OfferArtistsSection
+          artists={[...mockMultiArtists, mockFilmDirector]}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
+
+      expect(screen.getByText('Sam Worthington')).toBeOnTheScreen()
+      expect(screen.getByText('Zoe Saldana')).toBeOnTheScreen()
+      expect(screen.getByText('Sigourney Weaver')).toBeOnTheScreen()
+      expect(screen.getByText('James Cameron')).toBeOnTheScreen()
+    })
+
+    it('should filter artists when pressing filter button', async () => {
+      render(
+        <OfferArtistsSection
+          artists={[...mockMultiArtists, mockFilmDirector]}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
+
+      await user.press(screen.getByText('Réalisateur (1)'))
+
+      expect(screen.getByText('James Cameron')).toBeOnTheScreen()
+      expect(screen.queryByText('Sam Worthington')).not.toBeOnTheScreen()
+      expect(screen.queryByText('Zoe Saldana')).not.toBeOnTheScreen()
+      expect(screen.queryByText('Sigourney Weaver')).not.toBeOnTheScreen()
+    })
+
+    it('should display all artists when pressing filter button then deselected', async () => {
+      render(
+        <OfferArtistsSection
+          artists={[...mockMultiArtists, mockFilmDirector]}
+          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+          onPlaylistItemPress={jest.fn()}
+        />
+      )
+
+      await user.press(screen.getByText('Réalisateur (1)'))
+
+      expect(screen.getByText('James Cameron')).toBeOnTheScreen()
+      expect(screen.queryByText('Sam Worthington')).not.toBeOnTheScreen()
+      expect(screen.queryByText('Zoe Saldana')).not.toBeOnTheScreen()
+      expect(screen.queryByText('Sigourney Weaver')).not.toBeOnTheScreen()
+
+      await user.press(screen.getByText('Réalisateur (1)'))
+
+      expect(screen.getByText('Sam Worthington')).toBeOnTheScreen()
+      expect(screen.getByText('Zoe Saldana')).toBeOnTheScreen()
+      expect(screen.getByText('Sigourney Weaver')).toBeOnTheScreen()
+      expect(screen.getByText('James Cameron')).toBeOnTheScreen()
     })
   })
 })

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
@@ -90,7 +90,10 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
       ) : (
         <React.Fragment>
           {filterButtons.length > 1 ? (
-            <ButtonsContainer testID="filterButtons">
+            <ButtonsContainer
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              testID="filterButtons">
               {filterButtons.map(({ role, label }) => (
                 <SingleFilterButton
                   key={role}
@@ -124,10 +127,10 @@ const ArtistImage = styled(FastImage)(({ theme }) => ({
   borderColor: theme.designSystem.color.border.subtle,
 }))
 
-const ButtonsContainer = styled.View(({ theme }) => ({
-  flex: 1,
-  flexDirection: 'row',
-  alignItems: 'center',
-  columnGap: theme.designSystem.size.spacing.xs,
-  marginVertical: theme.designSystem.size.spacing.l,
-}))
+const ButtonsContainer = styled.ScrollView.attrs(({ theme }) => ({
+  contentContainerStyle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: theme.designSystem.size.spacing.s,
+  },
+}))``

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
@@ -1,10 +1,12 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useState } from 'react'
 import { styled, useTheme } from 'styled-components/native'
 
 import { CategoryIdEnum, OfferArtist, SubcategoryIdEnum } from 'api/gen'
 import { formatArtists } from 'features/artist/helpers/formatArtists'
 import { getArtistRole } from 'features/artist/helpers/getArtistRole'
 import { getArtistSectionTitle } from 'features/artist/helpers/getArtistSectionTitle'
+import { getArtistsFilterButtons } from 'features/offer/helpers/getArtistsFilterButtons/getArtistsFilterButtons'
+import { SingleFilterButton } from 'features/search/components/Buttons/SingleFilterButton/SingleFilterButton'
 import { FastImage } from 'libs/resizing-image-on-demand/FastImage'
 import { accessibilityRoleInternalNavigation } from 'shared/accessibility/helpers/accessibilityRoleInternalNavigation'
 import { Avatar } from 'ui/components/Avatar/Avatar'
@@ -34,6 +36,24 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
   const { designSystem } = useTheme()
   const sectionTitle = getArtistSectionTitle(offerSubcategoryId)
   const formattedArtists = formatArtists(artists, offerCategoryId)
+  const filterButtons = getArtistsFilterButtons(artists, offerCategoryId)
+
+  const [selectedFilterRoles, setSelectedFilterRoles] = useState<string[]>([])
+
+  const filteredFormattedArtists = formattedArtists.filter((artist) => {
+    if (!artist.role) return false
+    return selectedFilterRoles.includes(artist.role)
+  })
+
+  const handleFilterPress = (role: string) => {
+    setSelectedFilterRoles((prev) => {
+      if (prev.length === 0) {
+        return [role]
+      }
+
+      return prev.includes(role) ? prev.filter((id) => id !== role) : [...prev, role]
+    })
+  }
 
   const soloArtist = artists[0]
 
@@ -68,12 +88,27 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
           />
         </InternalTouchableLink>
       ) : (
-        <AvatarList
-          data={formattedArtists}
-          avatarConfig={{ size: AVATAR_MEDIUM }}
-          onItemPress={onPlaylistItemPress}
-          withMargins={false}
-        />
+        <React.Fragment>
+          {filterButtons.length > 1 ? (
+            <ButtonsContainer testID="filterButtons">
+              {filterButtons.map(({ role, label }) => (
+                <SingleFilterButton
+                  key={role}
+                  testID={role}
+                  label={label}
+                  isSelected={selectedFilterRoles.includes(role)}
+                  onPress={() => handleFilterPress(role)}
+                />
+              ))}
+            </ButtonsContainer>
+          ) : null}
+          <AvatarList
+            data={filteredFormattedArtists.length > 0 ? filteredFormattedArtists : formattedArtists}
+            avatarConfig={{ size: AVATAR_MEDIUM }}
+            onItemPress={onPlaylistItemPress}
+            withMargins={false}
+          />
+        </React.Fragment>
       )}
     </ViewGap>
   )
@@ -87,4 +122,12 @@ const ArtistImage = styled(FastImage)(({ theme }) => ({
   backgroundColor: theme.designSystem.color.background.subtle,
   borderWidth: 1,
   borderColor: theme.designSystem.color.border.subtle,
+}))
+
+const ButtonsContainer = styled.View(({ theme }) => ({
+  flex: 1,
+  flexDirection: 'row',
+  alignItems: 'center',
+  columnGap: theme.designSystem.size.spacing.xs,
+  marginVertical: theme.designSystem.size.spacing.l,
 }))

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
@@ -46,13 +46,9 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
   })
 
   const handleFilterPress = (role: string) => {
-    setSelectedFilterRoles((prev) => {
-      if (prev.length === 0) {
-        return [role]
-      }
-
-      return prev.includes(role) ? prev.filter((id) => id !== role) : [...prev, role]
-    })
+    setSelectedFilterRoles((prev) =>
+      prev.includes(role) ? prev.filter((id) => id !== role) : [...prev, role]
+    )
   }
 
   const soloArtist = artists[0]
@@ -106,7 +102,7 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
             </ButtonsContainer>
           ) : null}
           <AvatarList
-            data={filteredFormattedArtists.length > 0 ? filteredFormattedArtists : formattedArtists}
+            data={selectedFilterRoles.length > 0 ? filteredFormattedArtists : formattedArtists}
             avatarConfig={{ size: AVATAR_MEDIUM }}
             onItemPress={onPlaylistItemPress}
             withMargins={false}

--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -482,6 +482,38 @@ describe('<OfferBody />', () => {
     })
   })
 
+  describe('Accessibility section', () => {
+    it('should display accessibility when disabilities are defined', () => {
+      const offer: OfferResponse = {
+        ...offerResponseSnap,
+        description: 'Cette offre est super cool cool cool cool cool cool',
+        extraData: {
+          speaker: 'Toto',
+        },
+        accessibility: {
+          audioDisability: true,
+          mentalDisability: true,
+          motorDisability: false,
+          visualDisability: true,
+        },
+      }
+      renderOfferBody({ offer })
+
+      expect(screen.getByText('Handicap visuel')).toBeOnTheScreen()
+    })
+
+    it('should not display accessibility when disabilities are not defined', () => {
+      const offer: OfferResponse = {
+        ...offerResponseSnap,
+        accessibility: {},
+      }
+
+      renderOfferBody({ offer })
+
+      expect(screen.queryByText('Accessibilité de l’offre')).not.toBeOnTheScreen()
+    })
+  })
+
   describe('ProposedBy section', () => {
     const offerWithDifferentAddress: OfferResponse = {
       ...offerResponseSnap,

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -133,8 +133,7 @@ export const OfferBody: FunctionComponent<Props> = ({
     isNullOrUndefined(offer.accessibility.motorDisability)
   )
 
-  const shouldDisplayAboutSection =
-    shouldDisplayAccessibilitySection || !!offer.description || hasMetadata
+  const shouldDisplayAboutSection = !!offer.description || hasMetadata
 
   const handleArtistLinkPress = (artists: OfferArtist[]) => {
     if (artists.length === 0) return
@@ -231,12 +230,7 @@ export const OfferBody: FunctionComponent<Props> = ({
 
       {shouldDisplayAboutSection ? (
         <MarginContainer gap={0}>
-          <OfferAbout
-            offer={offer}
-            metadata={metadata}
-            hasMetadata={hasMetadata}
-            shouldDisplayAccessibilitySection={shouldDisplayAccessibilitySection}
-          />
+          <OfferAbout offer={offer} metadata={metadata} hasMetadata={hasMetadata} />
         </MarginContainer>
       ) : null}
 

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -9,6 +9,7 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { isCurrentBeneficiary } from 'features/auth/helpers/checkStatusType'
 import { UseNavigationType, UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
 import { OfferAbout } from 'features/offer/components/OfferAbout/OfferAbout'
+import { OfferAccessibility } from 'features/offer/components/OfferAccessibility/OfferAccessibility'
 import { OfferArtists } from 'features/offer/components/OfferArtists/OfferArtists'
 import { OfferArtistsSection } from 'features/offer/components/OfferArtistsSection/OfferArtistsSection'
 import { ProposedBySection } from 'features/offer/components/OfferBody/ProposedBySection/ProposedBySection'
@@ -247,6 +248,12 @@ export const OfferBody: FunctionComponent<Props> = ({
             offerSubcategoryId={offer.subcategoryId}
             onPlaylistItemPress={handleOnArtistPlaylistItemPress}
           />
+        </MarginContainer>
+      ) : null}
+
+      {shouldDisplayAccessibilitySection ? (
+        <MarginContainer gap={0}>
+          <OfferAccessibility accessibility={offer.accessibility} />
         </MarginContainer>
       ) : null}
 

--- a/src/features/offer/helpers/getArtistsFilterButtons/getArtistsFilterButtons.native.test.ts
+++ b/src/features/offer/helpers/getArtistsFilterButtons/getArtistsFilterButtons.native.test.ts
@@ -1,0 +1,47 @@
+import { ArtistType, CategoryIdEnum, OfferArtist } from 'api/gen'
+import { getArtistsFilterButtons } from 'features/offer/helpers/getArtistsFilterButtons/getArtistsFilterButtons'
+
+describe('getArtistsFilterButtons', () => {
+  it('should return an empty array when given an empty list of artists', () => {
+    const result = getArtistsFilterButtons([], CategoryIdEnum.CINEMA)
+
+    expect(result).toEqual([])
+  })
+
+  it('should ignore artists who do not have a role or an id', () => {
+    const mockArtists: OfferArtist[] = [
+      { id: '1', name: 'Valid Actor', role: ArtistType.film_actor },
+      { id: undefined, name: 'Missing Id', role: ArtistType.film_director },
+      { id: '3', name: 'Missing Role', role: undefined },
+    ]
+
+    const result = getArtistsFilterButtons(mockArtists, CategoryIdEnum.CINEMA)
+
+    expect(result).toEqual([{ label: 'Acteur (1)', role: 'Acteur' }])
+  })
+
+  it('should correctly format labels to singular when a role group has only one artist', () => {
+    const mockArtists: OfferArtist[] = [
+      { id: '1', name: 'Actor One', role: ArtistType.film_actor },
+      { id: '2', name: 'Director One', role: ArtistType.film_director },
+    ]
+
+    const result = getArtistsFilterButtons(mockArtists, CategoryIdEnum.CINEMA)
+
+    expect(result).toEqual([
+      { role: 'Acteur', label: 'Acteur (1)' },
+      { role: 'Réalisateur', label: 'Réalisateur (1)' },
+    ])
+  })
+
+  it('should correctly format labels to plural when a role group has multiple artists', () => {
+    const mockArtists: OfferArtist[] = [
+      { id: '1', name: 'Actor One', role: ArtistType.film_actor },
+      { id: '2', name: 'Actor Two', role: ArtistType.film_actor },
+    ]
+
+    const result = getArtistsFilterButtons(mockArtists, CategoryIdEnum.CINEMA)
+
+    expect(result).toEqual([{ role: 'Acteur', label: 'Acteurs (2)' }])
+  })
+})

--- a/src/features/offer/helpers/getArtistsFilterButtons/getArtistsFilterButtons.ts
+++ b/src/features/offer/helpers/getArtistsFilterButtons/getArtistsFilterButtons.ts
@@ -1,0 +1,27 @@
+import { ArtistType, CategoryIdEnum, OfferArtist } from 'api/gen'
+import { getArtistRole } from 'features/artist/helpers/getArtistRole'
+
+export function getArtistsFilterButtons(artists: OfferArtist[], categoryId: CategoryIdEnum) {
+  const roleGroups = new Map<string, { count: number; role: ArtistType }>()
+
+  artists.forEach((artist) => {
+    if (!artist.role || !artist.id) return
+    const singular = getArtistRole(artist.role, categoryId, false)
+
+    const current = roleGroups.get(singular) ?? { count: 0, role: artist.role }
+
+    roleGroups.set(singular, {
+      ...current,
+      count: current.count + 1,
+    })
+  })
+
+  return Array.from(roleGroups.entries()).map(([singular, { count, role }]) => {
+    const roleLabel = count > 1 ? getArtistRole(role, categoryId, true) : singular
+
+    return {
+      role: singular,
+      label: `${roleLabel} (${count})`,
+    }
+  })
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42034

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="342" height="243" alt="Capture d’écran 2026-06-03 à 12 57 08" src="https://github.com/user-attachments/assets/6d8dd48e-7170-49c2-b6bf-61ff1924f067" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-03 at 14 50 58" src="https://github.com/user-attachments/assets/a5a7ae52-4f9a-4e9d-b2d2-ba6bb5f147f7" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-03 at 14 50 55" src="https://github.com/user-attachments/assets/fdcb0cfa-372e-4d9b-826a-9b6da14ad68e" />|
| Android          |               |<img width="1080" height="2400" alt="Screenshot_1780491046" src="https://github.com/user-attachments/assets/60c38f6e-1ceb-429a-bb2d-8b4e92804489" /> <img width="1080" height="2400" alt="Screenshot_1780491048" src="https://github.com/user-attachments/assets/6ebfebc2-f634-47df-bb2b-f5b343dda677" />|
| Phone - Chrome   |               |<img width="401" height="696" alt="Capture d’écran 2026-06-03 à 14 51 07" src="https://github.com/user-attachments/assets/e078536f-f43a-4da6-bc9a-e6328e94201f" /> <img width="398" height="685" alt="Capture d’écran 2026-06-03 à 14 51 13" src="https://github.com/user-attachments/assets/30ce1bbe-6514-47a4-b96d-85164ebca1f6" />|
| Desktop - Chrome |               |<img width="1506" height="769" alt="Capture d’écran 2026-06-03 à 14 51 35" src="https://github.com/user-attachments/assets/8741fb76-7e4c-42e9-aaac-d514153008b7" /> <img width="1511" height="772" alt="Capture d’écran 2026-06-03 à 14 51 45" src="https://github.com/user-attachments/assets/02360891-1c4b-48bb-aebf-7afd40b4299b" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
