### PR TITLE
(PC-42535) feat(profile): Fix delete and deactivation profile navigation

### DIFF
--- a/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`ConfirmDeleteProfile component should render confirm delete profile 1`] = `
+exports[`ConfirmDeleteProfile should render confirm delete profile 1`] = `
 <View
   isLandscape={false}
   style={

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`DeactivateProfileSuccess component should render delete profile success 1`] = `
+exports[`DeactivateProfileSuccess should render deactivate profile success 1`] = `
 <View
   isLandscape={false}
   style={

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`DeleteProfileSuccess component should render delete profile success 1`] = `
+exports[`DeleteProfileSuccess should render delete profile success 1`] = `
 <View
   isLandscape={false}
   style={

--- a/src/features/navigation/navigators/ProfileStackNavigator/ProfileStackNavigator.tsx
+++ b/src/features/navigation/navigators/ProfileStackNavigator/ProfileStackNavigator.tsx
@@ -161,14 +161,12 @@ const profileStackNavigatorPathDefinition = {
     // FIXME(PC-00000): Why is it not in the routes
     DeleteProfileSuccess: {
       screen: DeleteProfileSuccess,
-      if: useIsSignedIn,
       linking: {
         path: 'profile/suppression/succes',
       },
     },
     DeactivateProfileSuccess: {
       screen: DeactivateProfileSuccess,
-      if: useIsSignedIn,
       linking: {
         path: 'profile/desactivation/succes',
       },

--- a/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 
-import { reset, goBack } from '__mocks__/@react-navigation/native'
+import { goBack } from '__mocks__/@react-navigation/native'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
+import { resetFromRef } from 'features/navigation/navigationRef'
 import { Adjust } from 'libs/adjust/adjust'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render, screen, userEvent } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 
 import { ConfirmDeleteProfile } from './ConfirmDeleteProfile'
 
@@ -16,11 +17,18 @@ jest.mock('features/auth/context/AuthContext', () => ({
   useAuthContext: jest.fn(() => ({ isLoggedIn: true })),
 }))
 
+const mockSignOut = jest.fn()
+jest.mock('features/auth/helpers/useLogoutRoutine', () => ({
+  useLogoutRoutine: jest.fn(() => mockSignOut.mockResolvedValueOnce(jest.fn())),
+}))
+
 const openUrl = jest.spyOn(NavigationHelpers, 'openUrl')
 
 jest.mock('libs/firebase/analytics/analytics')
 
 jest.mock('libs/adjust/adjust')
+
+jest.mock('features/navigation/navigationRef', () => ({ resetFromRef: jest.fn() }))
 
 jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   return function createAnimatedComponent(Component: unknown) {
@@ -32,7 +40,7 @@ const user = userEvent.setup()
 
 jest.useFakeTimers()
 
-describe('ConfirmDeleteProfile component', () => {
+describe('ConfirmDeleteProfile', () => {
   it('should render confirm delete profile', () => {
     renderConfirmDeleteProfile()
 
@@ -45,21 +53,11 @@ describe('ConfirmDeleteProfile component', () => {
 
     await user.press(screen.getByText('Supprimer mon compte'))
 
-    expect(reset).toHaveBeenCalledWith({
-      index: 0,
-      routes: [
-        {
-          name: 'TabNavigator',
-          state: {
-            routes: [
-              {
-                name: 'ProfileStackNavigator',
-                state: { routes: [{ name: 'DeactivateProfileSuccess' }] },
-              },
-            ],
-          },
-        },
-      ],
+    await waitFor(() => {
+      expect(resetFromRef).toHaveBeenCalledWith('ProfileStackNavigator', {
+        screen: 'DeactivateProfileSuccess',
+        params: undefined,
+      })
     })
   })
 

--- a/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.tsx
+++ b/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.tsx
@@ -1,9 +1,10 @@
-import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 import styled from 'styled-components/native'
 
+import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
 import { useAccountSuspendMutation } from 'features/auth/queries/useAccountSuspendMutation'
-import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
+import { resetFromRef } from 'features/navigation/navigationRef'
+import { getProfileHookConfig } from 'features/navigation/navigators/ProfileStackNavigator/getProfileHookConfig'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { Adjust } from 'libs/adjust/adjust'
 import { analytics } from 'libs/analytics/provider'
@@ -19,26 +20,14 @@ import { Typo } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
 
 export function ConfirmDeleteProfile() {
-  const { reset } = useNavigation<UseNavigationType>()
+  const signOut = useLogoutRoutine()
 
   const { suspendAccount, isLoading } = useAccountSuspendMutation({
-    onSuccess: () => {
-      reset({
-        index: 0,
-        routes: [
-          {
-            name: 'TabNavigator',
-            state: {
-              routes: [
-                {
-                  name: 'ProfileStackNavigator',
-                  state: { routes: [{ name: 'DeactivateProfileSuccess' }] },
-                },
-              ],
-            },
-          },
-        ],
-      })
+    onSuccess: async () => {
+      await signOut()
+      // We use resetFromRef instead of navigation because signOut() may unmount the current screen
+      // (RootNavigator rebuild). resetFromRef ensures navigation still works after logout.
+      resetFromRef(...getProfileHookConfig('DeactivateProfileSuccess'))
     },
     onError: () => {
       showErrorSnackBar('Une erreur s’est produite pendant le chargement.')

--- a/src/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx
@@ -27,17 +27,11 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 const user = userEvent.setup()
 jest.useFakeTimers()
 
-describe('DeactivateProfileSuccess component', () => {
-  it('should render delete profile success', () => {
+describe('DeactivateProfileSuccess', () => {
+  it('should render deactivate profile success', () => {
     render(<DeactivateProfileSuccess />)
 
     expect(screen).toMatchSnapshot()
-  })
-
-  it('should log out user', () => {
-    render(<DeactivateProfileSuccess />)
-
-    expect(signOutMock).toHaveBeenCalledTimes(1)
   })
 
   it('should redirect to Home page when clicking on "Retourner à l’accueil" button', async () => {

--- a/src/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import styled from 'styled-components/native'
 
-import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
@@ -13,13 +12,8 @@ import { Again } from 'ui/svg/icons/Again'
 import { ProfileDeletion } from 'ui/svg/icons/ProfileDeletion'
 import { Typo } from 'ui/theme'
 
-export function DeactivateProfileSuccess() {
-  const signOut = useLogoutRoutine()
+export const DeactivateProfileSuccess = () => {
   const { data: reactivationLimit } = useAccountUnsuspensionLimit()
-
-  useEffect(() => {
-    void signOut()
-  }, [signOut])
 
   return (
     <GenericInfoPage

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx
@@ -4,6 +4,7 @@ import { navigate, goBack } from '__mocks__/@react-navigation/native'
 import * as API from 'api/api'
 import * as Auth from 'features/auth/context/AuthContext'
 import * as OpenUrlAPI from 'features/navigation/helpers/openUrl'
+import { resetFromRef } from 'features/navigation/navigationRef'
 import { nonBeneficiaryUser } from 'fixtures/user'
 import { Adjust } from 'libs/adjust/adjust'
 import { env } from 'libs/environment/fixtures'
@@ -38,6 +39,8 @@ jest.mock('features/auth/helpers/useLogoutRoutine', () => ({
 }))
 
 const postAnonymizeAccountSpy = jest.spyOn(API.api, 'postNativeV1AccountAnonymize')
+
+jest.mock('features/navigation/navigationRef', () => ({ resetFromRef: jest.fn() }))
 
 const user = userEvent.setup()
 jest.useFakeTimers()
@@ -93,7 +96,7 @@ describe('DeleteProfileConfirmation', () => {
 
     await user.press(screen.getByText('Supprimer mon compte'))
 
-    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+    expect(resetFromRef).toHaveBeenCalledWith('ProfileStackNavigator', {
       params: undefined,
       screen: 'DeleteProfileSuccess',
     })

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 
 import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
-import { navigateFromRef } from 'features/navigation/navigationRef'
+import { resetFromRef } from 'features/navigation/navigationRef'
 import { getProfileHookConfig } from 'features/navigation/navigators/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
 import { useAnonymizeAccountMutation } from 'features/profile/queries/useAnonymizeAccountMutation'
@@ -22,9 +22,9 @@ export const DeleteProfileConfirmation = () => {
   const { anonymizeAccount } = useAnonymizeAccountMutation({
     onSuccess: async () => {
       await signOut()
-      // We use navigateFromRef instead of navigation because signOut() may unmount the current screen
-      // (RootNavigator rebuild). navigateFromRef ensures navigation still works after logout.
-      navigateFromRef(...getProfileHookConfig('DeleteProfileSuccess'))
+      // We use resetFromRef instead of navigation because signOut() may unmount the current screen
+      // (RootNavigator rebuild). resetFromRef ensures navigation still works after logout.
+      resetFromRef(...getProfileHookConfig('DeleteProfileSuccess'))
     },
     onError: () => {
       showErrorSnackBar(

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx
@@ -23,17 +23,11 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 
 jest.useFakeTimers()
 
-describe('DeleteProfileSuccess component', () => {
+describe('DeleteProfileSuccess', () => {
   it('should render delete profile success', () => {
     render(<DeleteProfileSuccess />)
 
     expect(screen).toMatchSnapshot()
-  })
-
-  it('should log out user', () => {
-    render(<DeleteProfileSuccess />)
-
-    expect(signOutMock).toHaveBeenCalledTimes(1)
   })
 
   it('should redirect to Home page when clicking on "Retourner à l’accueil" button', async () => {

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import styled from 'styled-components/native'
 
-import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { Emoji } from 'ui/components/Emoji'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -9,34 +8,26 @@ import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { ProfileDeletion } from 'ui/svg/icons/ProfileDeletion'
 import { Typo } from 'ui/theme'
 
-export function DeleteProfileSuccess() {
-  const signOut = useLogoutRoutine()
-
-  useEffect(() => {
-    void signOut()
-  }, [signOut])
-
-  return (
-    <GenericInfoPage
-      illustration={ProfileDeletion}
-      title="Ton compte a été supprimé"
-      buttonPrimary={{
-        wording: 'Retourner à l’accueil',
-        navigateTo: { ...navigateToHomeConfig, params: { ...navigateToHomeConfig.params } },
-      }}>
-      <ViewGap gap={4}>
-        <StyledBody>
-          <Emoji.CryingFace withSpaceAfter />
-          On est super triste de te voir partir.
-        </StyledBody>
-        <StyledBody>
-          Tu peux malgré tout continuer à découvrir toute l’actu culturelle en consultant le
-          catalogue&nbsp;!
-        </StyledBody>
-      </ViewGap>
-    </GenericInfoPage>
-  )
-}
+export const DeleteProfileSuccess = () => (
+  <GenericInfoPage
+    illustration={ProfileDeletion}
+    title="Ton compte a été supprimé"
+    buttonPrimary={{
+      wording: 'Retourner à l’accueil',
+      navigateTo: { ...navigateToHomeConfig, params: { ...navigateToHomeConfig.params } },
+    }}>
+    <ViewGap gap={4}>
+      <StyledBody>
+        <Emoji.CryingFace withSpaceAfter />
+        On est super triste de te voir partir.
+      </StyledBody>
+      <StyledBody>
+        Tu peux malgré tout continuer à découvrir toute l’actu culturelle en consultant le
+        catalogue&nbsp;!
+      </StyledBody>
+    </ViewGap>
+  </GenericInfoPage>
+)
 
 const StyledBody = styled(Typo.Body)({
   textAlign: 'center',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42535

## Context

- J'ai retiré le logOut via un useEffect sur les pages (en doublons lors du clique sur les CTA de redirection)
- J'ai retiré l'obligation d'être logIn pour consulter les pages car on logOut avant de naviguer 
- J'ai utilisé reset plutôt que navigate car les goBack permettait de refaire l'action en étant déconnecté

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |   https://github.com/user-attachments/assets/a718bce0-0d32-4c7b-b238-48c3f7fba793   |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
