### PR TITLE
(PC-42269) feat(location): display a modal to activate GPS is disabled on Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "react-mobile-picker": "^0.2.1",
     "react-native": "0.80.2",
     "react-native-adjust": "^5.5.0",
+    "react-native-android-location-enabler": "^3.0.1",
     "react-native-animatable": "^1.3.3",
     "react-native-calendars": "1.1312.0",
     "react-native-date-picker": "^5.0.13",

--- a/src/features/location/helpers/selectAroundMeMode.native.test.ts
+++ b/src/features/location/helpers/selectAroundMeMode.native.test.ts
@@ -1,4 +1,4 @@
-import { Alert, Linking } from 'react-native'
+import { Linking } from 'react-native'
 
 import { GeolocPermissionState } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
@@ -9,7 +9,6 @@ import { locationModalSelectors } from 'libs/locationV2/locationModal.store'
 import { selectAroundMeMode } from './selectAroundMeMode'
 
 const openSettingsSpy = jest.spyOn(Linking, 'openSettings')
-const alertSpy = jest.spyOn(Alert, 'alert')
 const contextualRequestGeolocPermissionSpy = jest.spyOn(
   locationMethodsModule,
   'contextualRequestGeolocPermission'
@@ -62,25 +61,6 @@ describe('selectAroundMeMode', () => {
       await selectAroundMeMode({ shouldDirectlyValidate: true })
 
       expect(locationSelectors.selectLocationMode()).toBe(LocationMode.AROUND_ME)
-    })
-
-    it('should show alert and select everywhere mode when we do not have access to a position', async () => {
-      locationActions.setPermissionState(GeolocPermissionState.GRANTED)
-      locationActions.setGeolocPosition(null)
-
-      alertSpy.mockImplementationOnce((_title, _message, buttons) => {
-        buttons?.[0]?.onPress?.()
-      })
-
-      await selectAroundMeMode()
-
-      expect(alertSpy).toHaveBeenCalledWith(
-        'Paramètres de localisation',
-        'Nous n’avons pas pu récupérer ta position. Vérifie que la localisation est bien activée sur ton téléphone.',
-        [{ text: 'OK', onPress: expect.any(Function) }]
-      )
-
-      expect(locationSelectors.selectLocationMode()).toBe(LocationMode.EVERYWHERE)
     })
 
     describe('When permission is DENIED', () => {

--- a/src/features/location/helpers/selectAroundMeMode.ts
+++ b/src/features/location/helpers/selectAroundMeMode.ts
@@ -1,4 +1,4 @@
-import { Alert, Linking } from 'react-native'
+import { Linking } from 'react-native'
 
 import { analytics } from 'libs/analytics/provider'
 import { GeolocPermissionState } from 'libs/location/location'
@@ -16,7 +16,6 @@ export const selectAroundMeMode = async ({
   shouldDirectlyValidate,
 }: Params = {}) => {
   const permissionState = locationSelectors.selectPermissionState()
-  const isGeolocated = locationSelectors.selectIsGeolocated()
 
   if (permissionState === GeolocPermissionState.NEVER_ASK_AGAIN) {
     locationActions.setPlace(null)
@@ -32,12 +31,6 @@ export const selectAroundMeMode = async ({
         locationActions.showPermissionModal()
       }, 500)
     }
-  } else if (permissionState === GeolocPermissionState.GRANTED && !isGeolocated) {
-    Alert.alert(
-      'Paramètres de localisation',
-      'Nous n’avons pas pu récupérer ta position. Vérifie que la localisation est bien activée sur ton téléphone.',
-      [{ text: 'OK', onPress: () => locationActions.setLocationMode(LocationMode.EVERYWHERE) }]
-    )
   } else if (permissionState === GeolocPermissionState.GRANTED && shouldDirectlyValidate) {
     locationActions.setPlace(null)
     locationActions.setLocationMode(LocationMode.AROUND_ME)

--- a/src/libs/location/geolocation/requestGeolocPermission/requestGeolocPermission.android.test.ts
+++ b/src/libs/location/geolocation/requestGeolocPermission/requestGeolocPermission.android.test.ts
@@ -1,8 +1,14 @@
 import { PermissionsAndroid, Platform } from 'react-native'
+import { promptForEnableLocationIfNeeded } from 'react-native-android-location-enabler'
 
 import { GeolocPermissionState } from '../enums'
 
 import { requestGeolocPermission } from './requestGeolocPermission.android'
+
+jest.mock('react-native-android-location-enabler', () => ({
+  promptForEnableLocationIfNeeded: jest.fn(),
+}))
+const mockPromptForEnableLocationIfNeeded = jest.mocked(promptForEnableLocationIfNeeded)
 
 const requestSpy = jest.spyOn(PermissionsAndroid, 'request')
 
@@ -11,13 +17,24 @@ describe('requestGeolocPermission android', () => {
 
   it('should ask for android permission and return right state if granted', async () => {
     requestSpy.mockResolvedValueOnce(PermissionsAndroid.RESULTS.GRANTED)
+    mockPromptForEnableLocationIfNeeded.mockResolvedValueOnce('already-enabled')
 
     const permissionState = await requestGeolocPermission()
 
     expect(PermissionsAndroid.request).toHaveBeenCalledWith(
       PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION
     )
+    expect(promptForEnableLocationIfNeeded).toHaveBeenCalledWith()
     expect(permissionState).toEqual(GeolocPermissionState.GRANTED)
+  })
+
+  it('should return denied state if permission granted but user refuses to enable location', async () => {
+    requestSpy.mockResolvedValueOnce(PermissionsAndroid.RESULTS.GRANTED)
+    mockPromptForEnableLocationIfNeeded.mockRejectedValueOnce(new Error('denied'))
+
+    const permissionState = await requestGeolocPermission()
+
+    expect(permissionState).toEqual(GeolocPermissionState.DENIED)
   })
 
   it('should return right state if permission not granted', async () => {

--- a/src/libs/location/geolocation/requestGeolocPermission/requestGeolocPermission.android.ts
+++ b/src/libs/location/geolocation/requestGeolocPermission/requestGeolocPermission.android.ts
@@ -1,4 +1,5 @@
 import { PermissionsAndroid } from 'react-native'
+import { promptForEnableLocationIfNeeded } from 'react-native-android-location-enabler'
 
 import { AskGeolocPermission } from 'libs/location/types'
 
@@ -11,7 +12,12 @@ export const requestGeolocPermission: AskGeolocPermission = async () => {
 
   switch (status) {
     case PermissionsAndroid.RESULTS.GRANTED:
-      return GeolocPermissionState.GRANTED
+      try {
+        await promptForEnableLocationIfNeeded()
+        return GeolocPermissionState.GRANTED
+      } catch {
+        return GeolocPermissionState.DENIED
+      }
     case PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN:
       return GeolocPermissionState.NEVER_ASK_AGAIN
     default:

--- a/yarn.lock
+++ b/yarn.lock
@@ -11779,6 +11779,7 @@ __metadata:
     react-mobile-picker: "npm:^0.2.1"
     react-native: "npm:0.80.2"
     react-native-adjust: "npm:^5.5.0"
+    react-native-android-location-enabler: "npm:^3.0.1"
     react-native-animatable: "npm:^1.3.3"
     react-native-calendars: "npm:1.1312.0"
     react-native-date-picker: "npm:^5.0.13"
@@ -23934,6 +23935,16 @@ __metadata:
   version: 5.5.0
   resolution: "react-native-adjust@npm:5.5.0"
   checksum: 10/a937b70d3f8393422b7b96770741c84248846fbe6bfc82968e0fc79b16ab76dcedd83166b0d9aee45a609f053c7f82ab4f6e5df5bb40520351258e7a39a4b7e2
+  languageName: node
+  linkType: hard
+
+"react-native-android-location-enabler@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "react-native-android-location-enabler@npm:3.0.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/e51064ef2e2047a0509f59be766161ffd6536f8b2ec04459740761e16b466ea1f3a25682f1320a26f764964507bc9747e73c862c50d5fce63ffc73a322e5eba4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42269

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
