### PR TITLE
(PC-42325) feat(profile): Fix navigation after signOut

### DIFF
--- a/src/features/auth/pages/suspendedAccount/AccountStatusScreenHandler/AccountStatusScreenHandler.tsx
+++ b/src/features/auth/pages/suspendedAccount/AccountStatusScreenHandler/AccountStatusScreenHandler.tsx
@@ -36,11 +36,12 @@ export const AccountStatusScreenHandler = () => {
 
   useEffect(() => {
     return () => {
-      if (
+      const excludedRoutesFromSignOut =
         currentRoute?.name &&
         !['AccountReactivationSuccess', 'AccountStatusScreenHandler'].includes(currentRoute?.name)
-      ) {
-        signOut()
+
+      if (excludedRoutesFromSignOut) {
+        void signOut()
       }
     }
   }, [signOut, currentRoute?.name])

--- a/src/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.tsx
@@ -18,7 +18,7 @@ export function DeactivateProfileSuccess() {
   const { data: reactivationLimit } = useAccountUnsuspensionLimit()
 
   useEffect(() => {
-    signOut()
+    void signOut()
   }, [signOut])
 
   return (

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.tsx
@@ -2,6 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 
 import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
+import { navigateFromRef } from 'features/navigation/navigationRef'
 import { getProfileHookConfig } from 'features/navigation/navigators/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
 import { useAnonymizeAccountMutation } from 'features/profile/queries/useAnonymizeAccountMutation'
@@ -21,7 +22,9 @@ export const DeleteProfileConfirmation = () => {
   const { anonymizeAccount } = useAnonymizeAccountMutation({
     onSuccess: async () => {
       await signOut()
-      navigate(...getProfileHookConfig('DeleteProfileSuccess'))
+      // We use navigateFromRef instead of navigation because signOut() may unmount the current screen
+      // (RootNavigator rebuild). navigateFromRef ensures navigation still works after logout.
+      navigateFromRef(...getProfileHookConfig('DeleteProfileSuccess'))
     },
     onError: () => {
       showErrorSnackBar(

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.tsx
@@ -13,7 +13,7 @@ export function DeleteProfileSuccess() {
   const signOut = useLogoutRoutine()
 
   useEffect(() => {
-    signOut()
+    void signOut()
   }, [signOut])
 
   return (

--- a/src/features/profile/pages/ValidateEmailChange/ValidateEmailChange.native.test.tsx
+++ b/src/features/profile/pages/ValidateEmailChange/ValidateEmailChange.native.test.tsx
@@ -7,6 +7,7 @@ import * as API from 'api/api'
 import { ApiError } from 'api/ApiError'
 import { EmailHistoryEventTypeEnum, EmailUpdateStatusResponse } from 'api/gen'
 import * as Auth from 'features/auth/context/AuthContext'
+import { resetFromRef } from 'features/navigation/navigationRef'
 import { ProfileStackParamList } from 'features/navigation/navigators/ProfileStackNavigator/types'
 import {
   RootStackParamList,
@@ -53,6 +54,10 @@ const navigation = {
   RootStackParamList & ProfileStackParamList,
   'ValidateEmailChange'
 >
+
+jest.mock('features/navigation/navigationRef', () => ({
+  resetFromRef: jest.fn(),
+}))
 
 type RootAndProfileRouteProp = RouteProp<
   RootStackParamList & ProfileStackParamList,
@@ -114,8 +119,8 @@ describe('ValidateEmailChange', () => {
 
     await user.press(screen.getByText('Valider l’adresse e-mail'))
 
-    expect(navigation.reset).toHaveBeenNthCalledWith(1, {
-      routes: [{ name: 'LoginMethods', params: { from: StepperOrigin.VALIDATE_EMAIL_CHANGE } }],
+    expect(resetFromRef).toHaveBeenCalledWith('LoginMethods', {
+      from: StepperOrigin.VALIDATE_EMAIL_CHANGE,
     })
   })
 

--- a/src/features/profile/pages/ValidateEmailChange/ValidateEmailChange.tsx
+++ b/src/features/profile/pages/ValidateEmailChange/ValidateEmailChange.tsx
@@ -7,6 +7,7 @@ import { ApiError } from 'api/ApiError'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
+import { resetFromRef } from 'features/navigation/navigationRef'
 import { ProfileStackParamList } from 'features/navigation/navigators/ProfileStackNavigator/types'
 import {
   RootStackParamList,
@@ -49,16 +50,19 @@ export function ValidateEmailChange({ route: { params }, navigation }: ValidateE
     setIsLoading(true)
     try {
       await mutate()
+
       // A technical constraint requires disconnection for the moment. Possible improvement later
       if (isLoggedIn) {
         await signOut()
       }
+
       showSuccessSnackBar(
         'Ton adresse e-mail est modifiée. Tu peux te reconnecter avec ta nouvelle adresse e-mail.'
       )
-      navigation.reset({
-        routes: [{ name: 'LoginMethods', params: { from: StepperOrigin.VALIDATE_EMAIL_CHANGE } }],
-      })
+
+      // We use resetFromRef instead of reset because signOut() may unmount the current screen
+      // (RootNavigator rebuild). resetFromRef ensures navigation still works after logout.
+      resetFromRef('LoginMethods', { from: StepperOrigin.VALIDATE_EMAIL_CHANGE })
     } catch (error) {
       if (error instanceof ApiError && error.statusCode === 401) {
         navigation.reset({ routes: [{ name: 'ChangeEmailExpiredLink' }] })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42325

## Context

Le bug venait du fait qu’on naviguait avec navigation après un logout.

Quand on fait await `signOut()`, ça reconstruit complètement le navigator (`isLoggedIn` passe à false), donc l’écran `ValidateEmailChange` est démonté. 
Résultat : le `navigation` local devient invalide ou `undefined`, et le `reset()` plante.

C’est pour ça que Sentry dit : `Cannot read property 'reset' of undefined`

Pourquoi `navigationRef` règle le problème ? 

`navigationRef`, lui, n’est pas lié à l’écran. C’est une référence globale au `NavigationContainer`.

Donc même après le logout et le démontage du screen :
- le `navigation` local casse ❌
- mais `navigationRef` reste utilisable ✅


## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the [best practices][3] and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
