### PR TITLE
(PC-42229) refactor(app): use DS 56px size for components using InfoHeader and change AVATAR_SMALL size

### DIFF
--- a/src/features/bookings/components/Ticket/Ticket.tsx
+++ b/src/features/bookings/components/Ticket/Ticket.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native'
 import React from 'react'
+import { useTheme } from 'styled-components/native'
 
 import { extractApiErrorMessage } from 'api/apiHelpers'
 import { BookingResponse, TicketResponse, WithdrawalTypeEnum } from 'api/gen'
@@ -23,8 +24,6 @@ import { Banner } from 'ui/designSystem/Banner/Banner'
 import { showErrorSnackBar, showSuccessSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { IdCard } from 'ui/svg/icons/IdCard'
 
-const VENUE_THUMBNAIL_SIZE = 60
-
 type TicketProps = {
   properties: BookingProperties
   booking: BookingResponse
@@ -46,6 +45,7 @@ export const Ticket = ({
 }: TicketProps) => {
   const { navigate, goBack } = useNavigation<UseNavigationType>()
   const proAdvicesOnVenueSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_VENUE)
+  const { designSystem } = useTheme()
 
   const { mutate: archiveBooking } = useArchiveBookingMutation({
     bookingId: booking.id,
@@ -132,7 +132,7 @@ export const Ticket = ({
               venue={booking.stock.offer.venue}
               address={displayVenueAddress ? booking.stock.offer.address : undefined}
               offerId={offer.id}
-              thumbnailSize={VENUE_THUMBNAIL_SIZE}
+              thumbnailSize={designSystem.size.image.s}
               addressLabel={venueBlockAddress?.label ?? undefined}
               onSeeVenuePress={offer.venue.isOpenToPublic ? handleOnSeeVenuePress : undefined}
             />

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
@@ -17,7 +17,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { Typo } from 'ui/theme'
-import { AVATAR_MEDIUM } from 'ui/theme/constants'
+import { AVATAR_MEDIUM, AVATAR_SMALL } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 interface Props {
@@ -67,10 +67,10 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
           <InfoHeader
             title={soloArtist.name}
             subtitle={soloArtist.role ? getArtistRole(soloArtist.role, offerCategoryId) : undefined}
-            defaultThumbnailSize={AVATAR_MEDIUM}
+            defaultThumbnailSize={AVATAR_SMALL}
             thumbnailComponent={
               <Avatar
-                size={AVATAR_MEDIUM}
+                size={AVATAR_SMALL}
                 rounded={false}
                 borderRadius={designSystem.size.borderRadius.pill}>
                 {soloArtist.image ? (

--- a/src/features/offer/components/OfferVenueBlock/VenueBlock.tsx
+++ b/src/features/offer/components/OfferVenueBlock/VenueBlock.tsx
@@ -1,12 +1,11 @@
 import React, { FunctionComponent } from 'react'
-import styled from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
 import { accessibilityRoleInternalNavigation } from 'shared/accessibility/helpers/accessibilityRoleInternalNavigation'
 import { getComputedAccessibilityLabel } from 'shared/accessibility/helpers/getComputedAccessibilityLabel'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { VenueInfoHeader } from 'ui/components/VenueInfoHeader/VenueInfoHeader'
 import { Tag } from 'ui/designSystem/Tag/Tag'
-import { getSpacing } from 'ui/theme'
 
 type Props = {
   venueId: number
@@ -21,8 +20,6 @@ type Props = {
   shouldShowDistances?: boolean
 }
 
-const VENUE_THUMBNAIL_SIZE = getSpacing(14)
-
 export const VenueBlock: FunctionComponent<Props> = ({
   venueId,
   venueImageUrl = '',
@@ -35,6 +32,7 @@ export const VenueBlock: FunctionComponent<Props> = ({
   shouldShowDistances = true,
   isOfferAtSameAddressAsVenue,
 }) => {
+  const { designSystem } = useTheme()
   const shouldDisplayDistanceTag = shouldShowDistances && distance
   const isClickableVenueLink = isOfferAtSameAddressAsVenue && hasVenuePage
 
@@ -42,7 +40,7 @@ export const VenueBlock: FunctionComponent<Props> = ({
     <VenueInfoHeader
       title={title}
       subtitle={subtitle}
-      imageSize={thumbnailSize ?? VENUE_THUMBNAIL_SIZE}
+      imageSize={thumbnailSize ?? designSystem.size.image.s}
       imageURL={venueImageUrl}
       showArrow={showArrow}
     />

--- a/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
+++ b/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
@@ -32,7 +32,6 @@ export const VenueMapPreview: FunctionComponent<Props> = ({
 }) => {
   const { designSystem } = useTheme()
   const Wrapper = noBorder ? InternalTouchableLink : Container
-  const VENUE_THUMBNAIL_SIZE = designSystem.size.spacing.xxxxl
 
   return (
     <Wrapper {...touchableProps}>
@@ -43,7 +42,7 @@ export const VenueMapPreview: FunctionComponent<Props> = ({
       <StyledVenueInfoHeader
         title={venueName}
         subtitle={address}
-        imageSize={VENUE_THUMBNAIL_SIZE}
+        imageSize={designSystem.size.image.s}
         showArrow={withRightArrow}
         imageURL={bannerUrl}
       />

--- a/src/ui/theme/constants.ts
+++ b/src/ui/theme/constants.ts
@@ -22,7 +22,7 @@ export const DEFAULT_INLINE_BUTTON_HEIGHT = getSpacing(4)
 
 //avatars
 export const AVATAR_XSMALL = getSpacing(8)
-export const AVATAR_SMALL = getSpacing(13.5)
+export const AVATAR_SMALL = getSpacing(14)
 export const AVATAR_MEDIUM = getSpacing(18)
 export const AVATAR_LARGE = getSpacing(26)
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42229

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-08 at 17 42 28" src="https://github.com/user-attachments/assets/b9753b86-84f0-4311-a7e5-d4adfc7c5951" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-09 at 11 18 27" src="https://github.com/user-attachments/assets/14915427-4702-49da-bc8d-69d3823ffebf" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-09 at 11 18 50" src="https://github.com/user-attachments/assets/f24438f6-30fc-4410-89c1-99268e8084ad" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-09 at 11 19 12" src="https://github.com/user-attachments/assets/e04decf7-9790-4cbc-bcfd-849a9b96c96b" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-09 at 11 20 21" src="https://github.com/user-attachments/assets/d2a05bdc-5e3f-4117-b5e7-9c73e06fce38" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-09 at 10 20 01" src="https://github.com/user-attachments/assets/5c37c9d9-9de9-4756-a778-5ecc5bbb2780" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-09 at 10 20 23" src="https://github.com/user-attachments/assets/4b8ca6e6-dc5c-439b-973c-5854d5515403" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-09 at 10 41 04" src="https://github.com/user-attachments/assets/c035f526-70c5-4a79-97ca-4e9a0ab37669" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-09 at 10 46 02" src="https://github.com/user-attachments/assets/9429491e-637e-4b99-b35e-8683c2daf3d2" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-09 at 10 55 45" src="https://github.com/user-attachments/assets/11e6c616-8b7a-4dcc-a150-5b7dd7fc9e9e" />|
| Android          | | |
| Phone - Chrome   | | |
| Desktop - Chrome | | |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
