### PR TITLE
(PC-42350) feat(a11y): Fix orientation locked in Android

### DIFF
--- a/__snapshots__/features/profile/pages/Appearance/Appearance.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Appearance/Appearance.native.test.tsx.native-snap
@@ -354,12 +354,12 @@ exports[`Appearance should render correctly 1`] = `
                     }
                   >
                     <View
-                      accessibilityLabel="Permettre l’orientation - Interrupteur à bascule - non coché"
+                      accessibilityLabel="Permettre l’orientation - Interrupteur à bascule - coché"
                       accessibilityRole="switch"
                       accessibilityState={
                         {
                           "busy": undefined,
-                          "checked": false,
+                          "checked": true,
                           "disabled": false,
                           "expanded": undefined,
                           "selected": undefined,
@@ -389,13 +389,13 @@ exports[`Appearance should render correctly 1`] = `
                           "userSelect": "auto",
                         }
                       }
-                      testID="Permettre l’orientation - Interrupteur à bascule - non coché"
+                      testID="Permettre l’orientation - Interrupteur à bascule - coché"
                     >
                       <View
-                        active={false}
+                        active={true}
                         style={
                           {
-                            "backgroundColor": "#696a6f",
+                            "backgroundColor": "#15884f",
                             "borderBottomLeftRadius": 32,
                             "borderBottomRightRadius": 32,
                             "borderTopLeftRadius": 32,
@@ -423,14 +423,23 @@ exports[`Appearance should render correctly 1`] = `
                               "justifyContent": "center",
                               "transform": [
                                 {
-                                  "translateX": 2,
+                                  "translateX": 30,
                                 },
                               ],
                               "width": 32,
                             }
                           }
                           toggleSize={32}
-                        />
+                        >
+                          <View
+                            height={16}
+                            width={16}
+                          >
+                            <Text>
+                              undefined-SVG-Mock
+                            </Text>
+                          </View>
+                        </View>
                       </View>
                     </View>
                   </View>

--- a/src/App.native.test.tsx
+++ b/src/App.native.test.tsx
@@ -9,6 +9,15 @@ import { render, waitFor } from 'tests/utils'
 
 import { App } from './App'
 
+jest.mock('react-native-orientation-locker', () => ({
+  addOrientationListener: jest.fn(),
+  removeOrientationListener: jest.fn(),
+  getDeviceOrientation: jest.fn(() => 'PORTRAIT'),
+  lockToPortrait: jest.fn(),
+  lockToLandscape: jest.fn(),
+  unlockAllOrientations: jest.fn(),
+}))
+
 jest.mock('features/navigation/NavigationContainer/NavigationContainer', () => ({
   AppNavigationContainer: () => 'Placeholder for NavigationContainer',
 }))

--- a/src/features/profile/pages/Appearance/Appearance.native.test.tsx
+++ b/src/features/profile/pages/Appearance/Appearance.native.test.tsx
@@ -11,6 +11,15 @@ import { Appearance } from './Appearance'
 
 jest.mock('libs/firebase/analytics/analytics')
 
+jest.mock('react-native-orientation-locker', () => ({
+  lockToPortrait: jest.fn(),
+  unlockAllOrientations: jest.fn(),
+  addOrientationListener: jest.fn(),
+  removeOrientationListener: jest.fn(),
+  addLockListener: jest.fn(),
+  removeLockListener: jest.fn(),
+}))
+
 const useColorSchemeSpy = jest.spyOn(ReactNative, 'useColorScheme')
 const logUpdateAppThemeSpy = jest.spyOn(analytics, 'logUpdateAppTheme')
 const user = userEvent.setup()

--- a/src/features/profile/pages/Appearance/Appearance.tsx
+++ b/src/features/profile/pages/Appearance/Appearance.tsx
@@ -97,8 +97,8 @@ export const Appearance = () => {
               subtitle="L’affichage en mode paysage peut être moins optimal"
               isActive={!isOrientationLocked}
               toggle={() => {
-                toggleIsOrientationLocked()
-                debouncedLogChangeOrientationToggle(!isOrientationLocked)
+                void toggleIsOrientationLocked()
+                void debouncedLogChangeOrientationToggle(!isOrientationLocked)
               }}
             />
           )}

--- a/src/features/profile/pages/Appearance/Appearance.web.test.tsx
+++ b/src/features/profile/pages/Appearance/Appearance.web.test.tsx
@@ -7,6 +7,15 @@ import { Appearance } from './Appearance'
 
 jest.mock('ui/theme/customFocusOutline/customFocusOutline')
 
+jest.mock('react-native-orientation-locker', () => ({
+  lockToPortrait: jest.fn(),
+  unlockAllOrientations: jest.fn(),
+  addOrientationListener: jest.fn(),
+  removeOrientationListener: jest.fn(),
+  addLockListener: jest.fn(),
+  removeLockListener: jest.fn(),
+}))
+
 describe('Appearance', () => {
   it('should not have basic accessibility issues', async () => {
     const { container } = renderAppearance()

--- a/src/shared/hook/useOrientationLocked.native.test.ts
+++ b/src/shared/hook/useOrientationLocked.native.test.ts
@@ -1,95 +1,102 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import Orientation from 'react-native-orientation-locker'
 
-import { renderHook, waitFor } from 'tests/utils'
+import { act, renderHook, waitFor } from 'tests/utils'
 
 import { useOrientationLocked } from './useOrientationLocked'
 
-jest.mock('@react-native-async-storage/async-storage')
-jest.mock('react-native-orientation-locker')
+const storage: Record<string, string> = {}
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn((key: string) => Promise.resolve(storage[key] ?? null)),
+  setItem: jest.fn((key: string, value: string) => {
+    storage[key] = value
+    return Promise.resolve()
+  }),
+}))
+
+jest.mock('react-native-orientation-locker', () => ({
+  lockToPortrait: jest.fn(),
+  unlockAllOrientations: jest.fn(),
+
+  addOrientationListener: jest.fn(),
+  removeOrientationListener: jest.fn(),
+
+  addLockListener: jest.fn(),
+  removeLockListener: jest.fn(),
+}))
 
 describe('useOrientationLocked', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    Object.keys(storage).forEach((k) => delete storage[k])
   })
 
-  it('should initialize with unlocked orientation by default (no stored value)', async () => {
-    jest.spyOn(AsyncStorage, 'getItem').mockResolvedValueOnce(null)
-
-    const { result } = renderHook(() => useOrientationLocked())
+  it('should initialize with unlocked orientation by default', async () => {
+    renderHook(() => useOrientationLocked())
 
     await waitFor(() => {
-      const isOrientationLocked = result.current[0]
-
-      expect(isOrientationLocked).toBe(false)
+      expect(Orientation.unlockAllOrientations).toHaveBeenCalledTimes(1)
     })
-
-    expect(Orientation.unlockAllOrientations).toHaveBeenCalledTimes(1)
   })
 
   it('should initialize with locked orientation if stored value is true', async () => {
-    jest.spyOn(AsyncStorage, 'getItem').mockResolvedValueOnce('true')
-    jest.spyOn(Orientation, 'isLocked').mockReturnValueOnce(true)
+    storage.orientationLocked = 'true'
 
-    const { result } = renderHook(() => useOrientationLocked())
+    renderHook(() => useOrientationLocked())
 
     await waitFor(() => {
-      const isOrientationLocked = result.current[0]
-
-      expect(isOrientationLocked).toBe(true)
+      expect(Orientation.lockToPortrait).toHaveBeenCalledTimes(1)
     })
-
-    expect(Orientation.lockToPortrait).toHaveBeenCalledTimes(1)
   })
 
   it('should initialize with unlocked orientation if stored value is false', async () => {
-    jest.spyOn(AsyncStorage, 'getItem').mockResolvedValueOnce('false')
-    jest.spyOn(Orientation, 'isLocked').mockReturnValueOnce(false)
+    storage.orientationLocked = 'false'
 
-    const { result } = renderHook(() => useOrientationLocked())
+    renderHook(() => useOrientationLocked())
 
     await waitFor(() => {
-      const isOrientationLocked = result.current[0]
-
-      expect(isOrientationLocked).toBe(false)
+      expect(Orientation.unlockAllOrientations).toHaveBeenCalledTimes(1)
     })
-
-    expect(Orientation.lockToPortrait).not.toHaveBeenCalled()
-    expect(Orientation.unlockAllOrientations).toHaveBeenCalledTimes(1)
   })
 
   it('should lock orientation when toggling from unlocked state', async () => {
-    jest.spyOn(AsyncStorage, 'getItem').mockResolvedValueOnce('false')
-    jest
-      .spyOn(Orientation, 'isLocked')
-      .mockReturnValueOnce(false) // Initial call
-      .mockReturnValueOnce(false) // During toggleOrientation
-      .mockReturnValueOnce(false) // After useEffect
+    storage.orientationLocked = 'false'
 
     const { result } = renderHook(() => useOrientationLocked())
-    const toggleOrientation = result.current[1]
-    await toggleOrientation()
 
-    expect(AsyncStorage.setItem).toHaveBeenNthCalledWith(1, 'orientationLocked', 'true')
+    await act(async () => {
+      await result.current[1]()
+    })
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('orientationLocked', 'true')
+
     expect(Orientation.lockToPortrait).toHaveBeenCalledTimes(1)
   })
 
   it('should unlock orientation when toggling from locked state', async () => {
-    jest.spyOn(Orientation, 'isLocked').mockReturnValueOnce(true)
-    jest.spyOn(AsyncStorage, 'getItem').mockResolvedValueOnce('true')
+    storage.orientationLocked = 'true'
 
     const { result } = renderHook(() => useOrientationLocked())
-    const toggleOrientation = result.current[1]
-    await toggleOrientation()
 
-    expect(AsyncStorage.setItem).toHaveBeenNthCalledWith(1, 'orientationLocked', 'false')
+    await waitFor(() => {
+      expect(result.current[0]).toBe(true)
+    })
+
+    await act(async () => {
+      await result.current[1]()
+    })
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('orientationLocked', 'false')
+
     expect(Orientation.unlockAllOrientations).toHaveBeenCalledTimes(1)
   })
 
   it('should clean up listeners on unmount', () => {
     const { unmount } = renderHook(() => useOrientationLocked())
+
     unmount()
 
-    expect(Orientation.removeAllListeners).toHaveBeenCalledTimes(1)
+    expect(Orientation.removeOrientationListener).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/shared/hook/useOrientationLocked.ts
+++ b/src/shared/hook/useOrientationLocked.ts
@@ -1,30 +1,76 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { useCallback, useEffect, useState } from 'react'
+import { AppState, AppStateStatus } from 'react-native'
 import Orientation from 'react-native-orientation-locker'
 
+const STORAGE_KEY = 'orientationLocked'
+
 export const useOrientationLocked = () => {
-  const [isOrientationLocked, setIsOrientationLocked] = useState(Orientation.isLocked())
+  const [isOrientationLocked, setIsOrientationLocked] = useState(false)
 
-  const fetchOrientationLocked = useCallback(async () => {
-    const storedValue = await AsyncStorage.getItem('orientationLocked')
-    const shouldLock = storedValue === 'true'
-
-    setIsOrientationLocked(shouldLock)
-
-    if (shouldLock) Orientation.lockToPortrait()
-    else Orientation.unlockAllOrientations()
+  const applyOrientationLock = useCallback((locked: boolean) => {
+    if (locked) {
+      Orientation.lockToPortrait()
+    } else {
+      Orientation.unlockAllOrientations()
+    }
   }, [])
 
   useEffect(() => {
-    fetchOrientationLocked()
-    Orientation.addLockListener(() => setIsOrientationLocked(Orientation.isLocked()))
-    return () => Orientation.removeAllListeners()
-  }, [fetchOrientationLocked])
+    let mounted = true
+
+    const init = async () => {
+      const storedValue = await AsyncStorage.getItem(STORAGE_KEY)
+      const locked = storedValue === 'true'
+
+      if (!mounted) return
+
+      setIsOrientationLocked(locked)
+      applyOrientationLock(locked)
+    }
+
+    void init()
+
+    return () => {
+      mounted = false
+    }
+  }, [applyOrientationLock])
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state: AppStateStatus) => {
+      if (state === 'active' && isOrientationLocked) {
+        Orientation.lockToPortrait()
+      }
+    })
+
+    return () => subscription.remove()
+  }, [isOrientationLocked])
+
+  useEffect(() => {
+    const handler = (orientation: string) => {
+      if (
+        isOrientationLocked &&
+        (orientation === 'LANDSCAPE-LEFT' || orientation === 'LANDSCAPE-RIGHT')
+      ) {
+        Orientation.lockToPortrait()
+      }
+    }
+
+    Orientation.addOrientationListener(handler)
+
+    return () => {
+      Orientation.removeOrientationListener(handler)
+    }
+  }, [isOrientationLocked])
 
   const toggleOrientationLocked = useCallback(async () => {
-    await AsyncStorage.setItem('orientationLocked', (!Orientation.isLocked()).toString())
-    Orientation.isLocked() ? Orientation.unlockAllOrientations() : Orientation.lockToPortrait()
-  }, [])
+    const nextValue = !isOrientationLocked
+
+    setIsOrientationLocked(nextValue)
+    await AsyncStorage.setItem(STORAGE_KEY, String(nextValue))
+
+    applyOrientationLock(nextValue)
+  }, [applyOrientationLock, isOrientationLocked])
 
   return [isOrientationLocked, toggleOrientationLocked] as const
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42350

## Context

Origine du problème :
Sur Android, le verrouillage d’orientation appliqué via `react-native-orientation-locker `n’était pas systématiquement réappliqué lorsque le système restaurait l’orientation de l’`Activity` (notamment après un changement d’orientation ou un retour en foreground). L’application pouvait donc rester affichée en paysage alors que le verrouillage portrait était activé.

Correction :
Le hook utilise maintenant son état local comme source de vérité au lieu de dépendre de `Orientation.isLocked()`. Le verrouillage portrait est réappliqué au retour de l’application au premier plan et un listener d’orientation force le retour en portrait si Android passe malgré tout en paysage lorsque le verrouillage est actif.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
