### PR TITLE
(PC-42313) refactor(location): remove permission NEED_ASK_POSITION_DIRECTLY

### DIFF
--- a/src/libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.ts
+++ b/src/libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.ts
@@ -2,14 +2,9 @@ import { ReadGeolocPermission } from 'libs/location/types'
 
 import { GeolocPermissionState } from './../enums'
 
-// Note : `navigator.permissions` is not yet supported for Safari desktop and mobile :
-// https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API#browser_compatibility
 export const checkGeolocPermission: ReadGeolocPermission = async function () {
-  if (navigator.permissions) {
-    const { state } = await navigator.permissions.query({ name: 'geolocation' })
-    if (state === 'granted') return GeolocPermissionState.GRANTED
-    if (state === 'prompt') return GeolocPermissionState.DENIED
-    return GeolocPermissionState.NEVER_ASK_AGAIN
-  }
-  return GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY
+  const { state } = await navigator.permissions.query({ name: 'geolocation' })
+  if (state === 'granted') return GeolocPermissionState.GRANTED
+  if (state === 'prompt') return GeolocPermissionState.DENIED
+  return GeolocPermissionState.NEVER_ASK_AGAIN
 }

--- a/src/libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.web.test.ts
+++ b/src/libs/location/geolocation/checkGeolocPermission/checkGeolocPermission.web.test.ts
@@ -9,10 +9,6 @@ function resetNavigatorPermissions() {
   global.navigator.permissions = initialNavigatorPermissions
   mockQuery = jest.mocked(initialNavigatorPermissions.query)
 }
-function mockNavigatorPermissionsUndefined() {
-  // @ts-expect-error : `permissions` is a read-only property
-  global.navigator.permissions = undefined
-}
 
 describe('checkGeolocPermission()', () => {
   afterEach(resetNavigatorPermissions)
@@ -38,15 +34,4 @@ describe('checkGeolocPermission()', () => {
       expect(state).toEqual(expectedState)
     }
   )
-
-  it('should return need_ask_position_directly when permissionStatus is undefined and permissionAPI is undefined', async () => {
-    mockNavigatorPermissionsUndefined()
-    // @ts-expect-error: this is a mock
-    mockQuery.mockResolvedValueOnce(undefined)
-    const state = await checkGeolocPermission()
-
-    expect(mockQuery).not.toHaveBeenCalled()
-
-    expect(state).toEqual(GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY)
-  })
 })

--- a/src/libs/location/geolocation/requestGeolocPermission/requestGeolocPermission.ts
+++ b/src/libs/location/geolocation/requestGeolocPermission/requestGeolocPermission.ts
@@ -1,13 +1,17 @@
 import { AskGeolocPermission } from '../../types'
 import { GeolocPermissionState } from '../enums'
 
-// Note : `navigator.permissions` is not yet supported for Safari desktop and mobile :
-// https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API#browser_compatibility
-export const requestGeolocPermission: AskGeolocPermission = async function () {
-  if (navigator.permissions) {
-    const { state } = await navigator.permissions.query({ name: 'geolocation' })
-    if (state === 'granted') return GeolocPermissionState.GRANTED
-    if (state === 'denied') return GeolocPermissionState.NEVER_ASK_AGAIN
-  }
-  return GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY
+export const requestGeolocPermission: AskGeolocPermission = async () => {
+  const { state } = await navigator.permissions.query({ name: 'geolocation' })
+
+  // the dialog has been ignored 3 times, the brower won't display it again
+  if (state === 'denied') return GeolocPermissionState.NEVER_ASK_AGAIN
+
+  return new Promise<GeolocPermissionState>((resolve) => {
+    // display a dialog to ask for geolocation permission
+    navigator.geolocation.getCurrentPosition(
+      () => resolve(GeolocPermissionState.GRANTED),
+      () => resolve(GeolocPermissionState.DENIED)
+    )
+  })
 }

--- a/src/libs/location/geolocation/requestGeolocPermission/requestGeolocPermission.web.test.ts
+++ b/src/libs/location/geolocation/requestGeolocPermission/requestGeolocPermission.web.test.ts
@@ -2,19 +2,8 @@ import { GeolocPermissionState } from '../enums'
 
 import { requestGeolocPermission } from './requestGeolocPermission'
 
-let mockQuery = jest.mocked(navigator.permissions.query)
+const mockQuery = jest.mocked(navigator.permissions.query)
 const mockGetCurrentPosition = jest.mocked(navigator.geolocation.getCurrentPosition)
-
-const initialNavigatorPermissions = { ...navigator.permissions }
-function resetNavigatorPermissions() {
-  // @ts-expect-error : `permissions` is a read-only property
-  global.navigator.permissions = initialNavigatorPermissions
-  mockQuery = jest.mocked(initialNavigatorPermissions.query)
-}
-function mockNavigatorPermissionsUndefined() {
-  // @ts-expect-error : `permissions` is a read-only property
-  global.navigator.permissions = undefined
-}
 
 describe('requestGeolocPermission()', () => {
   it('should return GRANTED if web permission is "granted"', async () => {
@@ -33,54 +22,15 @@ describe('requestGeolocPermission()', () => {
     expect(state).toEqual(GeolocPermissionState.NEVER_ASK_AGAIN)
   })
 
-  it('should return NEED_ASK_POSITION_DIRECTLY if web permission is "prompt" and getCurrentPosition() executes its successCallback', async () => {
-    mockQuery.mockResolvedValueOnce({ state: 'prompt' } as PermissionStatus)
-    mockGetCurrentPositionSuccess()
-    const state = await requestGeolocPermission()
-
-    expect(mockQuery).toHaveBeenCalledTimes(1)
-    expect(state).toEqual(GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY)
-  })
-
-  it('should return NEED_ASK_POSITION_DIRECTLY if navigator.permissions is undefined and getCurrentPosition() executes its successCallback', async () => {
-    mockNavigatorPermissionsUndefined()
-    mockGetCurrentPositionSuccess()
-    const state = await requestGeolocPermission()
-
-    expect(mockQuery).not.toHaveBeenCalled()
-    expect(state).toEqual(GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY)
-
-    resetNavigatorPermissions()
-  })
-
-  it('should return NEED_ASK_POSITION_DIRECTLY if web permission is "prompt" and getCurrentPosition() executes its errorCallback', async () => {
+  it('should return DENIED if web permission is "prompt" and getCurrentPosition() executes its errorCallback', async () => {
     mockQuery.mockResolvedValueOnce({ state: 'prompt' } as PermissionStatus)
     mockGetCurrentPositionError()
     const state = await requestGeolocPermission()
 
     expect(mockQuery).toHaveBeenCalledTimes(1)
-    expect(state).toEqual(GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY)
-  })
-
-  it('should return NEED_ASK_POSITION_DIRECTLY if navigator.permissions is undefined and getCurrentPosition() executes its errorCallback', async () => {
-    mockNavigatorPermissionsUndefined()
-    mockGetCurrentPositionError()
-    const state = await requestGeolocPermission()
-
-    expect(mockQuery).not.toHaveBeenCalled()
-    expect(state).toEqual(GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY)
-
-    resetNavigatorPermissions()
+    expect(state).toEqual(GeolocPermissionState.DENIED)
   })
 })
-
-function mockGetCurrentPositionSuccess() {
-  mockGetCurrentPosition.mockImplementationOnce((successCallback) =>
-    Promise.resolve(
-      successCallback({ coords: { latitude: 48.85, longitude: 2.29 } } as GeolocationPosition)
-    )
-  )
-}
 
 function mockGetCurrentPositionError() {
   mockGetCurrentPosition.mockImplementationOnce((_successCallback, errorCallback) => {

--- a/src/libs/location/useLocation.native.test.ts
+++ b/src/libs/location/useLocation.native.test.ts
@@ -9,8 +9,7 @@ import {
 } from 'libs/locationV2/location.methods'
 import { renderHook, waitFor } from 'tests/utils'
 
-import { GeolocPermissionState, GeolocPositionError } from './geolocation/enums'
-import { GeolocationError } from './types'
+import { GeolocPermissionState } from './geolocation/enums'
 import { useLocation } from './useLocation'
 
 jest.mock('libs/location/geolocation/getGeolocPosition/getGeolocPosition')
@@ -85,59 +84,18 @@ describe('useLocation()', () => {
       })
     })
 
-    it('should call onSubmit() and onAcceptance() when requestGeolocPermission() returns NEED_ASK_POSITION_DIRECTLY and position is not null', async () => {
-      mockPermissionResult(GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY)
-      const { result } = renderUseLocation()
+    it(`should call getGeolocPosition() when permission is ${GeolocPermissionState.GRANTED}`, async () => {
+      mockPermissionResult(GeolocPermissionState.GRANTED)
+
       await act(async () => {
-        await contextualRequestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
+        initLocationPermission()
       })
+      renderUseLocation()
 
       await waitFor(() => {
-        expect(result.current.permissionState).toEqual(GeolocPermissionState.GRANTED)
-        expect(result.current.geolocPosition).toBe(MOCK_POSITION)
-        expect(onSubmit).toHaveBeenCalledTimes(1)
-        expect(onRefusal).not.toHaveBeenCalled()
-        expect(onAcceptance).toHaveBeenCalledTimes(1)
+        expect(getGeolocPositionMock).toHaveBeenCalledTimes(1)
       })
     })
-
-    it('should call onSubmit() and onRefusal() when requestGeolocPermission() returns NEED_ASK_POSITION_DIRECTLY and position is null', async () => {
-      mockGetGeolocPositionFail()
-      mockPermissionResult(GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY)
-      const { result } = renderUseLocation()
-      await act(async () => {
-        await contextualRequestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
-      })
-
-      await waitFor(() => {
-        expect(result.current.permissionState).toEqual(GeolocPermissionState.NEVER_ASK_AGAIN)
-        expect(result.current.geolocPosition).toBe(null)
-        expect(onSubmit).toHaveBeenCalledTimes(1)
-        expect(onRefusal).toHaveBeenCalledTimes(1)
-        expect(onAcceptance).not.toHaveBeenCalled()
-      })
-    })
-
-    it.each`
-      permission
-      ${GeolocPermissionState.GRANTED}
-      ${GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY}
-    `(
-      'should call getGeolocPosition() when permission is $permission',
-      async (params: { permission: GeolocPermissionState }) => {
-        const { permission } = params
-        mockPermissionResult(permission)
-
-        await act(async () => {
-          initLocationPermission()
-        })
-        renderUseLocation()
-
-        await waitFor(() => {
-          expect(getGeolocPositionMock).toHaveBeenCalledTimes(1)
-        })
-      }
-    )
 
     it.each`
       permission
@@ -165,13 +123,6 @@ describe('useLocation()', () => {
 
 const mockGetGeolocPositionSuccess = () => {
   getGeolocPositionMock.mockResolvedValue(MOCK_POSITION)
-}
-
-const mockGetGeolocPositionFail = () => {
-  getGeolocPositionMock.mockRejectedValue({
-    type: GeolocPositionError.POSITION_UNAVAILABLE,
-    message: 'error message',
-  } as GeolocationError)
 }
 
 const renderUseLocation = () => {

--- a/src/libs/locationV2/location.methods.ts
+++ b/src/libs/locationV2/location.methods.ts
@@ -1,4 +1,4 @@
-import { AppState, AppStateStatus, Linking } from 'react-native'
+import { AppState, Linking } from 'react-native'
 
 import { analytics } from 'libs/analytics/provider'
 import { checkGeolocPermission } from 'libs/location/geolocation/checkGeolocPermission/checkGeolocPermission'
@@ -8,66 +8,48 @@ import { requestGeolocPermission } from 'libs/location/geolocation/requestGeoloc
 import { GeolocationError, LocationMode, RequestGeolocPermissionParams } from 'libs/location/types'
 import { locationActions, locationSelectors } from 'libs/locationV2/location.store'
 
-const triggerPositionUpdate = async () => {
-  try {
-    const newPosition = await getGeolocPosition()
-    locationActions.setGeolocPosition(newPosition)
-    locationActions.setGeolocationError(null)
-    return newPosition
-  } catch (e) {
-    const newPositionError = e as { cause: GeolocationError } | null
-    locationActions.setGeolocPosition(null)
-    locationActions.setGeolocationError(newPositionError?.cause ?? null)
-    return null
-  }
-}
-
-const getPermissionState = async (permission: GeolocPermissionState) => {
-  if (shouldTriggerPositionUpdate(permission)) {
-    const newPosition = await triggerPositionUpdate()
-    if (permission === GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY) {
-      return newPosition === null
-        ? GeolocPermissionState.NEVER_ASK_AGAIN
-        : GeolocPermissionState.GRANTED
+export const initLocationPermission = () => {
+  void syncPermissionsAndLocation()
+  return AppState.addEventListener('change', (state) => {
+    if (state === 'active') {
+      void syncPermissionsAndLocation()
     }
-  }
-  return permission
+  })
 }
 
-// this function is used to set OS permissions according to user choice on native geolocation popup
-export const contextualRequestGeolocPermission = async (params?: RequestGeolocPermissionParams) => {
-  params?.onSubmit?.()
-
-  const permission = await getPermissionState(await requestGeolocPermission())
-  locationActions.setPermissionState(permission)
-
-  if (permission === GeolocPermissionState.GRANTED) {
-    params?.onAcceptance?.()
-    return
-  }
-  params?.onRefusal?.()
+export const syncPermissionsAndLocation = async () => {
+  await syncPermissions()
+  await syncLocationMode()
+  await syncLocation()
 }
 
-// in case user updates his preferences in his phone settings we check if his local
-// storage choice is consistent with phone permissions, and update position if not
-export const contextualCheckPermission = async () => {
-  const permission = await getPermissionState(await checkGeolocPermission())
+const syncPermissions = async () => {
+  const permission = await checkGeolocPermission()
   locationActions.setPermissionState(permission)
-  if (permission !== GeolocPermissionState.GRANTED || !locationSelectors.selectIsGeolocated()) {
+}
+
+const syncLocationMode = async () => {
+  if (
+    locationSelectors.selectPermissionState() !== GeolocPermissionState.GRANTED &&
+    locationSelectors.selectLocationMode() === LocationMode.AROUND_ME
+  ) {
     locationActions.setLocationMode(LocationMode.EVERYWHERE)
   }
 }
 
-export const initLocationPermission = () => {
-  let currentState = AppState.currentState
-
-  void contextualCheckPermission()
-  return AppState.addEventListener('change', (nextState: AppStateStatus) => {
-    if (currentState.match(/inactive|background/) && nextState.match(/active/)) {
-      void contextualCheckPermission()
+const syncLocation = async () => {
+  const permission = locationSelectors.selectPermissionState()
+  if (permission === GeolocPermissionState.GRANTED) {
+    try {
+      const newPosition = await getGeolocPosition()
+      locationActions.setGeolocPosition(newPosition)
+      locationActions.setGeolocationError(null)
+    } catch (e) {
+      const newPositionError = e as { cause: GeolocationError } | null
+      locationActions.setGeolocPosition(null)
+      locationActions.setGeolocationError(newPositionError?.cause ?? null)
     }
-    currentState = nextState
-  })
+  }
 }
 
 export const onPressGeolocPermissionModalButton = () => {
@@ -76,6 +58,18 @@ export const onPressGeolocPermissionModalButton = () => {
   void analytics.logOpenLocationSettings()
 }
 
-const shouldTriggerPositionUpdate = (permission: GeolocPermissionState) =>
-  permission === GeolocPermissionState.GRANTED ||
-  permission === GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY
+// this function is used to set OS permissions according to user choice on native geolocation popup
+export const contextualRequestGeolocPermission = async (params?: RequestGeolocPermissionParams) => {
+  params?.onSubmit?.()
+
+  const permission = await requestGeolocPermission()
+  locationActions.setPermissionState(permission)
+
+  await syncLocation()
+
+  if (permission === GeolocPermissionState.GRANTED) {
+    params?.onAcceptance?.()
+    return
+  }
+  params?.onRefusal?.()
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42313

## Contexte

Le check de la permission `NEED_ASK_POSITION_DIRECTLY` n'a plus lieu d'être car Safari s'est mis à jour.
De la complexité peut ainsi être retiré et les méthodes de localisation ont pu être réécrites en respectant les règles du clean code
