### PR TITLE
(PC-42677) fix(location): turn permission modal into navigation modal

### DIFF
--- a/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
@@ -1,94 +1,1328 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HomeLocationModal should render correctly if modal visible 1`] = `
-<View
-  style={
-    {
-      "backgroundColor": "#ffffff",
-      "flexBasis": 0,
-      "flexGrow": 1,
-      "flexShrink": 1,
-    }
-  }
->
-  <View
-    style={
-      {
-        "paddingBottom": 16,
-        "paddingLeft": 16,
-        "paddingRight": 16,
-        "paddingTop": 16,
-        "width": "100%",
-      }
-    }
+[
+  <Modal
+    animationType="fade"
+    onRequestClose={[MockFunction]}
+    statusBarTranslucent={true}
+    testID="modal-geoloc-permission-modal"
+    transparent={true}
+    visible={true}
   >
     <View
-      marginTop={0}
-      style={
+      accessibilityState={
         {
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "center",
-          "marginTop": 0,
-          "width": "100%",
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
         }
       }
-      testID="modalHeader"
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          [
+            {
+              "userSelect": "auto",
+            },
+            {
+              "backgroundColor": "#23232329",
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "height": "100%",
+              "justifyContent": "flex-end",
+              "position": "absolute",
+              "width": "100%",
+            },
+          ],
+          {
+            "opacity": 1,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        {
+          "height": "100%",
+          "justifyContent": "center",
+        }
+      }
     >
       <View
-        justifyContent="left"
+        accessibilityLabelledBy="testUuidV4"
+        gap={6}
+        maxHeight={1334}
         style={
           {
-            "alignItems": "flex-start",
-            "flexDirection": "row",
-            "height": 28,
-            "justifyContent": "flex-start",
-            "width": 28,
-          }
-        }
-      />
-      <View
-        style={
-          {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 12,
-            "zIndex": 1,
-          }
-        }
-      >
-        <Text
-          accessibilityRole="header"
-          style={
-            {
-              "color": "#161617",
-              "fontFamily": "Montserrat-Bold",
-              "fontSize": 17,
-              "lineHeight": 27.2,
-              "textAlign": "center",
-            }
-          }
-          testID="modalHeaderTitle"
-        >
-          Localisation
-        </Text>
-      </View>
-      <View
-        justifyContent="right"
-        style={
-          {
-            "alignItems": "flex-start",
-            "flexDirection": "row",
-            "height": 28,
-            "justifyContent": "flex-end",
-            "width": 28,
+            "alignItems": "center",
+            "alignSelf": "center",
+            "backgroundColor": "#ffffff",
+            "borderBottomLeftRadius": 4,
+            "borderBottomRightRadius": 4,
+            "borderTopLeftRadius": 4,
+            "borderTopRightRadius": 4,
+            "gap": 24,
+            "maxHeight": "100%",
+            "paddingBottom": 32,
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "paddingTop": 24,
+            "width": 928,
           }
         }
       >
         <View
-          accessibilityLabel="Fermer la modale"
+          marginTop={0}
+          style={
+            {
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "marginTop": 0,
+              "width": "100%",
+            }
+          }
+          testID="modalHeader"
+        >
+          <View
+            justifyContent="left"
+            style={
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "height": 28,
+                "justifyContent": "flex-start",
+                "width": 28,
+              }
+            }
+          />
+          <View
+            style={
+              {
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "center",
+                "paddingHorizontal": 12,
+                "zIndex": 1,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="header"
+              nativeID="testUuidV4"
+              style={
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 17,
+                  "lineHeight": 27.2,
+                  "textAlign": "center",
+                }
+              }
+              testID="modalHeaderTitle"
+            >
+              Paramètres de localisation
+            </Text>
+          </View>
+          <View
+            justifyContent="right"
+            style={
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "height": 28,
+                "justifyContent": "flex-end",
+                "width": 28,
+              }
+            }
+          >
+            <View
+              accessibilityLabel="Fermer la modale"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  [
+                    {
+                      "userSelect": "auto",
+                    },
+                    {
+                      "alignItems": "center",
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
+                      "width": "auto",
+                    },
+                  ],
+                  {
+                    "opacity": 1,
+                  },
+                ]
+              }
+              testID="Fermer la modale"
+            >
+              <View
+                gap={0}
+                hasIcon={true}
+                isMultiline={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "columnGap": 0,
+                    "flexDirection": "row",
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  jestAnimatedProps={
+                    {
+                      "value": {},
+                    }
+                  }
+                  jestAnimatedStyle={
+                    {
+                      "value": {},
+                    }
+                  }
+                  jestInlineStyle={
+                    {
+                      "flexShrink": 0,
+                    }
+                  }
+                  nativeID="0"
+                  style={
+                    [
+                      {
+                        "flexShrink": 0,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    height={22}
+                    testID="rightIcon"
+                    width={22}
+                  >
+                    <Text>
+                      rightIcon-SVG-Mock
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <RCTScrollView
+          bounces={false}
+          showsVerticalScrollIndicator={true}
+          style={
+            {
+              "flexGrow": 0,
+              "maxWidth": 500,
+              "width": "100%",
+            }
+          }
+          testID="appInformationModalScrollView"
+        >
+          <View>
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                }
+              }
+            >
+              <View
+                height={100}
+                width={100}
+              >
+                <Text>
+                  undefined-SVG-Mock
+                </Text>
+              </View>
+              <Text
+                style={
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
+                    "marginTop": 40,
+                    "textAlign": "center",
+                  }
+                }
+              >
+                Retrouve toutes les offres autour de chez toi en activant les données de localisation.
+              </Text>
+              <Text
+                style={
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
+                    "marginTop": 16,
+                    "textAlign": "center",
+                  }
+                }
+              >
+                Tu peux activer ou désactiver cette fonctionnalité dans les paramètres de localisation de ton téléphone.
+              </Text>
+              <View
+                style={
+                  {
+                    "marginTop": 24,
+                  }
+                }
+              >
+                <View
+                  accessibilityLabel="Activer la géolocalisation"
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "alignItems": "center",
+                          "alignSelf": "center",
+                          "backgroundColor": "#6123df",
+                          "borderBottomLeftRadius": 8,
+                          "borderBottomRightRadius": 8,
+                          "borderColor": "#6123df",
+                          "borderStyle": "solid",
+                          "borderTopLeftRadius": 8,
+                          "borderTopRightRadius": 8,
+                          "borderWidth": 1,
+                          "flexDirection": "row",
+                          "justifyContent": "center",
+                          "paddingBottom": 8,
+                          "paddingLeft": 12,
+                          "paddingRight": 12,
+                          "paddingTop": 8,
+                          "width": "100%",
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Activer la géolocalisation"
+                >
+                  <View
+                    fullWidth={true}
+                    gap={8}
+                    hasIcon={false}
+                    isMultiline={false}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "columnGap": 8,
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                        "width": "100%",
+                      }
+                    }
+                  >
+                    <Text
+                      style={
+                        [
+                          {
+                            "color": "#161617",
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 22,
+                          },
+                          {
+                            "color": "#ffffff",
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                            "maxWidth": "100%",
+                            "minWidth": 0,
+                            "textAlign": "center",
+                          },
+                        ]
+                      }
+                    >
+                      Activer la géolocalisation
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RCTScrollView>
+      </View>
+    </View>
+  </Modal>,
+  <View
+    style={
+      {
+        "backgroundColor": "#ffffff",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "paddingBottom": 16,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "paddingTop": 16,
+          "width": "100%",
+        }
+      }
+    >
+      <View
+        marginTop={0}
+        style={
+          {
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "marginTop": 0,
+            "width": "100%",
+          }
+        }
+        testID="modalHeader"
+      >
+        <View
+          justifyContent="left"
+          style={
+            {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "height": 28,
+              "justifyContent": "flex-start",
+              "width": 28,
+            }
+          }
+        />
+        <View
+          style={
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "justifyContent": "center",
+              "paddingHorizontal": 12,
+              "zIndex": 1,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="header"
+            style={
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 17,
+                "lineHeight": 27.2,
+                "textAlign": "center",
+              }
+            }
+            testID="modalHeaderTitle"
+          >
+            Localisation
+          </Text>
+        </View>
+        <View
+          justifyContent="right"
+          style={
+            {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "height": 28,
+              "justifyContent": "flex-end",
+              "width": 28,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Fermer la modale"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "paddingBottom": 8,
+                    "paddingLeft": 8,
+                    "paddingRight": 8,
+                    "paddingTop": 8,
+                    "width": "auto",
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Fermer la modale"
+          >
+            <View
+              gap={0}
+              hasIcon={true}
+              isMultiline={false}
+              style={
+                {
+                  "alignItems": "center",
+                  "columnGap": 0,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                jestAnimatedProps={
+                  {
+                    "value": {},
+                  }
+                }
+                jestAnimatedStyle={
+                  {
+                    "value": {},
+                  }
+                }
+                jestInlineStyle={
+                  {
+                    "flexShrink": 0,
+                  }
+                }
+                nativeID="1"
+                style={
+                  [
+                    {
+                      "flexShrink": 0,
+                    },
+                  ]
+                }
+              >
+                <View
+                  height={22}
+                  testID="rightIcon"
+                  width={22}
+                >
+                  <Text>
+                    rightIcon-SVG-Mock
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <RCTScrollView
+      keyboardShouldPersistTaps="handled"
+      style={
+        {
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "marginTop": 24,
+          "paddingHorizontal": 24,
+        }
+      }
+    >
+      <View>
+        <View
+          accessibilityRole="none"
+          style={
+            {
+              "gap": 8,
+            }
+          }
+          useFlatList={false}
+        >
+          <View
+            style={
+              {
+                "gap": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                }
+              }
+            >
+              Sélectionne ta localisation
+            </Text>
+          </View>
+          <View
+            display="vertical"
+            style={
+              {
+                "flexDirection": "column",
+                "flexWrap": "nowrap",
+                "gap": 8,
+              }
+            }
+            variant="detailed"
+          >
+            <View
+              collapsable={false}
+              jestAnimatedProps={
+                {
+                  "value": {},
+                }
+              }
+              jestAnimatedStyle={
+                {
+                  "value": {},
+                }
+              }
+              jestInlineStyle={
+                {
+                  "overflow": "hidden",
+                }
+              }
+              layout={
+                LinearTransition {
+                  "build": [Function],
+                  "durationV": 250,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              nativeID="2"
+              style={
+                [
+                  {
+                    "overflow": "hidden",
+                  },
+                ]
+              }
+            >
+              <View
+                collapsed={null}
+                isHover={false}
+                radioState={
+                  {
+                    "disabled": false,
+                    "error": false,
+                    "selected": false,
+                  }
+                }
+                sizing="fill"
+                style={
+                  {
+                    "backgroundColor": "#ffffff",
+                    "borderBottomLeftRadius": 8,
+                    "borderBottomRightRadius": 8,
+                    "borderColor": "#90949d",
+                    "borderTopLeftRadius": 8,
+                    "borderTopRightRadius": 8,
+                    "borderWidth": 1,
+                    "paddingBottom": 16,
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                    "paddingTop": 16,
+                    "width": "100%",
+                  }
+                }
+                variant="detailed"
+              >
+                <View
+                  accessibilityLabel="Sélectionne ta localisation - Liste - Élément 1 sur 3 - Utiliser ma position actuelle - non sélectionné"
+                  accessibilityRole="radio"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "alignItems": "center",
+                          "columnGap": 12,
+                          "flexDirection": "row",
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Sélectionne ta localisation - Liste - Élément 1 sur 3 - Utiliser ma position actuelle - non sélectionné"
+                >
+                  <View
+                    isHover={false}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    radioState={
+                      {
+                        "disabled": false,
+                        "error": false,
+                        "selected": false,
+                      }
+                    }
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderBottomLeftRadius": 20,
+                        "borderBottomRightRadius": 20,
+                        "borderColor": "#90949d",
+                        "borderTopLeftRadius": 20,
+                        "borderTopRightRadius": 20,
+                        "borderWidth": 2,
+                        "height": 20,
+                        "justifyContent": "center",
+                        "width": 20,
+                      }
+                    }
+                    variant="detailed"
+                  />
+                  <View
+                    style={
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      isHover={false}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      radioState={
+                        {
+                          "disabled": false,
+                          "error": false,
+                          "selected": false,
+                        }
+                      }
+                      style={
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        }
+                      }
+                    >
+                      Utiliser ma position actuelle
+                    </Text>
+                  </View>
+                  <View
+                    style={
+                      {
+                        "justifyContent": "center",
+                      }
+                    }
+                  >
+                    <View
+                      fill="none"
+                      height={32}
+                      width={32}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              jestAnimatedProps={
+                {
+                  "value": {},
+                }
+              }
+              jestAnimatedStyle={
+                {
+                  "value": {},
+                }
+              }
+              jestInlineStyle={
+                {
+                  "overflow": "hidden",
+                }
+              }
+              layout={
+                LinearTransition {
+                  "build": [Function],
+                  "durationV": 250,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              nativeID="3"
+              style={
+                [
+                  {
+                    "overflow": "hidden",
+                  },
+                ]
+              }
+            >
+              <View
+                collapsed={null}
+                isHover={false}
+                radioState={
+                  {
+                    "disabled": false,
+                    "error": false,
+                    "selected": false,
+                  }
+                }
+                sizing="fill"
+                style={
+                  {
+                    "backgroundColor": "#ffffff",
+                    "borderBottomLeftRadius": 8,
+                    "borderBottomRightRadius": 8,
+                    "borderColor": "#90949d",
+                    "borderTopLeftRadius": 8,
+                    "borderTopRightRadius": 8,
+                    "borderWidth": 1,
+                    "paddingBottom": 16,
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                    "paddingTop": 16,
+                    "width": "100%",
+                  }
+                }
+                variant="detailed"
+              >
+                <View
+                  accessibilityLabel="Sélectionne ta localisation - Liste - Élément 2 sur 3 - Choisir une zone géographique - Ville, code postal, adresse - non sélectionné"
+                  accessibilityRole="radio"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "alignItems": "center",
+                          "columnGap": 12,
+                          "flexDirection": "row",
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Sélectionne ta localisation - Liste - Élément 2 sur 3 - Choisir une zone géographique - Ville, code postal, adresse - non sélectionné"
+                >
+                  <View
+                    isHover={false}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    radioState={
+                      {
+                        "disabled": false,
+                        "error": false,
+                        "selected": false,
+                      }
+                    }
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderBottomLeftRadius": 20,
+                        "borderBottomRightRadius": 20,
+                        "borderColor": "#90949d",
+                        "borderTopLeftRadius": 20,
+                        "borderTopRightRadius": 20,
+                        "borderWidth": 2,
+                        "height": 20,
+                        "justifyContent": "center",
+                        "width": 20,
+                      }
+                    }
+                    variant="detailed"
+                  />
+                  <View
+                    style={
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      isHover={false}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      radioState={
+                        {
+                          "disabled": false,
+                          "error": false,
+                          "selected": false,
+                        }
+                      }
+                      style={
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        }
+                      }
+                    >
+                      Choisir une zone géographique
+                    </Text>
+                    <Text
+                      isHover={false}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      radioState={
+                        {
+                          "disabled": false,
+                          "error": false,
+                          "selected": false,
+                        }
+                      }
+                      style={
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        }
+                      }
+                    >
+                      Ville, code postal, adresse
+                    </Text>
+                  </View>
+                  <View
+                    style={
+                      {
+                        "justifyContent": "center",
+                      }
+                    }
+                  >
+                    <View
+                      fill="none"
+                      height={32}
+                      width={32}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              jestAnimatedProps={
+                {
+                  "value": {},
+                }
+              }
+              jestAnimatedStyle={
+                {
+                  "value": {},
+                }
+              }
+              jestInlineStyle={
+                {
+                  "overflow": "hidden",
+                }
+              }
+              layout={
+                LinearTransition {
+                  "build": [Function],
+                  "durationV": 250,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              nativeID="4"
+              style={
+                [
+                  {
+                    "overflow": "hidden",
+                  },
+                ]
+              }
+            >
+              <View
+                isHover={false}
+                radioState={
+                  {
+                    "disabled": false,
+                    "error": false,
+                    "selected": true,
+                  }
+                }
+                sizing="fill"
+                style={
+                  {
+                    "backgroundColor": "#f3edff",
+                    "borderBottomLeftRadius": 8,
+                    "borderBottomRightRadius": 8,
+                    "borderColor": "#6123df",
+                    "borderTopLeftRadius": 8,
+                    "borderTopRightRadius": 8,
+                    "borderWidth": 1,
+                    "paddingBottom": 16,
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                    "paddingTop": 16,
+                    "width": "100%",
+                  }
+                }
+                variant="detailed"
+              >
+                <View
+                  accessibilityLabel="Sélectionne ta localisation - Liste - Élément 3 sur 3 - France entière - sélectionné"
+                  accessibilityRole="radio"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": true,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "alignItems": "center",
+                          "columnGap": 12,
+                          "flexDirection": "row",
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Sélectionne ta localisation - Liste - Élément 3 sur 3 - France entière - sélectionné"
+                >
+                  <View
+                    isHover={false}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    radioState={
+                      {
+                        "disabled": false,
+                        "error": false,
+                        "selected": true,
+                      }
+                    }
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#f3edff",
+                        "borderBottomLeftRadius": 20,
+                        "borderBottomRightRadius": 20,
+                        "borderColor": "#6123df",
+                        "borderTopLeftRadius": 20,
+                        "borderTopRightRadius": 20,
+                        "borderWidth": 2,
+                        "height": 20,
+                        "justifyContent": "center",
+                        "width": 20,
+                      }
+                    }
+                    variant="detailed"
+                  >
+                    <View
+                      isHover={false}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      radioState={
+                        {
+                          "disabled": false,
+                          "error": false,
+                          "selected": true,
+                        }
+                      }
+                      style={
+                        {
+                          "alignItems": "center",
+                          "backgroundColor": "#6123df",
+                          "borderBottomLeftRadius": 6,
+                          "borderBottomRightRadius": 6,
+                          "borderColor": "#6123df",
+                          "borderTopLeftRadius": 6,
+                          "borderTopRightRadius": 6,
+                          "height": 10,
+                          "justifyContent": "center",
+                          "width": 10,
+                        }
+                      }
+                      variant="detailed"
+                    />
+                  </View>
+                  <View
+                    style={
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      isHover={false}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      radioState={
+                        {
+                          "disabled": false,
+                          "error": false,
+                          "selected": true,
+                        }
+                      }
+                      style={
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        }
+                      }
+                    >
+                      France entière
+                    </Text>
+                  </View>
+                  <View
+                    style={
+                      {
+                        "justifyContent": "center",
+                      }
+                    }
+                  >
+                    <View
+                      height={32}
+                      width={32}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+    <View
+      style={
+        {
+          "paddingBottom": 32,
+        }
+      }
+    >
+      <View
+        paddingBottom={0}
+        style={
+          {
+            "alignItems": "center",
+            "paddingHorizontal": 24,
+            "paddingTop": 8,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Valider la localisation"
           accessibilityRole="button"
           accessibilityState={
             {
@@ -124,15 +1358,22 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
                 },
                 {
                   "alignItems": "center",
-                  "backgroundColor": "transparent",
-                  "borderWidth": 0,
+                  "alignSelf": "center",
+                  "backgroundColor": "#6123df",
+                  "borderBottomLeftRadius": 8,
+                  "borderBottomRightRadius": 8,
+                  "borderColor": "#6123df",
+                  "borderStyle": "solid",
+                  "borderTopLeftRadius": 8,
+                  "borderTopRightRadius": 8,
+                  "borderWidth": 1,
                   "flexDirection": "row",
                   "justifyContent": "center",
                   "paddingBottom": 8,
-                  "paddingLeft": 8,
-                  "paddingRight": 8,
+                  "paddingLeft": 12,
+                  "paddingRight": 12,
                   "paddingTop": 8,
-                  "width": "auto",
+                  "width": "100%",
                 },
               ],
               {
@@ -140,865 +1381,59 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
               },
             ]
           }
-          testID="Fermer la modale"
+          testID="Valider la localisation"
         >
           <View
-            gap={0}
-            hasIcon={true}
+            fullWidth={true}
+            gap={8}
+            hasIcon={false}
             isMultiline={false}
             style={
               {
                 "alignItems": "center",
-                "columnGap": 0,
+                "columnGap": 8,
                 "flexDirection": "row",
+                "justifyContent": "center",
+                "width": "100%",
               }
             }
           >
-            <View
-              collapsable={false}
-              jestAnimatedProps={
-                {
-                  "value": {},
-                }
-              }
-              jestAnimatedStyle={
-                {
-                  "value": {},
-                }
-              }
-              jestInlineStyle={
-                {
-                  "flexShrink": 0,
-                }
-              }
-              nativeID="0"
+            <Text
               style={
                 [
                   {
-                    "flexShrink": 0,
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  {
+                    "color": "#ffffff",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "maxWidth": "100%",
+                    "minWidth": 0,
+                    "textAlign": "center",
                   },
                 ]
               }
             >
-              <View
-                height={22}
-                testID="rightIcon"
-                width={22}
-              >
-                <Text>
-                  rightIcon-SVG-Mock
-                </Text>
-              </View>
-            </View>
+              Valider la localisation
+            </Text>
           </View>
         </View>
       </View>
     </View>
-  </View>
-  <RCTScrollView
-    keyboardShouldPersistTaps="handled"
-    style={
-      {
-        "flexBasis": 0,
-        "flexGrow": 1,
-        "flexShrink": 1,
-        "marginTop": 24,
-        "paddingHorizontal": 24,
-      }
-    }
-  >
-    <View>
-      <View
-        accessibilityRole="none"
-        style={
-          {
-            "gap": 8,
-          }
-        }
-        useFlatList={false}
-      >
-        <View
-          style={
-            {
-              "gap": 4,
-            }
-          }
-        >
-          <Text
-            style={
-              {
-                "color": "#161617",
-                "fontFamily": "Montserrat-Medium",
-                "fontSize": 16,
-                "lineHeight": 25.6,
-              }
-            }
-          >
-            Sélectionne ta localisation
-          </Text>
-        </View>
-        <View
-          display="vertical"
-          style={
-            {
-              "flexDirection": "column",
-              "flexWrap": "nowrap",
-              "gap": 8,
-            }
-          }
-          variant="detailed"
-        >
-          <View
-            collapsable={false}
-            jestAnimatedProps={
-              {
-                "value": {},
-              }
-            }
-            jestAnimatedStyle={
-              {
-                "value": {},
-              }
-            }
-            jestInlineStyle={
-              {
-                "overflow": "hidden",
-              }
-            }
-            layout={
-              LinearTransition {
-                "build": [Function],
-                "durationV": 250,
-                "randomizeDelay": false,
-                "reduceMotionV": "system",
-              }
-            }
-            nativeID="1"
-            style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-              ]
-            }
-          >
-            <View
-              collapsed={null}
-              isHover={false}
-              radioState={
-                {
-                  "disabled": false,
-                  "error": false,
-                  "selected": false,
-                }
-              }
-              sizing="fill"
-              style={
-                {
-                  "backgroundColor": "#ffffff",
-                  "borderBottomLeftRadius": 8,
-                  "borderBottomRightRadius": 8,
-                  "borderColor": "#90949d",
-                  "borderTopLeftRadius": 8,
-                  "borderTopRightRadius": 8,
-                  "borderWidth": 1,
-                  "paddingBottom": 16,
-                  "paddingLeft": 16,
-                  "paddingRight": 16,
-                  "paddingTop": 16,
-                  "width": "100%",
-                }
-              }
-              variant="detailed"
-            >
-              <View
-                accessibilityLabel="Sélectionne ta localisation - Liste - Élément 1 sur 3 - Utiliser ma position actuelle - non sélectionné"
-                accessibilityRole="radio"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "alignItems": "center",
-                        "columnGap": 12,
-                        "flexDirection": "row",
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Sélectionne ta localisation - Liste - Élément 1 sur 3 - Utiliser ma position actuelle - non sélectionné"
-              >
-                <View
-                  isHover={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  radioState={
-                    {
-                      "disabled": false,
-                      "error": false,
-                      "selected": false,
-                    }
-                  }
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "#ffffff",
-                      "borderBottomLeftRadius": 20,
-                      "borderBottomRightRadius": 20,
-                      "borderColor": "#90949d",
-                      "borderTopLeftRadius": 20,
-                      "borderTopRightRadius": 20,
-                      "borderWidth": 2,
-                      "height": 20,
-                      "justifyContent": "center",
-                      "width": 20,
-                    }
-                  }
-                  variant="detailed"
-                />
-                <View
-                  style={
-                    {
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                    }
-                  }
-                >
-                  <Text
-                    isHover={false}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    radioState={
-                      {
-                        "disabled": false,
-                        "error": false,
-                        "selected": false,
-                      }
-                    }
-                    style={
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                  >
-                    Utiliser ma position actuelle
-                  </Text>
-                </View>
-                <View
-                  style={
-                    {
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    fill="none"
-                    height={32}
-                    width={32}
-                  >
-                    <Text>
-                      undefined-SVG-Mock
-                    </Text>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            collapsable={false}
-            jestAnimatedProps={
-              {
-                "value": {},
-              }
-            }
-            jestAnimatedStyle={
-              {
-                "value": {},
-              }
-            }
-            jestInlineStyle={
-              {
-                "overflow": "hidden",
-              }
-            }
-            layout={
-              LinearTransition {
-                "build": [Function],
-                "durationV": 250,
-                "randomizeDelay": false,
-                "reduceMotionV": "system",
-              }
-            }
-            nativeID="2"
-            style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-              ]
-            }
-          >
-            <View
-              collapsed={null}
-              isHover={false}
-              radioState={
-                {
-                  "disabled": false,
-                  "error": false,
-                  "selected": false,
-                }
-              }
-              sizing="fill"
-              style={
-                {
-                  "backgroundColor": "#ffffff",
-                  "borderBottomLeftRadius": 8,
-                  "borderBottomRightRadius": 8,
-                  "borderColor": "#90949d",
-                  "borderTopLeftRadius": 8,
-                  "borderTopRightRadius": 8,
-                  "borderWidth": 1,
-                  "paddingBottom": 16,
-                  "paddingLeft": 16,
-                  "paddingRight": 16,
-                  "paddingTop": 16,
-                  "width": "100%",
-                }
-              }
-              variant="detailed"
-            >
-              <View
-                accessibilityLabel="Sélectionne ta localisation - Liste - Élément 2 sur 3 - Choisir une zone géographique - Ville, code postal, adresse - non sélectionné"
-                accessibilityRole="radio"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "alignItems": "center",
-                        "columnGap": 12,
-                        "flexDirection": "row",
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Sélectionne ta localisation - Liste - Élément 2 sur 3 - Choisir une zone géographique - Ville, code postal, adresse - non sélectionné"
-              >
-                <View
-                  isHover={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  radioState={
-                    {
-                      "disabled": false,
-                      "error": false,
-                      "selected": false,
-                    }
-                  }
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "#ffffff",
-                      "borderBottomLeftRadius": 20,
-                      "borderBottomRightRadius": 20,
-                      "borderColor": "#90949d",
-                      "borderTopLeftRadius": 20,
-                      "borderTopRightRadius": 20,
-                      "borderWidth": 2,
-                      "height": 20,
-                      "justifyContent": "center",
-                      "width": 20,
-                    }
-                  }
-                  variant="detailed"
-                />
-                <View
-                  style={
-                    {
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                    }
-                  }
-                >
-                  <Text
-                    isHover={false}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    radioState={
-                      {
-                        "disabled": false,
-                        "error": false,
-                        "selected": false,
-                      }
-                    }
-                    style={
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                  >
-                    Choisir une zone géographique
-                  </Text>
-                  <Text
-                    isHover={false}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    radioState={
-                      {
-                        "disabled": false,
-                        "error": false,
-                        "selected": false,
-                      }
-                    }
-                    style={
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 12,
-                        "lineHeight": 19.2,
-                      }
-                    }
-                  >
-                    Ville, code postal, adresse
-                  </Text>
-                </View>
-                <View
-                  style={
-                    {
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    fill="none"
-                    height={32}
-                    width={32}
-                  >
-                    <Text>
-                      undefined-SVG-Mock
-                    </Text>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            collapsable={false}
-            jestAnimatedProps={
-              {
-                "value": {},
-              }
-            }
-            jestAnimatedStyle={
-              {
-                "value": {},
-              }
-            }
-            jestInlineStyle={
-              {
-                "overflow": "hidden",
-              }
-            }
-            layout={
-              LinearTransition {
-                "build": [Function],
-                "durationV": 250,
-                "randomizeDelay": false,
-                "reduceMotionV": "system",
-              }
-            }
-            nativeID="3"
-            style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-              ]
-            }
-          >
-            <View
-              isHover={false}
-              radioState={
-                {
-                  "disabled": false,
-                  "error": false,
-                  "selected": true,
-                }
-              }
-              sizing="fill"
-              style={
-                {
-                  "backgroundColor": "#f3edff",
-                  "borderBottomLeftRadius": 8,
-                  "borderBottomRightRadius": 8,
-                  "borderColor": "#6123df",
-                  "borderTopLeftRadius": 8,
-                  "borderTopRightRadius": 8,
-                  "borderWidth": 1,
-                  "paddingBottom": 16,
-                  "paddingLeft": 16,
-                  "paddingRight": 16,
-                  "paddingTop": 16,
-                  "width": "100%",
-                }
-              }
-              variant="detailed"
-            >
-              <View
-                accessibilityLabel="Sélectionne ta localisation - Liste - Élément 3 sur 3 - France entière - sélectionné"
-                accessibilityRole="radio"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": true,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "alignItems": "center",
-                        "columnGap": 12,
-                        "flexDirection": "row",
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Sélectionne ta localisation - Liste - Élément 3 sur 3 - France entière - sélectionné"
-              >
-                <View
-                  isHover={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  radioState={
-                    {
-                      "disabled": false,
-                      "error": false,
-                      "selected": true,
-                    }
-                  }
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "#f3edff",
-                      "borderBottomLeftRadius": 20,
-                      "borderBottomRightRadius": 20,
-                      "borderColor": "#6123df",
-                      "borderTopLeftRadius": 20,
-                      "borderTopRightRadius": 20,
-                      "borderWidth": 2,
-                      "height": 20,
-                      "justifyContent": "center",
-                      "width": 20,
-                    }
-                  }
-                  variant="detailed"
-                >
-                  <View
-                    isHover={false}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    radioState={
-                      {
-                        "disabled": false,
-                        "error": false,
-                        "selected": true,
-                      }
-                    }
-                    style={
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "#6123df",
-                        "borderBottomLeftRadius": 6,
-                        "borderBottomRightRadius": 6,
-                        "borderColor": "#6123df",
-                        "borderTopLeftRadius": 6,
-                        "borderTopRightRadius": 6,
-                        "height": 10,
-                        "justifyContent": "center",
-                        "width": 10,
-                      }
-                    }
-                    variant="detailed"
-                  />
-                </View>
-                <View
-                  style={
-                    {
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                    }
-                  }
-                >
-                  <Text
-                    isHover={false}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    radioState={
-                      {
-                        "disabled": false,
-                        "error": false,
-                        "selected": true,
-                      }
-                    }
-                    style={
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-SemiBold",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                  >
-                    France entière
-                  </Text>
-                </View>
-                <View
-                  style={
-                    {
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    height={32}
-                    width={32}
-                  >
-                    <Text>
-                      undefined-SVG-Mock
-                    </Text>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </RCTScrollView>
-  <View
-    style={
-      {
-        "paddingBottom": 32,
-      }
-    }
-  >
     <View
-      paddingBottom={0}
+      customHeight={8}
+      enable={true}
       style={
         {
-          "alignItems": "center",
-          "paddingHorizontal": 24,
-          "paddingTop": 8,
+          "height": 8,
         }
       }
-    >
-      <View
-        accessibilityLabel="Valider la localisation"
-        accessibilityRole="button"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": false,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          [
-            [
-              {
-                "userSelect": "auto",
-              },
-              {
-                "alignItems": "center",
-                "alignSelf": "center",
-                "backgroundColor": "#6123df",
-                "borderBottomLeftRadius": 8,
-                "borderBottomRightRadius": 8,
-                "borderColor": "#6123df",
-                "borderStyle": "solid",
-                "borderTopLeftRadius": 8,
-                "borderTopRightRadius": 8,
-                "borderWidth": 1,
-                "flexDirection": "row",
-                "justifyContent": "center",
-                "paddingBottom": 8,
-                "paddingLeft": 12,
-                "paddingRight": 12,
-                "paddingTop": 8,
-                "width": "100%",
-              },
-            ],
-            {
-              "opacity": 1,
-            },
-          ]
-        }
-        testID="Valider la localisation"
-      >
-        <View
-          fullWidth={true}
-          gap={8}
-          hasIcon={false}
-          isMultiline={false}
-          style={
-            {
-              "alignItems": "center",
-              "columnGap": 8,
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "width": "100%",
-            }
-          }
-        >
-          <Text
-            style={
-              [
-                {
-                  "color": "#161617",
-                  "fontFamily": "Montserrat-SemiBold",
-                  "fontSize": 16,
-                  "lineHeight": 22,
-                },
-                {
-                  "color": "#ffffff",
-                  "flexBasis": 0,
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "maxWidth": "100%",
-                  "minWidth": 0,
-                  "textAlign": "center",
-                },
-              ]
-            }
-          >
-            Valider la localisation
-          </Text>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    customHeight={8}
-    enable={true}
-    style={
-      {
-        "height": 8,
-      }
-    }
-  />
-</View>
+    />
+  </View>,
+]
 `;

--- a/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
@@ -4,7 +4,19 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
 [
   <Modal
     animationType="fade"
-    onRequestClose={[MockFunction]}
+    onRequestClose={
+      [MockFunction] {
+        "calls": [
+          [],
+        ],
+        "results": [
+          {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
     statusBarTranslucent={true}
     testID="modal-geoloc-permission-modal"
     transparent={true}

--- a/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
@@ -4,7 +4,19 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
 [
   <Modal
     animationType="fade"
-    onRequestClose={[MockFunction]}
+    onRequestClose={
+      [MockFunction] {
+        "calls": [
+          [],
+        ],
+        "results": [
+          {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
     statusBarTranslucent={true}
     testID="modal-geoloc-permission-modal"
     transparent={true}

--- a/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
@@ -1,94 +1,1279 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SearchLocationModal should render correctly if modal visible 1`] = `
-<View
-  style={
-    {
-      "backgroundColor": "#ffffff",
-      "flexBasis": 0,
-      "flexGrow": 1,
-      "flexShrink": 1,
-    }
-  }
->
-  <View
-    style={
-      {
-        "paddingBottom": 16,
-        "paddingLeft": 16,
-        "paddingRight": 16,
-        "paddingTop": 16,
-        "width": "100%",
-      }
-    }
+[
+  <Modal
+    animationType="fade"
+    onRequestClose={[MockFunction]}
+    statusBarTranslucent={true}
+    testID="modal-geoloc-permission-modal"
+    transparent={true}
+    visible={true}
   >
     <View
-      marginTop={0}
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={false}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         {
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "center",
-          "marginTop": 0,
+          "backgroundColor": "#23232329",
+          "flexDirection": "column",
+          "flexGrow": 1,
+          "height": "100%",
+          "justifyContent": "flex-end",
+          "opacity": 1,
+          "position": "absolute",
+          "userSelect": "auto",
           "width": "100%",
         }
       }
-      testID="modalHeader"
+    />
+    <View
+      style={
+        {
+          "height": "100%",
+          "justifyContent": "center",
+        }
+      }
     >
       <View
-        justifyContent="left"
+        accessibilityLabelledBy="testUuidV4"
+        gap={6}
+        maxHeight={1334}
         style={
           {
-            "alignItems": "flex-start",
-            "flexDirection": "row",
-            "height": 28,
-            "justifyContent": "flex-start",
-            "width": 28,
-          }
-        }
-      />
-      <View
-        style={
-          {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 12,
-            "zIndex": 1,
-          }
-        }
-      >
-        <Text
-          accessibilityRole="header"
-          style={
-            {
-              "color": "#161617",
-              "fontFamily": "Montserrat-Bold",
-              "fontSize": 17,
-              "lineHeight": 27.2,
-              "textAlign": "center",
-            }
-          }
-          testID="modalHeaderTitle"
-        >
-          Localisation
-        </Text>
-      </View>
-      <View
-        justifyContent="right"
-        style={
-          {
-            "alignItems": "flex-start",
-            "flexDirection": "row",
-            "height": 28,
-            "justifyContent": "flex-end",
-            "width": 28,
+            "alignItems": "center",
+            "alignSelf": "center",
+            "backgroundColor": "#ffffff",
+            "borderBottomLeftRadius": 4,
+            "borderBottomRightRadius": 4,
+            "borderTopLeftRadius": 4,
+            "borderTopRightRadius": 4,
+            "gap": 24,
+            "maxHeight": "100%",
+            "paddingBottom": 32,
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "paddingTop": 24,
+            "width": 928,
           }
         }
       >
         <View
-          accessibilityLabel="Fermer la modale"
+          marginTop={0}
+          style={
+            {
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "marginTop": 0,
+              "width": "100%",
+            }
+          }
+          testID="modalHeader"
+        >
+          <View
+            justifyContent="left"
+            style={
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "height": 28,
+                "justifyContent": "flex-start",
+                "width": 28,
+              }
+            }
+          />
+          <View
+            style={
+              {
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "center",
+                "paddingHorizontal": 12,
+                "zIndex": 1,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="header"
+              nativeID="testUuidV4"
+              style={
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 17,
+                  "lineHeight": 27.2,
+                  "textAlign": "center",
+                }
+              }
+              testID="modalHeaderTitle"
+            >
+              Paramètres de localisation
+            </Text>
+          </View>
+          <View
+            justifyContent="right"
+            style={
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "height": 28,
+                "justifyContent": "flex-end",
+                "width": 28,
+              }
+            }
+          >
+            <View
+              accessibilityLabel="Fermer la modale"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingBottom": 8,
+                  "paddingLeft": 8,
+                  "paddingRight": 8,
+                  "paddingTop": 8,
+                  "userSelect": "auto",
+                  "width": "auto",
+                }
+              }
+              testID="Fermer la modale"
+            >
+              <View
+                gap={0}
+                hasIcon={true}
+                isMultiline={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "columnGap": 0,
+                    "flexDirection": "row",
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  jestAnimatedProps={
+                    {
+                      "value": {},
+                    }
+                  }
+                  jestAnimatedStyle={
+                    {
+                      "value": {},
+                    }
+                  }
+                  jestInlineStyle={
+                    {
+                      "flexShrink": 0,
+                    }
+                  }
+                  nativeID="0"
+                  style={
+                    [
+                      {
+                        "flexShrink": 0,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    height={22}
+                    testID="rightIcon"
+                    width={22}
+                  >
+                    <Text>
+                      rightIcon-SVG-Mock
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <RCTScrollView
+          bounces={false}
+          showsVerticalScrollIndicator={true}
+          style={
+            {
+              "flexGrow": 0,
+              "maxWidth": 500,
+              "width": "100%",
+            }
+          }
+          testID="appInformationModalScrollView"
+        >
+          <View>
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                }
+              }
+            >
+              <View
+                height={100}
+                width={100}
+              >
+                <Text>
+                  undefined-SVG-Mock
+                </Text>
+              </View>
+              <Text
+                style={
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
+                    "marginTop": 40,
+                    "textAlign": "center",
+                  }
+                }
+              >
+                Retrouve toutes les offres autour de chez toi en activant les données de localisation.
+              </Text>
+              <Text
+                style={
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
+                    "marginTop": 16,
+                    "textAlign": "center",
+                  }
+                }
+              >
+                Tu peux activer ou désactiver cette fonctionnalité dans les paramètres de localisation de ton téléphone.
+              </Text>
+              <View
+                style={
+                  {
+                    "marginTop": 24,
+                  }
+                }
+              >
+                <View
+                  accessibilityLabel="Activer la géolocalisation"
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "alignSelf": "center",
+                      "backgroundColor": "#6123df",
+                      "borderBottomLeftRadius": 8,
+                      "borderBottomRightRadius": 8,
+                      "borderColor": "#6123df",
+                      "borderStyle": "solid",
+                      "borderTopLeftRadius": 8,
+                      "borderTopRightRadius": 8,
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                      "opacity": 1,
+                      "paddingBottom": 8,
+                      "paddingLeft": 12,
+                      "paddingRight": 12,
+                      "paddingTop": 8,
+                      "userSelect": "auto",
+                      "width": "100%",
+                    }
+                  }
+                  testID="Activer la géolocalisation"
+                >
+                  <View
+                    fullWidth={true}
+                    gap={8}
+                    hasIcon={false}
+                    isMultiline={false}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "columnGap": 8,
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                        "width": "100%",
+                      }
+                    }
+                  >
+                    <Text
+                      style={
+                        [
+                          {
+                            "color": "#161617",
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 22,
+                          },
+                          {
+                            "color": "#ffffff",
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                            "maxWidth": "100%",
+                            "minWidth": 0,
+                            "textAlign": "center",
+                          },
+                        ]
+                      }
+                    >
+                      Activer la géolocalisation
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RCTScrollView>
+      </View>
+    </View>
+  </Modal>,
+  <View
+    style={
+      {
+        "backgroundColor": "#ffffff",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "paddingBottom": 16,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "paddingTop": 16,
+          "width": "100%",
+        }
+      }
+    >
+      <View
+        marginTop={0}
+        style={
+          {
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "marginTop": 0,
+            "width": "100%",
+          }
+        }
+        testID="modalHeader"
+      >
+        <View
+          justifyContent="left"
+          style={
+            {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "height": 28,
+              "justifyContent": "flex-start",
+              "width": 28,
+            }
+          }
+        />
+        <View
+          style={
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "justifyContent": "center",
+              "paddingHorizontal": 12,
+              "zIndex": 1,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="header"
+            style={
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 17,
+                "lineHeight": 27.2,
+                "textAlign": "center",
+              }
+            }
+            testID="modalHeaderTitle"
+          >
+            Localisation
+          </Text>
+        </View>
+        <View
+          justifyContent="right"
+          style={
+            {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "height": 28,
+              "justifyContent": "flex-end",
+              "width": 28,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Fermer la modale"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "transparent",
+                "borderWidth": 0,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "opacity": 1,
+                "paddingBottom": 8,
+                "paddingLeft": 8,
+                "paddingRight": 8,
+                "paddingTop": 8,
+                "userSelect": "auto",
+                "width": "auto",
+              }
+            }
+            testID="Fermer la modale"
+          >
+            <View
+              gap={0}
+              hasIcon={true}
+              isMultiline={false}
+              style={
+                {
+                  "alignItems": "center",
+                  "columnGap": 0,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                jestAnimatedProps={
+                  {
+                    "value": {},
+                  }
+                }
+                jestAnimatedStyle={
+                  {
+                    "value": {},
+                  }
+                }
+                jestInlineStyle={
+                  {
+                    "flexShrink": 0,
+                  }
+                }
+                nativeID="1"
+                style={
+                  [
+                    {
+                      "flexShrink": 0,
+                    },
+                  ]
+                }
+              >
+                <View
+                  height={22}
+                  testID="rightIcon"
+                  width={22}
+                >
+                  <Text>
+                    rightIcon-SVG-Mock
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <RCTScrollView
+      keyboardShouldPersistTaps="handled"
+      style={
+        {
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "marginTop": 24,
+          "paddingHorizontal": 24,
+        }
+      }
+    >
+      <View>
+        <View
+          accessibilityRole="none"
+          style={
+            {
+              "gap": 8,
+            }
+          }
+          useFlatList={false}
+        >
+          <View
+            style={
+              {
+                "gap": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                }
+              }
+            >
+              Sélectionne ta localisation
+            </Text>
+          </View>
+          <View
+            display="vertical"
+            style={
+              {
+                "flexDirection": "column",
+                "flexWrap": "nowrap",
+                "gap": 8,
+              }
+            }
+            variant="detailed"
+          >
+            <View
+              collapsable={false}
+              jestAnimatedProps={
+                {
+                  "value": {},
+                }
+              }
+              jestAnimatedStyle={
+                {
+                  "value": {},
+                }
+              }
+              jestInlineStyle={
+                {
+                  "overflow": "hidden",
+                }
+              }
+              layout={
+                LinearTransition {
+                  "build": [Function],
+                  "durationV": 250,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              nativeID="2"
+              style={
+                [
+                  {
+                    "overflow": "hidden",
+                  },
+                ]
+              }
+            >
+              <View
+                collapsed={null}
+                isHover={false}
+                radioState={
+                  {
+                    "disabled": false,
+                    "error": false,
+                    "selected": false,
+                  }
+                }
+                sizing="fill"
+                style={
+                  {
+                    "backgroundColor": "#ffffff",
+                    "borderBottomLeftRadius": 8,
+                    "borderBottomRightRadius": 8,
+                    "borderColor": "#90949d",
+                    "borderTopLeftRadius": 8,
+                    "borderTopRightRadius": 8,
+                    "borderWidth": 1,
+                    "paddingBottom": 16,
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                    "paddingTop": 16,
+                    "width": "100%",
+                  }
+                }
+                variant="detailed"
+              >
+                <View
+                  accessibilityLabel="Sélectionne ta localisation - Liste - Élément 1 sur 3 - Utiliser ma position actuelle - non sélectionné"
+                  accessibilityRole="radio"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "columnGap": 12,
+                      "flexDirection": "row",
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Sélectionne ta localisation - Liste - Élément 1 sur 3 - Utiliser ma position actuelle - non sélectionné"
+                >
+                  <View
+                    isHover={false}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    radioState={
+                      {
+                        "disabled": false,
+                        "error": false,
+                        "selected": false,
+                      }
+                    }
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderBottomLeftRadius": 20,
+                        "borderBottomRightRadius": 20,
+                        "borderColor": "#90949d",
+                        "borderTopLeftRadius": 20,
+                        "borderTopRightRadius": 20,
+                        "borderWidth": 2,
+                        "height": 20,
+                        "justifyContent": "center",
+                        "width": 20,
+                      }
+                    }
+                    variant="detailed"
+                  />
+                  <View
+                    style={
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      isHover={false}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      radioState={
+                        {
+                          "disabled": false,
+                          "error": false,
+                          "selected": false,
+                        }
+                      }
+                      style={
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        }
+                      }
+                    >
+                      Utiliser ma position actuelle
+                    </Text>
+                  </View>
+                  <View
+                    style={
+                      {
+                        "justifyContent": "center",
+                      }
+                    }
+                  >
+                    <View
+                      fill="none"
+                      height={32}
+                      width={32}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              jestAnimatedProps={
+                {
+                  "value": {},
+                }
+              }
+              jestAnimatedStyle={
+                {
+                  "value": {},
+                }
+              }
+              jestInlineStyle={
+                {
+                  "overflow": "hidden",
+                }
+              }
+              layout={
+                LinearTransition {
+                  "build": [Function],
+                  "durationV": 250,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              nativeID="3"
+              style={
+                [
+                  {
+                    "overflow": "hidden",
+                  },
+                ]
+              }
+            >
+              <View
+                collapsed={null}
+                isHover={false}
+                radioState={
+                  {
+                    "disabled": false,
+                    "error": false,
+                    "selected": false,
+                  }
+                }
+                sizing="fill"
+                style={
+                  {
+                    "backgroundColor": "#ffffff",
+                    "borderBottomLeftRadius": 8,
+                    "borderBottomRightRadius": 8,
+                    "borderColor": "#90949d",
+                    "borderTopLeftRadius": 8,
+                    "borderTopRightRadius": 8,
+                    "borderWidth": 1,
+                    "paddingBottom": 16,
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                    "paddingTop": 16,
+                    "width": "100%",
+                  }
+                }
+                variant="detailed"
+              >
+                <View
+                  accessibilityLabel="Sélectionne ta localisation - Liste - Élément 2 sur 3 - Choisir une zone géographique - Ville, code postal, adresse - non sélectionné"
+                  accessibilityRole="radio"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "columnGap": 12,
+                      "flexDirection": "row",
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Sélectionne ta localisation - Liste - Élément 2 sur 3 - Choisir une zone géographique - Ville, code postal, adresse - non sélectionné"
+                >
+                  <View
+                    isHover={false}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    radioState={
+                      {
+                        "disabled": false,
+                        "error": false,
+                        "selected": false,
+                      }
+                    }
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderBottomLeftRadius": 20,
+                        "borderBottomRightRadius": 20,
+                        "borderColor": "#90949d",
+                        "borderTopLeftRadius": 20,
+                        "borderTopRightRadius": 20,
+                        "borderWidth": 2,
+                        "height": 20,
+                        "justifyContent": "center",
+                        "width": 20,
+                      }
+                    }
+                    variant="detailed"
+                  />
+                  <View
+                    style={
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      isHover={false}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      radioState={
+                        {
+                          "disabled": false,
+                          "error": false,
+                          "selected": false,
+                        }
+                      }
+                      style={
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        }
+                      }
+                    >
+                      Choisir une zone géographique
+                    </Text>
+                    <Text
+                      isHover={false}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      radioState={
+                        {
+                          "disabled": false,
+                          "error": false,
+                          "selected": false,
+                        }
+                      }
+                      style={
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        }
+                      }
+                    >
+                      Ville, code postal, adresse
+                    </Text>
+                  </View>
+                  <View
+                    style={
+                      {
+                        "justifyContent": "center",
+                      }
+                    }
+                  >
+                    <View
+                      fill="none"
+                      height={32}
+                      width={32}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              jestAnimatedProps={
+                {
+                  "value": {},
+                }
+              }
+              jestAnimatedStyle={
+                {
+                  "value": {},
+                }
+              }
+              jestInlineStyle={
+                {
+                  "overflow": "hidden",
+                }
+              }
+              layout={
+                LinearTransition {
+                  "build": [Function],
+                  "durationV": 250,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              nativeID="4"
+              style={
+                [
+                  {
+                    "overflow": "hidden",
+                  },
+                ]
+              }
+            >
+              <View
+                isHover={false}
+                radioState={
+                  {
+                    "disabled": false,
+                    "error": false,
+                    "selected": true,
+                  }
+                }
+                sizing="fill"
+                style={
+                  {
+                    "backgroundColor": "#f3edff",
+                    "borderBottomLeftRadius": 8,
+                    "borderBottomRightRadius": 8,
+                    "borderColor": "#6123df",
+                    "borderTopLeftRadius": 8,
+                    "borderTopRightRadius": 8,
+                    "borderWidth": 1,
+                    "paddingBottom": 16,
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                    "paddingTop": 16,
+                    "width": "100%",
+                  }
+                }
+                variant="detailed"
+              >
+                <View
+                  accessibilityLabel="Sélectionne ta localisation - Liste - Élément 3 sur 3 - France entière - sélectionné"
+                  accessibilityRole="radio"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": true,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "columnGap": 12,
+                      "flexDirection": "row",
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Sélectionne ta localisation - Liste - Élément 3 sur 3 - France entière - sélectionné"
+                >
+                  <View
+                    isHover={false}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    radioState={
+                      {
+                        "disabled": false,
+                        "error": false,
+                        "selected": true,
+                      }
+                    }
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#f3edff",
+                        "borderBottomLeftRadius": 20,
+                        "borderBottomRightRadius": 20,
+                        "borderColor": "#6123df",
+                        "borderTopLeftRadius": 20,
+                        "borderTopRightRadius": 20,
+                        "borderWidth": 2,
+                        "height": 20,
+                        "justifyContent": "center",
+                        "width": 20,
+                      }
+                    }
+                    variant="detailed"
+                  >
+                    <View
+                      isHover={false}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      radioState={
+                        {
+                          "disabled": false,
+                          "error": false,
+                          "selected": true,
+                        }
+                      }
+                      style={
+                        {
+                          "alignItems": "center",
+                          "backgroundColor": "#6123df",
+                          "borderBottomLeftRadius": 6,
+                          "borderBottomRightRadius": 6,
+                          "borderColor": "#6123df",
+                          "borderTopLeftRadius": 6,
+                          "borderTopRightRadius": 6,
+                          "height": 10,
+                          "justifyContent": "center",
+                          "width": 10,
+                        }
+                      }
+                      variant="detailed"
+                    />
+                  </View>
+                  <View
+                    style={
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      isHover={false}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      radioState={
+                        {
+                          "disabled": false,
+                          "error": false,
+                          "selected": true,
+                        }
+                      }
+                      style={
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        }
+                      }
+                    >
+                      France entière
+                    </Text>
+                  </View>
+                  <View
+                    style={
+                      {
+                        "justifyContent": "center",
+                      }
+                    }
+                  >
+                    <View
+                      height={32}
+                      width={32}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+    <View
+      style={
+        {
+          "paddingBottom": 32,
+        }
+      }
+    >
+      <View
+        paddingBottom={0}
+        style={
+          {
+            "alignItems": "center",
+            "paddingHorizontal": 24,
+            "paddingTop": 8,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Valider la localisation"
           accessibilityRole="button"
           accessibilityState={
             {
@@ -120,850 +1305,79 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
           style={
             {
               "alignItems": "center",
-              "backgroundColor": "transparent",
-              "borderWidth": 0,
+              "alignSelf": "center",
+              "backgroundColor": "#6123df",
+              "borderBottomLeftRadius": 8,
+              "borderBottomRightRadius": 8,
+              "borderColor": "#6123df",
+              "borderStyle": "solid",
+              "borderTopLeftRadius": 8,
+              "borderTopRightRadius": 8,
+              "borderWidth": 1,
               "flexDirection": "row",
               "justifyContent": "center",
               "opacity": 1,
               "paddingBottom": 8,
-              "paddingLeft": 8,
-              "paddingRight": 8,
+              "paddingLeft": 12,
+              "paddingRight": 12,
               "paddingTop": 8,
               "userSelect": "auto",
-              "width": "auto",
+              "width": "100%",
             }
           }
-          testID="Fermer la modale"
+          testID="Valider la localisation"
         >
           <View
-            gap={0}
-            hasIcon={true}
+            fullWidth={true}
+            gap={8}
+            hasIcon={false}
             isMultiline={false}
             style={
               {
                 "alignItems": "center",
-                "columnGap": 0,
+                "columnGap": 8,
                 "flexDirection": "row",
+                "justifyContent": "center",
+                "width": "100%",
               }
             }
           >
-            <View
-              collapsable={false}
-              jestAnimatedProps={
-                {
-                  "value": {},
-                }
-              }
-              jestAnimatedStyle={
-                {
-                  "value": {},
-                }
-              }
-              jestInlineStyle={
-                {
-                  "flexShrink": 0,
-                }
-              }
-              nativeID="0"
+            <Text
               style={
                 [
                   {
-                    "flexShrink": 0,
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  {
+                    "color": "#ffffff",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "maxWidth": "100%",
+                    "minWidth": 0,
+                    "textAlign": "center",
                   },
                 ]
               }
             >
-              <View
-                height={22}
-                testID="rightIcon"
-                width={22}
-              >
-                <Text>
-                  rightIcon-SVG-Mock
-                </Text>
-              </View>
-            </View>
+              Valider la localisation
+            </Text>
           </View>
         </View>
       </View>
     </View>
-  </View>
-  <RCTScrollView
-    keyboardShouldPersistTaps="handled"
-    style={
-      {
-        "flexBasis": 0,
-        "flexGrow": 1,
-        "flexShrink": 1,
-        "marginTop": 24,
-        "paddingHorizontal": 24,
-      }
-    }
-  >
-    <View>
-      <View
-        accessibilityRole="none"
-        style={
-          {
-            "gap": 8,
-          }
-        }
-        useFlatList={false}
-      >
-        <View
-          style={
-            {
-              "gap": 4,
-            }
-          }
-        >
-          <Text
-            style={
-              {
-                "color": "#161617",
-                "fontFamily": "Montserrat-Medium",
-                "fontSize": 16,
-                "lineHeight": 25.6,
-              }
-            }
-          >
-            Sélectionne ta localisation
-          </Text>
-        </View>
-        <View
-          display="vertical"
-          style={
-            {
-              "flexDirection": "column",
-              "flexWrap": "nowrap",
-              "gap": 8,
-            }
-          }
-          variant="detailed"
-        >
-          <View
-            collapsable={false}
-            jestAnimatedProps={
-              {
-                "value": {},
-              }
-            }
-            jestAnimatedStyle={
-              {
-                "value": {},
-              }
-            }
-            jestInlineStyle={
-              {
-                "overflow": "hidden",
-              }
-            }
-            layout={
-              LinearTransition {
-                "build": [Function],
-                "durationV": 250,
-                "randomizeDelay": false,
-                "reduceMotionV": "system",
-              }
-            }
-            nativeID="1"
-            style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-              ]
-            }
-          >
-            <View
-              collapsed={null}
-              isHover={false}
-              radioState={
-                {
-                  "disabled": false,
-                  "error": false,
-                  "selected": false,
-                }
-              }
-              sizing="fill"
-              style={
-                {
-                  "backgroundColor": "#ffffff",
-                  "borderBottomLeftRadius": 8,
-                  "borderBottomRightRadius": 8,
-                  "borderColor": "#90949d",
-                  "borderTopLeftRadius": 8,
-                  "borderTopRightRadius": 8,
-                  "borderWidth": 1,
-                  "paddingBottom": 16,
-                  "paddingLeft": 16,
-                  "paddingRight": 16,
-                  "paddingTop": 16,
-                  "width": "100%",
-                }
-              }
-              variant="detailed"
-            >
-              <View
-                accessibilityLabel="Sélectionne ta localisation - Liste - Élément 1 sur 3 - Utiliser ma position actuelle - non sélectionné"
-                accessibilityRole="radio"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "alignItems": "center",
-                    "columnGap": 12,
-                    "flexDirection": "row",
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Sélectionne ta localisation - Liste - Élément 1 sur 3 - Utiliser ma position actuelle - non sélectionné"
-              >
-                <View
-                  isHover={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  radioState={
-                    {
-                      "disabled": false,
-                      "error": false,
-                      "selected": false,
-                    }
-                  }
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "#ffffff",
-                      "borderBottomLeftRadius": 20,
-                      "borderBottomRightRadius": 20,
-                      "borderColor": "#90949d",
-                      "borderTopLeftRadius": 20,
-                      "borderTopRightRadius": 20,
-                      "borderWidth": 2,
-                      "height": 20,
-                      "justifyContent": "center",
-                      "width": 20,
-                    }
-                  }
-                  variant="detailed"
-                />
-                <View
-                  style={
-                    {
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                    }
-                  }
-                >
-                  <Text
-                    isHover={false}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    radioState={
-                      {
-                        "disabled": false,
-                        "error": false,
-                        "selected": false,
-                      }
-                    }
-                    style={
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                  >
-                    Utiliser ma position actuelle
-                  </Text>
-                </View>
-                <View
-                  style={
-                    {
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    fill="none"
-                    height={32}
-                    width={32}
-                  >
-                    <Text>
-                      undefined-SVG-Mock
-                    </Text>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            collapsable={false}
-            jestAnimatedProps={
-              {
-                "value": {},
-              }
-            }
-            jestAnimatedStyle={
-              {
-                "value": {},
-              }
-            }
-            jestInlineStyle={
-              {
-                "overflow": "hidden",
-              }
-            }
-            layout={
-              LinearTransition {
-                "build": [Function],
-                "durationV": 250,
-                "randomizeDelay": false,
-                "reduceMotionV": "system",
-              }
-            }
-            nativeID="2"
-            style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-              ]
-            }
-          >
-            <View
-              collapsed={null}
-              isHover={false}
-              radioState={
-                {
-                  "disabled": false,
-                  "error": false,
-                  "selected": false,
-                }
-              }
-              sizing="fill"
-              style={
-                {
-                  "backgroundColor": "#ffffff",
-                  "borderBottomLeftRadius": 8,
-                  "borderBottomRightRadius": 8,
-                  "borderColor": "#90949d",
-                  "borderTopLeftRadius": 8,
-                  "borderTopRightRadius": 8,
-                  "borderWidth": 1,
-                  "paddingBottom": 16,
-                  "paddingLeft": 16,
-                  "paddingRight": 16,
-                  "paddingTop": 16,
-                  "width": "100%",
-                }
-              }
-              variant="detailed"
-            >
-              <View
-                accessibilityLabel="Sélectionne ta localisation - Liste - Élément 2 sur 3 - Choisir une zone géographique - Ville, code postal, adresse - non sélectionné"
-                accessibilityRole="radio"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "alignItems": "center",
-                    "columnGap": 12,
-                    "flexDirection": "row",
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Sélectionne ta localisation - Liste - Élément 2 sur 3 - Choisir une zone géographique - Ville, code postal, adresse - non sélectionné"
-              >
-                <View
-                  isHover={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  radioState={
-                    {
-                      "disabled": false,
-                      "error": false,
-                      "selected": false,
-                    }
-                  }
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "#ffffff",
-                      "borderBottomLeftRadius": 20,
-                      "borderBottomRightRadius": 20,
-                      "borderColor": "#90949d",
-                      "borderTopLeftRadius": 20,
-                      "borderTopRightRadius": 20,
-                      "borderWidth": 2,
-                      "height": 20,
-                      "justifyContent": "center",
-                      "width": 20,
-                    }
-                  }
-                  variant="detailed"
-                />
-                <View
-                  style={
-                    {
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                    }
-                  }
-                >
-                  <Text
-                    isHover={false}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    radioState={
-                      {
-                        "disabled": false,
-                        "error": false,
-                        "selected": false,
-                      }
-                    }
-                    style={
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                  >
-                    Choisir une zone géographique
-                  </Text>
-                  <Text
-                    isHover={false}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    radioState={
-                      {
-                        "disabled": false,
-                        "error": false,
-                        "selected": false,
-                      }
-                    }
-                    style={
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 12,
-                        "lineHeight": 19.2,
-                      }
-                    }
-                  >
-                    Ville, code postal, adresse
-                  </Text>
-                </View>
-                <View
-                  style={
-                    {
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    fill="none"
-                    height={32}
-                    width={32}
-                  >
-                    <Text>
-                      undefined-SVG-Mock
-                    </Text>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            collapsable={false}
-            jestAnimatedProps={
-              {
-                "value": {},
-              }
-            }
-            jestAnimatedStyle={
-              {
-                "value": {},
-              }
-            }
-            jestInlineStyle={
-              {
-                "overflow": "hidden",
-              }
-            }
-            layout={
-              LinearTransition {
-                "build": [Function],
-                "durationV": 250,
-                "randomizeDelay": false,
-                "reduceMotionV": "system",
-              }
-            }
-            nativeID="3"
-            style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-              ]
-            }
-          >
-            <View
-              isHover={false}
-              radioState={
-                {
-                  "disabled": false,
-                  "error": false,
-                  "selected": true,
-                }
-              }
-              sizing="fill"
-              style={
-                {
-                  "backgroundColor": "#f3edff",
-                  "borderBottomLeftRadius": 8,
-                  "borderBottomRightRadius": 8,
-                  "borderColor": "#6123df",
-                  "borderTopLeftRadius": 8,
-                  "borderTopRightRadius": 8,
-                  "borderWidth": 1,
-                  "paddingBottom": 16,
-                  "paddingLeft": 16,
-                  "paddingRight": 16,
-                  "paddingTop": 16,
-                  "width": "100%",
-                }
-              }
-              variant="detailed"
-            >
-              <View
-                accessibilityLabel="Sélectionne ta localisation - Liste - Élément 3 sur 3 - France entière - sélectionné"
-                accessibilityRole="radio"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": true,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "alignItems": "center",
-                    "columnGap": 12,
-                    "flexDirection": "row",
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Sélectionne ta localisation - Liste - Élément 3 sur 3 - France entière - sélectionné"
-              >
-                <View
-                  isHover={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  radioState={
-                    {
-                      "disabled": false,
-                      "error": false,
-                      "selected": true,
-                    }
-                  }
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "#f3edff",
-                      "borderBottomLeftRadius": 20,
-                      "borderBottomRightRadius": 20,
-                      "borderColor": "#6123df",
-                      "borderTopLeftRadius": 20,
-                      "borderTopRightRadius": 20,
-                      "borderWidth": 2,
-                      "height": 20,
-                      "justifyContent": "center",
-                      "width": 20,
-                    }
-                  }
-                  variant="detailed"
-                >
-                  <View
-                    isHover={false}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    radioState={
-                      {
-                        "disabled": false,
-                        "error": false,
-                        "selected": true,
-                      }
-                    }
-                    style={
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "#6123df",
-                        "borderBottomLeftRadius": 6,
-                        "borderBottomRightRadius": 6,
-                        "borderColor": "#6123df",
-                        "borderTopLeftRadius": 6,
-                        "borderTopRightRadius": 6,
-                        "height": 10,
-                        "justifyContent": "center",
-                        "width": 10,
-                      }
-                    }
-                    variant="detailed"
-                  />
-                </View>
-                <View
-                  style={
-                    {
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                    }
-                  }
-                >
-                  <Text
-                    isHover={false}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    radioState={
-                      {
-                        "disabled": false,
-                        "error": false,
-                        "selected": true,
-                      }
-                    }
-                    style={
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-SemiBold",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                  >
-                    France entière
-                  </Text>
-                </View>
-                <View
-                  style={
-                    {
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    height={32}
-                    width={32}
-                  >
-                    <Text>
-                      undefined-SVG-Mock
-                    </Text>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </RCTScrollView>
-  <View
-    style={
-      {
-        "paddingBottom": 32,
-      }
-    }
-  >
     <View
-      paddingBottom={0}
+      customHeight={8}
+      enable={true}
       style={
         {
-          "alignItems": "center",
-          "paddingHorizontal": 24,
-          "paddingTop": 8,
+          "height": 8,
         }
       }
-    >
-      <View
-        accessibilityLabel="Valider la localisation"
-        accessibilityRole="button"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": false,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          {
-            "alignItems": "center",
-            "alignSelf": "center",
-            "backgroundColor": "#6123df",
-            "borderBottomLeftRadius": 8,
-            "borderBottomRightRadius": 8,
-            "borderColor": "#6123df",
-            "borderStyle": "solid",
-            "borderTopLeftRadius": 8,
-            "borderTopRightRadius": 8,
-            "borderWidth": 1,
-            "flexDirection": "row",
-            "justifyContent": "center",
-            "opacity": 1,
-            "paddingBottom": 8,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 8,
-            "userSelect": "auto",
-            "width": "100%",
-          }
-        }
-        testID="Valider la localisation"
-      >
-        <View
-          fullWidth={true}
-          gap={8}
-          hasIcon={false}
-          isMultiline={false}
-          style={
-            {
-              "alignItems": "center",
-              "columnGap": 8,
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "width": "100%",
-            }
-          }
-        >
-          <Text
-            style={
-              [
-                {
-                  "color": "#161617",
-                  "fontFamily": "Montserrat-SemiBold",
-                  "fontSize": 16,
-                  "lineHeight": 22,
-                },
-                {
-                  "color": "#ffffff",
-                  "flexBasis": 0,
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "maxWidth": "100%",
-                  "minWidth": 0,
-                  "textAlign": "center",
-                },
-              ]
-            }
-          >
-            Valider la localisation
-          </Text>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    customHeight={8}
-    enable={true}
-    style={
-      {
-        "height": 8,
-      }
-    }
-  />
-</View>
+    />
+  </View>,
+]
 `;

--- a/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
@@ -4,7 +4,19 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
 [
   <Modal
     animationType="fade"
-    onRequestClose={[MockFunction]}
+    onRequestClose={
+      [MockFunction] {
+        "calls": [
+          [],
+        ],
+        "results": [
+          {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
     statusBarTranslucent={true}
     testID="modal-geoloc-permission-modal"
     transparent={true}

--- a/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
@@ -1,94 +1,1112 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
-<View
-  style={
-    {
-      "backgroundColor": "#ffffff",
-      "flexBasis": 0,
-      "flexGrow": 1,
-      "flexShrink": 1,
-    }
-  }
->
-  <View
-    style={
-      {
-        "paddingBottom": 16,
-        "paddingLeft": 16,
-        "paddingRight": 16,
-        "paddingTop": 16,
-        "width": "100%",
-      }
-    }
+[
+  <Modal
+    animationType="fade"
+    onRequestClose={[MockFunction]}
+    statusBarTranslucent={true}
+    testID="modal-geoloc-permission-modal"
+    transparent={true}
+    visible={true}
   >
     <View
-      marginTop={0}
-      style={
+      accessibilityState={
         {
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "center",
-          "marginTop": 0,
-          "width": "100%",
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
         }
       }
-      testID="modalHeader"
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          [
+            {
+              "userSelect": "auto",
+            },
+            {
+              "backgroundColor": "#23232329",
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "height": "100%",
+              "justifyContent": "flex-end",
+              "position": "absolute",
+              "width": "100%",
+            },
+          ],
+          {
+            "opacity": 1,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        {
+          "height": "100%",
+          "justifyContent": "center",
+        }
+      }
     >
       <View
-        justifyContent="left"
+        accessibilityLabelledBy="testUuidV4"
+        gap={6}
+        maxHeight={1334}
         style={
           {
-            "alignItems": "flex-start",
-            "flexDirection": "row",
-            "height": 28,
-            "justifyContent": "flex-start",
-            "width": 28,
-          }
-        }
-      />
-      <View
-        style={
-          {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 12,
-            "zIndex": 1,
-          }
-        }
-      >
-        <Text
-          accessibilityRole="header"
-          style={
-            {
-              "color": "#161617",
-              "fontFamily": "Montserrat-Bold",
-              "fontSize": 17,
-              "lineHeight": 27.2,
-              "textAlign": "center",
-            }
-          }
-          testID="modalHeaderTitle"
-        >
-          Localisation
-        </Text>
-      </View>
-      <View
-        justifyContent="right"
-        style={
-          {
-            "alignItems": "flex-start",
-            "flexDirection": "row",
-            "height": 28,
-            "justifyContent": "flex-end",
-            "width": 28,
+            "alignItems": "center",
+            "alignSelf": "center",
+            "backgroundColor": "#ffffff",
+            "borderBottomLeftRadius": 4,
+            "borderBottomRightRadius": 4,
+            "borderTopLeftRadius": 4,
+            "borderTopRightRadius": 4,
+            "gap": 24,
+            "maxHeight": "100%",
+            "paddingBottom": 32,
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "paddingTop": 24,
+            "width": 928,
           }
         }
       >
         <View
-          accessibilityLabel="Fermer la modale"
+          marginTop={0}
+          style={
+            {
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "marginTop": 0,
+              "width": "100%",
+            }
+          }
+          testID="modalHeader"
+        >
+          <View
+            justifyContent="left"
+            style={
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "height": 28,
+                "justifyContent": "flex-start",
+                "width": 28,
+              }
+            }
+          />
+          <View
+            style={
+              {
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "center",
+                "paddingHorizontal": 12,
+                "zIndex": 1,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="header"
+              nativeID="testUuidV4"
+              style={
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 17,
+                  "lineHeight": 27.2,
+                  "textAlign": "center",
+                }
+              }
+              testID="modalHeaderTitle"
+            >
+              Paramètres de localisation
+            </Text>
+          </View>
+          <View
+            justifyContent="right"
+            style={
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "height": 28,
+                "justifyContent": "flex-end",
+                "width": 28,
+              }
+            }
+          >
+            <View
+              accessibilityLabel="Fermer la modale"
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  [
+                    {
+                      "userSelect": "auto",
+                    },
+                    {
+                      "alignItems": "center",
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
+                      "width": "auto",
+                    },
+                  ],
+                  {
+                    "opacity": 1,
+                  },
+                ]
+              }
+              testID="Fermer la modale"
+            >
+              <View
+                gap={0}
+                hasIcon={true}
+                isMultiline={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "columnGap": 0,
+                    "flexDirection": "row",
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  jestAnimatedProps={
+                    {
+                      "value": {},
+                    }
+                  }
+                  jestAnimatedStyle={
+                    {
+                      "value": {},
+                    }
+                  }
+                  jestInlineStyle={
+                    {
+                      "flexShrink": 0,
+                    }
+                  }
+                  nativeID="0"
+                  style={
+                    [
+                      {
+                        "flexShrink": 0,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    height={22}
+                    testID="rightIcon"
+                    width={22}
+                  >
+                    <Text>
+                      rightIcon-SVG-Mock
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <RCTScrollView
+          bounces={false}
+          showsVerticalScrollIndicator={true}
+          style={
+            {
+              "flexGrow": 0,
+              "maxWidth": 500,
+              "width": "100%",
+            }
+          }
+          testID="appInformationModalScrollView"
+        >
+          <View>
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                }
+              }
+            >
+              <View
+                height={100}
+                width={100}
+              >
+                <Text>
+                  undefined-SVG-Mock
+                </Text>
+              </View>
+              <Text
+                style={
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
+                    "marginTop": 40,
+                    "textAlign": "center",
+                  }
+                }
+              >
+                Retrouve toutes les offres autour de chez toi en activant les données de localisation.
+              </Text>
+              <Text
+                style={
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
+                    "marginTop": 16,
+                    "textAlign": "center",
+                  }
+                }
+              >
+                Tu peux activer ou désactiver cette fonctionnalité dans les paramètres de localisation de ton téléphone.
+              </Text>
+              <View
+                style={
+                  {
+                    "marginTop": 24,
+                  }
+                }
+              >
+                <View
+                  accessibilityLabel="Activer la géolocalisation"
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "alignItems": "center",
+                          "alignSelf": "center",
+                          "backgroundColor": "#6123df",
+                          "borderBottomLeftRadius": 8,
+                          "borderBottomRightRadius": 8,
+                          "borderColor": "#6123df",
+                          "borderStyle": "solid",
+                          "borderTopLeftRadius": 8,
+                          "borderTopRightRadius": 8,
+                          "borderWidth": 1,
+                          "flexDirection": "row",
+                          "justifyContent": "center",
+                          "paddingBottom": 8,
+                          "paddingLeft": 12,
+                          "paddingRight": 12,
+                          "paddingTop": 8,
+                          "width": "100%",
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Activer la géolocalisation"
+                >
+                  <View
+                    fullWidth={true}
+                    gap={8}
+                    hasIcon={false}
+                    isMultiline={false}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "columnGap": 8,
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                        "width": "100%",
+                      }
+                    }
+                  >
+                    <Text
+                      style={
+                        [
+                          {
+                            "color": "#161617",
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 22,
+                          },
+                          {
+                            "color": "#ffffff",
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                            "maxWidth": "100%",
+                            "minWidth": 0,
+                            "textAlign": "center",
+                          },
+                        ]
+                      }
+                    >
+                      Activer la géolocalisation
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RCTScrollView>
+      </View>
+    </View>
+  </Modal>,
+  <View
+    style={
+      {
+        "backgroundColor": "#ffffff",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "paddingBottom": 16,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "paddingTop": 16,
+          "width": "100%",
+        }
+      }
+    >
+      <View
+        marginTop={0}
+        style={
+          {
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "marginTop": 0,
+            "width": "100%",
+          }
+        }
+        testID="modalHeader"
+      >
+        <View
+          justifyContent="left"
+          style={
+            {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "height": 28,
+              "justifyContent": "flex-start",
+              "width": 28,
+            }
+          }
+        />
+        <View
+          style={
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "justifyContent": "center",
+              "paddingHorizontal": 12,
+              "zIndex": 1,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="header"
+            style={
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 17,
+                "lineHeight": 27.2,
+                "textAlign": "center",
+              }
+            }
+            testID="modalHeaderTitle"
+          >
+            Localisation
+          </Text>
+        </View>
+        <View
+          justifyContent="right"
+          style={
+            {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "height": 28,
+              "justifyContent": "flex-end",
+              "width": 28,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Fermer la modale"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "paddingBottom": 8,
+                    "paddingLeft": 8,
+                    "paddingRight": 8,
+                    "paddingTop": 8,
+                    "width": "auto",
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Fermer la modale"
+          >
+            <View
+              gap={0}
+              hasIcon={true}
+              isMultiline={false}
+              style={
+                {
+                  "alignItems": "center",
+                  "columnGap": 0,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                jestAnimatedProps={
+                  {
+                    "value": {},
+                  }
+                }
+                jestAnimatedStyle={
+                  {
+                    "value": {},
+                  }
+                }
+                jestInlineStyle={
+                  {
+                    "flexShrink": 0,
+                  }
+                }
+                nativeID="1"
+                style={
+                  [
+                    {
+                      "flexShrink": 0,
+                    },
+                  ]
+                }
+              >
+                <View
+                  height={22}
+                  testID="rightIcon"
+                  width={22}
+                >
+                  <Text>
+                    rightIcon-SVG-Mock
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <RCTScrollView
+      keyboardShouldPersistTaps="handled"
+      style={
+        {
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "marginTop": 24,
+          "paddingHorizontal": 24,
+        }
+      }
+    >
+      <View>
+        <View
+          accessibilityRole="none"
+          style={
+            {
+              "gap": 8,
+            }
+          }
+          useFlatList={false}
+        >
+          <View
+            style={
+              {
+                "gap": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                }
+              }
+            >
+              Sélectionne ta localisation
+            </Text>
+          </View>
+          <View
+            display="vertical"
+            style={
+              {
+                "flexDirection": "column",
+                "flexWrap": "nowrap",
+                "gap": 8,
+              }
+            }
+            variant="detailed"
+          >
+            <View
+              collapsable={false}
+              jestAnimatedProps={
+                {
+                  "value": {},
+                }
+              }
+              jestAnimatedStyle={
+                {
+                  "value": {},
+                }
+              }
+              jestInlineStyle={
+                {
+                  "overflow": "hidden",
+                }
+              }
+              layout={
+                LinearTransition {
+                  "build": [Function],
+                  "durationV": 250,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              nativeID="2"
+              style={
+                [
+                  {
+                    "overflow": "hidden",
+                  },
+                ]
+              }
+            >
+              <View
+                collapsed={null}
+                isHover={false}
+                radioState={
+                  {
+                    "disabled": false,
+                    "error": false,
+                    "selected": false,
+                  }
+                }
+                sizing="fill"
+                style={
+                  {
+                    "backgroundColor": "#ffffff",
+                    "borderBottomLeftRadius": 8,
+                    "borderBottomRightRadius": 8,
+                    "borderColor": "#90949d",
+                    "borderTopLeftRadius": 8,
+                    "borderTopRightRadius": 8,
+                    "borderWidth": 1,
+                    "paddingBottom": 16,
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                    "paddingTop": 16,
+                    "width": "100%",
+                  }
+                }
+                variant="detailed"
+              >
+                <View
+                  accessibilityLabel="Sélectionne ta localisation - Liste - Élément 1 sur 2 - Utiliser ma position actuelle - non sélectionné"
+                  accessibilityRole="radio"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "alignItems": "center",
+                          "columnGap": 12,
+                          "flexDirection": "row",
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Sélectionne ta localisation - Liste - Élément 1 sur 2 - Utiliser ma position actuelle - non sélectionné"
+                >
+                  <View
+                    isHover={false}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    radioState={
+                      {
+                        "disabled": false,
+                        "error": false,
+                        "selected": false,
+                      }
+                    }
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderBottomLeftRadius": 20,
+                        "borderBottomRightRadius": 20,
+                        "borderColor": "#90949d",
+                        "borderTopLeftRadius": 20,
+                        "borderTopRightRadius": 20,
+                        "borderWidth": 2,
+                        "height": 20,
+                        "justifyContent": "center",
+                        "width": 20,
+                      }
+                    }
+                    variant="detailed"
+                  />
+                  <View
+                    style={
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      isHover={false}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      radioState={
+                        {
+                          "disabled": false,
+                          "error": false,
+                          "selected": false,
+                        }
+                      }
+                      style={
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        }
+                      }
+                    >
+                      Utiliser ma position actuelle
+                    </Text>
+                  </View>
+                  <View
+                    style={
+                      {
+                        "justifyContent": "center",
+                      }
+                    }
+                  >
+                    <View
+                      fill="none"
+                      height={32}
+                      width={32}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              jestAnimatedProps={
+                {
+                  "value": {},
+                }
+              }
+              jestAnimatedStyle={
+                {
+                  "value": {},
+                }
+              }
+              jestInlineStyle={
+                {
+                  "overflow": "hidden",
+                }
+              }
+              layout={
+                LinearTransition {
+                  "build": [Function],
+                  "durationV": 250,
+                  "randomizeDelay": false,
+                  "reduceMotionV": "system",
+                }
+              }
+              nativeID="3"
+              style={
+                [
+                  {
+                    "overflow": "hidden",
+                  },
+                ]
+              }
+            >
+              <View
+                collapsed={null}
+                isHover={false}
+                radioState={
+                  {
+                    "disabled": false,
+                    "error": false,
+                    "selected": false,
+                  }
+                }
+                sizing="fill"
+                style={
+                  {
+                    "backgroundColor": "#ffffff",
+                    "borderBottomLeftRadius": 8,
+                    "borderBottomRightRadius": 8,
+                    "borderColor": "#90949d",
+                    "borderTopLeftRadius": 8,
+                    "borderTopRightRadius": 8,
+                    "borderWidth": 1,
+                    "paddingBottom": 16,
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                    "paddingTop": 16,
+                    "width": "100%",
+                  }
+                }
+                variant="detailed"
+              >
+                <View
+                  accessibilityLabel="Sélectionne ta localisation - Liste - Élément 2 sur 2 - Choisir une zone géographique - Ville, code postal, adresse - non sélectionné"
+                  accessibilityRole="radio"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "alignItems": "center",
+                          "columnGap": 12,
+                          "flexDirection": "row",
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Sélectionne ta localisation - Liste - Élément 2 sur 2 - Choisir une zone géographique - Ville, code postal, adresse - non sélectionné"
+                >
+                  <View
+                    isHover={false}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    radioState={
+                      {
+                        "disabled": false,
+                        "error": false,
+                        "selected": false,
+                      }
+                    }
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderBottomLeftRadius": 20,
+                        "borderBottomRightRadius": 20,
+                        "borderColor": "#90949d",
+                        "borderTopLeftRadius": 20,
+                        "borderTopRightRadius": 20,
+                        "borderWidth": 2,
+                        "height": 20,
+                        "justifyContent": "center",
+                        "width": 20,
+                      }
+                    }
+                    variant="detailed"
+                  />
+                  <View
+                    style={
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      isHover={false}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      radioState={
+                        {
+                          "disabled": false,
+                          "error": false,
+                          "selected": false,
+                        }
+                      }
+                      style={
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        }
+                      }
+                    >
+                      Choisir une zone géographique
+                    </Text>
+                    <Text
+                      isHover={false}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      radioState={
+                        {
+                          "disabled": false,
+                          "error": false,
+                          "selected": false,
+                        }
+                      }
+                      style={
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        }
+                      }
+                    >
+                      Ville, code postal, adresse
+                    </Text>
+                  </View>
+                  <View
+                    style={
+                      {
+                        "justifyContent": "center",
+                      }
+                    }
+                  >
+                    <View
+                      fill="none"
+                      height={32}
+                      width={32}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+    <View
+      style={
+        {
+          "paddingBottom": 32,
+        }
+      }
+    >
+      <View
+        paddingBottom={0}
+        style={
+          {
+            "alignItems": "center",
+            "paddingHorizontal": 24,
+            "paddingTop": 8,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Valider et voir sur la carte"
           accessibilityRole="button"
           accessibilityState={
             {
@@ -124,15 +1142,22 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
                 },
                 {
                   "alignItems": "center",
-                  "backgroundColor": "transparent",
-                  "borderWidth": 0,
+                  "alignSelf": "center",
+                  "backgroundColor": "#6123df",
+                  "borderBottomLeftRadius": 8,
+                  "borderBottomRightRadius": 8,
+                  "borderColor": "#6123df",
+                  "borderStyle": "solid",
+                  "borderTopLeftRadius": 8,
+                  "borderTopRightRadius": 8,
+                  "borderWidth": 1,
                   "flexDirection": "row",
                   "justifyContent": "center",
                   "paddingBottom": 8,
-                  "paddingLeft": 8,
-                  "paddingRight": 8,
+                  "paddingLeft": 12,
+                  "paddingRight": 12,
                   "paddingTop": 8,
-                  "width": "auto",
+                  "width": "100%",
                 },
               ],
               {
@@ -140,649 +1165,59 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
               },
             ]
           }
-          testID="Fermer la modale"
+          testID="Valider et voir sur la carte"
         >
           <View
-            gap={0}
-            hasIcon={true}
+            fullWidth={true}
+            gap={8}
+            hasIcon={false}
             isMultiline={false}
             style={
               {
                 "alignItems": "center",
-                "columnGap": 0,
+                "columnGap": 8,
                 "flexDirection": "row",
+                "justifyContent": "center",
+                "width": "100%",
               }
             }
           >
-            <View
-              collapsable={false}
-              jestAnimatedProps={
-                {
-                  "value": {},
-                }
-              }
-              jestAnimatedStyle={
-                {
-                  "value": {},
-                }
-              }
-              jestInlineStyle={
-                {
-                  "flexShrink": 0,
-                }
-              }
-              nativeID="0"
+            <Text
               style={
                 [
                   {
-                    "flexShrink": 0,
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  {
+                    "color": "#ffffff",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "maxWidth": "100%",
+                    "minWidth": 0,
+                    "textAlign": "center",
                   },
                 ]
               }
             >
-              <View
-                height={22}
-                testID="rightIcon"
-                width={22}
-              >
-                <Text>
-                  rightIcon-SVG-Mock
-                </Text>
-              </View>
-            </View>
+              Valider et voir sur la carte
+            </Text>
           </View>
         </View>
       </View>
     </View>
-  </View>
-  <RCTScrollView
-    keyboardShouldPersistTaps="handled"
-    style={
-      {
-        "flexBasis": 0,
-        "flexGrow": 1,
-        "flexShrink": 1,
-        "marginTop": 24,
-        "paddingHorizontal": 24,
-      }
-    }
-  >
-    <View>
-      <View
-        accessibilityRole="none"
-        style={
-          {
-            "gap": 8,
-          }
-        }
-        useFlatList={false}
-      >
-        <View
-          style={
-            {
-              "gap": 4,
-            }
-          }
-        >
-          <Text
-            style={
-              {
-                "color": "#161617",
-                "fontFamily": "Montserrat-Medium",
-                "fontSize": 16,
-                "lineHeight": 25.6,
-              }
-            }
-          >
-            Sélectionne ta localisation
-          </Text>
-        </View>
-        <View
-          display="vertical"
-          style={
-            {
-              "flexDirection": "column",
-              "flexWrap": "nowrap",
-              "gap": 8,
-            }
-          }
-          variant="detailed"
-        >
-          <View
-            collapsable={false}
-            jestAnimatedProps={
-              {
-                "value": {},
-              }
-            }
-            jestAnimatedStyle={
-              {
-                "value": {},
-              }
-            }
-            jestInlineStyle={
-              {
-                "overflow": "hidden",
-              }
-            }
-            layout={
-              LinearTransition {
-                "build": [Function],
-                "durationV": 250,
-                "randomizeDelay": false,
-                "reduceMotionV": "system",
-              }
-            }
-            nativeID="1"
-            style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-              ]
-            }
-          >
-            <View
-              collapsed={null}
-              isHover={false}
-              radioState={
-                {
-                  "disabled": false,
-                  "error": false,
-                  "selected": false,
-                }
-              }
-              sizing="fill"
-              style={
-                {
-                  "backgroundColor": "#ffffff",
-                  "borderBottomLeftRadius": 8,
-                  "borderBottomRightRadius": 8,
-                  "borderColor": "#90949d",
-                  "borderTopLeftRadius": 8,
-                  "borderTopRightRadius": 8,
-                  "borderWidth": 1,
-                  "paddingBottom": 16,
-                  "paddingLeft": 16,
-                  "paddingRight": 16,
-                  "paddingTop": 16,
-                  "width": "100%",
-                }
-              }
-              variant="detailed"
-            >
-              <View
-                accessibilityLabel="Sélectionne ta localisation - Liste - Élément 1 sur 2 - Utiliser ma position actuelle - non sélectionné"
-                accessibilityRole="radio"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "alignItems": "center",
-                        "columnGap": 12,
-                        "flexDirection": "row",
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Sélectionne ta localisation - Liste - Élément 1 sur 2 - Utiliser ma position actuelle - non sélectionné"
-              >
-                <View
-                  isHover={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  radioState={
-                    {
-                      "disabled": false,
-                      "error": false,
-                      "selected": false,
-                    }
-                  }
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "#ffffff",
-                      "borderBottomLeftRadius": 20,
-                      "borderBottomRightRadius": 20,
-                      "borderColor": "#90949d",
-                      "borderTopLeftRadius": 20,
-                      "borderTopRightRadius": 20,
-                      "borderWidth": 2,
-                      "height": 20,
-                      "justifyContent": "center",
-                      "width": 20,
-                    }
-                  }
-                  variant="detailed"
-                />
-                <View
-                  style={
-                    {
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                    }
-                  }
-                >
-                  <Text
-                    isHover={false}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    radioState={
-                      {
-                        "disabled": false,
-                        "error": false,
-                        "selected": false,
-                      }
-                    }
-                    style={
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                  >
-                    Utiliser ma position actuelle
-                  </Text>
-                </View>
-                <View
-                  style={
-                    {
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    fill="none"
-                    height={32}
-                    width={32}
-                  >
-                    <Text>
-                      undefined-SVG-Mock
-                    </Text>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            collapsable={false}
-            jestAnimatedProps={
-              {
-                "value": {},
-              }
-            }
-            jestAnimatedStyle={
-              {
-                "value": {},
-              }
-            }
-            jestInlineStyle={
-              {
-                "overflow": "hidden",
-              }
-            }
-            layout={
-              LinearTransition {
-                "build": [Function],
-                "durationV": 250,
-                "randomizeDelay": false,
-                "reduceMotionV": "system",
-              }
-            }
-            nativeID="2"
-            style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-              ]
-            }
-          >
-            <View
-              collapsed={null}
-              isHover={false}
-              radioState={
-                {
-                  "disabled": false,
-                  "error": false,
-                  "selected": false,
-                }
-              }
-              sizing="fill"
-              style={
-                {
-                  "backgroundColor": "#ffffff",
-                  "borderBottomLeftRadius": 8,
-                  "borderBottomRightRadius": 8,
-                  "borderColor": "#90949d",
-                  "borderTopLeftRadius": 8,
-                  "borderTopRightRadius": 8,
-                  "borderWidth": 1,
-                  "paddingBottom": 16,
-                  "paddingLeft": 16,
-                  "paddingRight": 16,
-                  "paddingTop": 16,
-                  "width": "100%",
-                }
-              }
-              variant="detailed"
-            >
-              <View
-                accessibilityLabel="Sélectionne ta localisation - Liste - Élément 2 sur 2 - Choisir une zone géographique - Ville, code postal, adresse - non sélectionné"
-                accessibilityRole="radio"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "alignItems": "center",
-                        "columnGap": 12,
-                        "flexDirection": "row",
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
-                }
-                testID="Sélectionne ta localisation - Liste - Élément 2 sur 2 - Choisir une zone géographique - Ville, code postal, adresse - non sélectionné"
-              >
-                <View
-                  isHover={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  radioState={
-                    {
-                      "disabled": false,
-                      "error": false,
-                      "selected": false,
-                    }
-                  }
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "#ffffff",
-                      "borderBottomLeftRadius": 20,
-                      "borderBottomRightRadius": 20,
-                      "borderColor": "#90949d",
-                      "borderTopLeftRadius": 20,
-                      "borderTopRightRadius": 20,
-                      "borderWidth": 2,
-                      "height": 20,
-                      "justifyContent": "center",
-                      "width": 20,
-                    }
-                  }
-                  variant="detailed"
-                />
-                <View
-                  style={
-                    {
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                    }
-                  }
-                >
-                  <Text
-                    isHover={false}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    radioState={
-                      {
-                        "disabled": false,
-                        "error": false,
-                        "selected": false,
-                      }
-                    }
-                    style={
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      }
-                    }
-                  >
-                    Choisir une zone géographique
-                  </Text>
-                  <Text
-                    isHover={false}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    radioState={
-                      {
-                        "disabled": false,
-                        "error": false,
-                        "selected": false,
-                      }
-                    }
-                    style={
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 12,
-                        "lineHeight": 19.2,
-                      }
-                    }
-                  >
-                    Ville, code postal, adresse
-                  </Text>
-                </View>
-                <View
-                  style={
-                    {
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    fill="none"
-                    height={32}
-                    width={32}
-                  >
-                    <Text>
-                      undefined-SVG-Mock
-                    </Text>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </RCTScrollView>
-  <View
-    style={
-      {
-        "paddingBottom": 32,
-      }
-    }
-  >
     <View
-      paddingBottom={0}
+      customHeight={8}
+      enable={true}
       style={
         {
-          "alignItems": "center",
-          "paddingHorizontal": 24,
-          "paddingTop": 8,
+          "height": 8,
         }
       }
-    >
-      <View
-        accessibilityLabel="Valider et voir sur la carte"
-        accessibilityRole="button"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": false,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          [
-            [
-              {
-                "userSelect": "auto",
-              },
-              {
-                "alignItems": "center",
-                "alignSelf": "center",
-                "backgroundColor": "#6123df",
-                "borderBottomLeftRadius": 8,
-                "borderBottomRightRadius": 8,
-                "borderColor": "#6123df",
-                "borderStyle": "solid",
-                "borderTopLeftRadius": 8,
-                "borderTopRightRadius": 8,
-                "borderWidth": 1,
-                "flexDirection": "row",
-                "justifyContent": "center",
-                "paddingBottom": 8,
-                "paddingLeft": 12,
-                "paddingRight": 12,
-                "paddingTop": 8,
-                "width": "100%",
-              },
-            ],
-            {
-              "opacity": 1,
-            },
-          ]
-        }
-        testID="Valider et voir sur la carte"
-      >
-        <View
-          fullWidth={true}
-          gap={8}
-          hasIcon={false}
-          isMultiline={false}
-          style={
-            {
-              "alignItems": "center",
-              "columnGap": 8,
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "width": "100%",
-            }
-          }
-        >
-          <Text
-            style={
-              [
-                {
-                  "color": "#161617",
-                  "fontFamily": "Montserrat-SemiBold",
-                  "fontSize": 16,
-                  "lineHeight": 22,
-                },
-                {
-                  "color": "#ffffff",
-                  "flexBasis": 0,
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "maxWidth": "100%",
-                  "minWidth": 0,
-                  "textAlign": "center",
-                },
-              ]
-            }
-          >
-            Valider et voir sur la carte
-          </Text>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    customHeight={8}
-    enable={true}
-    style={
-      {
-        "height": 8,
-      }
-    }
-  />
-</View>
+    />
+  </View>,
+]
 `;

--- a/__snapshots__/libs/location/components/GeolocationActivationModal.native.test.tsx.native-snap
+++ b/__snapshots__/libs/location/components/GeolocationActivationModal.native.test.tsx.native-snap
@@ -3,7 +3,7 @@
 exports[`GeolocationActivationModal should render properly 1`] = `
 <Modal
   animationType="fade"
-  onRequestClose={[Function]}
+  onRequestClose={[MockFunction]}
   statusBarTranslucent={true}
   testID="modal-geoloc-permission-modal"
   transparent={true}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,6 @@ import { initAlgoliaAnalytics } from 'libs/algolia/analytics/initAlgoliaAnalytic
 import { env } from 'libs/environment/env'
 import { AnalyticsInitializer } from 'libs/firebase/analytics/AnalyticsInitializer'
 import { FirestoreNetworkObserver } from 'libs/firebase/firestore/FirestoreNetworkObserver/FirestoreNetworkObserver'
-import { GeolocationActivationModal } from 'libs/location/components/GeolocationActivationModal'
 import { initLocation } from 'libs/locationV2/initLocation'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { NetInfoWrapper } from 'libs/network/NetInfoWrapper'
@@ -94,30 +93,27 @@ const App: FunctionComponent = function () {
                 <NetInfoWrapper>
                   <FirestoreNetworkObserver />
                   <AuthWrapper>
-                    <React.Fragment>
-                      <GeolocationActivationModal />
-                      <AccessibilityFiltersWrapper>
-                        <FavoritesWrapper>
-                          <SearchWrapper>
-                            <SnackBarWrapper>
-                              <CulturalSurveyContextProvider>
-                                <SubscriptionContextProvider>
-                                  <SplashScreenProvider>
-                                    <ShareAppWrapper>
-                                      <OfflineModeContainer>
-                                        <ScreenErrorProvider>
-                                          <AppNavigationContainer />
-                                        </ScreenErrorProvider>
-                                      </OfflineModeContainer>
-                                    </ShareAppWrapper>
-                                  </SplashScreenProvider>
-                                </SubscriptionContextProvider>
-                              </CulturalSurveyContextProvider>
-                            </SnackBarWrapper>
-                          </SearchWrapper>
-                        </FavoritesWrapper>
-                      </AccessibilityFiltersWrapper>
-                    </React.Fragment>
+                    <AccessibilityFiltersWrapper>
+                      <FavoritesWrapper>
+                        <SearchWrapper>
+                          <SnackBarWrapper>
+                            <CulturalSurveyContextProvider>
+                              <SubscriptionContextProvider>
+                                <SplashScreenProvider>
+                                  <ShareAppWrapper>
+                                    <OfflineModeContainer>
+                                      <ScreenErrorProvider>
+                                        <AppNavigationContainer />
+                                      </ScreenErrorProvider>
+                                    </OfflineModeContainer>
+                                  </ShareAppWrapper>
+                                </SplashScreenProvider>
+                              </SubscriptionContextProvider>
+                            </CulturalSurveyContextProvider>
+                          </SnackBarWrapper>
+                        </SearchWrapper>
+                      </FavoritesWrapper>
+                    </AccessibilityFiltersWrapper>
                   </AuthWrapper>
                 </NetInfoWrapper>
               </AnalyticsInitializer>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -20,7 +20,6 @@ import { getDeviceInfo } from 'features/trustedDevice/helpers/getDeviceInfo'
 import { initAlgoliaAnalytics } from 'libs/algolia/analytics/initAlgoliaAnalytics'
 import { AppWebHead } from 'libs/appWebHead'
 import { env } from 'libs/environment/env'
-import { GeolocationActivationModal } from 'libs/location/components/GeolocationActivationModal'
 import { initLocation } from 'libs/locationV2/initLocation'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { SafeAreaProvider } from 'libs/react-native-save-area-provider'
@@ -72,27 +71,24 @@ export function App() {
               <GoogleOAuthProvider clientId={env.GOOGLE_CLIENT_ID}>
                 <AuthWrapper>
                   <ErrorBoundary FallbackComponent={AsyncErrorBoundaryWithoutNavigation}>
-                    <React.Fragment>
-                      <GeolocationActivationModal />
-                      <AccessibilityFiltersWrapper>
-                        <FavoritesWrapper>
-                          <SearchWrapper>
-                            <SnackBarWrapper>
-                              <CulturalSurveyContextProvider>
-                                <SubscriptionContextProvider>
-                                  <AppWebHead />
-                                  <ScreenErrorProvider>
-                                    <Suspense fallback={<LoadingPage />}>
-                                      <AppNavigationContainer />
-                                    </Suspense>
-                                  </ScreenErrorProvider>
-                                </SubscriptionContextProvider>
-                              </CulturalSurveyContextProvider>
-                            </SnackBarWrapper>
-                          </SearchWrapper>
-                        </FavoritesWrapper>
-                      </AccessibilityFiltersWrapper>
-                    </React.Fragment>
+                    <AccessibilityFiltersWrapper>
+                      <FavoritesWrapper>
+                        <SearchWrapper>
+                          <SnackBarWrapper>
+                            <CulturalSurveyContextProvider>
+                              <SubscriptionContextProvider>
+                                <AppWebHead />
+                                <ScreenErrorProvider>
+                                  <Suspense fallback={<LoadingPage />}>
+                                    <AppNavigationContainer />
+                                  </Suspense>
+                                </ScreenErrorProvider>
+                              </SubscriptionContextProvider>
+                            </CulturalSurveyContextProvider>
+                          </SnackBarWrapper>
+                        </SearchWrapper>
+                      </FavoritesWrapper>
+                    </AccessibilityFiltersWrapper>
                   </ErrorBoundary>
                 </AuthWrapper>
               </GoogleOAuthProvider>

--- a/src/features/location/components/HomeLocationModal.native.test.tsx
+++ b/src/features/location/components/HomeLocationModal.native.test.tsx
@@ -10,7 +10,7 @@ import { checkGeolocPermission, GeolocPermissionState } from 'libs/location/loca
 import { initLocation } from 'libs/locationV2/initLocation'
 import { SuggestedPlace } from 'libs/place/types'
 import { MODAL_TO_SHOW_TIME } from 'tests/constants'
-import { act, fireEvent, render, screen, userEvent } from 'tests/utils'
+import { act, fireEvent, render, screen, userEvent, within } from 'tests/utils'
 
 jest.useFakeTimers()
 
@@ -93,7 +93,14 @@ describe('HomeLocationModal', () => {
       jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
     })
 
-    await user.press(screen.getByLabelText('Fermer la modale'))
+    const geolocModal = screen.getByTestId('modal-geoloc-permission-modal')
+    const geolocCloseButton = within(geolocModal).getByLabelText('Fermer la modale')
+    const closeButtons = screen.getAllByLabelText('Fermer la modale')
+    const locationModalCloseButton = closeButtons.find((button) => button !== geolocCloseButton)
+
+    expect(locationModalCloseButton).toBeTruthy()
+
+    await user.press(locationModalCloseButton as NonNullable<typeof locationModalCloseButton>)
 
     expect(goBack).toHaveBeenCalledTimes(1)
   })

--- a/src/features/location/components/HomeLocationModal.native.test.tsx
+++ b/src/features/location/components/HomeLocationModal.native.test.tsx
@@ -100,6 +100,8 @@ describe('HomeLocationModal', () => {
 
     expect(locationModalCloseButton).toBeTruthy()
 
+    goBack.mockClear()
+
     await user.press(locationModalCloseButton as NonNullable<typeof locationModalCloseButton>)
 
     expect(goBack).toHaveBeenCalledTimes(1)

--- a/src/features/location/components/ModalScreenWrapper.web.tsx
+++ b/src/features/location/components/ModalScreenWrapper.web.tsx
@@ -1,10 +1,15 @@
 import React, { useState } from 'react'
 import { Pressable, StyleSheet } from 'react-native'
-import { Easing, FadeIn, FadeOut, SlideInDown, SlideOutDown } from 'react-native-reanimated'
+import Animated, {
+  Easing,
+  FadeIn,
+  FadeOut,
+  SlideInDown,
+  SlideOutDown,
+} from 'react-native-reanimated'
 import { scheduleOnRN } from 'react-native-worklets'
 import styled from 'styled-components/native'
 
-import Animated from 'libs/react-native-reanimated'
 import { useEscapeKeyAction } from 'ui/hooks/useEscapeKeyAction'
 
 import { ModalScreenWrapperProps } from './ModalScreenWrapper'
@@ -43,7 +48,7 @@ export const ModalScreenWrapper = ({ onClose, children }: ModalScreenWrapperProp
             entering={BACKDROP_ENTERING}
             exiting={BACKDROP_EXITING}
             onPress={closeWithTransition}
-            accessibilityLabel="Fermer la modale"
+            accessibilityLabel="Fermer la modale en touchant l’arrière-plan"
           />
           <ModalContainer entering={MODAL_ENTERING} exiting={createModalExiting(onClose)}>
             {children(closeWithTransition)}

--- a/src/features/location/components/SearchLocationModal.native.test.tsx
+++ b/src/features/location/components/SearchLocationModal.native.test.tsx
@@ -16,7 +16,7 @@ import { LocationMode } from 'libs/location/types'
 import { initLocation } from 'libs/locationV2/initLocation'
 import { SuggestedPlace } from 'libs/place/types'
 import { MODAL_TO_SHOW_TIME } from 'tests/constants'
-import { act, fireEvent, render, screen, userEvent } from 'tests/utils'
+import { act, fireEvent, render, screen, userEvent, within } from 'tests/utils'
 
 jest.useFakeTimers()
 
@@ -113,7 +113,14 @@ describe('SearchLocationModal', () => {
       jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
     })
 
-    await user.press(screen.getByLabelText('Fermer la modale'))
+    const geolocModal = screen.getByTestId('modal-geoloc-permission-modal')
+    const geolocCloseButton = within(geolocModal).getByLabelText('Fermer la modale')
+    const closeButtons = screen.getAllByLabelText('Fermer la modale')
+    const locationModalCloseButton = closeButtons.find((button) => button !== geolocCloseButton)
+
+    expect(locationModalCloseButton).toBeTruthy()
+
+    await user.press(locationModalCloseButton as NonNullable<typeof locationModalCloseButton>)
 
     expect(goBack).toHaveBeenCalledTimes(1)
   })

--- a/src/features/location/components/SearchLocationModal.native.test.tsx
+++ b/src/features/location/components/SearchLocationModal.native.test.tsx
@@ -14,6 +14,7 @@ import { requestGeolocPermission } from 'libs/location/geolocation/requestGeoloc
 import { checkGeolocPermission, GeolocPermissionState } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
 import { initLocation } from 'libs/locationV2/initLocation'
+import { locationActions } from 'libs/locationV2/location.store'
 import { SuggestedPlace } from 'libs/place/types'
 import { MODAL_TO_SHOW_TIME } from 'tests/constants'
 import { act, fireEvent, render, screen, userEvent, within } from 'tests/utils'
@@ -72,6 +73,7 @@ const user = userEvent.setup()
 
 describe('SearchLocationModal', () => {
   beforeEach(() => {
+    locationActions.setPermissionState(GeolocPermissionState.GRANTED)
     initLocation()
   })
 
@@ -119,6 +121,8 @@ describe('SearchLocationModal', () => {
     const locationModalCloseButton = closeButtons.find((button) => button !== geolocCloseButton)
 
     expect(locationModalCloseButton).toBeTruthy()
+
+    goBack.mockClear()
 
     await user.press(locationModalCloseButton as NonNullable<typeof locationModalCloseButton>)
 

--- a/src/features/location/components/VenueMapLocationModal.native.test.tsx
+++ b/src/features/location/components/VenueMapLocationModal.native.test.tsx
@@ -15,7 +15,7 @@ import { initLocation } from 'libs/locationV2/initLocation'
 import { locationActions } from 'libs/locationV2/location.store'
 import { SuggestedPlace } from 'libs/place/types'
 import { MODAL_TO_SHOW_TIME } from 'tests/constants'
-import { act, fireEvent, render, screen, userEvent } from 'tests/utils'
+import { act, fireEvent, render, screen, userEvent, within } from 'tests/utils'
 
 jest.useFakeTimers()
 
@@ -111,7 +111,14 @@ describe('VenueMapLocationModal', () => {
       jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
     })
 
-    await user.press(screen.getByLabelText('Fermer la modale'))
+    const geolocModal = screen.getByTestId('modal-geoloc-permission-modal')
+    const geolocCloseButton = within(geolocModal).getByLabelText('Fermer la modale')
+    const closeButtons = screen.getAllByLabelText('Fermer la modale')
+    const locationModalCloseButton = closeButtons.find((button) => button !== geolocCloseButton)
+
+    expect(locationModalCloseButton).toBeTruthy()
+
+    await user.press(locationModalCloseButton as NonNullable<typeof locationModalCloseButton>)
 
     expect(goBack).toHaveBeenCalledTimes(1)
   })

--- a/src/features/location/components/VenueMapLocationModal.native.test.tsx
+++ b/src/features/location/components/VenueMapLocationModal.native.test.tsx
@@ -118,6 +118,8 @@ describe('VenueMapLocationModal', () => {
 
     expect(locationModalCloseButton).toBeTruthy()
 
+    goBack.mockClear()
+
     await user.press(locationModalCloseButton as NonNullable<typeof locationModalCloseButton>)
 
     expect(goBack).toHaveBeenCalledTimes(1)

--- a/src/features/navigation/navigators/RootNavigator/RootStackNavigator.tsx
+++ b/src/features/navigation/navigators/RootNavigator/RootStackNavigator.tsx
@@ -73,6 +73,7 @@ import { Venue } from 'features/venue/pages/Venue/Venue'
 import { VenuePreviewCarousel } from 'features/venue/pages/VenuePreviewCarousel/VenuePreviewCarousel'
 import { VenueMap } from 'features/venueMap/pages/VenueMap/VenueMap'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import { GeolocationActivationModal } from 'libs/location/components/GeolocationActivationModal'
 import { useSplashScreenContext } from 'libs/splashscreen/splashscreen'
 import { storage } from 'libs/storage'
 import { VerticalPlaylistArtists } from 'shared/verticalPlaylist/pages/VerticalPlaylistArtists'
@@ -416,6 +417,13 @@ const rootScreens: RouteConfig[] = [
     name: 'VenueMapLocationModal',
     component: VenueMapLocationModal,
     options: MODAL_SCREEN_OPTIONS,
+  },
+  {
+    name: 'GeolocationActivationModal',
+    component: GeolocationActivationModal,
+    options: {
+      presentation: 'transparentModal',
+    },
   },
 ]
 

--- a/src/features/navigation/navigators/RootNavigator/types.ts
+++ b/src/features/navigation/navigators/RootNavigator/types.ts
@@ -352,6 +352,7 @@ export type RootStackParamList = {
     openedFrom: Referrals
     shouldOpenMapInTab?: boolean
   }
+  GeolocationActivationModal: undefined
 } & TrustedDeviceRootStackParamList
 
 export type AllNavParamList = RootStackParamList &

--- a/src/features/offer/components/VenueSelectionModal/VenueSelectionModal.native.test.tsx
+++ b/src/features/offer/components/VenueSelectionModal/VenueSelectionModal.native.test.tsx
@@ -20,6 +20,10 @@ const mockRequestOSGeolocPermission = jest.mocked(requestOSGeolocPermission)
 
 jest.mock('libs/locationV2/syncLocation')
 
+jest.mock('features/navigation/navigationRef', () => ({
+  navigationRef: { navigate: jest.fn() },
+}))
+
 jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   return function createAnimatedComponent(Component: unknown) {
     return Component
@@ -216,7 +220,7 @@ describe('<VenueSelectionModal />', () => {
       expect(screen.getByText('Active ta géolocalisation')).toBeOnTheScreen()
     })
 
-    it('should open "Paramètres de localisation" modal when pressing "Active ta géolocalisation" button and permission is never ask again', async () => {
+    it('should navigate to "Paramètres de localisation" modal when pressing "Active ta géolocalisation" button and permission is never ask again', async () => {
       mockRequestOSGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.NEVER_ASK_AGAIN)
 
       render(
@@ -241,37 +245,12 @@ describe('<VenueSelectionModal />', () => {
 
       await user.press(button)
 
-      await waitFor(() => expect(locationSelectors.selectIsPermissionModalVisible()).toBe(true))
-    })
-
-    it('should close geolocation modal when pressing "Activer la géolocalisation"', async () => {
-      mockRequestOSGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.NEVER_ASK_AGAIN)
-
-      render(
-        <VenueSelectionModal
-          headerMessage=""
-          subTitle=""
-          rightIconAccessibilityLabel=""
-          validateButtonLabel=""
-          isVisible
-          items={items}
-          title="Lieu de retrait"
-          onSubmit={jest.fn()}
-          onClosePress={jest.fn()}
-          nbLoadedHits={nbLoadedHits}
-          nbHits={nbHits}
-          isFetchingNextPage
-          isSharingLocation={false}
-          onEndReached={jest.fn()}
-        />
+      const { navigationRef } = jest.requireMock('features/navigation/navigationRef') as {
+        navigationRef: { navigate: jest.Mock }
+      }
+      await waitFor(() =>
+        expect(navigationRef.navigate).toHaveBeenCalledWith('GeolocationActivationModal')
       )
-      const button = screen.getByText('Active ta géolocalisation')
-
-      await user.press(button)
-
-      await user.press(screen.getByText('Activer la géolocalisation'))
-
-      expect(locationSelectors.selectIsPermissionModalVisible()).toBe(false)
     })
   })
 

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -30,7 +30,6 @@ import { LocationMode } from 'libs/location/types'
 import {
   defaultLocationState,
   locationActions,
-  locationSelectors,
   useLocationV2,
 } from 'libs/locationV2/location.store'
 import { SuggestedPlace } from 'libs/place/types'
@@ -131,6 +130,10 @@ jest.mock('libs/location/geolocation/requestGeolocPermission/requestGeolocPermis
 const mockRequestOSGeolocPermission = jest.mocked(requestOSGeolocPermission)
 
 jest.mock('libs/locationV2/syncLocation')
+
+jest.mock('features/navigation/navigationRef', () => ({
+  navigationRef: { navigate: jest.fn() },
+}))
 
 jest.mock('queries/venueMap/useVenuesInRegionQuery')
 const mockUseVenuesInRegionQuery = useVenuesInRegionQuery as jest.Mock
@@ -328,7 +331,12 @@ describe('SearchResultsContent component', () => {
 
     await user.press(await screen.findByText('Géolocalise-toi'))
 
-    await waitFor(() => expect(locationSelectors.selectIsPermissionModalVisible()).toBe(true))
+    const { navigationRef } = jest.requireMock('features/navigation/navigationRef') as {
+      navigationRef: { navigate: jest.Mock }
+    }
+    await waitFor(() =>
+      expect(navigationRef.navigate).toHaveBeenCalledWith('GeolocationActivationModal')
+    )
   })
 
   it('should not log PerformSearch when there is not search query execution', async () => {

--- a/src/libs/location/components/GeolocationActivationModal.native.test.tsx
+++ b/src/libs/location/components/GeolocationActivationModal.native.test.tsx
@@ -1,17 +1,15 @@
 import React from 'react'
+import { Linking } from 'react-native'
 
 import { analytics } from 'libs/analytics/provider'
 import { GeolocationActivationModal } from 'libs/location/components/GeolocationActivationModal'
-import { GeolocPermissionState } from 'libs/location/location'
-import { locationActions } from 'libs/locationV2/location.store'
 import { render, screen, userEvent } from 'tests/utils'
 
-const onPressGeolocPermissionModalButton = jest.spyOn(locationActions, 'showPermissionModal')
-
-let mockPermissionState = GeolocPermissionState.GRANTED
-jest.mock('libs/location/useLocation', () => ({
-  useLocation: () => ({
-    permissionState: mockPermissionState,
+const mockGoBack = jest.fn()
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as Record<string, unknown>),
+  useNavigation: () => ({
+    goBack: mockGoBack,
   }),
 }))
 
@@ -22,34 +20,33 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 })
 
 const user = userEvent.setup()
-jest.useFakeTimers()
 
 describe('GeolocationActivationModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('should render properly', () => {
-    mockPermissionState = GeolocPermissionState.DENIED
-    locationActions.showPermissionModal()
     renderGeolocationActivationModal()
 
     expect(screen).toMatchSnapshot()
   })
 
-  it('should open settings to activate geoloc when press on "Activer la géolocalisation"', async () => {
-    mockPermissionState = GeolocPermissionState.DENIED
-    locationActions.showPermissionModal()
+  it('should go back when pressing close icon', async () => {
     renderGeolocationActivationModal()
 
-    await user.press(screen.getByText('Activer la géolocalisation'))
+    await user.press(screen.getByLabelText('Fermer la modale'))
 
-    expect(onPressGeolocPermissionModalButton).toHaveBeenCalledTimes(1)
+    expect(mockGoBack).toHaveBeenCalledTimes(1)
   })
 
-  it('should log event deeplinkEnableLocation when press on "Activer la géolocalisation"', async () => {
-    mockPermissionState = GeolocPermissionState.DENIED
-    locationActions.showPermissionModal()
+  it('should open settings to activate geoloc when press on "Activer la géolocalisation"', async () => {
+    jest.spyOn(Linking, 'openSettings').mockResolvedValueOnce(undefined as unknown as void)
     renderGeolocationActivationModal()
 
     await user.press(screen.getByText('Activer la géolocalisation'))
 
+    expect(Linking.openSettings).toHaveBeenCalledTimes(1)
     expect(analytics.logOpenLocationSettings).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/libs/location/components/GeolocationActivationModal.native.test.tsx
+++ b/src/libs/location/components/GeolocationActivationModal.native.test.tsx
@@ -1,17 +1,12 @@
 import React from 'react'
 import { Linking } from 'react-native'
 
+import { goBack } from '__mocks__/@react-navigation/native'
 import { analytics } from 'libs/analytics/provider'
 import { GeolocationActivationModal } from 'libs/location/components/GeolocationActivationModal'
+import { GeolocPermissionState } from 'libs/location/geolocation/enums'
+import { locationActions } from 'libs/locationV2/location.store'
 import { render, screen, userEvent } from 'tests/utils'
-
-const mockGoBack = jest.fn()
-jest.mock('@react-navigation/native', () => ({
-  ...(jest.requireActual('@react-navigation/native') as Record<string, unknown>),
-  useNavigation: () => ({
-    goBack: mockGoBack,
-  }),
-}))
 
 jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   return function createAnimatedComponent(Component: unknown) {
@@ -23,7 +18,8 @@ const user = userEvent.setup()
 
 describe('GeolocationActivationModal', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
+    locationActions.setPermissionState(GeolocPermissionState.DENIED)
+    goBack.mockClear()
   })
 
   it('should render properly', () => {
@@ -37,7 +33,15 @@ describe('GeolocationActivationModal', () => {
 
     await user.press(screen.getByLabelText('Fermer la modale'))
 
-    expect(mockGoBack).toHaveBeenCalledTimes(1)
+    expect(goBack).toHaveBeenCalledTimes(1)
+  })
+
+  it('should go back when permission is granted', () => {
+    locationActions.setPermissionState(GeolocPermissionState.GRANTED)
+
+    renderGeolocationActivationModal()
+
+    expect(goBack).toHaveBeenCalledTimes(1)
   })
 
   it('should open settings to activate geoloc when press on "Activer la géolocalisation"', async () => {

--- a/src/libs/location/components/GeolocationActivationModal.tsx
+++ b/src/libs/location/components/GeolocationActivationModal.tsx
@@ -1,9 +1,10 @@
+import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 import { Linking, Platform } from 'react-native'
 import styled from 'styled-components/native'
 
+import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
-import { locationActions, useLocationV2 } from 'libs/locationV2/location.store'
 import { AppInformationModal } from 'ui/components/modals/AppInformationModal'
 import { Button } from 'ui/designSystem/Button/Button'
 import { LocationPointer as InitialLocationPointer } from 'ui/svg/icons/LocationPointer'
@@ -17,13 +18,13 @@ const informationText = Platform.select({
 const isNative = Platform.OS === 'android' || Platform.OS === 'ios'
 
 export const GeolocationActivationModal: React.FC = () => {
-  const { isPermissionModalVisible } = useLocationV2()
+  const { goBack } = useNavigation<UseNavigationType>()
 
   return (
     <AppInformationModal
       title="Paramètres de localisation"
-      visible={isPermissionModalVisible}
-      onCloseIconPress={locationActions.hidePermissionModal}
+      visible
+      onCloseIconPress={goBack}
       testIdSuffix="geoloc-permission-modal">
       {/** Special case where theme.icons.sizes is not used */}
       <LocationPointer />
@@ -42,7 +43,6 @@ export const GeolocationActivationModal: React.FC = () => {
 
 const onPress = () => {
   void Linking.openSettings()
-  locationActions.hidePermissionModal()
   void analytics.logOpenLocationSettings()
 }
 

--- a/src/libs/location/components/GeolocationActivationModal.tsx
+++ b/src/libs/location/components/GeolocationActivationModal.tsx
@@ -1,10 +1,12 @@
-import { useNavigation } from '@react-navigation/native'
-import React from 'react'
+import { useFocusEffect, useNavigation } from '@react-navigation/native'
+import React, { useCallback } from 'react'
 import { Linking, Platform } from 'react-native'
 import styled from 'styled-components/native'
 
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
+import { GeolocPermissionState } from 'libs/location/geolocation/enums'
+import { locationStore } from 'libs/locationV2/location.store'
 import { AppInformationModal } from 'ui/components/modals/AppInformationModal'
 import { Button } from 'ui/designSystem/Button/Button'
 import { LocationPointer as InitialLocationPointer } from 'ui/svg/icons/LocationPointer'
@@ -19,6 +21,15 @@ const isNative = Platform.OS === 'android' || Platform.OS === 'ios'
 
 export const GeolocationActivationModal: React.FC = () => {
   const { goBack } = useNavigation<UseNavigationType>()
+  const permission = locationStore.hooks.usePermissionState()
+
+  useFocusEffect(
+    useCallback(() => {
+      if (permission === GeolocPermissionState.GRANTED) {
+        goBack()
+      }
+    }, [goBack, permission])
+  )
 
   return (
     <AppInformationModal

--- a/src/libs/location/types.ts
+++ b/src/libs/location/types.ts
@@ -36,7 +36,6 @@ export type UseLocationReturnType = {
   geolocPosition: Position
   geolocPositionError: GeolocationError | null
   permissionState: GeolocPermissionState | null
-  showGeolocPermissionModal: () => void
   selectedLocationMode: LocationMode
   setSelectedLocationMode: (locationMode: LocationMode) => void
   selectedPlace: SuggestedPlace | null

--- a/src/libs/location/useLocation.ts
+++ b/src/libs/location/useLocation.ts
@@ -24,12 +24,7 @@ export const useLocation = (): UseLocationReturnType => {
 
   const { radius: aroundPlaceRadius } = useLocationConfiguration(LocationMode.AROUND_PLACE)
   const place = usePlace()
-  const {
-    setPlace,
-    setAroundPlaceRadius,
-    setAroundMeRadius,
-    showPermissionModal: showGeolocPermissionModal,
-  } = locationActions
+  const { setPlace, setAroundPlaceRadius, setAroundMeRadius } = locationActions
 
   const userLocation = useUserLocation()
 
@@ -40,7 +35,6 @@ export const useLocation = (): UseLocationReturnType => {
     hasGeolocPosition,
     place,
     setPlace,
-    showGeolocPermissionModal,
     selectedLocationMode,
     setSelectedLocationMode: locationActions.setLocationMode,
     onResetPlace: locationModalActions.resetPlace,

--- a/src/libs/locationV2/initLocation.native.test.ts
+++ b/src/libs/locationV2/initLocation.native.test.ts
@@ -67,19 +67,23 @@ describe('initLocation', () => {
       })
     })
 
-    it('should hide permission modal if permission is GRANTED', async () => {
-      locationActions.setLocationMode(LocationMode.EVERYWHERE)
+    it('should update permission state when app becomes active', async () => {
       mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.NEVER_ASK_AGAIN)
 
       initLocation()
-      locationActions.showPermissionModal()
+
+      await waitFor(() => {
+        expect(locationSelectors.selectPermissionState()).toBe(
+          GeolocPermissionState.NEVER_ASK_AGAIN
+        )
+      })
 
       AppState.__triggerChange('inactive')
       mockCheckGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.GRANTED)
       AppState.__triggerChange('active')
 
       await waitFor(() => {
-        expect(locationSelectors.selectIsPermissionModalVisible()).toBe(false)
+        expect(locationSelectors.selectPermissionState()).toBe(GeolocPermissionState.GRANTED)
       })
     })
   })

--- a/src/libs/locationV2/location.store.ts
+++ b/src/libs/locationV2/location.store.ts
@@ -8,7 +8,6 @@ import { createStore } from 'libs/store/createStore'
 export type LocationState = {
   permissionState: GeolocPermissionState | null
   geolocationError: GeolocationError | null
-  isPermissionModalVisible: boolean
   locationMode: LocationMode
   configuration: {
     [LocationMode.AROUND_ME]: {
@@ -39,7 +38,6 @@ export const defaultLocationState: LocationState = {
   locationMode: LocationMode.EVERYWHERE,
   permissionState: null,
   geolocationError: null,
-  isPermissionModalVisible: false,
   configuration: {
     [LocationMode.AROUND_ME]: {
       label: 'Ma position',
@@ -97,16 +95,11 @@ export const locationStore = createStore({
       setPermissionState: (permissionState: GeolocPermissionState | null) => {
         set((state) => ({
           permissionState,
-          ...(permissionsGrantedWhilePermissionModalOpen(state, permissionState) && {
-            isPermissionModalVisible: false,
-          }),
           ...(permissionsRejectedWhileAroundMe(state) && {
             locationMode: LocationMode.EVERYWHERE,
           }),
         }))
       },
-      showPermissionModal: () => set({ isPermissionModalVisible: true }),
-      hidePermissionModal: () => set({ isPermissionModalVisible: false }),
     }
   },
   selectors: {
@@ -133,7 +126,6 @@ export const locationStore = createStore({
 
       return LocationModeToLocationTypeMap[state.locationMode]
     },
-    selectIsPermissionModalVisible: () => (state) => state.isPermissionModalVisible,
     selectLocationLabel: () => (state) => state.configuration[state.locationMode].label,
   },
   options: { persist: true, persistKeys: ['locationMode', 'configuration'] },
@@ -150,11 +142,6 @@ const isRejected = (permission: GeolocPermissionState | null) => {
     permission === GeolocPermissionState.NEVER_ASK_AGAIN
   )
 }
-
-const permissionsGrantedWhilePermissionModalOpen = (
-  state: LocationState,
-  newPermissionState: GeolocPermissionState | null
-) => newPermissionState === GeolocPermissionState.GRANTED && state.isPermissionModalVisible
 
 const permissionsRejectedWhileAroundMe = (state: LocationState) =>
   state.locationMode === LocationMode.AROUND_ME && isRejected(state.permissionState)

--- a/src/libs/locationV2/requestGeolocPermission.native.test.ts
+++ b/src/libs/locationV2/requestGeolocPermission.native.test.ts
@@ -4,6 +4,10 @@ import { locationSelectors } from 'libs/locationV2/location.store'
 import { requestGeolocPermission } from 'libs/locationV2/requestGeolocPermission'
 import { syncLocation } from 'libs/locationV2/syncLocation'
 
+jest.mock('features/navigation/navigationRef', () => ({
+  navigationRef: { navigate: jest.fn() },
+}))
+
 jest.mock('libs/location/geolocation/requestGeolocPermission/requestGeolocPermission')
 const mockRequestOSGeolocPermission = jest.mocked(requestOSGeolocPermission)
 
@@ -29,13 +33,18 @@ describe('requestGeolocPermission', () => {
     expect(onSuccess).toHaveBeenCalledTimes(1)
   })
 
-  it('should show permission modal when permission is NEVER_ASK_AGAIN', async () => {
+  it('should navigate to activation modal when permission is NEVER_ASK_AGAIN', async () => {
     mockRequestOSGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.NEVER_ASK_AGAIN)
     const onSuccess = jest.fn()
 
     await requestGeolocPermission({ onSuccess })
 
-    expect(locationSelectors.selectIsPermissionModalVisible()).toBe(true)
+    const { navigationRef } = jest.requireMock('features/navigation/navigationRef') as {
+      navigationRef: { navigate: jest.Mock }
+    }
+
+    expect(navigationRef.navigate).toHaveBeenCalledWith('GeolocationActivationModal')
+    expect(locationSelectors.selectPermissionState()).toBe(GeolocPermissionState.NEVER_ASK_AGAIN)
     expect(onSuccess).not.toHaveBeenCalled()
   })
 })

--- a/src/libs/locationV2/requestGeolocPermission.ts
+++ b/src/libs/locationV2/requestGeolocPermission.ts
@@ -1,3 +1,4 @@
+import { navigationRef } from 'features/navigation/navigationRef'
 import { GeolocPermissionState } from 'libs/location/geolocation/enums'
 import { requestGeolocPermission as requestOSGeolocPermission } from 'libs/location/geolocation/requestGeolocPermission/requestGeolocPermission'
 import { locationActions } from 'libs/locationV2/location.store'
@@ -17,6 +18,6 @@ export const requestGeolocPermission = async (params: { onSuccess?: () => void }
     return params.onSuccess?.()
   }
   if (permission === GeolocPermissionState.NEVER_ASK_AGAIN) {
-    locationActions.showPermissionModal()
+    navigationRef.navigate('GeolocationActivationModal')
   }
 }

--- a/src/libs/locationV2/syncLocation.native.test.ts
+++ b/src/libs/locationV2/syncLocation.native.test.ts
@@ -2,6 +2,7 @@ import { GeolocPermissionState, GeolocPositionError } from 'libs/location/geoloc
 import { getGeolocPosition } from 'libs/location/geolocation/getGeolocPosition/getGeolocPosition'
 import { GeolocationError, LocationMode } from 'libs/location/types'
 import { locationActions, locationSelectors } from 'libs/locationV2/location.store'
+import { locationModalSelectors } from 'libs/locationV2/locationModal.store'
 import { syncLocation } from 'libs/locationV2/syncLocation'
 
 jest.mock('libs/location/geolocation/getGeolocPosition/getGeolocPosition')
@@ -28,6 +29,14 @@ describe('syncLocation', () => {
       locationSelectors.selectLocationConfiguration(LocationMode.AROUND_ME).geolocation
     ).toEqual(position)
     expect(locationSelectors.selectState().geolocationError).toBeNull()
+  })
+
+  it('should set location mode to EVERYWHERE when permission is not GRANTED', async () => {
+    locationActions.setPermissionState(GeolocPermissionState.DENIED)
+
+    await syncLocation()
+
+    expect(locationModalSelectors.selectLocationMode()).toEqual(LocationMode.EVERYWHERE)
   })
 
   it('should clear position and set error when getGeolocPosition fails', async () => {

--- a/src/libs/locationV2/syncLocation.ts
+++ b/src/libs/locationV2/syncLocation.ts
@@ -1,7 +1,8 @@
 import { GeolocPermissionState } from 'libs/location/geolocation/enums'
 import { getGeolocPosition } from 'libs/location/geolocation/getGeolocPosition/getGeolocPosition'
-import { GeolocationError } from 'libs/location/types'
+import { GeolocationError, LocationMode } from 'libs/location/types'
 import { locationActions, locationSelectors } from 'libs/locationV2/location.store'
+import { locationModalActions } from 'libs/locationV2/locationModal.store'
 
 export const syncLocation = async () => {
   const permission = locationSelectors.selectPermissionState()
@@ -15,5 +16,7 @@ export const syncLocation = async () => {
       locationActions.setGeolocPosition(null)
       locationActions.setGeolocationError(newPositionError?.cause ?? null)
     }
+  } else {
+    locationModalActions.setLocationMode(LocationMode.EVERYWHERE)
   }
 }

--- a/src/shared/Banners/GeolocationBanner.native.test.tsx
+++ b/src/shared/Banners/GeolocationBanner.native.test.tsx
@@ -20,6 +20,10 @@ const mockRequestOSGeolocPermission = jest.mocked(requestOSGeolocPermission)
 
 jest.mock('libs/locationV2/syncLocation')
 
+jest.mock('features/navigation/navigationRef', () => ({
+  navigationRef: { navigate: jest.fn() },
+}))
+
 const user = userEvent.setup()
 jest.useFakeTimers()
 
@@ -43,7 +47,7 @@ describe('<GeolocationBanner />', () => {
     expect(screen.getByTestId('systemBanner')).toBeOnTheScreen()
   })
 
-  it('should open "Paramètres de localisation" modal when pressing button and permission is never ask again', async () => {
+  it('should navigate to "Paramètres de localisation" modal when pressing button and permission is never ask again', async () => {
     mockRequestOSGeolocPermission.mockResolvedValueOnce(GeolocPermissionState.NEVER_ASK_AGAIN)
 
     render(
@@ -59,7 +63,12 @@ describe('<GeolocationBanner />', () => {
 
     await user.press(button)
 
-    await waitFor(() => expect(locationSelectors.selectIsPermissionModalVisible()).toBe(true))
+    const { navigationRef } = jest.requireMock('features/navigation/navigationRef') as {
+      navigationRef: { navigate: jest.Mock }
+    }
+    await waitFor(() =>
+      expect(navigationRef.navigate).toHaveBeenCalledWith('GeolocationActivationModal')
+    )
   })
 
   it('should ask for permission when pressing button and permission is denied', async () => {

--- a/src/ui/designSystem/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/src/ui/designSystem/RadioButtonGroup/RadioButtonGroup.tsx
@@ -149,7 +149,9 @@ export const RadioButtonGroup: FunctionComponent<Props> = ({
 
     return (
       <OptionsContainer display={display} variant={variant}>
-        {options.map((item, index) => renderRadioButton(item, index))}
+        {options.map((item, index) => (
+          <React.Fragment key={item.key}>{renderRadioButton(item, index)}</React.Fragment>
+        ))}
       </OptionsContainer>
     )
   }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42677

## Contexte

La modale de permission n'apparait plus sur IOS depuis que la modale de localisation est passée en navigation.
Cette modale devait être affichée au dessus de la modale de localisation.
La modale de navigation sur ios crée une nouvelle stack séparée de la stack principale.
La modale de permission ne peut pas apparaitre car elle est dans `<App />`, qui est stacké quand la modale de navigation s'ouvre

## Solution

Transformer la modale de permission en modale de navigation corrige le problème.
Cette modale est en dehors de toute vue et peut être appelée n'importe où dans l'app.

## Limites

C'est encore une modale native qui est utilisée dans une modale de navigation. C'est un comportement bizzare que de faire apparaitre une modale native dans une modale de react navigation. Il faudrait designer le même layout en dehors des modales react native et les utiliser directement. Je ne l'ai pas fait ici par manque de temps

Il faut bien tester que le design soit correct sur web, ios et android