### PR TITLE
(PC-42161) feat(offer): display artist entered manually in artist playlist in item not pressable

### DIFF
--- a/src/features/artist/helpers/formatArtists.native.test.ts
+++ b/src/features/artist/helpers/formatArtists.native.test.ts
@@ -1,30 +1,9 @@
 import { CategoryIdEnum } from 'api/gen'
-import { mockArtists, mockMixedArtists } from 'features/artist/fixtures/mockArtist'
+import { mockMixedArtists } from 'features/artist/fixtures/mockArtist'
 import { formatArtists } from 'features/artist/helpers/formatArtists'
 
 describe('formatArtists', () => {
   it('should format a valid offer artist correctly', () => {
-    const result = formatArtists(mockArtists, CategoryIdEnum.SPECTACLE)
-
-    expect(result).toEqual([
-      {
-        id: 'cb22d035-f081-4ccb-99d8-8f5725a8ac9c',
-        image: 'http://commons.wikimedia.org/wiki/Special:FilePath/Virginie%20Despentes%202012.jpg',
-        name: 'Avril Lavigne',
-        role: 'Artiste',
-        accessibilityLabel: 'Accéder à la page artiste de Avril Lavigne',
-      },
-      {
-        id: 'f7a2b9e4-3d12-4b5c-a81f-67d4e32b901a',
-        image: 'https://fr.wikipedia.org/wiki/Lady_Gaga#/media/Fichier:Lady_Gaga-65189.jpg',
-        name: 'Lady Gaga',
-        role: 'Artiste',
-        accessibilityLabel: 'Accéder à la page artiste de Lady Gaga',
-      },
-    ])
-  })
-
-  it('should format only offer artist with id and exclude those without id', () => {
     const result = formatArtists(mockMixedArtists, CategoryIdEnum.SPECTACLE)
 
     expect(result).toEqual([
@@ -34,6 +13,13 @@ describe('formatArtists', () => {
         name: 'Avril Lavigne',
         role: 'Artiste',
         accessibilityLabel: 'Accéder à la page artiste de Avril Lavigne',
+      },
+      {
+        id: '',
+        accessibilityLabel: 'Accéder à la page artiste de Mika',
+        image: 'http://example.com/mika.jpg',
+        name: 'Mika',
+        role: 'Artiste',
       },
       {
         id: 'f7a2b9e4-3d12-4b5c-a81f-67d4e32b901a',

--- a/src/features/artist/helpers/formatArtists.ts
+++ b/src/features/artist/helpers/formatArtists.ts
@@ -4,10 +4,8 @@ import { Artist } from 'features/venue/types'
 
 export function formatArtists(artists: OfferArtist[], offerCategoryId: CategoryIdEnum): Artist[] {
   return artists.flatMap((artist) => {
-    if (!artist.id) return []
-
     return {
-      id: artist.id,
+      id: artist.id ?? '',
       name: artist.name,
       image: artist.image ?? undefined,
       role: artist.role ? getArtistRole(artist.role, offerCategoryId) : 'Artiste',

--- a/src/ui/components/Avatar/AvatarListItem.native.test.tsx
+++ b/src/ui/components/Avatar/AvatarListItem.native.test.tsx
@@ -43,4 +43,18 @@ describe('<AvatarListItem />', () => {
 
     expect(screen.getByLabelText('Oda')).toBeOnTheScreen()
   })
+
+  it('should not use link when avatar has an empty string as id', () => {
+    render(
+      <AvatarListItem
+        id=""
+        name="Oda"
+        onItemPress={jest.fn()}
+        role="Auteur"
+        accessibilityLabel="Accéder à la page artiste de Oda"
+      />
+    )
+
+    expect(screen.queryByLabelText('Accéder à la page artiste de Oda')).not.toBeOnTheScreen()
+  })
 })

--- a/src/ui/components/Avatar/AvatarListItem.tsx
+++ b/src/ui/components/Avatar/AvatarListItem.tsx
@@ -29,41 +29,56 @@ export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
   accessibilityLabel,
   ...props
 }) => {
+  const content = (
+    <StyledView gap={2} isFullWidth={isFullWidth}>
+      <Avatar size={size} {...props}>
+        {image ? (
+          <StyledImage url={image} testID="artistAvatar" />
+        ) : (
+          <DefaultAvatar testID="defaultArtistAvatar" />
+        )}
+      </Avatar>
+      <View>
+        <ArtistName
+          numberOfLines={2}
+          maxWidth={size ?? 0}
+          isFullWidth={isFullWidth}
+          isDisabled={!id}>
+          {name}
+        </ArtistName>
+        {role ? (
+          <ArtistRole numberOfLines={2} maxWidth={size ?? 0} isFullWidth={isFullWidth}>
+            {role}
+          </ArtistRole>
+        ) : null}
+      </View>
+    </StyledView>
+  )
+
+  if (!id) {
+    return content
+  }
+
   return (
     <InternalTouchableLink
       accessibilityLabel={accessibilityLabel ?? name}
       navigateTo={{ screen: 'Artist', params: { id: id.toString() } }}
       onBeforeNavigate={() => onItemPress(id.toString(), name)}>
-      <StyledView gap={2} isFullWidth={isFullWidth}>
-        <Avatar size={size} {...props}>
-          {image ? (
-            <StyledImage url={image} testID="artistAvatar" />
-          ) : (
-            <DefaultAvatar testID="defaultArtistAvatar" />
-          )}
-        </Avatar>
-        <View>
-          <ArtistName numberOfLines={2} maxWidth={size ?? 0} isFullWidth={isFullWidth}>
-            {name}
-          </ArtistName>
-          {role ? (
-            <ArtistRole numberOfLines={2} maxWidth={size ?? 0} isFullWidth={isFullWidth}>
-              {role}
-            </ArtistRole>
-          ) : null}
-        </View>
-      </StyledView>
+      {content}
     </InternalTouchableLink>
   )
 }
 
-const ArtistName = styled(Typo.BodyAccentS)<{ maxWidth: number; isFullWidth: boolean }>(
-  ({ maxWidth, isFullWidth }) => ({
-    textAlign: 'center',
-    maxWidth: isFullWidth ? '100%' : maxWidth,
-    alignSelf: isFullWidth ? 'center' : 'self-start',
-  })
-)
+const ArtistName = styled(Typo.BodyAccentS)<{
+  maxWidth: number
+  isFullWidth: boolean
+  isDisabled: boolean
+}>(({ maxWidth, isFullWidth, isDisabled, theme }) => ({
+  textAlign: 'center',
+  maxWidth: isFullWidth ? '100%' : maxWidth,
+  alignSelf: 'center',
+  color: isDisabled ? theme.designSystem.color.text.subtle : theme.designSystem.color.text.default,
+}))
 
 const ArtistRole = styled(Typo.BodyAccentXs)<{ maxWidth: number; isFullWidth: boolean }>(
   ({ theme, maxWidth, isFullWidth }) => ({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42161

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="379" height="347" alt="Capture d’écran 2026-06-03 à 17 04 26" src="https://github.com/user-attachments/assets/9789c3e8-44a4-4d58-a429-c3797535f0c4" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-03 at 17 05 19" src="https://github.com/user-attachments/assets/571a7c08-0b62-43ef-86d9-6c0f376be371" />|
| Android          |               |<img width="1080" height="2400" alt="Screenshot_1780499110" src="https://github.com/user-attachments/assets/8b2eea73-306a-4340-8944-9b20bf201181" />|
| Phone - Chrome   |               |<img width="387" height="681" alt="Capture d’écran 2026-06-03 à 17 04 56" src="https://github.com/user-attachments/assets/61437cfb-60a1-4511-b488-6baffa114d09" />|
| Desktop - Chrome |               |<img width="1507" height="766" alt="Capture d’écran 2026-06-03 à 17 04 37" src="https://github.com/user-attachments/assets/9938a4ea-d3f1-4b5c-9a69-23d1cb36ed1e" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
