### PR TITLE
(PC-40021) feat(artist): display similar artists section

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -4209,6 +4209,38 @@ export interface SigninResponseV2 {
 }
 /**
  * @export
+ * @interface SimilarArtistItem
+ */
+export interface SimilarArtistItem {
+  /**
+   * @type {string}
+   * @memberof SimilarArtistItem
+   */
+  id: string
+  /**
+   * @type {string | null}
+   * @memberof SimilarArtistItem
+   */
+  image?: string | null
+  /**
+   * @type {string}
+   * @memberof SimilarArtistItem
+   */
+  name: string
+}
+/**
+ * @export
+ * @interface SimilarArtistsResponse
+ */
+export interface SimilarArtistsResponse {
+  /**
+   * @type {Array<SimilarArtistItem>}
+   * @memberof SimilarArtistsResponse
+   */
+  artists: Array<SimilarArtistItem>
+}
+/**
+ * @export
  * @interface SimilarOffersRequestQuery
  */
 export interface SimilarOffersRequestQuery {
@@ -5635,6 +5667,33 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
         )
       }
       let pathname = `/native/v1/artists/{artist_id}`.replace(
+        `{${'artist_id'}}`,
+        encodeURIComponent(String(artist_id))
+      )
+      let secureOptions = Object.assign(options, { credentials: 'omit' })
+      const localVarRequestOptions = Object.assign({ method: 'GET' }, secureOptions)
+      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
+      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
+      return {
+        url: pathname,
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     * @summary get_similar_artists <GET>
+     * @param {string} artist_id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getNativeV1ArtistsartistIdSimilar(artist_id: string, options: any = {}): Promise<FetchArgs> {
+      // verify required parameter 'artist_id' is not null or undefined
+      if (artist_id === null || artist_id === undefined) {
+        throw new RequiredError(
+          'artist_id',
+          'Required parameter artist_id was null or undefined when calling getNativeV1ArtistsartistIdSimilar.'
+        )
+      }
+      let pathname = `/native/v1/artists/{artist_id}/similar`.replace(
         `{${'artist_id'}}`,
         encodeURIComponent(String(artist_id))
       )
@@ -7772,7 +7831,19 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
       return handleGeneratedApiResponse(response)
     },
     /**
-     * 
+     *
+     * @summary get_similar_artists <GET>
+     * @param {string} artist_id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getNativeV1ArtistsartistIdSimilar(artist_id: string, options?: any): Promise<SimilarArtistsResponse> {
+      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1ArtistsartistIdSimilar(artist_id, options)
+      const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
+      return handleGeneratedApiResponse(response)
+    },
+    /**
+     *
      * @summary get_banner <GET>
      * @param {boolean} [isGeolocated] 
      * @param {*} [options] Override http request option.
@@ -8771,7 +8842,19 @@ export class DefaultApi extends BaseAPI {
     return DefaultApiFp(this, configuration).getNativeV1ArtistsartistId(artist_id, options)
   }
   /**
-    * 
+    *
+    * @summary get_similar_artists <GET>
+    * @param {string} artist_id
+    * @param {*} [options] Override http request option.
+    * @throws {RequiredError}
+    * @memberof DefaultApi
+    */
+  public async getNativeV1ArtistsartistIdSimilar(artist_id: string, options?: any) {
+    const configuration = this.getConfiguration()
+    return DefaultApiFp(this, configuration).getNativeV1ArtistsartistIdSimilar(artist_id, options)
+  }
+  /**
+    *
     * @summary get_banner <GET>
     * @param {boolean} [isGeolocated] 
     * @param {*} [options] Override http request option.

--- a/src/features/artist/components/ArtistBody/ArtistBody.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.tsx
@@ -7,6 +7,7 @@ import styled, { useTheme } from 'styled-components/native'
 import { ArtistResponse } from 'api/gen'
 import { ArtistHeader } from 'features/artist/components/ArtistHeader/ArtistHeader'
 import { ArtistPlaylist } from 'features/artist/components/ArtistPlaylist/ArtistPlaylist'
+import { ArtistSimilarArtists } from 'features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists'
 import { ArtistTopOffers } from 'features/artist/components/ArtistTopOffers/ArtistTopOffers'
 import { ArtistWebMetaHeader } from 'features/artist/components/ArtistWebMetaHeader'
 import { getSearchHookConfig } from 'features/navigation/navigators/SearchStackNavigator/getSearchHookConfig'
@@ -162,6 +163,7 @@ export const ArtistBody: FunctionComponent<Props> = ({
             items={artistPlaylist}
             onViewableItemsChanged={onViewableItemsChanged}
           />
+          <ArtistSimilarArtists artistId={artist.id} />
         </ViewGap>
       </ContentContainer>
 

--- a/src/features/artist/components/ArtistHeader/ArtistHeader.tsx
+++ b/src/features/artist/components/ArtistHeader/ArtistHeader.tsx
@@ -23,10 +23,14 @@ export const ArtistHeader = ({ avatarImage, name }: ArtistHeaderProps) => {
           <DefaultAvatar testID="defaultArtistAvatar" size={50} />
         )}
       </Avatar>
-      <Typo.Title1>{name}</Typo.Title1>
+      <ArtistName>{name}</ArtistName>
     </ArtistHeaderWrapper>
   )
 }
+
+const ArtistName = styled(Typo.Title1)({
+  textAlign: 'center',
+})
 
 const StyledImage = styled(FastImage)({
   width: '100%',

--- a/src/features/artist/components/ArtistHeader/ArtistHeaderWrapper.tsx
+++ b/src/features/artist/components/ArtistHeader/ArtistHeaderWrapper.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components/native'
 
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 
-export const ArtistHeaderWrapper = styled(ViewGap)({
+export const ArtistHeaderWrapper = styled(ViewGap)(({ theme }) => ({
   alignItems: 'center',
-})
+  marginHorizontal: theme.contentPage.marginHorizontal,
+}))

--- a/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.native.test.tsx
+++ b/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.native.test.tsx
@@ -1,0 +1,130 @@
+import * as reactNavigationNative from '@react-navigation/native'
+import React from 'react'
+
+import { SimilarArtistsResponse } from 'api/gen'
+import { ArtistSimilarArtists } from 'features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists'
+import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { mockServer } from 'tests/mswServer'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
+
+jest.mock('libs/firebase/analytics/analytics')
+
+const mockPush = jest.fn()
+const mockNavigate = jest.fn()
+jest.spyOn(reactNavigationNative, 'useNavigation').mockReturnValue({
+  navigate: mockNavigate,
+  push: mockPush,
+})
+
+const artistId = 'cb22d035-f081-4ccb-99d8-8f5725a8ac9c'
+const TITLE = 'Tu peux aussi aimer'
+
+const similarArtistsResponse: SimilarArtistsResponse = {
+  artists: [
+    { id: 'artist-1', name: 'Coleen Hoover', image: 'https://example.com/coleen.jpg' },
+    { id: 'artist-2', name: 'Sarah J. Maas', image: null },
+  ],
+}
+
+const user = userEvent.setup()
+
+describe('<ArtistSimilarArtists />', () => {
+  beforeEach(() => {
+    mockPush.mockClear()
+    mockNavigate.mockClear()
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_SIMILAR_ARTISTS])
+  })
+
+  it('should not render anything when the feature flag is disabled', async () => {
+    setFeatureFlags()
+    mockServer.getApi(`/v1/artists/${artistId}/similar`, similarArtistsResponse)
+
+    render(reactQueryProviderHOC(<ArtistSimilarArtists artistId={artistId} />))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('playlistTitle')).not.toBeOnTheScreen()
+    })
+  })
+
+  it('should display the section with similar artists when API returns at least one', async () => {
+    mockServer.getApi(`/v1/artists/${artistId}/similar`, similarArtistsResponse)
+
+    render(reactQueryProviderHOC(<ArtistSimilarArtists artistId={artistId} />))
+
+    expect(await screen.findByLabelText('Coleen Hoover')).toBeOnTheScreen()
+    expect(screen.getByLabelText('Sarah J. Maas')).toBeOnTheScreen()
+    expect(screen.getByTestId('playlistTitle')).toBeOnTheScreen()
+  })
+
+  it('should not render anything when API returns an empty list', async () => {
+    mockServer.getApi(`/v1/artists/${artistId}/similar`, { artists: [] })
+
+    render(reactQueryProviderHOC(<ArtistSimilarArtists artistId={artistId} />))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('playlistTitle')).not.toBeOnTheScreen()
+    })
+  })
+
+  it('should log consult artist analytics with from=artist when tapping a card', async () => {
+    mockServer.getApi(`/v1/artists/${artistId}/similar`, similarArtistsResponse)
+
+    render(reactQueryProviderHOC(<ArtistSimilarArtists artistId={artistId} />))
+
+    const card = await screen.findByLabelText('Coleen Hoover')
+    await user.press(card)
+
+    expect(analytics.logConsultArtist).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artistId: 'artist-1',
+        artistName: 'Coleen Hoover',
+        from: 'artist',
+      })
+    )
+  })
+
+  it('should push a new Artist entry (not navigate) when tapping a card so back returns to the previous artist', async () => {
+    mockServer.getApi(`/v1/artists/${artistId}/similar`, similarArtistsResponse)
+
+    render(reactQueryProviderHOC(<ArtistSimilarArtists artistId={artistId} />))
+
+    const card = await screen.findByLabelText('Coleen Hoover')
+    await user.press(card)
+
+    expect(mockPush).toHaveBeenCalledWith('Artist', { id: 'artist-1' })
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('should navigate to the vertical similar-artists playlist when tapping "Voir tout"', async () => {
+    mockServer.getApi(`/v1/artists/${artistId}/similar`, similarArtistsResponse)
+
+    render(reactQueryProviderHOC(<ArtistSimilarArtists artistId={artistId} />))
+
+    const seeAllButton = await screen.findByLabelText(`Voir tout pour la sélection ${TITLE}`)
+    await user.press(seeAllButton)
+
+    expect(mockNavigate).toHaveBeenCalledWith('VerticalPlaylistArtists', {
+      title: TITLE,
+      subtitle: undefined,
+      similarToArtistId: artistId,
+    })
+  })
+
+  it('should log click see all analytics with from=artist when tapping "Voir tout"', async () => {
+    mockServer.getApi(`/v1/artists/${artistId}/similar`, similarArtistsResponse)
+
+    render(reactQueryProviderHOC(<ArtistSimilarArtists artistId={artistId} />))
+
+    const seeAllButton = await screen.findByLabelText(`Voir tout pour la sélection ${TITLE}`)
+    await user.press(seeAllButton)
+
+    expect(analytics.logClickSeeAll).toHaveBeenCalledWith({
+      type: 'artists',
+      moduleName: TITLE,
+      from: 'artist',
+    })
+  })
+})

--- a/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
+++ b/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
@@ -1,0 +1,87 @@
+import React, { FunctionComponent } from 'react'
+import { View } from 'react-native'
+import styled from 'styled-components/native'
+
+import { useSimilarArtistsQuery } from 'features/artist/queries/useSimilarArtistsQuery'
+import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
+import { analytics } from 'libs/analytics/provider'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { AvatarList } from 'ui/components/Avatar/AvatarList'
+import { SeeAllButton } from 'ui/components/SeeAllButton/SeeAllButton'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { Typo } from 'ui/theme'
+import { AVATAR_MEDIUM } from 'ui/theme/constants'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+
+type Props = {
+  artistId: string
+}
+
+const TITLE = 'Tu peux aussi aimer'
+
+export const ArtistSimilarArtists: FunctionComponent<Props> = ({ artistId }) => {
+  const isSimilarArtistsEnabled = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ENABLE_SIMILAR_ARTISTS)
+  const { data: artists = [] } = useSimilarArtistsQuery(artistId, {
+    enabled: isSimilarArtistsEnabled,
+  })
+
+  const onBeforeNavigate = () => {
+    void analytics.logClickSeeAll({ type: 'artists', moduleName: TITLE, from: 'artist' })
+  }
+
+  const handleItemPress = (id: string, name: string) => {
+    void analytics.logConsultArtist({ artistId: id, artistName: name, from: 'artist' })
+  }
+
+  if (!isSimilarArtistsEnabled || artists.length === 0) return null
+
+  return (
+    <View>
+      <HeaderContainer>
+        <TitleRow gap={3}>
+          <TitleContainer>
+            <AccessibleTitle title={TITLE} TitleComponent={TitleLevel2} withMargin={false} />
+          </TitleContainer>
+          {artists.length > 1 ? (
+            <SeeAllButton
+              playlistTitle={TITLE}
+              data={{
+                onBeforeNavigate,
+                navigateToVerticalPlaylist: {
+                  screen: 'VerticalPlaylistArtists',
+                  params: { title: TITLE, subtitle: undefined, similarToArtistId: artistId },
+                },
+                hideSearchSeeAll: true,
+              }}
+            />
+          ) : null}
+        </TitleRow>
+      </HeaderContainer>
+      <AvatarList
+        data={artists}
+        avatarConfig={{ size: AVATAR_MEDIUM, rounded: true }}
+        onItemPress={handleItemPress}
+        withMargins
+        withPush
+      />
+    </View>
+  )
+}
+
+const TitleLevel2 = styled(Typo.Title3).attrs(getHeadingAttrs(2))``
+
+const HeaderContainer = styled.View(({ theme }) => ({
+  marginHorizontal: theme.contentPage.marginHorizontal,
+  marginBottom: theme.designSystem.size.spacing.m,
+}))
+
+const TitleContainer = styled.View({
+  flex: 1,
+})
+
+const TitleRow = styled(ViewGap)({
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+})

--- a/src/features/artist/pages/Artist.native.test.tsx
+++ b/src/features/artist/pages/Artist.native.test.tsx
@@ -26,6 +26,7 @@ describe('<Artist />', () => {
 
   beforeEach(() => {
     mockServer.getApi('/v1/subcategories/v2', subcategoriesDataTest)
+    mockServer.getApi(`/v1/artists/${mockArtist.id}/similar`, { artists: [] })
     setFeatureFlags()
   })
 

--- a/src/features/artist/queries/useSimilarArtistsQuery.ts
+++ b/src/features/artist/queries/useSimilarArtistsQuery.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { api } from 'api/api'
+import { Artist } from 'features/venue/types'
+import { QueryKeys } from 'libs/queryKeys'
+
+type Options = {
+  enabled?: boolean
+}
+
+export const useSimilarArtistsQuery = (artistId: string, { enabled = true }: Options = {}) =>
+  useQuery({
+    queryKey: [QueryKeys.SIMILAR_ARTISTS, artistId],
+    queryFn: () => api.getNativeV1ArtistsartistIdSimilar(artistId),
+    enabled: !!artistId && enabled,
+    select: (data): Artist[] =>
+      data.artists.map((similarArtist) => ({
+        id: similarArtist.id,
+        name: similarArtist.name,
+        image: similarArtist.image ?? undefined,
+      })),
+  })

--- a/src/features/navigation/navigators/RootNavigator/types.ts
+++ b/src/features/navigation/navigators/RootNavigator/types.ts
@@ -333,7 +333,12 @@ export type RootStackParamList = {
   _DeeplinkOnlyVenuePreviewCarousel2: VenuePreviewCarouselParams
   _DeeplinkOnlyVenuePreviewCarousel3: VenuePreviewCarouselParams
   VerifyEligibility: undefined
-  VerticalPlaylistArtists: { title: string; subtitle?: string; venueId?: number }
+  VerticalPlaylistArtists: {
+    title: string
+    subtitle?: string
+    venueId?: number
+    similarToArtistId?: string
+  }
   VerticalPlaylistOffers: VerticalPlaylistOffersSource
   VerticalPlaylistVenues: { module: VenuesModule }
   VideoModulePage: VideoModulePageParams

--- a/src/libs/queryKeys.ts
+++ b/src/libs/queryKeys.ts
@@ -53,6 +53,7 @@ export enum QueryKeys {
   SEARCH_RESULTS_VENUES = 'searchResultsVenues',
   SETTINGS = 'settings',
   SIGNUP_CONFIRMATION_EXPIRED_LINK = 'signupConfirmationExpiredLink',
+  SIMILAR_ARTISTS = 'similarArtists',
   SIMILAR_OFFERS_IDS = 'similarOffersIds',
   STEPPER_INFO = 'stepperInfo',
   SUBCATEGORIES = 'subcategories',

--- a/src/shared/verticalPlaylist/helpers/useGetArtistsFromPlaylist.native.test.ts
+++ b/src/shared/verticalPlaylist/helpers/useGetArtistsFromPlaylist.native.test.ts
@@ -1,3 +1,4 @@
+import { useSimilarArtistsQuery } from 'features/artist/queries/useSimilarArtistsQuery'
 import { useSearchArtistsQuery } from 'features/search/queries/useSearchArtists/useSearchArtistsQuery'
 import { getVenueOffersArtists } from 'features/venue/helpers/getVenueOffersArtists'
 import { useRemoteConfigQuery } from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
@@ -24,12 +25,20 @@ const mockGetVenueOffersArtists = getVenueOffersArtists as jest.Mock
 jest.mock('features/search/queries/useSearchArtists/useSearchArtistsQuery')
 const mockUseSearchArtistsQuery = useSearchArtistsQuery as jest.Mock
 
+jest.mock('features/artist/queries/useSimilarArtistsQuery')
+const mockUseSimilarArtistsQuery = useSimilarArtistsQuery as jest.Mock
+mockUseSimilarArtistsQuery.mockReturnValue({ data: undefined })
+
 const paramsFromSearch = {
   params: { title: 'Artists title', subtitle: 'Artists subtitle' },
 }
 
 const paramsWithVenue = {
   params: { title: 'Artists title', subtitle: 'Artists subtitle', venueId: 123 },
+}
+
+const paramsWithSimilarArtist = {
+  params: { title: 'Artists title', subtitle: 'Artists subtitle', similarToArtistId: 'artist-id' },
 }
 
 describe('useGetArtistsFromPlaylist', () => {
@@ -43,6 +52,24 @@ describe('useGetArtistsFromPlaylist', () => {
 
     expect(result.current.nbItems).toBe(2)
     expect(result.current.items).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  it('should return similar artists and disable venue/search queries when similarToArtistId is provided', () => {
+    mockUseSimilarArtistsQuery.mockReturnValueOnce({ data: [{ id: 5 }, { id: 6 }] })
+    mockUseSearchArtistsQuery.mockReturnValueOnce({ data: [{ id: 3 }] })
+
+    const { result } = renderHook(() => useGetArtistsFromPlaylist(paramsWithSimilarArtist), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+
+    expect(result.current.nbItems).toBe(2)
+    expect(result.current.items).toEqual([{ id: 5 }, { id: 6 }])
+    expect(mockUseSimilarArtistsQuery).toHaveBeenCalledWith('artist-id', { enabled: true })
+    expect(mockUseSearchArtistsQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ enabled: false })
+    )
+    expect(mockGetVenueOffersArtists).not.toHaveBeenCalled()
   })
 
   it('should fallback to search artists when no venue artists', () => {

--- a/src/shared/verticalPlaylist/helpers/useGetArtistsFromPlaylist.ts
+++ b/src/shared/verticalPlaylist/helpers/useGetArtistsFromPlaylist.ts
@@ -1,4 +1,6 @@
 import { useAccessibilityFiltersContext } from 'features/accessibility/context/AccessibilityFiltersWrapper'
+import { useSimilarArtistsQuery } from 'features/artist/queries/useSimilarArtistsQuery'
+import { RootStackParamList } from 'features/navigation/navigators/RootNavigator/types'
 import { useIsUserUnderage } from 'features/profile/helpers/useIsUserUnderage'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { selectSearchArtists } from 'features/search/queries/useSearchArtists/selectors/selectSearchArtists'
@@ -14,9 +16,17 @@ import { VerticalPlaylistArtistsData } from 'shared/verticalPlaylist/types'
 
 const NO_ARTISTS: Artist[] = []
 
-export const useGetArtistsFromPlaylist = ({ params }): VerticalPlaylistArtistsData => {
-  const { title, subtitle, venueId } = params
-  const isVenue = !!venueId
+type UseGetArtistsFromPlaylistProps = {
+  params: RootStackParamList['VerticalPlaylistArtists']
+}
+
+export const useGetArtistsFromPlaylist = ({
+  params,
+}: UseGetArtistsFromPlaylistProps): VerticalPlaylistArtistsData => {
+  const { title, subtitle, venueId, similarToArtistId } = params
+  const isSimilar = !!similarToArtistId
+  const isVenue = !isSimilar && !!venueId
+  const isSearch = !isSimilar && !isVenue
 
   const { searchState } = useSearch()
 
@@ -43,7 +53,7 @@ export const useGetArtistsFromPlaylist = ({ params }): VerticalPlaylistArtistsDa
     isUserUnderage,
   }
 
-  const { data: venue } = useVenueQuery(venueId, { enabled: isVenue })
+  const { data: venue } = useVenueQuery(venueId ?? 0, { enabled: isVenue })
 
   const venueSearchParams = useVenueSearchParameters(venue)
   const { data: venueOffers } = useVenueOffersQuery({
@@ -58,18 +68,29 @@ export const useGetArtistsFromPlaylist = ({ params }): VerticalPlaylistArtistsDa
 
   const venueOffersHits = venueOffers?.hits
   const artistsFromRemoteConfig = remoteConfig.artistPageSubcategories.subcategories
-  const { data: venueArtists } = venueId
+  const { data: venueArtists } = isVenue
     ? getVenueOffersArtists(artistsFromRemoteConfig, venueOffersHits)
     : { data: { artists: [] } }
 
   const query = useSearchArtistsQuery(queryParams, {
-    enabled: !venueId,
+    enabled: isSearch,
     select: (data) => selectSearchArtists(data),
+  })
+
+  const { data: similarArtistsList } = useSimilarArtistsQuery(similarToArtistId ?? '', {
+    enabled: isSimilar,
   })
 
   const artistsFromVenue = venueArtists?.artists
   const searchArtistsList = query.data
-  const items = venueId ? (artistsFromVenue ?? NO_ARTISTS) : (searchArtistsList ?? NO_ARTISTS)
+
+  const getItems = (): Artist[] => {
+    if (isSimilar) return similarArtistsList ?? NO_ARTISTS
+    if (isVenue) return artistsFromVenue ?? NO_ARTISTS
+    return searchArtistsList ?? NO_ARTISTS
+  }
+
+  const items = getItems()
   const nbItems = items.length
 
   return {

--- a/src/ui/components/Avatar/AvatarList.tsx
+++ b/src/ui/components/Avatar/AvatarList.tsx
@@ -16,6 +16,7 @@ type AvatarListProps = {
   onViewableItemsChanged?: ({ viewableItems }: { viewableItems: ViewToken[] }) => void
   listRef?: Ref<FlatList>
   withMargins?: boolean
+  withPush?: boolean
 }
 
 const AVATAR_DEFAULT_CONFIG = {
@@ -30,6 +31,7 @@ export const AvatarList: FunctionComponent<AvatarListProps> = ({
   listRef,
   onViewableItemsChanged,
   withMargins,
+  withPush,
 }) => {
   const mergedAvatarConfig = mergeWith(
     avatarConfig,
@@ -45,10 +47,11 @@ export const AvatarList: FunctionComponent<AvatarListProps> = ({
         onItemPress={onItemPress}
         role={item.role}
         accessibilityLabel={item.accessibilityLabel}
+        withPush={withPush}
         {...mergedAvatarConfig}
       />
     ),
-    [onItemPress, mergedAvatarConfig]
+    [onItemPress, mergedAvatarConfig, withPush]
   )
 
   const size = mergedAvatarConfig.size

--- a/src/ui/components/Avatar/AvatarListItem.tsx
+++ b/src/ui/components/Avatar/AvatarListItem.tsx
@@ -16,6 +16,7 @@ export type AvatarListItemProps = {
   isFullWidth?: boolean
   role?: string
   accessibilityLabel?: string
+  withPush?: boolean
 } & AvatarProps
 
 export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
@@ -27,6 +28,7 @@ export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
   isFullWidth = false,
   role,
   accessibilityLabel,
+  withPush,
   ...props
 }) => {
   const content = (
@@ -62,7 +64,7 @@ export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
   return (
     <InternalTouchableLink
       accessibilityLabel={accessibilityLabel ?? name}
-      navigateTo={{ screen: 'Artist', params: { id: id.toString() } }}
+      navigateTo={{ screen: 'Artist', params: { id: id.toString() }, withPush }}
       onBeforeNavigate={() => onItemPress(id.toString(), name)}>
       {content}
     </InternalTouchableLink>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-40021

## 🎯 Objectif

[PC-40021] Afficher une section « Tu peux aussi aimer » (carrousel d'artistes
similaires) en bas de la page artiste, pour prolonger l'exploration et augmenter
la découverte sans friction.

## ✨ Changements

### Fonctionnalité principale
- Nouvelle section `ArtistSimilarArtists` affichée après la playlist
  « Toutes ses offres disponibles ».
- Carrousel horizontal d'avatars circulaires (72 px) + nom de l'artiste.
- La section est **masquée** si l'API ne retourne aucun artiste similaire
  (pas d'état vide).
- Tap sur une carte → navigation vers la page de l'artiste concerné.
- Bouton « Voir tout » (si ≥ 2 artistes) → page verticale listant tous les
  artistes similaires.

### Implémentation
- `ArtistSimilarArtists` est **composé directement sur les primitives partagées**
  (`AvatarList` + `AccessibleTitle` + `SeeAllButton`), comme le font déjà les
  pages offre, lieu et recherche — plutôt que de dépendre d'un composant de page
  spécifique.
- `VerticalPlaylistArtists` étendu avec un mode « artistes similaires »
  (param de route `similarToArtistId`) pour alimenter le « Voir tout ».
- Hook `useSimilarArtistsQuery` (mapping `SimilarArtistItem → Artist` centralisé
  via `select`), branché sur `GET /native/v1/artists/{id}/similar`.
- Ajout d'un `withPush` opt-in sur `AvatarList` / `AvatarListItem` : corrige la
  navigation artiste → artiste (le bouton retour revient bien à l'artiste
  précédent au lieu de sauter par-dessus).

### Correctif UI annexe
- Centrage + marge horizontale du titre de la page artiste (`ArtistHeader`),
  qui se collait au bord gauche avec les noms longs.

## ✅ Règles de gestion couvertes
- [x] Section affichée uniquement si ≥ 1 artiste similaire
- [x] Section masquée si liste vide (aucun état vide)
- [x] Carrousel horizontal scrollable, sans pagination
- [x] Avatar circulaire 72 px + nom tronqué (2 lignes)
- [x] Position après « Toutes ses offres disponibles »
- [x] Tap → navigation vers la page de l'artiste
- [x] Max 10 artistes (géré par le backend)
- [x] Accessibilité : titre `<h2>`, label lecteur d'écran + touch zone ≥ 44 px

## 🧪 Tests
- Tests unitaires `ArtistSimilarArtists` : affichage, masquage si vide,
  analytics au tap, `push` (retour correct), navigation « Voir tout ».
- Mode « similaires » de `useGetArtistsFromPlaylist` couvert.
- Tests existants `ArtistSection` / recherche inchangés et verts
  (aucune régression).

## 📸 Captures
<img width="429" height="888" alt="SCR-20260608-mlue" src="https://github.com/user-attachments/assets/0115fc85-97f0-4b9f-a02a-c25e5569570d" />
<img width="380" height="671" alt="SCR-20260608-mudh" src="https://github.com/user-attachments/assets/0a3be7db-bcef-420f-9436-afa72010e867" />
<img width="1728" height="999" alt="SCR-20260608-mubl" src="https://github.com/user-attachments/assets/91a13b17-db99-4d5e-85f9-9edce281ace9" />
<img width="438" height="894" alt="SCR-20260608-mlyf" src="https://github.com/user-attachments/assets/0f23b795-971e-4f22-a9ba-fdab4c6b3a12" />
<img width="429" height="891" alt="SCR-20260608-mlwi" src="https://github.com/user-attachments/assets/43c378bb-6f27-412f-8e63-d624e2a6c197" />


[PC-40021]: https://passculture.atlassian.net/browse/PC-40021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ