### PR TITLE
(PC-42260) fix(locationWidget): move location widget to the right on web

### DIFF
--- a/src/features/home/components/headers/HomeHeader.tsx
+++ b/src/features/home/components/headers/HomeHeader.tsx
@@ -62,13 +62,13 @@ export const HomeHeader: FunctionComponent = function () {
           <Spacer.TopScreen />
           <HeaderContainer>
             <TitleContainer>
-              <Title testID="web-location-widget">
-                <TitleLabel numberOfLines={1}>{welcomeTitle}</TitleLabel>
-                <StyledSeparator height={height} />
-                <LocationWidgetDesktop />
-              </Title>
+              <TitleLabel numberOfLines={1}>{welcomeTitle}</TitleLabel>
               <Subtitle>{getSubtitle()}</Subtitle>
             </TitleContainer>
+            <LocationWidgetDesktopContainer testID="web-location-widget">
+              <StyledSeparator height={height} />
+              <LocationWidgetDesktop />
+            </LocationWidgetDesktopContainer>
           </HeaderContainer>
         </React.Fragment>
       )
@@ -99,13 +99,15 @@ export const HomeHeader: FunctionComponent = function () {
 
 const HeaderContainer = styled.View(({ theme }) => ({
   flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'flex-start',
   marginTop: theme.designSystem.size.spacing.xl,
   marginHorizontal: theme.contentPage.marginHorizontal,
   zIndex: theme.zIndex.header,
 }))
 
 const TitleContainer = styled.View({
-  width: '100%',
+  flex: 1,
 })
 
 const Subtitle = styled(Typo.BodyAccentXs)(({ theme }) => ({
@@ -114,13 +116,14 @@ const Subtitle = styled(Typo.BodyAccentXs)(({ theme }) => ({
 }))
 
 const TitleLabel = styled(Typo.Title1)({
-  maxWidth: '70%',
+  maxWidth: '100%',
 })
 
-const Title = styled.View(({ theme }) => ({
+const LocationWidgetDesktopContainer = styled.View(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'center',
   zIndex: theme.zIndex.locationWidget,
+  marginLeft: theme.designSystem.size.spacing.s,
 }))
 
 const StyledSeparator = styled(Separator.Vertical)(({ theme }) => ({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/42260

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |<img width="1019" height="769" alt="Capture d’écran 2026-06-09 à 11 36 09" src="https://github.com/user-attachments/assets/0c3e5b11-0a3e-4931-b498-f0ba0fa72a89" />|<img width="1021" height="751" alt="Capture d’écran 2026-06-09 à 11 35 36" src="https://github.com/user-attachments/assets/44af4c14-b0a7-475e-a145-01fd316701e4" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
