### PR TITLE
(PC-42400) fix(auth): keep success screen on account deletion and pre…

### DIFF
--- a/src/api/apiHelpers.native.test.ts
+++ b/src/api/apiHelpers.native.test.ts
@@ -7,6 +7,7 @@ import * as Keychain from 'libs/keychain/keychain'
 import { eventMonitoring } from 'libs/monitoring/services'
 import * as PackageJson from 'libs/packageJson'
 import { deviceInfoStoreActions } from 'shared/store/deviceInfoStore'
+import { logoutStoreActions } from 'shared/store/logoutStore'
 import { mockServer } from 'tests/mswServer'
 
 import { ApiError } from './ApiError'
@@ -357,6 +358,10 @@ describe('[api] helpers', () => {
   describe('handleGeneratedApiResponse', () => {
     const navigateFromRef = jest.spyOn(NavigationRef, 'navigateFromRef')
 
+    beforeEach(() => {
+      logoutStoreActions.setIsLoggingOut(false)
+    })
+
     it('should return body when status is ok', async () => {
       const response = await respondWith('apiResponse')
 
@@ -450,6 +455,15 @@ describe('[api] helpers', () => {
       const result = await handleGeneratedApiResponse(createNeedsAuthenticationResponse(apiUrl))
 
       expect(navigateFromRef).toHaveBeenCalledWith('LoginMethods', undefined)
+      expect(result).toEqual({})
+    })
+
+    it('should not navigate to LoginMethods when a logout is in progress', async () => {
+      logoutStoreActions.setIsLoggingOut(true)
+
+      const result = await handleGeneratedApiResponse(createNeedsAuthenticationResponse(apiUrl))
+
+      expect(navigateFromRef).not.toHaveBeenCalled()
       expect(result).toEqual({})
     })
   })

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -150,8 +150,7 @@ export async function handleGeneratedApiResponse(response: Response): Promise<an
     response.status === NeedsAuthenticationStatus.status &&
     response.statusText === NeedsAuthenticationStatus.statusText
   ) {
-    // During an intentional logout the tokens are cleared on purpose: requests still
-    // in flight end up here, and the login page must not open on its own.
+    // Skip the auto-redirect when the logout is intentional (tokens cleared on purpose).
     if (!logoutStoreSelectors.selectIsLoggingOut()) {
       navigateToLoginMethods()
     }

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -11,6 +11,7 @@ import { getAppVersion } from 'libs/packageJson'
 import { getDeviceId } from 'libs/react-native-device-info/getDeviceId'
 import { storage } from 'libs/storage'
 import { getErrorMessage } from 'shared/getErrorMessage/getErrorMessage'
+import { logoutStoreSelectors } from 'shared/store/logoutStore'
 
 import { ApiError } from './ApiError'
 import { DefaultApi } from './gen'
@@ -149,7 +150,11 @@ export async function handleGeneratedApiResponse(response: Response): Promise<an
     response.status === NeedsAuthenticationStatus.status &&
     response.statusText === NeedsAuthenticationStatus.statusText
   ) {
-    navigateToLoginMethods()
+    // During an intentional logout the tokens are cleared on purpose: requests still
+    // in flight end up here, and the login page must not open on its own.
+    if (!logoutStoreSelectors.selectIsLoggingOut()) {
+      navigateToLoginMethods()
+    }
     return {}
   }
 

--- a/src/features/auth/helpers/useLoginRoutine.native.test.ts
+++ b/src/features/auth/helpers/useLoginRoutine.native.test.ts
@@ -11,6 +11,7 @@ import { analytics } from 'libs/analytics/provider'
 import { firebaseAnalytics } from 'libs/firebase/analytics/analytics'
 import * as Keychain from 'libs/keychain/keychain'
 import { storage } from 'libs/storage'
+import { logoutStoreActions, logoutStoreSelectors } from 'shared/store/logoutStore'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, renderHook, waitFor } from 'tests/utils'
 
@@ -94,6 +95,14 @@ describe('useLoginRoutine', () => {
     await act(loginFunction(result.current))
 
     await waitFor(() => expect(scheduleAccessTokenRemovalSpy).toHaveBeenCalledWith(accessToken))
+  })
+
+  it('should lift the logout guard so the API layer can redirect to login again', async () => {
+    logoutStoreActions.setIsLoggingOut(true)
+    const { result } = renderUseLoginRoutine()
+    await act(loginFunction(result.current))
+
+    expect(logoutStoreSelectors.selectIsLoggingOut()).toBe(false)
   })
 
   describe('connectServicesRequiringUserId', () => {

--- a/src/features/auth/helpers/useLoginRoutine.ts
+++ b/src/features/auth/helpers/useLoginRoutine.ts
@@ -27,8 +27,6 @@ export function useLoginRoutine(): LoginRoutine {
    */
 
   return async (response, method, analyticsType) => {
-    // A new session starts: lift the logout guard so the API layer can redirect to
-    // the login page again if the session breaks (e.g. expired refresh token).
     logoutStoreActions.setIsLoggingOut(false)
     connectServicesRequiringUserId(response.accessToken)
     await saveRefreshToken(response.refreshToken)

--- a/src/features/auth/helpers/useLoginRoutine.ts
+++ b/src/features/auth/helpers/useLoginRoutine.ts
@@ -7,6 +7,7 @@ import { LoginRoutineMethod, LoginType } from 'libs/analytics/logEventAnalytics'
 import { analytics } from 'libs/analytics/provider'
 import { saveRefreshToken } from 'libs/keychain/keychain'
 import { storage } from 'libs/storage'
+import { logoutStoreActions } from 'shared/store/logoutStore'
 
 export type LoginRoutine = (
   response: SigninResponseV2,
@@ -26,6 +27,9 @@ export function useLoginRoutine(): LoginRoutine {
    */
 
   return async (response, method, analyticsType) => {
+    // A new session starts: lift the logout guard so the API layer can redirect to
+    // the login page again if the session breaks (e.g. expired refresh token).
+    logoutStoreActions.setIsLoggingOut(false)
     connectServicesRequiringUserId(response.accessToken)
     await saveRefreshToken(response.refreshToken)
     await storage.saveString('access_token', response.accessToken)

--- a/src/features/auth/helpers/useLogoutRoutine.native.test.ts
+++ b/src/features/auth/helpers/useLogoutRoutine.native.test.ts
@@ -6,6 +6,7 @@ import { analytics } from 'libs/analytics/provider'
 import * as Keychain from 'libs/keychain/keychain'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { googleLogout } from 'libs/react-native-google-sso/googleLogout'
+import { logoutStoreActions, logoutStoreSelectors } from 'shared/store/logoutStore'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { renderHook } from 'tests/utils'
 
@@ -15,9 +16,11 @@ jest.mock('libs/keychain/keychain')
 
 let queryClient: QueryClient
 const removeQueriesMock = jest.fn()
+const cancelQueriesMock = jest.fn()
 const setupQueryClient = (client: QueryClient) => {
   queryClient = client
   jest.spyOn(queryClient, 'removeQueries').mockImplementation(removeQueriesMock)
+  jest.spyOn(queryClient, 'cancelQueries').mockImplementation(cancelQueriesMock)
 }
 
 jest.mock('libs/firebase/analytics/analytics')
@@ -113,6 +116,25 @@ describe('useLogoutRoutine', () => {
     await result.current()
 
     expect(removeQueriesMock).toHaveBeenCalledWith(query)
+  })
+
+  it.each(
+    LoggedInQueryKeys.map((key) => ({
+      queryKey: [key],
+    }))
+  )('should cancel in-flight query: "%s"', async (query) => {
+    const { result } = renderUseLogoutRoutine()
+    await result.current()
+
+    expect(cancelQueriesMock).toHaveBeenCalledWith(query)
+  })
+
+  it('should mark the logout as in progress to prevent automatic navigation to login page', async () => {
+    logoutStoreActions.setIsLoggingOut(false)
+    const { result } = renderUseLogoutRoutine()
+    await result.current()
+
+    expect(logoutStoreSelectors.selectIsLoggingOut()).toBe(true)
   })
 
   it('should logout from Google account', async () => {

--- a/src/features/auth/helpers/useLogoutRoutine.native.test.ts
+++ b/src/features/auth/helpers/useLogoutRoutine.native.test.ts
@@ -130,11 +130,19 @@ describe('useLogoutRoutine', () => {
   })
 
   it('should mark the logout as in progress to prevent automatic navigation to login page', async () => {
+    const setIsLoggingOutSpy = jest.spyOn(logoutStoreActions, 'setIsLoggingOut')
+    const { result } = renderUseLogoutRoutine()
+    await result.current()
+
+    expect(setIsLoggingOutSpy).toHaveBeenNthCalledWith(1, true)
+  })
+
+  it('should lift the logout guard once the routine is done', async () => {
     logoutStoreActions.setIsLoggingOut(false)
     const { result } = renderUseLogoutRoutine()
     await result.current()
 
-    expect(logoutStoreSelectors.selectIsLoggingOut()).toBe(true)
+    expect(logoutStoreSelectors.selectIsLoggingOut()).toBe(false)
   })
 
   it('should logout from Google account', async () => {

--- a/src/features/auth/helpers/useLogoutRoutine.ts
+++ b/src/features/auth/helpers/useLogoutRoutine.ts
@@ -18,11 +18,7 @@ export function useLogoutRoutine(): () => Promise<void> {
 
   return useCallback(async () => {
     try {
-      // Prevent the API layer from opening the login page when authenticated calls
-      // still in flight fail because the tokens are being cleared on purpose.
       logoutStoreActions.setIsLoggingOut(true)
-      // Disable the `enabled: isLoggedIn` queries before touching the cache or the
-      // tokens, otherwise their still-active observers refetch without tokens.
       setIsLoggedIn(false)
 
       handleBatchProfileReset()
@@ -47,6 +43,7 @@ export function useLogoutRoutine(): () => Promise<void> {
       eventMonitoring.captureException(err)
     } finally {
       setIsLoggedIn(false)
+      logoutStoreActions.setIsLoggingOut(false)
     }
   }, [queryClient, setIsLoggedIn])
 }

--- a/src/features/auth/helpers/useLogoutRoutine.ts
+++ b/src/features/auth/helpers/useLogoutRoutine.ts
@@ -10,6 +10,7 @@ import { QueryKeys } from 'libs/queryKeys'
 import { BatchProfile } from 'libs/react-native-batch'
 import { googleLogout } from 'libs/react-native-google-sso/googleLogout'
 import { storage } from 'libs/storage'
+import { logoutStoreActions } from 'shared/store/logoutStore'
 
 export function useLogoutRoutine(): () => Promise<void> {
   const queryClient = useQueryClient()
@@ -17,13 +18,18 @@ export function useLogoutRoutine(): () => Promise<void> {
 
   return useCallback(async () => {
     try {
+      // Prevent the API layer from opening the login page when authenticated calls
+      // still in flight fail because the tokens are being cleared on purpose.
+      logoutStoreActions.setIsLoggingOut(true)
+      // Disable the `enabled: isLoggedIn` queries before touching the cache or the
+      // tokens, otherwise their still-active observers refetch without tokens.
+      setIsLoggedIn(false)
+
       handleBatchProfileReset()
 
-      LoggedInQueryKeys.forEach((queryKey) => {
-        queryClient.removeQueries({
-          queryKey: [queryKey],
-        })
-      })
+      await Promise.all(
+        LoggedInQueryKeys.map((queryKey) => queryClient.cancelQueries({ queryKey: [queryKey] }))
+      )
       await Promise.all([
         analytics.logLogout(),
         storage.clear('access_token'),
@@ -31,6 +37,11 @@ export function useLogoutRoutine(): () => Promise<void> {
         AsyncStorage.multiRemove(LoggedInQueryKeys),
         googleLogout(),
       ])
+      LoggedInQueryKeys.forEach((queryKey) => {
+        queryClient.removeQueries({
+          queryKey: [queryKey],
+        })
+      })
       eventMonitoring.setUser(null)
     } catch (err) {
       eventMonitoring.captureException(err)
@@ -51,6 +62,7 @@ function handleBatchProfileReset() {
 
 // List of keys that are accessible only when logged in to clean when logging out
 export const LoggedInQueryKeys: QueryKeys[] = [
+  QueryKeys.AVAILABLE_REACTION,
   QueryKeys.CULTURAL_SURVEY_QUESTIONS,
   QueryKeys.FAVORITES,
   QueryKeys.FAVORITES_COUNT,

--- a/src/features/navigation/navigators/ProfileStackNavigator/ProfileStackNavigator.tsx
+++ b/src/features/navigation/navigators/ProfileStackNavigator/ProfileStackNavigator.tsx
@@ -158,9 +158,6 @@ const profileStackNavigatorPathDefinition = {
         path: 'profile/suppression/confirmation',
       },
     },
-    // No `if: useIsSignedIn` on the deletion success screens: they are displayed at the
-    // very moment the app logs the user out (they call signOut on mount), so gating them
-    // on the logged-in state would remove them from the navigator before/while shown.
     DeleteProfileSuccess: {
       screen: DeleteProfileSuccess,
       linking: {

--- a/src/features/navigation/navigators/ProfileStackNavigator/ProfileStackNavigator.tsx
+++ b/src/features/navigation/navigators/ProfileStackNavigator/ProfileStackNavigator.tsx
@@ -158,17 +158,17 @@ const profileStackNavigatorPathDefinition = {
         path: 'profile/suppression/confirmation',
       },
     },
-    // FIXME(PC-00000): Why is it not in the routes
+    // No `if: useIsSignedIn` on the deletion success screens: they are displayed at the
+    // very moment the app logs the user out (they call signOut on mount), so gating them
+    // on the logged-in state would remove them from the navigator before/while shown.
     DeleteProfileSuccess: {
       screen: DeleteProfileSuccess,
-      if: useIsSignedIn,
       linking: {
         path: 'profile/suppression/succes',
       },
     },
     DeactivateProfileSuccess: {
       screen: DeactivateProfileSuccess,
-      if: useIsSignedIn,
       linking: {
         path: 'profile/desactivation/succes',
       },

--- a/src/features/reactions/queries/useAvailableReactionQuery.test.ts
+++ b/src/features/reactions/queries/useAvailableReactionQuery.test.ts
@@ -29,11 +29,12 @@ describe('useAvailableReaction', () => {
     await waitFor(() => expect(result.current.data).toEqual({}))
   })
 
-  it('should handle errors correctly', async () => {
-    mockServer.getApi('/v2/reaction/available', { responseOptions: { statusCode: 400, data: {} } })
+  it('should swallow a 401 error so the tab badge never crashes the app', async () => {
+    mockServer.getApi('/v2/reaction/available', { responseOptions: { statusCode: 401, data: {} } })
 
     const { result } = renderUseAvailableReaction()
 
+    // The 401 is exposed as recoverable query state instead of being thrown to the boundary.
     await waitFor(() => expect(result.current.isError).toBeTruthy())
 
     expect(result.current.data).toBeUndefined()

--- a/src/features/reactions/queries/useAvailableReactionQuery.ts
+++ b/src/features/reactions/queries/useAvailableReactionQuery.ts
@@ -11,5 +11,9 @@ export const useAvailableReactionQuery = () => {
     queryKey: [QueryKeys.AVAILABLE_REACTION],
     queryFn: () => api.getNativeV2ReactionAvailable(),
     enabled: isLoggedIn,
+    // A tab badge must never crash the app: the endpoint returns 401 when the
+    // account is suspended while the app still holds valid tokens (e.g. right
+    // after an account deletion or when reconnecting to a suspended account).
+    throwOnError: false,
   })
 }

--- a/src/features/reactions/queries/useAvailableReactionQuery.ts
+++ b/src/features/reactions/queries/useAvailableReactionQuery.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { api } from 'api/api'
+import { isApiError } from 'api/apiHelpers'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { QueryKeys } from 'libs/queryKeys'
 
@@ -11,9 +12,8 @@ export const useAvailableReactionQuery = () => {
     queryKey: [QueryKeys.AVAILABLE_REACTION],
     queryFn: () => api.getNativeV2ReactionAvailable(),
     enabled: isLoggedIn,
-    // A tab badge must never crash the app: the endpoint returns 401 when the
-    // account is suspended while the app still holds valid tokens (e.g. right
-    // after an account deletion or when reconnecting to a suspended account).
-    throwOnError: false,
+    // Swallow the 401 raised when the account is suspended so the tab badge never crashes
+    // the app; other errors keep their default behaviour.
+    throwOnError: (error) => !(isApiError(error) && error.statusCode === 401),
   })
 }

--- a/src/shared/store/logoutStore.ts
+++ b/src/shared/store/logoutStore.ts
@@ -6,10 +6,8 @@ type State = {
 
 const defaultState: State = { isLoggingOut: false }
 
-// Tracks intentional logouts outside of React. When the user logs out, the tokens are
-// cleared on purpose: authenticated calls still in flight then fail to refresh their
-// access token, and the API layer must not interpret this as a broken session by
-// forcing a navigation to the login page.
+// Tracks an intentional logout so the API layer doesn't redirect to login on the 401s
+// triggered by clearing the tokens on purpose.
 const logoutStore = createStore({
   name: 'logout',
   defaultState,

--- a/src/shared/store/logoutStore.ts
+++ b/src/shared/store/logoutStore.ts
@@ -1,0 +1,25 @@
+import { createStore } from 'libs/store/createStore'
+
+type State = {
+  isLoggingOut: boolean
+}
+
+const defaultState: State = { isLoggingOut: false }
+
+// Tracks intentional logouts outside of React. When the user logs out, the tokens are
+// cleared on purpose: authenticated calls still in flight then fail to refresh their
+// access token, and the API layer must not interpret this as a broken session by
+// forcing a navigation to the login page.
+const logoutStore = createStore({
+  name: 'logout',
+  defaultState,
+  actions: (set: (state: State) => void) => ({
+    setIsLoggingOut: (isLoggingOut: boolean) => set({ isLoggingOut }),
+  }),
+  selectors: {
+    selectIsLoggingOut: () => (state: State) => state.isLoggingOut,
+  },
+})
+
+export const logoutStoreActions = logoutStore.actions
+export const logoutStoreSelectors = logoutStore.selectors


### PR DESCRIPTION
…vent login redirect on intentional logout

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42400

## Contexte

Lors de la suppression ou de la désactivation d'un compte (et lors d'une reconnexion à un compte suspendu), l'app effaçait les tokens volontairement. Les requêtes authentifiées encore en vol recevaient alors un `401`, interprété comme une session cassée : l'app **redirigeait de force vers la page de connexion** et/ou **plantait**, au lieu d'afficher l'écran de succès.

## Vidéos

### Avant


https://github.com/user-attachments/assets/9d11d717-48ec-403d-b036-49efe4ec83e6

### Après


https://github.com/user-attachments/assets/b5db8c4a-38e4-4b68-b89e-8e693bfba596



## Changements

- **`shared/store/logoutStore.ts`** (nouveau) : flag `isLoggingOut` hors React pour distinguer une déconnexion volontaire d'une session réellement expirée.
- **`api/apiHelpers.ts`** : on n'ouvre plus la page de login sur un `401` quand une déconnexion volontaire est en cours.
- **`auth/helpers/useLogoutRoutine.ts`** : pose `isLoggingOut`, désactive `isLoggedIn` **avant** de toucher au cache/tokens, `cancelQueries` avant `removeQueries`. Ajout de `AVAILABLE_REACTION` aux `LoggedInQueryKeys`.
- **`auth/helpers/useLoginRoutine.ts`** : lève le flag (`isLoggingOut = false`) au démarrage d'une nouvelle session, pour réactiver la redirection login en cas de vraie session cassée.
- **`reactions/queries/useAvailableReactionQuery.ts`** : `throwOnError: false` — le badge de réactions ne doit jamais faire planter l'app sur un `401`.
- **`navigation/.../ProfileStackNavigator.tsx`** : suppression du `if: useIsSignedIn` sur `DeleteProfileSuccess` / `DeactivateProfileSuccess` (ces écrans déclenchent le logout au montage ; le gating les retirait du navigator avant affichage).

## Comportement attendu après correctif

- L'écran de succès (« Compte supprimé » / « Compte désactivé ») s'affiche et reste affiché.
- Aucune redirection automatique vers la page de connexion ni crash sur une déconnexion volontaire.
- La redirection login reste active pour une vraie session cassée (ex. refresh token expiré en cours d'usage).

## Tests

- [ ] Suppression de compte → écran de succès affiché, pas de redirection login
- [ ] Désactivation de compte → écran de succès affiché
- [ ] Reconnexion sur un compte suspendu → pas de crash
- [ ] Session réellement expirée → redirection login toujours fonctionnelle
