### PR TITLE
(PC-42246) feat(analytics): track artist recommendation playlists eng…

### DIFF
--- a/src/features/artist/components/ArtistPlaylist/ArtistCategoryPlaylist.tsx
+++ b/src/features/artist/components/ArtistPlaylist/ArtistCategoryPlaylist.tsx
@@ -100,6 +100,7 @@ export const ArtistCategoryPlaylist: FunctionComponent<ArtistCategoryPlaylistPro
             euroToPacificFrancRate,
             analyticsFrom,
             artistName: artist.name,
+            originDetails: 'artistRecommendation',
             theme,
             hasSmallLayout: true,
             priceDisplay: (item: Offer) =>

--- a/src/features/artist/components/ArtistPlaylist/ArtistPlaylist.native.test.tsx
+++ b/src/features/artist/components/ArtistPlaylist/ArtistPlaylist.native.test.tsx
@@ -96,6 +96,7 @@ describe('ArtistPlaylist', () => {
       from: 'artist',
       isHeadline: false,
       offerId: '2',
+      originDetails: 'artistRecommendation',
       playlistType: PlaylistType.ARTIST_CATEGORY_PLAYLIST,
     })
   })

--- a/src/features/artist/components/ArtistTopOffers/ArtistTopOffers.native.test.tsx
+++ b/src/features/artist/components/ArtistTopOffers/ArtistTopOffers.native.test.tsx
@@ -50,6 +50,7 @@ describe('ArtistTopOffers', () => {
       from: 'artist',
       isHeadline: false,
       offerId: '16302',
+      originDetails: 'artistRecommendation',
       playlistType: PlaylistType.ARTIST_TOP_OFFERS,
     })
   })

--- a/src/features/artist/components/ArtistTopOffers/ArtistTopOffers.tsx
+++ b/src/features/artist/components/ArtistTopOffers/ArtistTopOffers.tsx
@@ -75,6 +75,7 @@ export const ArtistTopOffers: FunctionComponent<Props> = ({
         euroToPacificFrancRate,
         analyticsFrom: 'artist',
         artistName,
+        originDetails: 'artistRecommendation',
         theme,
         hasSmallLayout: true,
         priceDisplay: (item: Offer) =>

--- a/src/features/home/components/modules/ArtistPlaylistModule.native.test.tsx
+++ b/src/features/home/components/modules/ArtistPlaylistModule.native.test.tsx
@@ -187,6 +187,7 @@ describe('ArtistPlaylistModule', () => {
         artistId: mockArtist.id,
         artistName: mockArtist.name,
         from: 'home',
+        originDetails: 'artistRecommendation',
       })
     })
   })

--- a/src/features/home/components/modules/ArtistPlaylistModule.tsx
+++ b/src/features/home/components/modules/ArtistPlaylistModule.tsx
@@ -99,6 +99,8 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
           moduleName={moduleName}
           moduleId={moduleId}
           homeEntryId={homeEntryId}
+          artistName={artist?.name}
+          originDetails="artistRecommendation"
           width={width}
           height={height}
           analyticsFrom="home"
@@ -107,7 +109,7 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
       )
     },
 
-    [moduleName, moduleId, homeEntryId]
+    [moduleName, moduleId, homeEntryId, artist?.name]
   )
 
   const { itemWidth, itemHeight } = getPlaylistItemDimensionsFromLayout('three-items')
@@ -145,7 +147,12 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
   }
 
   const onArtistPress = (artistId: string, artistName: string) => {
-    void analytics.logConsultArtist({ artistId, artistName, from: 'home' })
+    void analytics.logConsultArtist({
+      artistId,
+      artistName,
+      from: 'home',
+      originDetails: 'artistRecommendation',
+    })
   }
 
   return (

--- a/src/features/offer/components/OfferPlaylistItem/OfferPlaylistItem.tsx
+++ b/src/features/offer/components/OfferPlaylistItem/OfferPlaylistItem.tsx
@@ -25,6 +25,7 @@ type OfferPlaylistItemProps = {
   euroToPacificFrancRate: number
   theme: DefaultTheme
   artistName?: string
+  originDetails?: string
   apiRecoParams?: RecommendationApiParams
   analyticsFrom?: Referrals
   priceDisplay: (item: Offer) => string
@@ -46,6 +47,7 @@ export const OfferPlaylistItem = ({
   categoryMapping,
   labelMapping,
   artistName,
+  originDetails,
   apiRecoParams,
   theme,
   analyticsFrom = 'offer',
@@ -87,6 +89,7 @@ export const OfferPlaylistItem = ({
         playlistType={playlistType}
         apiRecoParams={apiRecoParams}
         artistName={artistName}
+        originDetails={originDetails}
         navigationMethod={navigationMethod}
         interactionTag={tag}
       />

--- a/src/features/offer/components/OfferTile/OfferTile.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.tsx
@@ -35,6 +35,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
     apiRecoParams,
     index,
     artistName,
+    originDetails,
     interactionTag,
     navigationMethod = NAVIGATION_METHOD.NAVIGATE,
     containerWidth,
@@ -88,6 +89,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
       searchId,
       index,
       artistName,
+      originDetails,
       displayAdvice: proAdvicesOnOfferSegment === 'A',
     })
   }

--- a/src/features/offer/types.ts
+++ b/src/features/offer/types.ts
@@ -46,6 +46,7 @@ export interface OfferTileProps {
   apiRecoParams?: RecommendationApiParams
   index?: number
   artistName?: string
+  originDetails?: string
   navigationMethod?: NavigationMethod
   interactionTag?: ReactNode
   containerWidth?: number

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -114,6 +114,7 @@ export type ConsultArtistOriginDetails =
   | 'venue'
   | 'offer'
   | 'searchResults'
+  | 'artistRecommendation'
 
 /* eslint sort-keys-fix/sort-keys-fix: "error" */
 export const logEventAnalytics = {

--- a/src/libs/analytics/types.ts
+++ b/src/libs/analytics/types.ts
@@ -26,6 +26,7 @@ export type OfferAnalyticsParams = {
   playlistType?: PlaylistType
   artistName?: string
   isHeadline?: boolean
+  originDetails?: string
 }
 
 export type ConsultOfferLogParams = {

--- a/src/shared/verticalPlaylist/components/VerticalPlaylistOffersModule.tsx
+++ b/src/shared/verticalPlaylist/components/VerticalPlaylistOffersModule.tsx
@@ -20,6 +20,7 @@ export const VerticalPlaylistOffersModule = ({ module }: Props) => {
       artistId={
         module.type === HomepageModuleType.ArtistPlaylistModule ? module.artistId : undefined
       }
+      moduleId={module.type === HomepageModuleType.ArtistPlaylistModule ? module.id : undefined}
     />
   )
 }

--- a/src/shared/verticalPlaylist/components/VerticalPlaylistOffersView.native.test.tsx
+++ b/src/shared/verticalPlaylist/components/VerticalPlaylistOffersView.native.test.tsx
@@ -140,6 +140,7 @@ describe('<VerticalPlaylistOffersView />', () => {
       artistId: '1',
       artistName: 'Artist 1',
       from: 'home',
+      originDetails: 'artistRecommendation',
     })
   })
 })

--- a/src/shared/verticalPlaylist/components/VerticalPlaylistOffersView.tsx
+++ b/src/shared/verticalPlaylist/components/VerticalPlaylistOffersView.tsx
@@ -42,6 +42,7 @@ type Props = {
   searchQuery?: string
   analyticsFrom: Referrals
   artistId?: string
+  moduleId?: string
 }
 
 export const VerticalPlaylistOffersView = ({
@@ -52,6 +53,7 @@ export const VerticalPlaylistOffersView = ({
   searchQuery,
   analyticsFrom,
   artistId,
+  moduleId,
 }: Props) => {
   const { goBack } = useNavigation<UseNavigationType>()
   const { headerTransition, onScroll } = useOpacityTransition()
@@ -68,6 +70,8 @@ export const VerticalPlaylistOffersView = ({
   const nbHits = items.length
 
   const artist = items[0]?.artists?.find((artist) => artist.id === artistId)
+  const originDetails = artist ? 'artistRecommendation' : undefined
+  const artistName = artist?.name
 
   const onGridListButtonPress = (layout: GridListLayout) => {
     if (!canUseGrid) return
@@ -97,6 +101,9 @@ export const VerticalPlaylistOffersView = ({
           height={tileWidth / RATIO_HOME_IMAGE}
           width={tileWidth}
           searchId={searchId}
+          moduleId={moduleId}
+          artistName={artistName}
+          originDetails={originDetails}
           containerWidth={width / nbrOfTilesToDisplay - contentPage.marginHorizontal}
         />
       ) : (
@@ -107,6 +114,9 @@ export const VerticalPlaylistOffersView = ({
             index,
             searchId,
             from: analyticsFrom,
+            moduleId,
+            artistName,
+            originDetails,
           }}
         />
       ),
@@ -120,11 +130,19 @@ export const VerticalPlaylistOffersView = ({
       searchQuery,
       searchState.query,
       analyticsFrom,
+      moduleId,
+      artistName,
+      originDetails,
     ]
   )
 
   const onArtistPress = (artistId: string, artistName: string) => {
-    void analytics.logConsultArtist({ artistId, artistName, from: analyticsFrom })
+    void analytics.logConsultArtist({
+      artistId,
+      artistName,
+      from: analyticsFrom,
+      originDetails: 'artistRecommendation',
+    })
   }
 
   return (


### PR DESCRIPTION
…agement

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Contexte

La feature « Recos d'artiste » met en avant des recommandations culturelles
partagées par des personnalités (module Home, écran détail « Tout voir », page
artiste). Cette PR instrumente le tracking des consultations d'offres et
d'artistes depuis ces playlists, afin de distinguer ce trafic des autres
playlists et de mesurer l'engagement par personnalité.

## Changements

Ajout de l'attribution `originDetails: 'artistRecommendation'` sur les events
concernés, et transmission des paramètres manquants (`artistName`, `moduleId`)
jusqu'aux tiles d'offres.

| Écran | Event | `from` | Ajout |
|-------|-------|--------|-------|
| Home — Tout voir | `ClickSeeAll` | `home` | déjà conforme |
| Home — clic artiste | `ConsultArtist` | `home` | `originDetails` |
| Home carousel — clic offre | `ConsultOffer` | `home` | `artistName` + `originDetails` |
| Écran détail — clic artiste | `ConsultArtist` | `verticalplaylistoffers` | `originDetails` |
| Écran détail — clic offre | `ConsultOffer` | `verticalplaylistoffers` | `moduleId` + `artistName` + `originDetails` |
| Page artiste — clic offre | `ConsultOffer` | `artist` | `originDetails` |

### Détails techniques

- Élargissement des types analytics : `ConsultArtistOriginDetails`,
  `OfferAnalyticsParams`, `OfferTileProps` acceptent `originDetails`.
- `OfferTile` relaie `originDetails` à `triggerConsultOfferLog` (propagation
  automatique à `HorizontalOfferTile` via `analyticsParams`).
- L'écran détail (`VerticalPlaylistOffersView`) étant partagé par toutes les
  playlists verticales, l'attribution n'est appliquée qu'en contexte reco
  d'artiste (détecté via l'artiste résolu) : aucune régression sur les autres
  playlists, où `originDetails` reste `undefined`.

## Tests

- Assertions `originDetails` ajoutées sur `ConsultArtist` (Home + écran détail)
  et `ConsultOffer` (page artiste : top offers + playlists par catégorie).
