### PR TITLE
(PC-42503) refactor(artist): use wipArtistCategoryPlaylists FF to display playlist by category

### DIFF
--- a/src/features/artist/components/ArtistBody/ArtistBody.native.test.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.native.test.tsx
@@ -7,8 +7,11 @@ import { ArtistBody } from 'features/artist/components/ArtistBody/ArtistBody'
 import { mockArtist } from 'features/artist/fixtures/mockArtist'
 import { mockOffer } from 'features/bookOffer/fixtures/offer'
 import * as useGoBack from 'features/navigation/useGoBack'
+import { mockedAlgoliaOffersWithSameArtistResponse } from 'libs/algolia/fixtures/algoliaFixtures'
+import { AlgoliaOfferWithArtistAndEan } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent, waitFor } from 'tests/utils'
 
@@ -246,4 +249,94 @@ describe('<ArtistBody />', () => {
       { subject: 'Retrouve "Avril Lavigne" sur le pass Culture' }
     )
   })
+
+  it('should display artist playlist by category when wipArtistCategoryPlaylists FF activated', async () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_ARTIST_CATEGORY_PLAYLISTS])
+    render(
+      reactQueryProviderHOC(
+        <ArtistBody
+          artist={mockArtist}
+          artistPlaylist={[
+            buildArtistOffer({
+              objectID: '1',
+              name: 'Concert',
+              subcategoryId: SubcategoryIdEnum.CONCERT,
+            }),
+            buildArtistOffer({
+              objectID: '2',
+              name: 'Livre papier',
+              subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
+            }),
+            buildArtistOffer({
+              objectID: '3',
+              name: 'Festival livre',
+              subcategoryId: SubcategoryIdEnum.FESTIVAL_LIVRE,
+            }),
+          ]}
+          artistTopOffers={[]}
+          onViewableItemsChanged={jest.fn()}
+          onExpandBioPress={jest.fn()}
+        />
+      )
+    )
+
+    expect(await screen.findByLabelText('Prochains concerts et festivals')).toBeOnTheScreen()
+    expect(screen.getByLabelText('Livres')).toBeOnTheScreen()
+    expect(screen.getByLabelText('Prochains festivals et salons du livre')).toBeOnTheScreen()
+  })
+
+  it('should not display artist playlist by category when wipArtistCategoryPlaylists FF deactivated', async () => {
+    render(
+      reactQueryProviderHOC(
+        <ArtistBody
+          artist={mockArtist}
+          artistPlaylist={[
+            buildArtistOffer({
+              objectID: '1',
+              name: 'Concert',
+              subcategoryId: SubcategoryIdEnum.CONCERT,
+            }),
+            buildArtistOffer({
+              objectID: '2',
+              name: 'Livre papier',
+              subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
+            }),
+            buildArtistOffer({
+              objectID: '3',
+              name: 'Festival livre',
+              subcategoryId: SubcategoryIdEnum.FESTIVAL_LIVRE,
+            }),
+          ]}
+          artistTopOffers={[]}
+          onViewableItemsChanged={jest.fn()}
+          onExpandBioPress={jest.fn()}
+        />
+      )
+    )
+
+    await screen.findAllByText('Avril Lavigne')
+
+    expect(screen.queryByLabelText('Prochains concerts et festivals')).not.toBeOnTheScreen()
+    expect(screen.queryByLabelText('Livres')).not.toBeOnTheScreen()
+    expect(screen.queryByLabelText('Prochains festivals et salons du livre')).not.toBeOnTheScreen()
+  })
+})
+
+const buildArtistOffer = ({
+  name,
+  objectID,
+  subcategoryId,
+}: {
+  name: string
+  objectID: string
+  subcategoryId: SubcategoryIdEnum
+}): AlgoliaOfferWithArtistAndEan => ({
+  ...mockedAlgoliaOffersWithSameArtistResponse[0],
+  objectID,
+  offer: {
+    ...mockedAlgoliaOffersWithSameArtistResponse[0].offer,
+    bookFormat: undefined,
+    name,
+    subcategoryId,
+  },
 })

--- a/src/features/artist/components/ArtistBody/ArtistBody.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.tsx
@@ -77,6 +77,9 @@ export const ArtistBody: FunctionComponent<Props> = ({
   const { headerTransition, onScroll } = useOpacityTransition()
   const proAdvicesSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
   const enableProAdvicesTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_PRO_REVIEWS_PLAYLIST)
+  const enablePlaylistByCategory = useFeatureFlag(
+    RemoteStoreFeatureFlags.WIP_ARTIST_CATEGORY_PLAYLISTS
+  )
 
   const { top } = useSafeAreaInsets()
   const headerHeight = appBarHeight + top
@@ -169,13 +172,15 @@ export const ArtistBody: FunctionComponent<Props> = ({
             proAdvicesSegment={proAdvicesSegment}
             enableProAdvicesTag={enableProAdvicesTag}
           />
-          <ArtistPlaylist
-            artist={artist}
-            items={artistPlaylist}
-            onViewableItemsChanged={onViewableItemsChanged}
-            proAdvicesSegment={proAdvicesSegment}
-            enableProAdvicesTag={enableProAdvicesTag}
-          />
+          {enablePlaylistByCategory ? (
+            <ArtistPlaylist
+              artist={artist}
+              items={artistPlaylist}
+              onViewableItemsChanged={onViewableItemsChanged}
+              proAdvicesSegment={proAdvicesSegment}
+              enableProAdvicesTag={enableProAdvicesTag}
+            />
+          ) : null}
           <ArtistSimilarArtists artistId={artist.id} />
         </ViewGap>
       </ContentContainer>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42503

## Context
Les playlist par catégorie ont été affichées sur la page artiste sans utiliser le FF wipArtistCategoryPlaylists prévu à cet effet. Cette PR prend en compte le FF.
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
