### PR TITLE
(PC-42477) fix(artist): add padding and loading skeleton to similar a…

### DIFF
--- a/src/features/artist/components/ArtistBody/ArtistBody.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.tsx
@@ -73,12 +73,12 @@ export const ArtistBody: FunctionComponent<Props> = ({
   onExpandBioPress,
 }) => {
   const { goBack } = useGoBack(...getSearchHookConfig('SearchLanding'))
-  const { appBarHeight } = useTheme()
+  const { appBarHeight, designSystem } = useTheme()
   const { headerTransition, onScroll } = useOpacityTransition()
   const proAdvicesSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
   const enableProAdvicesTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_PRO_REVIEWS_PLAYLIST)
 
-  const { top } = useSafeAreaInsets()
+  const { top, bottom } = useSafeAreaInsets()
   const headerHeight = appBarHeight + top
 
   const { name, description, image } = artist
@@ -125,7 +125,10 @@ export const ArtistBody: FunctionComponent<Props> = ({
         scrollEventThrottle={16}
         bounces={false}
         onScroll={onScroll}
-        contentContainerStyle={{ paddingTop: headerHeight }}>
+        contentContainerStyle={{
+          paddingTop: headerHeight,
+          paddingBottom: designSystem.size.spacing.xxl + bottom,
+        }}>
         <ViewGap gap={8}>
           <ViewGap gap={6}>
             <ArtistHeader name={name} avatarImage={image} />

--- a/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.native.test.tsx
+++ b/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.native.test.tsx
@@ -49,6 +49,19 @@ describe('<ArtistSimilarArtists />', () => {
     })
   })
 
+  it('should display the skeleton while loading then hide it once artists are loaded', async () => {
+    mockServer.getApi(`/v1/artists/${artistId}/similar`, similarArtistsResponse)
+
+    render(reactQueryProviderHOC(<ArtistSimilarArtists artistId={artistId} />))
+
+    expect(screen.getByTestId('ArtistSimilarArtistsSkeleton')).toBeOnTheScreen()
+    expect(screen.getByLabelText(TITLE)).toBeOnTheScreen()
+
+    await screen.findByLabelText('Coleen Hoover')
+
+    expect(screen.queryByTestId('ArtistSimilarArtistsSkeleton')).not.toBeOnTheScreen()
+  })
+
   it('should display the section with similar artists when API returns at least one', async () => {
     mockServer.getApi(`/v1/artists/${artistId}/similar`, similarArtistsResponse)
 

--- a/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
+++ b/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react'
 import { View } from 'react-native'
 import styled from 'styled-components/native'
 
+import { ArtistSimilarArtistsSkeleton } from 'features/artist/components/ArtistSimilarArtists/ArtistSimilarArtistsSkeleton'
 import { useSimilarArtistsQuery } from 'features/artist/queries/useSimilarArtistsQuery'
 import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
 import { analytics } from 'libs/analytics/provider'
@@ -22,7 +23,7 @@ const TITLE = 'Tu peux aussi aimer'
 
 export const ArtistSimilarArtists: FunctionComponent<Props> = ({ artistId }) => {
   const isSimilarArtistsEnabled = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ENABLE_SIMILAR_ARTISTS)
-  const { data: artists = [] } = useSimilarArtistsQuery(artistId, {
+  const { data: artists = [], isLoading } = useSimilarArtistsQuery(artistId, {
     enabled: isSimilarArtistsEnabled,
   })
 
@@ -34,7 +35,9 @@ export const ArtistSimilarArtists: FunctionComponent<Props> = ({ artistId }) => 
     void analytics.logConsultArtist({ artistId: id, artistName: name, from: 'artist' })
   }
 
-  if (!isSimilarArtistsEnabled || artists.length === 0) return null
+  if (!isSimilarArtistsEnabled) return null
+  if (isLoading) return <ArtistSimilarArtistsSkeleton title={TITLE} />
+  if (artists.length === 0) return null
 
   return (
     <View>

--- a/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtistsSkeleton.tsx
+++ b/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtistsSkeleton.tsx
@@ -1,0 +1,75 @@
+import React, { FunctionComponent } from 'react'
+import { View } from 'react-native'
+import styled, { useTheme } from 'styled-components/native'
+
+import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
+import { SkeletonTile } from 'ui/components/placeholders/SkeletonTile'
+import { Typo } from 'ui/theme'
+import { AVATAR_MEDIUM } from 'ui/theme/constants'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+
+const NUMBER_OF_AVATARS = 10
+const AVATAR_SKELETON_KEYS = Array.from(
+  { length: NUMBER_OF_AVATARS },
+  (_, index) => `artist-skeleton-${index}`
+)
+
+type Props = {
+  title: string
+}
+
+export const ArtistSimilarArtistsSkeleton: FunctionComponent<Props> = ({ title }) => {
+  const { designSystem } = useTheme()
+
+  return (
+    <View testID="ArtistSimilarArtistsSkeleton">
+      <HeaderContainer>
+        <AccessibleTitle title={title} TitleComponent={TitleLevel2} withMargin={false} />
+      </HeaderContainer>
+      <AvatarsRow>
+        {AVATAR_SKELETON_KEYS.map((key) => (
+          <AvatarPlaceholder key={key}>
+            <SkeletonTile
+              width={AVATAR_MEDIUM}
+              height={AVATAR_MEDIUM}
+              borderRadius={AVATAR_MEDIUM / 2}
+            />
+            <NameContainer>
+              <SkeletonTile
+                width={AVATAR_MEDIUM * 0.7}
+                height={designSystem.size.spacing.m}
+                borderRadius={designSystem.size.borderRadius.m}
+              />
+            </NameContainer>
+          </AvatarPlaceholder>
+        ))}
+      </AvatarsRow>
+    </View>
+  )
+}
+
+const TitleLevel2 = styled(Typo.Title3).attrs(getHeadingAttrs(2))``
+
+const HeaderContainer = styled.View(({ theme }) => ({
+  marginHorizontal: theme.contentPage.marginHorizontal,
+  marginBottom: theme.designSystem.size.spacing.m,
+}))
+
+const AvatarsRow = styled.View(({ theme }) => ({
+  flexDirection: 'row',
+  marginHorizontal: theme.contentPage.marginHorizontal,
+  gap: theme.designSystem.size.spacing.l,
+}))
+
+const AvatarPlaceholder = styled.View(({ theme }) => ({
+  alignItems: 'center',
+  gap: theme.designSystem.size.spacing.s,
+}))
+
+// Reserve roughly one text line so the layout does not shift on load.
+const NameContainer = styled.View(({ theme }) => ({
+  width: AVATAR_MEDIUM,
+  height: theme.designSystem.size.spacing.xl,
+  alignItems: 'center',
+  justifyContent: 'center',
+}))


### PR DESCRIPTION
…rtists

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42477

## But de la PR

Améliorer la section « Tu peux aussi aimer » (artistes similaires) en bas de la page Artiste :
- l'espace en bas de page manquait (rubrique tassée contre le bord / home indicator) ;
- aucun retour visuel n'était affiché pendant le chargement de la requête des artistes similaires.

## Modifications

- **Padding bas de page** : ajout de `spacing.xxl` (32px) + l'inset bas du safe-area au `contentContainerStyle` du ScrollView d'`ArtistBody`, pour que le dernier module ne soit plus collé au bord ni masqué par le home indicator.
- **Skeleton de chargement** : nouveau composant `ArtistSimilarArtistsSkeleton` (vrai titre + 10 avatars ronds), affiché pendant `isLoading`. Ses dimensions/espacements sont calés sur la vraie liste d'avatars pour éviter tout saut au chargement.
- **Tests** : ajout d'un cas vérifiant l'affichage du skeleton (titre inclus) pendant le chargement puis sa disparition une fois les artistes chargés.

