### PR TITLE
(PC-42227) feat(a11y): app modal zoom 200 correctly displayed

### DIFF
--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -270,10 +270,8 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                 style={
                   {
                     "alignItems": "center",
-                    "flexBasis": 0,
                     "flexDirection": "row",
-                    "flexGrow": 1,
-                    "flexShrink": 1,
+                    "flexShrink": 0,
                     "justifyContent": "flex-start",
                     "paddingLeft": 12,
                     "paddingRight": 12,
@@ -288,6 +286,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                 style={
                   {
                     "color": "#161617",
+                    "flexShrink": 1,
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 17,
                     "lineHeight": 27.2,
@@ -302,10 +301,8 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                 style={
                   {
                     "alignItems": "center",
-                    "flexBasis": 0,
                     "flexDirection": "row",
-                    "flexGrow": 1,
-                    "flexShrink": 1,
+                    "flexShrink": 0,
                     "justifyContent": "flex-end",
                     "paddingLeft": 12,
                     "paddingRight": 12,

--- a/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
@@ -229,7 +229,6 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
             >
               <Text
                 accessibilityRole="header"
-                numberOfLines={2}
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
@@ -232,7 +232,6 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
             >
               <Text
                 accessibilityRole="header"
-                numberOfLines={2}
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
@@ -255,7 +255,6 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
               >
                 <Text
                   accessibilityRole="header"
-                  numberOfLines={2}
                   style={
                     {
                       "color": "#161617",

--- a/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
@@ -293,7 +293,6 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
               >
                 <Text
                   accessibilityRole="header"
-                  numberOfLines={2}
                   style={
                     {
                       "color": "#161617",

--- a/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
@@ -129,7 +129,6 @@ exports[`PushNotificationsModal should render properly 1`] = `
           <Text
             accessibilityRole="header"
             nativeID="testUuidV4"
-            numberOfLines={2}
             style={
               {
                 "color": "#161617",

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -209,10 +209,8 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
               style={
                 {
                   "alignItems": "center",
-                  "flexBasis": 0,
                   "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexShrink": 0,
                   "justifyContent": "flex-start",
                   "paddingLeft": 12,
                   "paddingRight": 12,
@@ -227,6 +225,7 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
               style={
                 {
                   "color": "#161617",
+                  "flexShrink": 1,
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 17,
                   "lineHeight": 27.2,
@@ -241,10 +240,8 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
               style={
                 {
                   "alignItems": "center",
-                  "flexBasis": 0,
                   "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexShrink": 0,
                   "justifyContent": "flex-end",
                   "paddingLeft": 12,
                   "paddingRight": 12,

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -209,10 +209,8 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
               style={
                 {
                   "alignItems": "center",
-                  "flexBasis": 0,
                   "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexShrink": 0,
                   "justifyContent": "flex-start",
                   "paddingLeft": 12,
                   "paddingRight": 12,
@@ -227,6 +225,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
               style={
                 {
                   "color": "#161617",
+                  "flexShrink": 1,
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 17,
                   "lineHeight": 27.2,
@@ -241,10 +240,8 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
               style={
                 {
                   "alignItems": "center",
-                  "flexBasis": 0,
                   "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexShrink": 0,
                   "justifyContent": "flex-end",
                   "paddingLeft": 12,
                   "paddingRight": 12,

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -209,10 +209,8 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
               style={
                 {
                   "alignItems": "center",
-                  "flexBasis": 0,
                   "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexShrink": 0,
                   "justifyContent": "flex-start",
                   "paddingLeft": 12,
                   "paddingRight": 12,
@@ -227,6 +225,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
               style={
                 {
                   "color": "#161617",
+                  "flexShrink": 1,
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 17,
                   "lineHeight": 27.2,
@@ -241,10 +240,8 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
               style={
                 {
                   "alignItems": "center",
-                  "flexBasis": 0,
                   "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexShrink": 0,
                   "justifyContent": "flex-end",
                   "paddingLeft": 12,
                   "paddingRight": 12,

--- a/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
@@ -232,7 +232,6 @@ exports[`VenueModal should render correctly 1`] = `
             >
               <Text
                 accessibilityRole="header"
-                numberOfLines={2}
                 style={
                   {
                     "color": "#161617",

--- a/__snapshots__/libs/location/geolocation/components/GeolocationActivationModal.native.test.tsx.native-snap
+++ b/__snapshots__/libs/location/geolocation/components/GeolocationActivationModal.native.test.tsx.native-snap
@@ -129,7 +129,6 @@ exports[`GeolocationActivationModal should render properly 1`] = `
           <Text
             accessibilityRole="header"
             nativeID="testUuidV4"
-            numberOfLines={2}
             style={
               {
                 "color": "#161617",

--- a/src/features/advices/components/AdviceCardBody/AdviceCardBody.tsx
+++ b/src/features/advices/components/AdviceCardBody/AdviceCardBody.tsx
@@ -83,6 +83,7 @@ const BottomCardContainer = styled.View({
   flexDirection: 'row',
   justifyContent: 'space-between',
   alignItems: 'center',
+  flexWrap: 'wrap',
 })
 
 const PublicationDate = styled(Typo.BodyAccentXs)(({ theme }) => ({

--- a/src/features/advices/pages/AdvicesWritersModal/AdvicesWritersModal.tsx
+++ b/src/features/advices/pages/AdvicesWritersModal/AdvicesWritersModal.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react'
 
+import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
@@ -21,6 +22,7 @@ export const AdvicesWritersModal: FunctionComponent<Props> = ({
   modalWording,
   buttonWording,
 }) => {
+  const isZoomed = useMobileFontScaleToDisplay({ default: false, at200PercentZoom: true })
   return (
     <AppModal
       animationOutTiming={1}
@@ -28,6 +30,7 @@ export const AdvicesWritersModal: FunctionComponent<Props> = ({
       title={'Qui écrit les avis\u00a0?'}
       rightIconAccessibilityLabel="Fermer la modale"
       rightIcon={Close}
+      isUpToStatusBar={isZoomed}
       onRightIconPress={closeModal}>
       <ViewGap gap={6}>
         <Typo.Body>{modalWording}</Typo.Body>

--- a/src/features/identityCheck/components/countryPicker/CountryPicker.tsx
+++ b/src/features/identityCheck/components/countryPicker/CountryPicker.tsx
@@ -7,6 +7,7 @@ import { formatCallingCode } from 'features/identityCheck/components/countryPick
 import { Country } from 'features/identityCheck/components/countryPicker/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { getComputedAccessibilityLabel } from 'shared/accessibility/helpers/getComputedAccessibilityLabel'
+import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
 import { WHITELISTED_COUNTRIES } from 'shared/countries/constants'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { AppModal } from 'ui/components/modals/AppModal'
@@ -37,6 +38,8 @@ export const CountryPicker: React.FC<Props> = ({ selectedCountry, onSelect }) =>
     'Ouvrir la modale de choix de l’indicatif téléphonique'
   )
 
+  const isZoomed = useMobileFontScaleToDisplay({ default: false, at200PercentZoom: true })
+
   return (
     <React.Fragment>
       <StyledTouchable
@@ -52,6 +55,7 @@ export const CountryPicker: React.FC<Props> = ({ selectedCountry, onSelect }) =>
       <AppModal
         title="Choix de l’indicatif téléphonique"
         visible={visible}
+        isUpToStatusBar={isZoomed}
         rightIconAccessibilityLabel="Fermer la modale de choix de l’indicatif téléphonique"
         rightIcon={Close}
         onRightIconPress={hideModal}>

--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
@@ -137,4 +137,5 @@ const TagContainer = styled.View({
 const ProAdvicesCounterContainer = styled(ViewGap)({
   flexDirection: 'row',
   alignItems: 'center',
+  flexWrap: 'wrap',
 })

--- a/src/features/proAdvices/pages/ProAdvicesBase.tsx
+++ b/src/features/proAdvices/pages/ProAdvicesBase.tsx
@@ -11,6 +11,7 @@ import { AdvicesWritersModal } from 'features/advices/pages/AdvicesWritersModal/
 import { AdviceCardData } from 'features/advices/types'
 import { PRO_ADVICE_VARIANT_CONFIG } from 'features/clubAdvices/constants'
 import { getScrollMetrics } from 'features/proAdvices/helpers/getScrollMetrics'
+import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
 import { runAfterInteractionsMobile } from 'shared/runAfterInteractionsMobile/runAfterInteractionsMobile'
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
 import { useModal } from 'ui/components/modals/useModal'
@@ -105,12 +106,12 @@ export const ProAdvicesBase: FunctionComponent<Props> = ({
     },
     [advices.length]
   )
-
+  const isZoomed = useMobileFontScaleToDisplay({ default: false, at200PercentZoom: true })
   return (
     <React.Fragment>
       <AdvicesWebMetaHeader title={title} />
       <AdvicesHeader headerTransition={headerTransition} title={title} handleGoBack={goBack} />
-      <Container>
+      <Container isZoomed={isZoomed}>
         {children}
         <StyledAdviceCardList
           data={advices}
@@ -164,11 +165,12 @@ export const ProAdvicesBase: FunctionComponent<Props> = ({
   )
 }
 
-const Container = styled.View({
+const Container = styled.View<{ isZoomed: boolean }>(({ isZoomed }) => ({
   flex: 1,
   flexDirection: 'row',
   columnGap: getSpacing(18),
-})
+  ...(isZoomed ? { marginTop: getSpacing(18) } : {}),
+}))
 
 const StyledAdviceCardList = styled(AdviceCardList)({
   flex: 1,

--- a/src/features/search/components/SearchCustomModalHeader.tsx
+++ b/src/features/search/components/SearchCustomModalHeader.tsx
@@ -3,6 +3,10 @@ import { useTheme } from 'styled-components'
 import styled from 'styled-components/native'
 
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import {
+  useMobileFontScaleToDisplay,
+  useNumberOfLine,
+} from 'shared/accessibility/helpers/zoomHelpers'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { CloseButton } from 'ui/components/headers/CloseButton'
 import { Button } from 'ui/designSystem/Button/Button'
@@ -29,7 +33,10 @@ export const SearchCustomModalHeader: React.FC<Props> = ({
 }) => {
   const { top } = useCustomSafeInsets()
   const { isDesktopViewport, designSystem } = useTheme()
-  const headerHeight = getSpacing(18) + (isDesktopViewport ? top : 0)
+  const isZoomed = useMobileFontScaleToDisplay({ default: false, at200PercentZoom: true })
+  const headerheightAddition = isDesktopViewport ? top : 0
+  const headerHeight = isZoomed ? undefined : getSpacing(18) + headerheightAddition
+  const numberOfLine = useNumberOfLine(1)
 
   return (
     <Header>
@@ -46,7 +53,7 @@ export const SearchCustomModalHeader: React.FC<Props> = ({
             />
           ) : null}
         </ButtonContainer>
-        <StyledTitle4 numberOfLines={1} nativeID={titleId} {...getHeadingAttrs(1)}>
+        <StyledTitle4 numberOfLines={numberOfLine} nativeID={titleId} {...getHeadingAttrs(1)}>
           {title}
         </StyledTitle4>
         <ButtonContainer positionInHeader="right" testID="close-button-container">
@@ -65,7 +72,7 @@ const Header = styled.View.attrs<{ children: React.ReactNode }>({
   width: '100%',
 })
 
-const HeaderContent = styled.View<{ height: number }>(({ height, theme }) => ({
+const HeaderContent = styled.View<{ height?: number }>(({ height, theme }) => ({
   zIndex: theme.zIndex.header,
   alignItems: 'center',
   flexDirection: 'row',
@@ -77,8 +84,8 @@ const HeaderContent = styled.View<{ height: number }>(({ height, theme }) => ({
 const ButtonContainer = styled.View<{ positionInHeader: 'left' | 'right' }>(
   ({ positionInHeader = 'left', theme }) => ({
     alignItems: 'center',
-    flex: 1,
     flexDirection: 'row',
+    flexShrink: 0,
     justifyContent: positionInHeader === 'left' ? 'flex-start' : 'flex-end',
     paddingLeft: theme.designSystem.size.spacing.m,
     paddingRight: theme.designSystem.size.spacing.m,
@@ -87,6 +94,7 @@ const ButtonContainer = styled.View<{ positionInHeader: 'left' | 'right' }>(
 
 const StyledTitle4 = styled(Typo.Title4)({
   textAlign: 'center',
+  flexShrink: 1,
 })
 
 const StyledCloseButton = styledButton(CloseButton)(({ theme }) => ({

--- a/src/shared/AIFakeDoorModal/AIFakeDoorModal.tsx
+++ b/src/shared/AIFakeDoorModal/AIFakeDoorModal.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { styled } from 'styled-components/native'
 
 import { Position } from 'libs/location/types'
+import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
 import { buildAISurveyURL } from 'shared/AIFakeDoorModal/buildAISurveyURL'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
@@ -63,12 +64,13 @@ export const AIFakeDoorModal = ({ visible, close, userLocation, userCity }: Prop
         ),
         buttonVariant: 'primary',
       }
-
+  const isZoomed = useMobileFontScaleToDisplay({ default: false, at200PercentZoom: true })
   return (
     <AppModal
       title="Encore un peu de patience..."
       visible={visible}
       rightIcon={Close}
+      isUpToStatusBar={isZoomed}
       rightIconAccessibilityLabel="Fermer la fenêtre"
       onRightIconPress={close}>
       <Container gap={4}>

--- a/src/ui/components/modals/AppModal.tsx
+++ b/src/ui/components/modals/AppModal.tsx
@@ -17,6 +17,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 // eslint-disable-next-line no-restricted-imports
 import { isDesktopDeviceDetectOnWeb } from 'libs/react-device-detect'
+import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
 import { useIsLandscape } from 'shared/useIsLandscape/useIsLandscape'
 import { useKeyboardEvents } from 'ui/components/keyboard/useKeyboardEvents'
 import { appModalContainerStyle } from 'ui/components/modals/appModalContainerStyle'
@@ -233,6 +234,8 @@ export const AppModal: FunctionComponent<Props> = ({
     setFullscreenScrollViewRef,
   ])
 
+  const numberOfLines = useNumberOfLine(titleNumberOfLines ?? 2)
+
   return (
     <StyledModal
       accessibilityModal
@@ -271,7 +274,7 @@ export const AppModal: FunctionComponent<Props> = ({
           ) : (
             <ModalHeader
               title={title}
-              numberOfLines={titleNumberOfLines}
+              numberOfLines={numberOfLines}
               onLayout={updateHeaderHeight}
               titleID={titleId}
               modalSpacing={modalSpacing}

--- a/src/ui/components/modals/ModalHeader.tsx
+++ b/src/ui/components/modals/ModalHeader.tsx
@@ -29,7 +29,7 @@ export const ModalHeader: FunctionComponent<ModalHeaderProps> = ({
   rightIcon,
   rightIconAccessibilityLabel = 'Fermer la modale',
   onRightIconPress,
-  numberOfLines = 2,
+  numberOfLines,
   modalSpacing,
   onLayout,
 }) => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42227

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots
modales : https://app.notion.com/p/passcultureapp/Etat-zoom-200-36bad4e0ff9880559b09f27e9047b351?source=copy_link#37aad4e0ff988032bfa3dcda5addd0f1

offer advice : https://app.notion.com/p/passcultureapp/Etat-zoom-200-36bad4e0ff9880559b09f27e9047b351?source=copy_link#37aad4e0ff98807ebb7ce53459933857

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
