### PR TITLE
(PC-42425) feat(a11y): distance label in offer

### DIFF
--- a/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
@@ -793,7 +793,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                 }
               >
                 <View
-                  accessibilityLabel="Livre - La nuit des temps - 900+ km - 28 €"
+                  accessibilityLabel="Livre - La nuit des temps - à 900+ km - 28 €"
                   accessibilityRole="button"
                   accessibilityState={
                     {
@@ -843,7 +843,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       },
                     ]
                   }
-                  testID="Livre - La nuit des temps - 900+ km - 28 €"
+                  testID="Livre - La nuit des temps - à 900+ km - 28 €"
                 >
                   <View
                     style={
@@ -1142,7 +1142,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                 }
               >
                 <View
-                  accessibilityLabel="Concert - I want something more - 900+ km - 23 €"
+                  accessibilityLabel="Concert - I want something more - à 900+ km - 23 €"
                   accessibilityRole="button"
                   accessibilityState={
                     {
@@ -1192,7 +1192,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       },
                     ]
                   }
-                  testID="Concert - I want something more - 900+ km - 23 €"
+                  testID="Concert - I want something more - à 900+ km - 23 €"
                 >
                   <View
                     style={
@@ -1487,7 +1487,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                 }
               >
                 <View
-                  accessibilityLabel="Concert - Un lit sous une rivière - 49 km - 34 € - Duo - Possibilité de réserver 2 places."
+                  accessibilityLabel="Concert - Un lit sous une rivière - à 49 km - 34 € - Duo - Possibilité de réserver 2 places."
                   accessibilityRole="button"
                   accessibilityState={
                     {
@@ -1537,7 +1537,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       },
                     ]
                   }
-                  testID="Concert - Un lit sous une rivière - 49 km - 34 € - Duo - Possibilité de réserver 2 places."
+                  testID="Concert - Un lit sous une rivière - à 49 km - 34 € - Duo - Possibilité de réserver 2 places."
                 >
                   <View
                     style={
@@ -1831,7 +1831,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                 }
               >
                 <View
-                  accessibilityLabel="Concert - I want something more - 49 km - 28 €"
+                  accessibilityLabel="Concert - I want something more - à 49 km - 28 €"
                   accessibilityRole="button"
                   accessibilityState={
                     {
@@ -1881,7 +1881,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       },
                     ]
                   }
-                  testID="Concert - I want something more - 49 km - 28 €"
+                  testID="Concert - I want something more - à 49 km - 28 €"
                 >
                   <View
                     style={

--- a/src/libs/tileAccessibilityLabel.test.ts
+++ b/src/libs/tileAccessibilityLabel.test.ts
@@ -1,0 +1,26 @@
+import { tileAccessibilityLabel, TileContentType } from './tileAccessibilityLabel'
+
+describe('tileAccessibilityLabel', () => {
+  it('adds "à" before offer distance in accessibility label', () => {
+    const label = tileAccessibilityLabel(TileContentType.OFFER, {
+      name: 'Le film',
+      categoryLabel: 'Cinema',
+      price: '5 EUR',
+      date: 'Demain',
+      distance: '3 km',
+    })
+
+    expect(label).toBe('Cinema - Le film - à 3 km - 5 EUR - Demain')
+  })
+
+  it('does not add empty separators when offer distance is missing', () => {
+    const label = tileAccessibilityLabel(TileContentType.OFFER, {
+      name: 'Le film',
+      categoryLabel: 'Cinema',
+      price: '5 EUR',
+      date: 'Demain',
+    })
+
+    expect(label).toBe('Cinema - Le film - 5 EUR - Demain')
+  })
+})

--- a/src/libs/tileAccessibilityLabel.ts
+++ b/src/libs/tileAccessibilityLabel.ts
@@ -26,12 +26,13 @@ export enum TileContentType {
 
 function getOfferAccessibilityLabel(offer: Offer) {
   const { name, categoryLabel: category, distance, date, price, isDuo, interactionTagLabel } = offer
+  const distanceLabel = distance ? `à ${distance}` : undefined
   const duoLabel = isDuo ? 'Duo - Possibilité de réserver 2 places.' : undefined
   return getComputedAccessibilityLabel(
     category,
     interactionTagLabel,
     name,
-    distance,
+    distanceLabel,
     price,
     date,
     duoLabel

--- a/src/ui/components/OfferCaption.native.test.tsx
+++ b/src/ui/components/OfferCaption.native.test.tsx
@@ -27,6 +27,12 @@ describe('OfferCaption component', () => {
     expect(screen.getByText('Dès le 2 mars 2020')).toBeOnTheScreen()
   })
 
+  it('should display offer distance when provided', () => {
+    render(<OfferCaption {...props} distance="10 km" />)
+
+    expect(screen.getByText('à 10 km • Dès le 2 mars 2020')).toBeOnTheScreen()
+  })
+
   it('should display offer title', () => {
     render(<OfferCaption {...props} />)
 

--- a/src/ui/components/OfferCaption.tsx
+++ b/src/ui/components/OfferCaption.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { formatDistanceDate } from 'libs/parsers/formatDistanceDate'
-import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
+import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
 import { Typo } from 'ui/theme'
 
 type Props = {
@@ -23,20 +23,14 @@ export const OfferCaption: FC<Props> = ({
   distance,
   width,
 }: Props) => {
-  const categoryLabelNumberOfLines = useMobileFontScaleToDisplay({
-    default: 1,
-    at200PercentZoom: 3,
-  })
-  const nameNumberOfLines = useMobileFontScaleToDisplay({ default: 2, at200PercentZoom: 4 })
-  const distanceDateNumberOfLines = useMobileFontScaleToDisplay({ default: 1, at200PercentZoom: 4 })
-
+  const distanceDateNumberOfLines = useNumberOfLine(1)
   const distanceDate = formatDistanceDate(width, distance, date)
 
   return (
     <Fragment>
       <View>
-        <CategoryLabel numberOfLines={categoryLabelNumberOfLines}>{categoryLabel}</CategoryLabel>
-        <Typo.BodyAccentXs numberOfLines={nameNumberOfLines}>{name}</Typo.BodyAccentXs>
+        <CategoryLabel numberOfLines={useNumberOfLine(1)}>{categoryLabel}</CategoryLabel>
+        <Typo.BodyAccentXs numberOfLines={useNumberOfLine(2)}>{name}</Typo.BodyAccentXs>
       </View>
       <View>
         <Typo.BodyXs testID="priceIsDuo">{price}</Typo.BodyXs>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42425

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
