### PR TITLE
(PC-41647) fix(Bookings): ended bookings card display

### DIFF
--- a/__snapshots__/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx.native-snap
@@ -24,7 +24,6 @@ exports[`EndedBookings should render correctly 1`] = `
     {
       "flexGrow": 1,
       "paddingBottom": 98,
-      "paddingHorizontal": 24,
     }
   }
   data={

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.tsx
@@ -175,7 +175,6 @@ export const EndedBookings: FunctionComponent<Props> = ({ useEndedBookingsQuery 
 
 const contentContainerStyle = (designSystem) => ({
   flexGrow: 1,
-  paddingHorizontal: designSystem.size.spacing.xl,
   paddingBottom: TAB_BAR_COMP_HEIGHT_V2 + designSystem.size.spacing.xxl,
 })
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41647

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome | <img width="321" height="243" alt="Capture d’écran 2026-06-17 à 14 07 04" src="https://github.com/user-attachments/assets/6e276989-663d-4d4f-b06e-f1e43c9cbee7" /> |  <img width="324" height="239" alt="Capture d’écran 2026-06-17 à 14 07 23" src="https://github.com/user-attachments/assets/5ffddf94-ba79-4982-ae6d-cfd3facd6d05" /> |      
