### PR TITLE
(PC-41809) feat(Ubble): more accurate screen error

### DIFF
--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -213,7 +213,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="180"
+                          for="181"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -233,7 +233,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Autoriser l’envoi d’e-mails - Interrupteur à bascule - non coché"
-                            aria-labelledby="179"
+                            aria-labelledby="180"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Autoriser l’envoi d’e-mails - Interrupteur à bascule - non coché"
                             role="switch"
@@ -262,7 +262,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="180"
+                            id="181"
                             readonly=""
                             type="checkbox"
                           />
@@ -295,7 +295,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                         >
                           <label
                             class="c2"
-                            for="182"
+                            for="183"
                           >
                             <div
                               class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -315,7 +315,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                               aria-checked="false"
                               aria-disabled="true"
                               aria-label="Suivre tous les thèmes - Interrupteur à bascule - non coché"
-                              aria-labelledby="181"
+                              aria-labelledby="182"
                               class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                               data-testid="Suivre tous les thèmes - Interrupteur à bascule - non coché"
                               role="switch"
@@ -344,7 +344,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             </div>
                             <input
                               hidden=""
-                              id="182"
+                              id="183"
                               readonly=""
                               type="checkbox"
                             />
@@ -364,7 +364,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="184"
+                          for="185"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -384,7 +384,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Cinéma - Interrupteur à bascule - non coché"
-                            aria-labelledby="183"
+                            aria-labelledby="184"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Cinéma - Interrupteur à bascule - non coché"
                             role="switch"
@@ -413,7 +413,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="184"
+                            id="185"
                             readonly=""
                             type="checkbox"
                           />
@@ -432,7 +432,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="186"
+                          for="187"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -452,7 +452,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Lecture - Interrupteur à bascule - non coché"
-                            aria-labelledby="185"
+                            aria-labelledby="186"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Lecture - Interrupteur à bascule - non coché"
                             role="switch"
@@ -481,7 +481,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="186"
+                            id="187"
                             readonly=""
                             type="checkbox"
                           />
@@ -500,7 +500,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="188"
+                          for="189"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -520,7 +520,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Musique - Interrupteur à bascule - non coché"
-                            aria-labelledby="187"
+                            aria-labelledby="188"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Musique - Interrupteur à bascule - non coché"
                             role="switch"
@@ -549,7 +549,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="188"
+                            id="189"
                             readonly=""
                             type="checkbox"
                           />
@@ -568,7 +568,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="190"
+                          for="191"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -588,7 +588,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Spectacles - Interrupteur à bascule - non coché"
-                            aria-labelledby="189"
+                            aria-labelledby="190"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Spectacles - Interrupteur à bascule - non coché"
                             role="switch"
@@ -617,7 +617,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="190"
+                            id="191"
                             readonly=""
                             type="checkbox"
                           />
@@ -636,7 +636,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="192"
+                          for="193"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -656,7 +656,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Activités créatives - Interrupteur à bascule - non coché"
-                            aria-labelledby="191"
+                            aria-labelledby="192"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Activités créatives - Interrupteur à bascule - non coché"
                             role="switch"
@@ -685,7 +685,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="192"
+                            id="193"
                             readonly=""
                             type="checkbox"
                           />
@@ -704,7 +704,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="194"
+                          for="195"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -724,7 +724,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Visites et sorties - Interrupteur à bascule - non coché"
-                            aria-labelledby="193"
+                            aria-labelledby="194"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Visites et sorties - Interrupteur à bascule - non coché"
                             role="switch"
@@ -753,7 +753,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="194"
+                            id="195"
                             readonly=""
                             type="checkbox"
                           />

--- a/src/cheatcodes/pages/features/bonification/CheatcodesNavigationBonification.tsx
+++ b/src/cheatcodes/pages/features/bonification/CheatcodesNavigationBonification.tsx
@@ -58,6 +58,11 @@ const bonificationCheatcodeCategory: CheatcodeCategory = {
     },
     {
       id: uuidv4(),
+      title: 'BonificationIncorrectLink',
+      navigationTarget: getSubscriptionPropConfig('BonificationIncorrectLink'),
+    },
+    {
+      id: uuidv4(),
       title: 'BonificationGranted',
       navigationTarget: { screen: 'BonificationGranted' },
     },

--- a/src/features/bonification/pages/BonificationIncorrectLink.tsx
+++ b/src/features/bonification/pages/BonificationIncorrectLink.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
+import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
+import { SadFace } from 'ui/svg/icons/SadFace'
+import { Typo } from 'ui/theme'
+
+export function BonificationIncorrectLink() {
+  return (
+    <GenericInfoPage
+      illustration={SadFace}
+      title="Oups, ce lien semble incorrect"
+      buttonPrimary={{
+        wording: 'Revenir au catalogue',
+        navigateTo: navigateToHomeConfig,
+      }}>
+      <StyledBody>
+        Nous ne pouvons pas te rediriger vers cette page. Vérifie le lien ou retourne simplement à
+        l’accueil.
+      </StyledBody>
+    </GenericInfoPage>
+  )
+}
+
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  textAlign: 'center',
+  marginTop: theme.designSystem.size.spacing.l,
+}))

--- a/src/features/identityCheck/pages/identification/ubble/UbbleWebview.web.test.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/UbbleWebview.web.test.tsx
@@ -31,7 +31,7 @@ describe('<UbbleWebview/>', () => {
     })
   }),
     describe('Identification URL', () => {
-      it('should redirect to Error page when identification url is not valid', async () => {
+      it('should redirect to incorrect link page when identification url is not valid', async () => {
         mockServer.postApi<IdentificationSessionResponse>('/v1/ubble_identification', {
           identificationUrl: "javascript:alert('hello')",
         })
@@ -46,7 +46,7 @@ describe('<UbbleWebview/>', () => {
         await act(async () => {
           expect(navigate).toHaveBeenCalledWith('SubscriptionStackNavigator', {
             params: undefined,
-            screen: 'BonificationError',
+            screen: 'BonificationIncorrectLink',
           })
         })
       })

--- a/src/features/identityCheck/pages/identification/ubble/UbbleWebview.web.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/UbbleWebview.web.tsx
@@ -33,7 +33,7 @@ export const UbbleWebview: React.FC = () => {
   const identificationUrl = params?.identificationUrl
   const isValidUrl = isValidUbbleUrl(identificationUrl)
 
-  if (!isValidUrl) navigate(...getSubscriptionHookConfig('BonificationError'))
+  if (!isValidUrl) navigate(...getSubscriptionHookConfig('BonificationIncorrectLink'))
 
   useEffect(() => {
     if (isValidUrl) {

--- a/src/features/navigation/navigators/SubscriptionStackNavigator/SubscriptionStackNavigator.tsx
+++ b/src/features/navigation/navigators/SubscriptionStackNavigator/SubscriptionStackNavigator.tsx
@@ -5,6 +5,7 @@ import { BonificationBirthDate } from 'features/bonification/pages/BonificationB
 import { BonificationBirthPlace } from 'features/bonification/pages/BonificationBirthPlace'
 import { BonificationError } from 'features/bonification/pages/BonificationError'
 import { BonificationExplanations } from 'features/bonification/pages/BonificationExplanations'
+import { BonificationIncorrectLink } from 'features/bonification/pages/BonificationIncorrectLink'
 import { BonificationNames } from 'features/bonification/pages/BonificationNames'
 import { BonificationRecap } from 'features/bonification/pages/BonificationRecap'
 import { BonificationRefused } from 'features/bonification/pages/BonificationRefused'
@@ -328,6 +329,13 @@ const subscriptionStackNavigatorDefinition = {
       if: useIsSignedIn,
       linking: {
         path: 'bonification/erreur',
+      },
+    },
+    BonificationIncorrectLink: {
+      screen: BonificationIncorrectLink,
+      if: useIsSignedIn,
+      linking: {
+        path: 'bonification/lien-incorrect',
       },
     },
     BonificationRefused: {

--- a/src/features/navigation/navigators/SubscriptionStackNavigator/types.ts
+++ b/src/features/navigation/navigators/SubscriptionStackNavigator/types.ts
@@ -70,6 +70,7 @@ export type SubscriptionStackParamList = {
   BonificationRecap: undefined
   BonificationRefused?: { bonificationRefusedType: BonificationRefusedType }
   BonificationTitle: undefined
+  BonificationIncorrectLink: undefined
 } & CulturalSurveyRootStackParamList
 
 export type SubscriptionStackRouteName = keyof SubscriptionStackParamList


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41809

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots
<img width="1439" height="773" alt="Capture d’écran 2026-06-10 à 17 59 54" src="https://github.com/user-attachments/assets/9801a071-55a6-475e-b6ac-30713f9fee78" />
<img width="377" height="664" alt="Capture d’écran 2026-06-10 à 18 00 10" src="https://github.com/user-attachments/assets/1174dedf-deaa-45e0-a54c-1d38fa9ee4f3" />



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
