### PR TITLE
(PC-42021) feat(artist): add wipArtistCategoryPlaylists feature flag

### DIFF
--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -57,6 +57,7 @@ export enum RemoteStoreFeatureFlags {
   ENABLE_QUALTRICS_SURVEY = 'enableQualtricsSurvey',
   SHOW_REMOTE_GENERIC_BANNER = 'showRemoteBanner',
   SHOW_TECHNICAL_PROBLEM_BANNER = 'showTechnicalProblemBanner',
+  WIP_ARTIST_CATEGORY_PLAYLISTS = 'wipArtistCategoryPlaylists',
   WIP_ARTIST_PAGE = 'wipArtistPage',
   WIP_ARTIST_PAGE_IN_SEARCH = 'wipArtistPageInSearch',
   WIP_ARTIST_SECTION_REFACTO = 'wipArtistSectionRefacto',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42021

## But de la PR

Déclarer le Feature Flag `wipArtistCategoryPlaylists` qui pilotera la refonte de la page artiste (PC-41943), où la playlist unique « Toutes ses offres disponibles » sera remplacée par des playlists organisées par catégorie.

Ce ticket pose uniquement l'infrastructure : le flag est déclaré dans l'enum de référence, sans branchement ni changement visible par l'utilisateur. Le pilotage « désactivé par défaut en prod / activé sur staging » est géré côté Firestore (backend).

## Changements

- Ajout de l'entrée `WIP_ARTIST_CATEGORY_PLAYLISTS = 'wipArtistCategoryPlaylists'` à l'enum `RemoteStoreFeatureFlags` (`src/libs/firebase/firestore/types.ts`)
- Respect de la convention de nommage `WIP_* = 'wip*'` et de l'ordre alphabétique
- Le flag apparaît automatiquement dans la liste des cheatcodes (lecture dynamique de `Object.values(RemoteStoreFeatureFlags)`)

## Remarques

- Aucun changement visuel ou fonctionnel : le flag n'est encore consommé par aucun composant
- Le branchement dans la page artiste sera réalisé dans PC-41943