### PR TITLE
(PC-42005) fix(offer): remove duplicate distribution metadata on cine…

### DIFF
--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -124,7 +124,7 @@ export const OfferBody: FunctionComponent<Props> = ({
     isCinemaOffer,
   })
 
-  const metadata = getOfferMetadata(extraData)
+  const metadata = getOfferMetadata(extraData, subcategory.categoryId, artists.length > 0)
   const hasMetadata = metadata.length > 0
   const shouldDisplayAccessibilitySection = !(
     isNullOrUndefined(offer.accessibility.visualDisability) &&

--- a/src/features/offer/helpers/getOfferMetadata/getOfferMetadata.test.ts
+++ b/src/features/offer/helpers/getOfferMetadata/getOfferMetadata.test.ts
@@ -1,3 +1,4 @@
+import { CategoryIdEnum } from 'api/gen'
 import { getOfferMetadata } from 'features/offer/helpers/getOfferMetadata/getOfferMetadata'
 
 describe('getOfferMetadata', () => {
@@ -47,5 +48,40 @@ describe('getOfferMetadata', () => {
     const result = getOfferMetadata(extraData)
 
     expect(result).toEqual([{ label: '', value: 'Interdection au moins de 18 ans' }])
+  })
+
+  it('should not return Distribution metadata for cinema offers when artists are displayed', () => {
+    const extraData = { cast: ['Actor1', 'Actor2'] }
+    const result = getOfferMetadata(extraData, CategoryIdEnum.CINEMA, true)
+
+    expect(result).toEqual([])
+  })
+
+  it('should keep Distribution metadata for cinema offers when no artists are displayed', () => {
+    const extraData = { cast: ['Actor1', 'Actor2'] }
+    const result = getOfferMetadata(extraData, CategoryIdEnum.CINEMA, false)
+
+    expect(result).toEqual([{ label: 'Distribution', value: 'Actor1, Actor2' }])
+  })
+
+  it('should keep other cinema metadata while removing Distribution when artists are displayed', () => {
+    const extraData = {
+      certificate: 'Tous publics',
+      releaseDate: '2023-01-01',
+      cast: ['Actor1', 'Actor2'],
+    }
+    const result = getOfferMetadata(extraData, CategoryIdEnum.CINEMA, true)
+
+    expect(result).toEqual([
+      { label: '', value: 'Tous publics' },
+      { label: 'Date de sortie', value: '01 janvier 2023' },
+    ])
+  })
+
+  it('should keep Distribution metadata for non-cinema offers even when artists are displayed', () => {
+    const extraData = { cast: ['Actor1', 'Actor2'] }
+    const result = getOfferMetadata(extraData, CategoryIdEnum.SPECTACLE, true)
+
+    expect(result).toEqual([{ label: 'Distribution', value: 'Actor1, Actor2' }])
   })
 })

--- a/src/features/offer/helpers/getOfferMetadata/getOfferMetadata.ts
+++ b/src/features/offer/helpers/getOfferMetadata/getOfferMetadata.ts
@@ -1,4 +1,4 @@
-import { OfferExtraDataResponse } from 'api/gen'
+import { CategoryIdEnum, OfferExtraDataResponse } from 'api/gen'
 import { OfferMetadataItemProps } from 'features/offer/components/OfferMetadataItem/OfferMetadataItem'
 
 const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
@@ -21,8 +21,17 @@ function filterEmptyItems(item: OfferMetadataItemProps): boolean {
   return item.value !== ''
 }
 
-export function getOfferMetadata(extraData?: OfferExtraDataResponse): OfferMetadataItemProps[] {
+export function getOfferMetadata(
+  extraData?: OfferExtraDataResponse,
+  categoryId?: CategoryIdEnum,
+  hasArtists?: boolean
+): OfferMetadataItemProps[] {
   const castValue = extraData?.cast?.join(', ')
+  // For cinema offers, the cast is already displayed through the OfferArtists
+  // component, so the textual "Distribution" metadata would be a duplicate.
+  // It is only hidden when artists are actually rendered (hasArtists), otherwise
+  // the distribution information would disappear entirely from the page.
+  const isDistributionDuplicated = categoryId === CategoryIdEnum.CINEMA && !!hasArtists
 
   return [
     {
@@ -35,6 +44,6 @@ export function getOfferMetadata(extraData?: OfferExtraDataResponse): OfferMetad
     },
     { label: 'Intervenant', value: getValue(extraData?.speaker) },
     { label: 'Éditeur', value: getValue(extraData?.editeur) },
-    { label: 'Distribution', value: getValue(castValue) },
+    { label: 'Distribution', value: isDistributionDuplicated ? '' : getValue(castValue) },
   ].filter(filterEmptyItems)
 }


### PR DESCRIPTION
…ma offers

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42005
## Contexte

Sur les pages offre cinéma, le champ texte **« Distribution »** (issu de `extraData.cast`) était affiché dans la section « À propos » alors que le composant visuel `OfferArtists` présente déjà les mêmes acteurs et réalisateurs (avec photos et onglets). Ce doublon nuisait à la lisibilité de la page.

Le problème est spécifique au cinéma : pour les autres catégories (spectacles → `Intervenant`, livres → `Éditeur`, conférences…), métadonnées et `OfferArtists` couvrent des données complémentaires et restent inchangées.

## Changements

- `getOfferMetadata` prend deux nouveaux paramètres `categoryId` et `hasArtists`.
- La métadonnée texte « Distribution » est masquée **uniquement pour les offres cinéma** (`CategoryIdEnum.CINEMA`) **et seulement si des artistes sont réellement affichés** (`artists.length > 0`).
- `OfferBody` transmet `subcategory.categoryId` et `artists.length > 0` au helper.
- Les autres métadonnées cinéma (`certificate`, `releaseDate`) et les autres catégories ne sont pas impactées.

## Point d'attention : garde-fou sur la source des données

`offer.artists` et `extraData.cast` sont **deux sources distinctes**. `OfferArtists` n'est rendu que si `offer.artists` est non vide. Si une offre cinéma a un `extraData.cast` renseigné mais **aucun artiste mappé**, masquer la métadonnée ferait disparaître totalement l'information de distribution.

Le retrait est donc **conditionné à la présence effective d'artistes** : la déduplication ne s'applique que lorsque `OfferArtists` affiche réellement le cast.

> ⚠️ Ce comportement **diverge volontairement du scénario 3 du ticket** (qui déclarait ce cas « hors scope » avec disparition de la métadonnée). Le scénario 3 doit être amendé : *« la Distribution texte reste affichée si aucun artiste n'est rendu »*.

## Tests

- Cinéma **avec** artistes → « Distribution » masquée ✅
- Cinéma **sans** artistes → « Distribution » conservée ✅
- Cinéma → `certificate` / `releaseDate` toujours présents ✅
- Spectacle / livre / conférence → `Intervenant` / `Éditeur` / `Distribution` inchangés ✅

## Vérifications

- ✅ Tests unitaires : 11/11 (`getOfferMetadata.test.ts`)
- ✅ `tsc --noEmit` sans erreur
- ✅ ESLint sans erreur
