### PR TITLE
(PC-42245) feat(location): update location when app goes on foreground

### DIFF
--- a/__mocks__/react-native.ts
+++ b/__mocks__/react-native.ts
@@ -1,0 +1,44 @@
+import type { AppStateStatus } from 'react-native'
+
+declare module 'react-native' {
+  interface AppStateStatic {
+    __triggerChange: (state: AppStateStatus) => void
+  }
+}
+
+const RealReactNative = jest.requireActual('react-native')
+
+type AppStateCallback = (state: AppStateStatus) => void
+const listeners = new Map<string, AppStateCallback>()
+
+const AppStateMock = {
+  currentState: 'active' as AppStateStatus,
+
+  addEventListener: jest.fn((type: string, callback: AppStateCallback) => {
+    listeners.set(type, callback)
+    return {
+      remove: jest.fn(() => {
+        listeners.delete(type)
+      }),
+    }
+  }),
+
+  __triggerChange: (nextState: AppStateStatus) => {
+    AppStateMock.currentState = nextState
+    const callback = listeners.get('change')
+    if (callback) {
+      callback(nextState)
+    }
+  },
+}
+
+const descriptors = Object.getOwnPropertyDescriptors(RealReactNative)
+// We remove AppState from descriptors to avoid conflicts with our mock
+delete descriptors.AppState
+
+const mock = {}
+Object.defineProperties(mock, descriptors)
+// @ts-ignore: AppState is a getter in the original module and we want to override it with our mock
+mock.AppState = AppStateMock
+
+module.exports = mock

--- a/src/libs/locationV2/location.methods.native.test.ts
+++ b/src/libs/locationV2/location.methods.native.test.ts
@@ -1,0 +1,71 @@
+import { AppState } from 'react-native'
+
+import { checkGeolocPermission } from 'libs/location/geolocation/checkGeolocPermission/checkGeolocPermission'
+import { GeolocPermissionState } from 'libs/location/geolocation/enums'
+import { LocationMode } from 'libs/location/types'
+import { initLocationPermission } from 'libs/locationV2/location.methods'
+import { locationActions, locationSelectors } from 'libs/locationV2/location.store'
+import { waitFor } from 'tests/utils'
+
+jest.mock('libs/location/geolocation/checkGeolocPermission/checkGeolocPermission')
+const mockCheckGeolocPermission = jest.mocked(checkGeolocPermission)
+
+describe('location methods', () => {
+  describe('initLocationPermission', () => {
+    describe('when app starts', () => {
+      it('should set location mode to EVERYWHERE if permission is not GRANTED', async () => {
+        locationActions.setLocationMode(LocationMode.AROUND_ME)
+        mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.DENIED)
+
+        initLocationPermission()
+
+        await waitFor(() => {
+          expect(locationSelectors.selectLocationMode()).toBe(LocationMode.EVERYWHERE)
+        })
+      })
+
+      it('should keep location mode if permission is GRANTED', async () => {
+        locationActions.setLocationMode(LocationMode.AROUND_ME)
+        mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.GRANTED)
+
+        initLocationPermission()
+
+        await waitFor(() => {
+          expect(locationSelectors.selectLocationMode()).toBe(LocationMode.AROUND_ME)
+        })
+      })
+    })
+
+    describe('when app is resumed', () => {
+      it('should set location mode to EVERYWHERE if permission is not GRANTED', async () => {
+        locationActions.setLocationMode(LocationMode.AROUND_ME)
+        mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.GRANTED)
+
+        initLocationPermission()
+
+        AppState.__triggerChange('inactive')
+        mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.DENIED)
+        AppState.__triggerChange('active')
+
+        await waitFor(() => {
+          expect(locationSelectors.selectLocationMode()).toBe(LocationMode.EVERYWHERE)
+        })
+      })
+
+      it('should keep location mode if permission is GRANTED', async () => {
+        locationActions.setLocationMode(LocationMode.AROUND_ME)
+        mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.GRANTED)
+
+        initLocationPermission()
+
+        AppState.__triggerChange('inactive')
+        mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.GRANTED)
+        AppState.__triggerChange('active')
+
+        await waitFor(() => {
+          expect(locationSelectors.selectLocationMode()).toBe(LocationMode.AROUND_ME)
+        })
+      })
+    })
+  })
+})

--- a/src/libs/locationV2/location.methods.ts
+++ b/src/libs/locationV2/location.methods.ts
@@ -5,8 +5,8 @@ import { checkGeolocPermission } from 'libs/location/geolocation/checkGeolocPerm
 import { GeolocPermissionState } from 'libs/location/geolocation/enums'
 import { getGeolocPosition } from 'libs/location/geolocation/getGeolocPosition/getGeolocPosition'
 import { requestGeolocPermission } from 'libs/location/geolocation/requestGeolocPermission/requestGeolocPermission'
-import { GeolocationError, RequestGeolocPermissionParams } from 'libs/location/types'
-import { locationActions } from 'libs/locationV2/location.store'
+import { GeolocationError, LocationMode, RequestGeolocPermissionParams } from 'libs/location/types'
+import { locationActions, locationSelectors } from 'libs/locationV2/location.store'
 
 const triggerPositionUpdate = async () => {
   try {
@@ -53,6 +53,9 @@ export const contextualRequestGeolocPermission = async (params?: RequestGeolocPe
 export const contextualCheckPermission = async () => {
   const permission = await getPermissionState(await checkGeolocPermission())
   locationActions.setPermissionState(permission)
+  if (permission !== GeolocPermissionState.GRANTED || !locationSelectors.selectIsGeolocated()) {
+    locationActions.setLocationMode(LocationMode.EVERYWHERE)
+  }
 }
 
 export const initLocationPermission = () => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42245

## Contexte

Nous souhaitons passer l'app en France entière si nous n'avons pas les autorisations nécessaires à l'arrivée sur l'app ou lorsque l'on y revient

## Points d'attention

### Modification du mock de AppState

J'ai surchargé le mock de AppState, la lib qui permet d'écouter si l'app est en premier ou second plan.
J'y ai ajouté une méthode `__triggerChange` qui permet de mocker l'état dans lequel on veut être pour le test

```typescript
      it('should set location mode to EVERYWHERE if permission is not GRANTED', async () => {
        locationActions.setLocationMode(LocationMode.AROUND_ME)
        mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.GRANTED)

        initLocationPermission()

        // On simule la mise de l'app en arrière pla
        AppState.__triggerChange('inactive')
        // On simule le changement d'autorisations sur l'appareil de l'utiisateur
        mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.DENIED)
        // On simule la mise de l'app en avant plan
        AppState.__triggerChange('active')

        await waitFor(() => {
          expect(locationSelectors.selectLocationMode()).toBe(LocationMode.EVERYWHERE)
        })
      })
```



