### PR TITLE
(PC-42377) feat(a11y): decorative icon should not be read by screen readers and distance should be more explicit

### DIFF
--- a/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
@@ -930,7 +930,6 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
                       }
                     >
                       <View
-                        accessibilityLabel="position dans le monde"
                         height={32}
                         width={32}
                       >

--- a/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
@@ -925,7 +925,6 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
                         }
                       >
                         <View
-                          accessibilityLabel="position dans le monde"
                           height={32}
                           width={32}
                         >

--- a/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
+++ b/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
@@ -57,7 +57,7 @@ const UnmemoizedSearchVenueItem = ({
 
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.VENUE, {
     ...venue,
-    distance,
+    distance: distance ? `à ${distance}` : undefined,
   })
 
   const hasVenueImage = !!venue.banner_url

--- a/src/ui/svg/icons/WorldPosition.tsx
+++ b/src/ui/svg/icons/WorldPosition.tsx
@@ -17,7 +17,7 @@ const WorldPositionSvg: React.FunctionComponent<AccessibleIcon> = ({
       width={size}
       height={size}
       viewBox="0 0 48 48"
-      accessibilityLabel={accessibilityLabel ?? `position dans le monde`}
+      accessibilityLabel={accessibilityLabel}
       testID={testID}>
       <Path
         fill={color}


### PR DESCRIPTION

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42377

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
