### PR TITLE
(PC-41944) fix(artist): trigger ConsultOffer log with the right type of playlist

### DIFF
--- a/src/features/artist/components/ArtistPlaylist/ArtistCategoryPlaylist.tsx
+++ b/src/features/artist/components/ArtistPlaylist/ArtistCategoryPlaylist.tsx
@@ -89,7 +89,7 @@ export const ArtistCategoryPlaylist: FunctionComponent<ArtistCategoryPlaylistPro
     <ObservedPlaylist onViewableItemsChanged={handleArtistOffersViewableItemsChanged}>
       {({ listRef, handleViewableItemsChanged }) => (
         <PassPlaylist
-          playlistType={PlaylistType.SAME_ARTIST_PLAYLIST}
+          playlistType={PlaylistType.ARTIST_CATEGORY_PLAYLIST}
           title={title}
           data={items}
           FlatListComponent={FlatList}

--- a/src/features/artist/components/ArtistPlaylist/ArtistPlaylist.native.test.tsx
+++ b/src/features/artist/components/ArtistPlaylist/ArtistPlaylist.native.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { SubcategoryIdEnum } from 'api/gen'
 import { ArtistPlaylist } from 'features/artist/components/ArtistPlaylist/ArtistPlaylist'
+import { PlaylistType } from 'features/offer/enums'
 import { mockedAlgoliaOffersWithSameArtistResponse } from 'libs/algolia/fixtures/algoliaFixtures'
 import { AlgoliaOfferWithArtistAndEan } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics/provider'
@@ -58,6 +59,45 @@ describe('ArtistPlaylist', () => {
     expect(screen.getAllByText('Concert')[0]).toBeOnTheScreen()
     expect(screen.getByText('Livre papier')).toBeOnTheScreen()
     expect(screen.getByText('Festival livre')).toBeOnTheScreen()
+  })
+
+  it('should trigger ConsultOffer log with good parameters when pressing a playlist item', async () => {
+    render(
+      reactQueryProviderHOC(
+        <ArtistPlaylist
+          artist={{ id: '1', name: 'Céline Dion' }}
+          items={[
+            buildArtistOffer({
+              objectID: '1',
+              name: 'Concert',
+              subcategoryId: SubcategoryIdEnum.CONCERT,
+            }),
+            buildArtistOffer({
+              objectID: '2',
+              name: 'Livre papier',
+              subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
+            }),
+            buildArtistOffer({
+              objectID: '3',
+              name: 'Festival livre',
+              subcategoryId: SubcategoryIdEnum.FESTIVAL_LIVRE,
+            }),
+          ]}
+          onViewableItemsChanged={jest.fn()}
+        />
+      )
+    )
+
+    await user.press(screen.getByText('Livre papier'))
+
+    expect(analytics.logConsultOffer).toHaveBeenCalledWith({
+      artistName: 'Céline Dion',
+      displayAdvice: false,
+      from: 'artist',
+      isHeadline: false,
+      offerId: '2',
+      playlistType: PlaylistType.ARTIST_CATEGORY_PLAYLIST,
+    })
   })
 
   it('should not display playlists for offers excluded from artist category mapping', async () => {

--- a/src/features/artist/components/ArtistTopOffers/ArtistTopOffers.native.test.tsx
+++ b/src/features/artist/components/ArtistTopOffers/ArtistTopOffers.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { ArtistTopOffers } from 'features/artist/components/ArtistTopOffers/ArtistTopOffers'
+import { PlaylistType } from 'features/offer/enums'
 import { mockedAlgoliaOffersWithSameArtistResponse } from 'libs/algolia/fixtures/algoliaFixtures'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
@@ -29,6 +30,28 @@ describe('ArtistTopOffers', () => {
 
     expect(screen.getByLabelText('Ses oeuvres populaires')).toBeOnTheScreen()
     expect(screen.getByText('Manga one piece t91')).toBeOnTheScreen()
+  })
+
+  it('should trigger ConsultOffer log with good parameters when pressing a playlist item', async () => {
+    render(
+      reactQueryProviderHOC(
+        <ArtistTopOffers
+          artistName="Céline Dion"
+          items={mockedAlgoliaOffersWithSameArtistResponse}
+        />
+      )
+    )
+
+    await user.press(screen.getByText('Manga one piece t91'))
+
+    expect(analytics.logConsultOffer).toHaveBeenCalledWith({
+      artistName: 'Céline Dion',
+      displayAdvice: false,
+      from: 'artist',
+      isHeadline: false,
+      offerId: '16302',
+      playlistType: PlaylistType.ARTIST_TOP_OFFERS,
+    })
   })
 
   it('should display top offers in an horizontal carousel', () => {

--- a/src/features/artist/components/ArtistTopOffers/ArtistTopOffers.tsx
+++ b/src/features/artist/components/ArtistTopOffers/ArtistTopOffers.tsx
@@ -64,7 +64,7 @@ export const ArtistTopOffers: FunctionComponent<Props> = ({
 
   return topOffers.length > 0 ? (
     <PassPlaylist
-      playlistType={PlaylistType.SAME_ARTIST_PLAYLIST}
+      playlistType={PlaylistType.ARTIST_TOP_OFFERS}
       title={playlistTitle}
       data={topOffers}
       FlatListComponent={FlatList}

--- a/src/features/offer/enums.ts
+++ b/src/features/offer/enums.ts
@@ -1,8 +1,10 @@
 export enum PlaylistType {
-  SAME_CATEGORY_SIMILAR_OFFERS = 'sameCategorySimilarOffers',
+  ARTIST_CATEGORY_PLAYLIST = 'artistCategoryPlaylist',
+  ARTIST_TOP_OFFERS = 'artistTopOffers',
   BOOKS_SAME_CATEGORY_SIMILAR_OFFERS = 'booksSameCategorySimilarOffers',
   OTHER_CATEGORIES_SIMILAR_OFFERS = 'otherCategoriesSimilarOffers',
   SAME_ARTIST_PLAYLIST = 'sameArtistPlaylist',
+  SAME_CATEGORY_SIMILAR_OFFERS = 'sameCategorySimilarOffers',
   SEARCH_RESULTS = 'searchResults',
   TOP_OFFERS = 'topOffers',
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41944

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
