### PR TITLE
(PC-42188) refactor(location): move location permission init to App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { AnalyticsInitializer } from 'libs/firebase/analytics/AnalyticsInitializ
 import { FirestoreNetworkObserver } from 'libs/firebase/firestore/FirestoreNetworkObserver/FirestoreNetworkObserver'
 import { GeolocationActivationModal } from 'libs/location/geolocation/components/GeolocationActivationModal'
 import { LocationWrapper } from 'libs/location/location'
+import { initLocationPermission } from 'libs/locationV2/location.methods'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { NetInfoWrapper } from 'libs/network/NetInfoWrapper'
 import { OfflineModeContainer } from 'libs/network/OfflineModeContainer'
@@ -62,8 +63,13 @@ const App: FunctionComponent = function () {
 
   useEffect(() => {
     initAlgoliaAnalytics()
+    initLocationPermission()
     BatchPush.refreshToken() //  Synchronizes the user's iOS token with Batch. Should be called at each app launch. No effect on Android.
-    BatchMessaging.setFontOverride('Montserrat-Regular', 'Montserrat-Bold', 'Montserrat-Italic')
+    void BatchMessaging.setFontOverride(
+      'Montserrat-Regular',
+      'Montserrat-Bold',
+      'Montserrat-Italic'
+    )
     configureGoogleSignin({
       webClientId: env.GOOGLE_CLIENT_ID,
       iosClientId: env.GOOGLE_IOS_CLIENT_ID,

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -22,6 +22,7 @@ import { AppWebHead } from 'libs/appWebHead'
 import { env } from 'libs/environment/env'
 import { GeolocationActivationModal } from 'libs/location/geolocation/components/GeolocationActivationModal'
 import { LocationWrapper } from 'libs/location/location'
+import { initLocationPermission } from 'libs/locationV2/location.methods'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { SafeAreaProvider } from 'libs/react-native-save-area-provider'
 import { ReactQueryClientProvider } from 'libs/react-query/ReactQueryClientProvider'
@@ -38,11 +39,12 @@ globalThisShim()
 
 export function App() {
   useEffect(() => {
-    eventMonitoring.init({ enabled: !__DEV__ })
+    void eventMonitoring.init({ enabled: !__DEV__ })
   }, [])
 
   useEffect(() => {
     initAlgoliaAnalytics()
+    initLocationPermission()
     const setDeviceInfo = async () => {
       const existingDeviceInfo = deviceInfoStoreSelectors.selectDeviceInfo()
       if (existingDeviceInfo.deviceId) return
@@ -55,7 +57,7 @@ export function App() {
   // Unregister service workers (to make sure all sw cache is removed)
   useEffect(() => {
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.getRegistrations().then((registrations) => {
+      void navigator.serviceWorker.getRegistrations().then((registrations) => {
         registrations.forEach((registration) => registration.unregister())
       })
     }

--- a/src/features/location/components/HomeLocationModal.native.test.tsx
+++ b/src/features/location/components/HomeLocationModal.native.test.tsx
@@ -10,6 +10,7 @@ import {
   GeolocPermissionState,
   LocationWrapper,
 } from 'libs/location/location'
+import { initLocationPermission } from 'libs/locationV2/location.methods'
 import { locationModalActions } from 'libs/locationV2/locationModal.store'
 import { SuggestedPlace } from 'libs/place/types'
 import { MODAL_TO_HIDE_TIME, MODAL_TO_SHOW_TIME } from 'tests/constants'
@@ -57,6 +58,7 @@ describe('HomeLocationModal', () => {
   it('should render correctly if modal visible', async () => {
     act(() => {
       locationModalActions.show()
+      initLocationPermission()
     })
     renderHomeLocationModal()
 
@@ -70,6 +72,7 @@ describe('HomeLocationModal', () => {
   it('should trigger logEvent "logUserSetLocation" on onSubmit', async () => {
     act(() => {
       locationModalActions.show()
+      initLocationPermission()
     })
     renderHomeLocationModal()
     await act(async () => {
@@ -96,6 +99,7 @@ describe('HomeLocationModal', () => {
   it('should hide modal on close modal button press', async () => {
     act(() => {
       locationModalActions.show()
+      initLocationPermission()
     })
     renderHomeLocationModal()
     await act(async () => {
@@ -113,6 +117,7 @@ describe('HomeLocationModal', () => {
     getGeolocPositionMock.mockResolvedValueOnce({ latitude: 0, longitude: 0 })
     act(() => {
       locationModalActions.show()
+      initLocationPermission()
     })
 
     renderHomeLocationModal()
@@ -127,6 +132,7 @@ describe('HomeLocationModal', () => {
     mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.DENIED)
     act(() => {
       locationModalActions.show()
+      initLocationPermission()
     })
 
     renderHomeLocationModal()
@@ -143,6 +149,7 @@ describe('HomeLocationModal', () => {
     mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.NEVER_ASK_AGAIN)
     act(() => {
       locationModalActions.show()
+      initLocationPermission()
     })
 
     const Container = () => {

--- a/src/features/location/components/SearchLocationModal.native.test.tsx
+++ b/src/features/location/components/SearchLocationModal.native.test.tsx
@@ -17,6 +17,7 @@ import {
   LocationWrapper,
 } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
+import { initLocationPermission } from 'libs/locationV2/location.methods'
 import { locationModalActions } from 'libs/locationV2/locationModal.store'
 import { SuggestedPlace } from 'libs/place/types'
 import { MODAL_TO_HIDE_TIME, MODAL_TO_SHOW_TIME } from 'tests/constants'
@@ -75,6 +76,10 @@ jest.spyOn(useSearch, 'useSearch').mockReturnValue({
 const user = userEvent.setup()
 
 describe('SearchLocationModal', () => {
+  beforeEach(() => {
+    initLocationPermission()
+  })
+
   it('should render correctly if modal visible', async () => {
     renderSearchLocationModal()
     await user.press(screen.getByText('Open modal'))
@@ -184,6 +189,8 @@ describe('SearchLocationModal', () => {
         </LocationWrapper>
       )
     }
+    initLocationPermission()
+
     render(<Container />)
     locationModalActions.show()
 

--- a/src/features/location/components/VenueMapLocationModal.native.test.tsx
+++ b/src/features/location/components/VenueMapLocationModal.native.test.tsx
@@ -17,6 +17,7 @@ import {
   LocationWrapper,
 } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
+import { initLocationPermission } from 'libs/locationV2/location.methods'
 import { locationModalActions } from 'libs/locationV2/locationModal.store'
 import { SuggestedPlace } from 'libs/place/types'
 import { MODAL_TO_HIDE_TIME, MODAL_TO_SHOW_TIME } from 'tests/constants'
@@ -79,6 +80,10 @@ const removeSelectedVenueSpy = jest.spyOn(useVenueMapStore, 'removeSelectedVenue
 const user = userEvent.setup()
 
 describe('VenueMapLocationModal', () => {
+  beforeEach(() => {
+    initLocationPermission()
+  })
+
   it('should render correctly if modal visible', async () => {
     renderVenueMapLocationModal({})
     await act(async () => {
@@ -346,6 +351,9 @@ describe('VenueMapLocationModal', () => {
       )
     }
     render(<Container />)
+
+    initLocationPermission()
+
     await act(async () => {
       jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
     })

--- a/src/libs/location/LocationWrapper.native.test.tsx
+++ b/src/libs/location/LocationWrapper.native.test.tsx
@@ -1,6 +1,12 @@
+import { act } from 'react'
+
 import { checkGeolocPermission } from 'libs/location/geolocation/checkGeolocPermission/checkGeolocPermission'
 import { getGeolocPosition } from 'libs/location/geolocation/getGeolocPosition/getGeolocPosition'
 import { requestGeolocPermission } from 'libs/location/geolocation/requestGeolocPermission/requestGeolocPermission'
+import {
+  contextualRequestGeolocPermission,
+  initLocationPermission,
+} from 'libs/locationV2/location.methods'
 import { renderHook, waitFor } from 'tests/utils'
 
 import { GeolocPermissionState, GeolocPositionError } from './geolocation/enums'
@@ -34,7 +40,9 @@ describe('useLocation()', () => {
     it('should call onSubmit() and onAcceptance() when requestGeolocPermission() returns GRANTED', async () => {
       mockPermissionResult(GeolocPermissionState.GRANTED)
       const { result } = renderLocationHook()
-      result.current.requestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
+      await act(async () => {
+        await contextualRequestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
+      })
 
       await waitFor(() => {
         expect(result.current.permissionState).toEqual(GeolocPermissionState.GRANTED)
@@ -48,7 +56,9 @@ describe('useLocation()', () => {
     it('should call onSubmit() and onRefusal() when requestGeolocPermission() returns DENIED', async () => {
       mockPermissionResult(GeolocPermissionState.DENIED)
       const { result } = renderLocationHook()
-      result.current.requestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
+      await act(async () => {
+        await contextualRequestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
+      })
 
       await waitFor(() => {
         expect(result.current.permissionState).toEqual(GeolocPermissionState.DENIED)
@@ -62,7 +72,9 @@ describe('useLocation()', () => {
     it('should call onSubmit() and onRefusal() when requestGeolocPermission() returns NEVER_ASK_AGAIN', async () => {
       mockPermissionResult(GeolocPermissionState.NEVER_ASK_AGAIN)
       const { result } = renderLocationHook()
-      result.current.requestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
+      await act(async () => {
+        await contextualRequestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
+      })
 
       await waitFor(() => {
         expect(result.current.permissionState).toEqual(GeolocPermissionState.NEVER_ASK_AGAIN)
@@ -76,7 +88,9 @@ describe('useLocation()', () => {
     it('should call onSubmit() and onAcceptance() when requestGeolocPermission() returns NEED_ASK_POSITION_DIRECTLY and position is not null', async () => {
       mockPermissionResult(GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY)
       const { result } = renderLocationHook()
-      result.current.requestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
+      await act(async () => {
+        await contextualRequestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
+      })
 
       await waitFor(() => {
         expect(result.current.permissionState).toEqual(GeolocPermissionState.GRANTED)
@@ -91,7 +105,9 @@ describe('useLocation()', () => {
       mockGetGeolocPositionFail()
       mockPermissionResult(GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY)
       const { result } = renderLocationHook()
-      result.current.requestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
+      await act(async () => {
+        await contextualRequestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
+      })
 
       await waitFor(() => {
         expect(result.current.permissionState).toEqual(GeolocPermissionState.NEVER_ASK_AGAIN)
@@ -111,6 +127,10 @@ describe('useLocation()', () => {
       async (params: { permission: GeolocPermissionState }) => {
         const { permission } = params
         mockPermissionResult(permission)
+
+        await act(async () => {
+          initLocationPermission()
+        })
         renderLocationHook()
 
         await waitFor(() => {
@@ -128,6 +148,11 @@ describe('useLocation()', () => {
       async (params: { permission: GeolocPermissionState }) => {
         const { permission } = params
         mockPermissionResult(permission)
+
+        await act(async () => {
+          initLocationPermission()
+        })
+
         renderLocationHook()
 
         await waitFor(() => {

--- a/src/libs/location/LocationWrapper.tsx
+++ b/src/libs/location/LocationWrapper.tsx
@@ -1,13 +1,10 @@
-import React, { memo, useContext, useEffect, useMemo } from 'react'
+import React, { memo, useContext, useMemo } from 'react'
 
 import { DEFAULT_RADIUS } from 'features/search/constants'
-import { useAppStateChange } from 'libs/appState'
 import { LocationMode, ILocationContext } from 'libs/location/types'
 import {
-  contextualCheckPermission,
   contextualRequestGeolocPermission,
   onPressGeolocPermissionModalButton,
-  triggerPositionUpdate,
 } from 'libs/locationV2/location.methods'
 import {
   locationActions,
@@ -32,7 +29,6 @@ const LocationContext = React.createContext<ILocationContext>({
   geolocPositionError: null,
   permissionState: null,
   requestGeolocPermission: async () => {},
-  triggerPositionUpdate: () => null,
   showGeolocPermissionModal: () => null,
   onPressGeolocPermissionModalButton: () => null,
   selectedLocationMode: LocationMode.EVERYWHERE,
@@ -84,13 +80,6 @@ export const LocationWrapper = memo(function LocationWrapper({
     locationModalActions.setAddressInputValue('')
   }
 
-  useEffect(() => {
-    void contextualCheckPermission()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  useAppStateChange(contextualCheckPermission, undefined, [])
-
   const userLocation = useUserLocation()
 
   const value = useMemo(
@@ -100,7 +89,6 @@ export const LocationWrapper = memo(function LocationWrapper({
       permissionState,
       hasGeolocPosition,
       requestGeolocPermission: contextualRequestGeolocPermission,
-      triggerPositionUpdate,
       onPressGeolocPermissionModalButton,
       place,
       setPlace,

--- a/src/libs/location/__mocks__/location.ts
+++ b/src/libs/location/__mocks__/location.ts
@@ -26,7 +26,6 @@ const locationContext: ILocationContext = {
   geolocPositionError: null,
   permissionState: GeolocPermissionState.GRANTED,
   requestGeolocPermission,
-  triggerPositionUpdate,
   showGeolocPermissionModal,
   onPressGeolocPermissionModalButton,
   hasGeolocPosition: true,

--- a/src/libs/location/types.ts
+++ b/src/libs/location/types.ts
@@ -42,7 +42,6 @@ export type ILocationContext = {
   geolocPositionError: GeolocationError | null
   permissionState: GeolocPermissionState | null
   requestGeolocPermission: (params?: RequestGeolocPermissionParams) => Promise<void>
-  triggerPositionUpdate: () => void
   showGeolocPermissionModal: () => void
   onPressGeolocPermissionModalButton: () => void
   selectedLocationMode: LocationMode

--- a/src/libs/locationV2/location.methods.ts
+++ b/src/libs/locationV2/location.methods.ts
@@ -1,4 +1,4 @@
-import { Linking } from 'react-native'
+import { AppState, AppStateStatus, Linking } from 'react-native'
 
 import { analytics } from 'libs/analytics/provider'
 import { checkGeolocPermission } from 'libs/location/geolocation/checkGeolocPermission/checkGeolocPermission'
@@ -8,7 +8,7 @@ import { requestGeolocPermission } from 'libs/location/geolocation/requestGeoloc
 import { GeolocationError, RequestGeolocPermissionParams } from 'libs/location/types'
 import { locationActions } from 'libs/locationV2/location.store'
 
-export const triggerPositionUpdate = async () => {
+const triggerPositionUpdate = async () => {
   try {
     const newPosition = await getGeolocPosition()
     locationActions.setGeolocPosition(newPosition)
@@ -25,7 +25,7 @@ export const triggerPositionUpdate = async () => {
 const getPermissionState = async (permission: GeolocPermissionState) => {
   if (shouldTriggerPositionUpdate(permission)) {
     const newPosition = await triggerPositionUpdate()
-    if (isNeedAskPosition(permission)) {
+    if (permission === GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY) {
       return newPosition === null
         ? GeolocPermissionState.NEVER_ASK_AGAIN
         : GeolocPermissionState.GRANTED
@@ -39,13 +39,13 @@ export const contextualRequestGeolocPermission = async (params?: RequestGeolocPe
   params?.onSubmit?.()
 
   const permission = await getPermissionState(await requestGeolocPermission())
-
-  if (isGranted(permission)) {
-    !!params?.onAcceptance && params.onAcceptance()
-  } else {
-    !!params?.onRefusal && params.onRefusal()
-  }
   locationActions.setPermissionState(permission)
+
+  if (permission === GeolocPermissionState.GRANTED) {
+    params?.onAcceptance?.()
+    return
+  }
+  params?.onRefusal?.()
 }
 
 // in case user updates his preferences in his phone settings we check if his local
@@ -55,20 +55,24 @@ export const contextualCheckPermission = async () => {
   locationActions.setPermissionState(permission)
 }
 
+export const initLocationPermission = () => {
+  let currentState = AppState.currentState
+
+  void contextualCheckPermission()
+  return AppState.addEventListener('change', (nextState: AppStateStatus) => {
+    if (currentState.match(/inactive|background/) && nextState.match(/active/)) {
+      void contextualCheckPermission()
+    }
+    currentState = nextState
+  })
+}
+
 export const onPressGeolocPermissionModalButton = () => {
   void Linking.openSettings()
   locationActions.hidePermissionModal()
   void analytics.logOpenLocationSettings()
 }
 
-const isGranted = (permission: GeolocPermissionState) => {
-  return permission === GeolocPermissionState.GRANTED
-}
-
-const isNeedAskPosition = (permission: GeolocPermissionState) => {
-  return permission === GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY
-}
-
-const shouldTriggerPositionUpdate = (permission: GeolocPermissionState) => {
-  return isGranted(permission) || isNeedAskPosition(permission)
-}
+const shouldTriggerPositionUpdate = (permission: GeolocPermissionState) =>
+  permission === GeolocPermissionState.GRANTED ||
+  permission === GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42188

## Context

Dernière étape avant la suppression du locationWrapper, j'ai fonctionnalisé `contextualCheckPermission` pour le faire fonctionner en dehors de React en utilisant le même comportement que le `useAppState`

La fonction `initLocationPermission` est testable en dehors de React et appelé dans les `useEffect` de `App.web.tsx` et `App.tsx`
