### PR TITLE
(PC-42561) feat(cheatcodes): Add GenericInfoPage illustrations cheatcode

### DIFF
--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -213,7 +213,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="182"
+                          for="183"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -233,7 +233,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Autoriser l’envoi d’e-mails - Interrupteur à bascule - non coché"
-                            aria-labelledby="181"
+                            aria-labelledby="182"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Autoriser l’envoi d’e-mails - Interrupteur à bascule - non coché"
                             role="switch"
@@ -262,7 +262,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="182"
+                            id="183"
                             readonly=""
                             type="checkbox"
                           />
@@ -295,7 +295,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                         >
                           <label
                             class="c2"
-                            for="184"
+                            for="185"
                           >
                             <div
                               class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -315,7 +315,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                               aria-checked="false"
                               aria-disabled="true"
                               aria-label="Suivre tous les thèmes - Interrupteur à bascule - non coché"
-                              aria-labelledby="183"
+                              aria-labelledby="184"
                               class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                               data-testid="Suivre tous les thèmes - Interrupteur à bascule - non coché"
                               role="switch"
@@ -344,7 +344,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             </div>
                             <input
                               hidden=""
-                              id="184"
+                              id="185"
                               readonly=""
                               type="checkbox"
                             />
@@ -364,7 +364,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="186"
+                          for="187"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -384,7 +384,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Cinéma - Interrupteur à bascule - non coché"
-                            aria-labelledby="185"
+                            aria-labelledby="186"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Cinéma - Interrupteur à bascule - non coché"
                             role="switch"
@@ -413,7 +413,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="186"
+                            id="187"
                             readonly=""
                             type="checkbox"
                           />
@@ -432,7 +432,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="188"
+                          for="189"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -452,7 +452,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Lecture - Interrupteur à bascule - non coché"
-                            aria-labelledby="187"
+                            aria-labelledby="188"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Lecture - Interrupteur à bascule - non coché"
                             role="switch"
@@ -481,7 +481,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="188"
+                            id="189"
                             readonly=""
                             type="checkbox"
                           />
@@ -500,7 +500,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="190"
+                          for="191"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -520,7 +520,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Musique - Interrupteur à bascule - non coché"
-                            aria-labelledby="189"
+                            aria-labelledby="190"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Musique - Interrupteur à bascule - non coché"
                             role="switch"
@@ -549,7 +549,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="190"
+                            id="191"
                             readonly=""
                             type="checkbox"
                           />
@@ -568,7 +568,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="192"
+                          for="193"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -588,7 +588,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Spectacles - Interrupteur à bascule - non coché"
-                            aria-labelledby="191"
+                            aria-labelledby="192"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Spectacles - Interrupteur à bascule - non coché"
                             role="switch"
@@ -617,7 +617,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="192"
+                            id="193"
                             readonly=""
                             type="checkbox"
                           />
@@ -636,7 +636,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="194"
+                          for="195"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -656,7 +656,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Activités créatives - Interrupteur à bascule - non coché"
-                            aria-labelledby="193"
+                            aria-labelledby="194"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Activités créatives - Interrupteur à bascule - non coché"
                             role="switch"
@@ -685,7 +685,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="194"
+                            id="195"
                             readonly=""
                             type="checkbox"
                           />
@@ -704,7 +704,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c2"
-                          for="196"
+                          for="197"
                         >
                           <div
                             class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
@@ -724,7 +724,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Visites et sorties - Interrupteur à bascule - non coché"
-                            aria-labelledby="195"
+                            aria-labelledby="196"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Visites et sorties - Interrupteur à bascule - non coché"
                             role="switch"
@@ -753,7 +753,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="196"
+                            id="197"
                             readonly=""
                             type="checkbox"
                           />

--- a/src/cheatcodes/pages/others/CheatcodesNavigationGenericPages.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesNavigationGenericPages.tsx
@@ -40,6 +40,14 @@ const genericPagesCheatcodeCategory: CheatcodeCategory = {
     },
     {
       id: uuidv4(),
+      title: 'GenericInfoPage illustrations',
+      navigationTarget: {
+        screen: 'CheatcodesStackNavigator',
+        params: { screen: 'CheatcodesScreenGenericInfoPageIllustrations' },
+      },
+    },
+    {
+      id: uuidv4(),
       title: 'GenericErrorPage',
       navigationTarget: {
         screen: 'CheatcodesStackNavigator',

--- a/src/cheatcodes/pages/others/CheatcodesScreenGenericInfoPageIllustrations.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenGenericInfoPageIllustrations.tsx
@@ -1,0 +1,257 @@
+import React, { FunctionComponent } from 'react'
+import styled from 'styled-components/native'
+
+import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
+import { getCheatcodesHookConfig } from 'features/navigation/navigators/CheatcodesStackNavigator/getCheatcodesHookConfig'
+import { useGoBack } from 'features/navigation/useGoBack'
+import { CalendarIllustration } from 'ui/svg/icons/CalendarIllustration'
+import { EmailSent } from 'ui/svg/icons/EmailSent'
+import { ErrorIllustration } from 'ui/svg/icons/ErrorIllustration'
+import { HappyFace } from 'ui/svg/icons/HappyFace'
+import { HappyFaceWithTear } from 'ui/svg/icons/HappyFaceWithTear'
+import { Hourglass } from 'ui/svg/icons/Hourglass'
+import { IdCardError } from 'ui/svg/icons/IdCardError'
+import { IdCardInvalid } from 'ui/svg/icons/IdCardInvalid'
+import { MaintenanceCone } from 'ui/svg/icons/MaintenanceCone'
+import { NoBookings } from 'ui/svg/icons/NoBookings'
+import { NoOffer } from 'ui/svg/icons/NoOffer'
+import { Offers } from 'ui/svg/icons/Offers'
+import { PageNotFound } from 'ui/svg/icons/PageNotFound'
+import { PhonePending } from 'ui/svg/icons/PhonePending'
+import { ProfileDeletion } from 'ui/svg/icons/ProfileDeletion'
+import { RequestSent } from 'ui/svg/icons/RequestSent'
+import { SadFace } from 'ui/svg/icons/SadFace'
+import { TicketBooked } from 'ui/svg/icons/TicketBooked'
+import { AccessibleIcon } from 'ui/svg/icons/types'
+import { UserBlocked } from 'ui/svg/icons/UserBlocked'
+import { LogoDMS } from 'ui/svg/LogoDMS'
+import { UserError } from 'ui/svg/UserError'
+import { getSpacing, Typo } from 'ui/theme'
+
+type GenericInfoPageIllustrationItem = {
+  name: string
+  Illustration: FunctionComponent<AccessibleIcon>
+  contexts: string[]
+}
+
+const LogoDMSIllustration: FunctionComponent<AccessibleIcon> = () => (
+  <LogoDMS width={getSpacing(32)} />
+)
+
+const genericInfoPageIllustrations: GenericInfoPageIllustrationItem[] = [
+  {
+    name: 'NoOffer',
+    Illustration: NoOffer,
+    contexts: ['OfferNotFound', 'VenueNotFound'],
+  },
+  {
+    name: 'NoBookings',
+    Illustration: NoBookings,
+    contexts: ['BookingNotFound'],
+  },
+  {
+    name: 'HappyFaceWithTear',
+    Illustration: HappyFaceWithTear,
+    contexts: ['BonificationError', 'IdentityCheckUnavailable'],
+  },
+  {
+    name: 'UserBlocked',
+    Illustration: UserBlocked,
+    contexts: [
+      'GenericSuspendedAccount',
+      'AccountSecurity',
+      'DeleteProfileEmailHacked',
+      'DeleteProfileAccountHacked',
+    ],
+  },
+  {
+    name: 'ProfileDeletion',
+    Illustration: ProfileDeletion,
+    contexts: [
+      'SuspendedAccountUponUserRequest',
+      'DeactivateProfileSuccess',
+      'DeleteProfileConfirmation',
+      'DeleteProfileSuccess',
+    ],
+  },
+  {
+    name: 'ErrorIllustration',
+    Illustration: ErrorIllustration,
+    contexts: [
+      'QuitSignupModal',
+      'QuitIdentityCheckModal',
+      'ConfirmDeleteProfile',
+      'DeleteProfileAccountNotDeletable',
+    ],
+  },
+  {
+    name: 'CalendarIllustration',
+    Illustration: CalendarIllustration,
+    contexts: ['NotYetUnderageEligibility'],
+  },
+  {
+    name: 'PageNotFound',
+    Illustration: PageNotFound,
+    contexts: ['PageNotFound'],
+  },
+  {
+    name: 'UserError',
+    Illustration: UserError,
+    contexts: [
+      'SuspensionChoice',
+      'MandatoryUpdatePersonalData',
+      'SuspendAccountConfirmationWithoutAuthentication',
+      'SuspendAccountConfirmation',
+      'NotEligibleEduConnect - erreurs utilisateur',
+    ],
+  },
+  {
+    name: 'MaintenanceCone',
+    Illustration: MaintenanceCone,
+    contexts: ['NotEligibleEduConnect - erreur générique'],
+  },
+  {
+    name: 'Hourglass',
+    Illustration: Hourglass,
+    contexts: ['DisableActivation'],
+  },
+  {
+    name: 'RequestSent',
+    Illustration: RequestSent,
+    contexts: ['BeneficiaryRequestSent'],
+  },
+  {
+    name: 'SadFace',
+    Illustration: SadFace,
+    contexts: ['LayoutExpiredLink', 'SetProfileBookingError'],
+  },
+  {
+    name: 'IdCardError',
+    Illustration: IdCardError,
+    contexts: ['ExpiredOrLostID', 'IdentityCheckPending'],
+  },
+  {
+    name: 'IdCardInvalid',
+    Illustration: IdCardInvalid,
+    contexts: ['ComeBackLater'],
+  },
+  {
+    name: 'LogoDMS',
+    Illustration: LogoDMSIllustration,
+    contexts: ['DMSIntroduction'],
+  },
+  {
+    name: 'PhonePending',
+    Illustration: PhonePending,
+    contexts: ['ValidateEmailChange', 'ConfirmChangeEmail', 'CulturalSurveyIntro'],
+  },
+  {
+    name: 'HappyFace',
+    Illustration: HappyFace,
+    contexts: ['UpdatePersonalDataConfirmation'],
+  },
+  {
+    name: 'EmailSent',
+    Illustration: EmailSent,
+    contexts: ['DeleteProfileContactSupport'],
+  },
+  {
+    name: 'TicketBooked',
+    Illustration: TicketBooked,
+    contexts: ['BookingConfirmation'],
+  },
+  {
+    name: 'Offers',
+    Illustration: Offers,
+    contexts: ['VerticalPlaylistError'],
+  },
+]
+
+const genericInfoPageAnimations = [
+  'FrenchRepublicAnimation - BonificationGranted, BeneficiaryAccountCreated, FreeBeneficiaryAccountCreated',
+  'BirthdayCake - RecreditBirthdayNotification, EighteenBirthday, OnboardingNotEligible',
+  'QpiThanks - AccountReactivationSuccess, AccountCreated, CulturalSurveyThanks, OnboardingGeneralPublicWelcome',
+  'Geolocation - OnboardingGeolocation',
+]
+
+export function CheatcodesScreenGenericInfoPageIllustrations(): React.JSX.Element {
+  const { goBack } = useGoBack(...getCheatcodesHookConfig('CheatcodesNavigationGenericPages'))
+
+  return (
+    <CheatcodesTemplateScreen
+      title="Illustrations GenericInfoPage"
+      flexDirection="column"
+      onGoBack={goBack}>
+      <Intro>
+        {
+          'Galerie compacte des illustrations utilisées dans les GenericInfoPage, avec les écrans concernés.'
+        }
+      </Intro>
+
+      <CardsContainer>
+        {genericInfoPageIllustrations.map(({ name, Illustration, contexts }) => (
+          <Card key={name}>
+            <IllustrationContainer>
+              <Illustration
+                accessibilityLabel={`Illustration ${name}`}
+                size={getSpacing(32)}
+                testID={`genericInfoPageIllustration-${name}`}
+              />
+            </IllustrationContainer>
+            <CardContent>
+              <Typo.BodyAccent>{name}</Typo.BodyAccent>
+              {contexts.map((context) => (
+                <Context key={context}>{`• ${context}`}</Context>
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+      </CardsContainer>
+
+      <SectionTitle>{'Animations utilisées à la place d’une illustration'}</SectionTitle>
+      {genericInfoPageAnimations.map((animation) => (
+        <Context key={animation}>{`• ${animation}`}</Context>
+      ))}
+    </CheatcodesTemplateScreen>
+  )
+}
+
+const Intro = styled(Typo.Body)(({ theme }) => ({
+  marginBottom: theme.designSystem.size.spacing.l,
+}))
+
+const CardsContainer = styled.View(({ theme }) => ({
+  gap: theme.designSystem.size.spacing.m,
+}))
+
+const Card = styled.View(({ theme }) => ({
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: theme.designSystem.size.spacing.m,
+  padding: theme.designSystem.size.spacing.m,
+  borderRadius: theme.designSystem.size.borderRadius.m,
+  backgroundColor: theme.designSystem.color.background.subtle,
+}))
+
+const IllustrationContainer = styled.View(({ theme }) => ({
+  width: getSpacing(40),
+  minHeight: getSpacing(32),
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
+  backgroundColor: theme.designSystem.color.background.default,
+  borderRadius: theme.designSystem.size.borderRadius.m,
+}))
+
+const CardContent = styled.View({
+  flex: 1,
+})
+
+const Context = styled(Typo.BodyXs)(({ theme }) => ({
+  color: theme.designSystem.color.text.subtle,
+}))
+
+const SectionTitle = styled(Typo.BodyAccent)(({ theme }) => ({
+  marginTop: theme.designSystem.size.spacing.xl,
+  marginBottom: theme.designSystem.size.spacing.s,
+}))

--- a/src/features/navigation/navigators/CheatcodesStackNavigator/CheatcodesStackNavigator.tsx
+++ b/src/features/navigation/navigators/CheatcodesStackNavigator/CheatcodesStackNavigator.tsx
@@ -40,6 +40,7 @@ import { CheatcodesScreenDirectIdAccess } from 'cheatcodes/pages/others/Cheatcod
 import { CheatcodesScreenFeatureFlags } from 'cheatcodes/pages/others/CheatcodesScreenFeatureFlags'
 import { CheatcodesScreenGenericErrorPage } from 'cheatcodes/pages/others/CheatcodesScreenGenericErrorPage'
 import { CheatcodesScreenGenericInfoPage } from 'cheatcodes/pages/others/CheatcodesScreenGenericInfoPage'
+import { CheatcodesScreenGenericInfoPageIllustrations } from 'cheatcodes/pages/others/CheatcodesScreenGenericInfoPageIllustrations'
 import { CheatcodesScreenGenericOfficialPage } from 'cheatcodes/pages/others/CheatcodesScreenGenericOfficialPage'
 import { CheatcodesScreenLayoutExpiredLink } from 'cheatcodes/pages/others/CheatcodesScreenLayoutExpiredLink'
 import { CheatcodesScreenMandatoryUpdate } from 'cheatcodes/pages/others/CheatcodesScreenMandatoryUpdate'
@@ -284,6 +285,12 @@ const cheatcodesStackNavigatorPathDefinition = {
       screen: CheatcodesScreenGenericInfoPage,
       linking: {
         path: 'cheatcodes/other/generic-info-page',
+      },
+    },
+    CheatcodesScreenGenericInfoPageIllustrations: {
+      screen: CheatcodesScreenGenericInfoPageIllustrations,
+      linking: {
+        path: 'cheatcodes/other/generic-info-page-illustrations',
       },
     },
     CheatcodesScreenGenericOfficialPage: {

--- a/src/features/navigation/navigators/CheatcodesStackNavigator/types.ts
+++ b/src/features/navigation/navigators/CheatcodesStackNavigator/types.ts
@@ -44,6 +44,7 @@ export type CheatcodesStackParamList = {
   CheatcodesScreenFeatureFlags: undefined
   CheatcodesScreenGenericErrorPage: undefined
   CheatcodesScreenGenericInfoPage: undefined
+  CheatcodesScreenGenericInfoPageIllustrations: undefined
   CheatcodesScreenGenericOfficialPage: undefined
   CheatcodesScreenLayoutExpiredLink: undefined
   CheatcodesScreenMandatoryUpdate: undefined


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42561

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |<img width="1094" height="861" alt="Capture d’écran 2026-06-24 à 17 37 08" src="https://github.com/user-attachments/assets/a2d052be-8311-4cc1-a766-7f96fbc07dd3" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
