### PR TITLE
(PC-41544) feat(home): dont show ErrorPage when error 500 from API

### DIFF
--- a/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
@@ -43,7 +43,9 @@ exports[`Home page should render correctly 1`] = `
         <View
           testID="listHeader"
         >
-          <Header />
+          <Header
+            hasServerError={false}
+          />
           <Styled(View)>
             <HomeBanner
               isLoggedIn={false}

--- a/src/features/bookings/pages/Bookings/Bookings.tsx
+++ b/src/features/bookings/pages/Bookings/Bookings.tsx
@@ -148,11 +148,11 @@ export const Bookings = () => {
 const ZoomContainer = styled(ScrollView)(({ theme }) => ({
   backgroundColor: theme.designSystem.color.background.default,
   flex: 1,
-  gap: 6,
+  gap: 6, // Ça pousse le tag il faudrait trouver une solution plus propre pour éviter ça
 }))
 
 const DefaultStepContainer = styled.View(({ theme }) => ({
   backgroundColor: theme.designSystem.color.background.default,
   flex: 1,
-  gap: 6,
+  gap: 6, // Ça pousse le tag il faudrait trouver une solution plus propre pour éviter ça
 }))

--- a/src/features/home/api/useHomepageData.native.test.ts
+++ b/src/features/home/api/useHomepageData.native.test.ts
@@ -91,7 +91,7 @@ describe('useHomepageModules', () => {
     const expectedResult = homepageList[0]
 
     await waitFor(() => {
-      expect(result.current).toEqual(expectedResult)
+      expect(result.current).toEqual({ homepage: expectedResult, error: null })
     })
   })
 })

--- a/src/features/home/api/useHomepageData.ts
+++ b/src/features/home/api/useHomepageData.ts
@@ -80,11 +80,12 @@ export const getHomepageId = (
   return homePageRemoteConfig[homepageType]
 }
 
-export const useHomepageData = (): Homepage => {
+export const useHomepageData = () => {
   const { isLoggedIn, user } = useAuthContext()
   const { data: userHasBookings } = useUserHasBookingsQueryV2(isLoggedIn)
   const onboardingRole = useUserRoleFromOnboarding()
   const { data: remoteConfig } = useRemoteConfigQuery()
+
   const homepageId = getHomepageId(
     {
       isLoggedIn: isLoggedIn && !!user,
@@ -95,10 +96,12 @@ export const useHomepageData = (): Homepage => {
     },
     remoteConfig
   )
-  return useGetHomepageById(homepageId)
+
+  const { homepage, error } = useGetHomepageById(homepageId)
+  return { homepage, error }
 }
 
-export const useGetHomepageById = (homepageId: string): Homepage => {
-  const { data } = useFetchHomepageByIdQuery(homepageId)
-  return data ?? EMPTY_HOMEPAGE
+export const useGetHomepageById = (homepageId: string) => {
+  const query = useFetchHomepageByIdQuery(homepageId)
+  return { homepage: query.data ?? EMPTY_HOMEPAGE, error: query.error }
 }

--- a/src/features/home/components/headers/HomeHeader.tsx
+++ b/src/features/home/components/headers/HomeHeader.tsx
@@ -15,12 +15,15 @@ import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
 import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
 import { formatCurrencyFromCents } from 'shared/currency/formatCurrencyFromCents'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
+import { ServerErrorTag } from 'shared/ServerErrorTag/ServerErrorTag'
 import { useAvailableCredit } from 'shared/user/useAvailableCredit'
 import { PageHeader } from 'ui/components/headers/PageHeader'
 import { Separator } from 'ui/components/Separator'
 import { Spacer, Typo } from 'ui/theme'
 
-export const HomeHeader: FunctionComponent = function () {
+type Props = { hasServerError?: boolean }
+
+export const HomeHeader: FunctionComponent<Props> = function ({ hasServerError }) {
   const availableCredit = useAvailableCredit()
   const { isLoggedIn, user } = useAuthContext()
   const { isDesktopViewport, designSystem } = useTheme()
@@ -60,6 +63,7 @@ export const HomeHeader: FunctionComponent = function () {
       return (
         <React.Fragment>
           <Spacer.TopScreen />
+          {hasServerError ? <ServerErrorTag /> : null}
           <HeaderContainer>
             <TitleContainer>
               <Title testID="web-location-widget">
@@ -79,7 +83,8 @@ export const HomeHeader: FunctionComponent = function () {
         title={welcomeTitle}
         subtitle={getSubtitle()}
         numberOfLines={numberOfLines}
-        withMargins>
+        withMargins
+        hasServerError={hasServerError}>
         {isDesktopViewport ? null : <LocationWidget screenOrigin={ScreenOrigin.HOME} />}
       </PageHeader>
     )
@@ -92,6 +97,7 @@ export const HomeHeader: FunctionComponent = function () {
     currency,
     euroToPacificFrancRate,
     height,
+    hasServerError,
   ])
 
   return Header

--- a/src/features/home/pages/Home.native.test.tsx
+++ b/src/features/home/pages/Home.native.test.tsx
@@ -48,8 +48,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 useRoute.mockReturnValue({ params: undefined })
 
 mockUseHomepageData.mockReturnValue({
-  modules: [formattedVenuesModule],
-  homeEntryId: 'fakeEntryId',
+  homepage: { modules: [formattedVenuesModule], id: 'fakeEntryId' },
+  error: null,
 })
 
 jest.useFakeTimers()
@@ -66,8 +66,8 @@ describe('Home page', () => {
   it('should render correctly', async () => {
     useRoute.mockReturnValueOnce({ params: undefined })
     mockUseHomepageData.mockReturnValueOnce({
-      modules: [formattedVenuesModule],
-      id: 'fakeEntryId',
+      homepage: { modules: [formattedVenuesModule], id: 'fakeEntryId' },
+      error: null,
     })
     renderHome()
     await screen.findByText('Bienvenue !')
@@ -80,8 +80,8 @@ describe('Home page', () => {
   it('should log ConsultHome', async () => {
     useRoute.mockReturnValueOnce({ params: undefined })
     mockUseHomepageData.mockReturnValueOnce({
-      modules: [formattedVenuesModule],
-      id: 'fakeEntryId',
+      homepage: { modules: [formattedVenuesModule], id: 'fakeEntryId' },
+      error: null,
     })
     renderHome()
     await screen.findByText('Bienvenue !')

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -20,18 +20,24 @@ import { LocationMode } from 'libs/location/types'
 import { getAppVersion } from 'libs/packageJson'
 import { BatchProfile } from 'libs/react-native-batch'
 import { useBookingsV2Query } from 'queries/bookings/useBookingsQuery'
+import { isServerError } from 'shared/isServerError/isServerError'
 import { useModal } from 'ui/components/modals/useModal'
 import { StatusBarBlurredBackground } from 'ui/components/statusBar/statusBarBlurredBackground'
 
-const Header = () => (
+type Props = { hasServerError: boolean }
+
+const Header = ({ hasServerError }: Props) => (
   <ListHeaderContainer>
-    <HomeHeader />
+    <HomeHeader hasServerError={hasServerError} />
   </ListHeaderContainer>
 )
 
 export const Home: FunctionComponent = () => {
   const { params } = useRoute<UseRouteType<'Home'>>()
-  const { modules, id: homepageId } = useHomepageData()
+  const { homepage, error } = useHomepageData()
+  const { modules, id: homepageId } = homepage
+  const hasServerError = isServerError(error)
+
   const { hasGeolocPosition, selectedLocationMode, setSelectedLocationMode } = useLocation()
   const { isLoggedIn, user } = useAuthContext()
 
@@ -107,7 +113,7 @@ export const Home: FunctionComponent = () => {
       <GenericHome
         modules={modules}
         homeId={homepageId ?? ''}
-        Header={<Header />}
+        Header={<Header hasServerError={hasServerError} />}
         HomeBanner={<HomeBanner isLoggedIn={isLoggedIn} />}
         videoModuleId={params?.videoModuleId}
         statusBar={<StatusBarBlurredBackground />}

--- a/src/features/home/pages/Home.web.test.tsx
+++ b/src/features/home/pages/Home.web.test.tsx
@@ -31,6 +31,11 @@ jest.spyOn(CookiesUpToDate, 'useIsCookiesListUpToDate').mockReturnValue({
   isLoading: false,
 })
 
+mockUseHomepageData.mockReturnValue({
+  homepage: { modules: [formattedBusinessModule], id: 'fakeEntryId' },
+  error: null,
+})
+
 describe('<Home/>', () => {
   beforeEach(() => {
     mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', subcategoriesDataTest)
@@ -38,15 +43,6 @@ describe('<Home/>', () => {
 
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
-      mockUseHomepageData.mockReturnValueOnce({
-        modules: [formattedBusinessModule],
-        homeEntryId: 'fakeEntryId',
-      })
-      mockUseHomepageData.mockReturnValueOnce({
-        modules: [formattedBusinessModule],
-        homeEntryId: 'fakeEntryId',
-      }) // Adding useWhichModalToShow to Home.tsx caused an extra render
-
       const { container } = render(<Home />, {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
       })

--- a/src/features/home/pages/ThematicHome.tsx
+++ b/src/features/home/pages/ThematicHome.tsx
@@ -144,7 +144,8 @@ export const ThematicHome: FunctionComponent = () => {
   const { navigate } = useNavigation<UseNavigationType>()
 
   // if homepage fails to be fetched, `homeId` should not be `requestHomeId`, it would mislead tracker's data
-  const { id: homeId, modules, thematicHeader } = useGetHomepageById(requestHomeId)
+  const { homepage } = useGetHomepageById(requestHomeId)
+  const { id: homeId, modules, thematicHeader } = homepage
   const {
     userLocation,
     hasGeolocPosition,

--- a/src/features/home/queries/useGetHomepageQuery.ts
+++ b/src/features/home/queries/useGetHomepageQuery.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { adaptHomepageEntry } from 'libs/contentful/adapters/adaptHomepageEntries'
 import { fetchHomepageById } from 'libs/contentful/fetchHomepages'
 import { QueryKeys } from 'libs/queryKeys'
+import { isServerError } from 'shared/isServerError/isServerError'
 
 export const useFetchHomepageByIdQuery = (homepageId: string) =>
   useQuery({
@@ -12,4 +13,5 @@ export const useFetchHomepageByIdQuery = (homepageId: string) =>
     staleTime: 60 * 60 * 1000, // 1 hour
     meta: { persist: true },
     select: adaptHomepageEntry,
+    throwOnError: (error) => !isServerError(error),
   })

--- a/src/features/profile/containers/ProfileOnline/ProfileOnline.tsx
+++ b/src/features/profile/containers/ProfileOnline/ProfileOnline.tsx
@@ -65,6 +65,6 @@ const ScrollContainer = styled(ScrollView).attrs(({ theme }) => ({
   contentContainerStyle: {
     flexGrow: 1,
     paddingHorizontal: theme.contentPage.marginHorizontal,
-    paddingVertical: theme.contentPage.marginVertical,
+    paddingVertical: theme.contentPage.marginVertical, // Ça pousse le tag il faudrait trouver une solution plus propre pour éviter ça
   },
 }))``

--- a/src/libs/react-query/queryClient.ts
+++ b/src/libs/react-query/queryClient.ts
@@ -1,6 +1,7 @@
 import { QueryCache, QueryClient } from '@tanstack/react-query'
 
 import { env } from 'libs/environment/env'
+import { isServerError } from 'shared/isServerError/isServerError'
 
 const queryCache = new QueryCache()
 // Read https://tkdodo.eu/blog/placeholder-and-initial-data-in-react-query
@@ -9,7 +10,7 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 0,
-      throwOnError: true,
+      throwOnError: (error) => !isServerError(error),
       refetchOnWindowFocus: !(__DEV__ || env.ENV !== 'testing'),
     },
   },

--- a/src/shared/ServerErrorTag/ServerErrorTag.tsx
+++ b/src/shared/ServerErrorTag/ServerErrorTag.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { Tag } from 'ui/designSystem/Tag/Tag'
+import { TagVariant } from 'ui/designSystem/Tag/types'
+import { Warning } from 'ui/svg/icons/Warning'
+
+export const ServerErrorTag = () => (
+  <TagContainer>
+    <Tag label="Problème serveur" variant={TagVariant.WARNING} Icon={Warning} />
+  </TagContainer>
+)
+
+const TagContainer = styled.View(({ theme }) => ({
+  justifyContent: 'center',
+  flexDirection: 'row',
+  marginTop: theme.designSystem.size.spacing.m,
+}))

--- a/src/shared/isServerError/isServerError.native.test.ts
+++ b/src/shared/isServerError/isServerError.native.test.ts
@@ -1,0 +1,24 @@
+import { ApiError } from 'api/ApiError'
+
+import { isServerError } from './isServerError'
+
+describe('isServerError', () => {
+  it.each([500, 501, 502, 503, 504, 599])('should return true for status code %i', (statusCode) => {
+    expect(isServerError(new ApiError(statusCode, 'error'))).toBe(true)
+  })
+
+  it.each([100, 200, 300, 400, 404, 499, 600])(
+    'should return false for status code %i',
+    (statusCode) => {
+      expect(isServerError(new ApiError(statusCode, 'error'))).toBe(false)
+    }
+  )
+
+  it('should return false for a standard Error', () => {
+    expect(isServerError(new Error('error'))).toBe(false)
+  })
+
+  it('should return false for null', () => {
+    expect(isServerError(null)).toBe(false)
+  })
+})

--- a/src/shared/isServerError/isServerError.ts
+++ b/src/shared/isServerError/isServerError.ts
@@ -1,0 +1,4 @@
+import { ApiError } from 'api/ApiError'
+
+export const isServerError = (error: Error | null): boolean =>
+  error instanceof ApiError && Math.floor(error.statusCode / 100) === 5

--- a/src/ui/components/headers/PageHeader.tsx
+++ b/src/ui/components/headers/PageHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
+import { ServerErrorTag } from 'shared/ServerErrorTag/ServerErrorTag'
 import { Spacer, Typo } from 'ui/theme'
 
 type Props = {
@@ -9,6 +10,7 @@ type Props = {
   subtitle?: string
   children?: React.ReactNode
   withMargins?: boolean
+  hasServerError?: boolean
 }
 
 export const PageHeader = ({
@@ -16,12 +18,14 @@ export const PageHeader = ({
   numberOfLines = 1,
   subtitle,
   withMargins = false,
+  hasServerError = false,
   children,
 }: Props) => {
   return (
     <React.Fragment>
       {withMargins ? <Spacer.TopScreen /> : null}
       <HeaderContainer withMargins={withMargins}>
+        {hasServerError ? <ServerErrorTag /> : null}
         <TitleContainer>
           <TitleText numberOfLines={numberOfLines}>{title}</TitleText>
           {subtitle ? <StyledBodyAccentXs>{subtitle}</StyledBodyAccentXs> : null}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41544

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |   <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-06-03 at 17 29 31" src="https://github.com/user-attachments/assets/068ae31e-ddeb-4c39-8a20-ceb838b67334" />   |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
