### PR TITLE
(PC-42552) fix(analytics): send PerformSearch event on thematic searc…

### DIFF
--- a/src/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx
@@ -3,12 +3,15 @@ import React from 'react'
 
 import { popTo, navigate, useRoute } from '__mocks__/@react-navigation/native'
 import { SearchGroupNameEnumv2 } from 'api/gen'
+import { defaultDisabilitiesProperties } from 'features/accessibility/context/AccessibilityFiltersWrapper'
 import { gtlPlaylistAlgoliaSnapshot } from 'features/gtlPlaylist/fixtures/gtlPlaylistAlgoliaSnapshot'
 import * as useGTLPlaylists from 'features/gtlPlaylist/queries/useGTLPlaylistsQuery'
 import { GtlPlaylistData } from 'features/gtlPlaylist/types'
 import { initialSearchState } from 'features/search/context/reducer'
 import { ISearchContext } from 'features/search/context/SearchWrapper'
 import { ThematicSearch } from 'features/search/pages/ThematicSearch/ThematicSearch'
+import { SearchView } from 'features/search/types'
+import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
@@ -223,6 +226,51 @@ describe('<ThematicSearch/>', () => {
           userLocation: undefined,
         })
       })
+    })
+  })
+
+  describe('PerformSearch log', () => {
+    beforeEach(() => {
+      mockOfferCategoriesParams({ offerCategories: [SearchGroupNameEnumv2.LIVRES] })
+      mockUseLocation.mockReturnValue(defaultUseLocation)
+      mockUseSearchResults.mockReturnValue(defaultUseSearchResults)
+      mockedUseSearch.mockReturnValue({
+        ...defaultUseSearch,
+        searchState: { ...mockSearchState, offerCategories: [SearchGroupNameEnumv2.LIVRES] },
+      })
+    })
+
+    it('should log PerformSearch when search query execution ends', async () => {
+      mockUseSearchResults.mockReturnValueOnce({ ...defaultUseSearchResults, isLoading: true })
+      const { rerender } = render(reactQueryProviderHOC(<ThematicSearch />))
+
+      rerender(reactQueryProviderHOC(<ThematicSearch />))
+      await screen.findByText('Livres')
+
+      expect(analytics.logPerformSearch).toHaveBeenCalledWith(
+        { ...mockSearchState, offerCategories: [SearchGroupNameEnumv2.LIVRES] },
+        defaultDisabilitiesProperties,
+        0,
+        SearchView.Thematic
+      )
+    })
+
+    it('should log PerformSearch only one time when there is search query execution and several re-render', async () => {
+      mockUseSearchResults.mockReturnValueOnce({ ...defaultUseSearchResults, isLoading: true })
+      const { rerender } = render(reactQueryProviderHOC(<ThematicSearch />))
+
+      rerender(reactQueryProviderHOC(<ThematicSearch />))
+      rerender(reactQueryProviderHOC(<ThematicSearch />))
+      await screen.findByText('Livres')
+
+      expect(analytics.logPerformSearch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not log PerformSearch when there is no search query execution', async () => {
+      render(reactQueryProviderHOC(<ThematicSearch />))
+      await screen.findByText('Livres')
+
+      expect(analytics.logPerformSearch).not.toHaveBeenCalled()
     })
   })
 

--- a/src/features/search/pages/ThematicSearch/ThematicSearch.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearch.tsx
@@ -13,13 +13,16 @@ import { VenuePlaylist } from 'features/search/components/VenuePlaylist/VenuePla
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { getSearchVenuePlaylistTitle } from 'features/search/helpers/getSearchVenuePlaylistTitle/getSearchVenuePlaylistTitle'
 import { convertAlgoliaVenue2AlgoliaVenueOfferListItem } from 'features/search/helpers/searchList/getReconciledVenues'
+import { usePrevious } from 'features/search/helpers/usePrevious'
 import { BookPlaylists } from 'features/search/pages/ThematicSearch/Book/BookPlaylists'
 import { CinemaPlaylists } from 'features/search/pages/ThematicSearch/Cinema/CinemaPlaylists'
 import { ConcertsAndFestivalsPlaylists } from 'features/search/pages/ThematicSearch/ConcertsAndFestivals/ConcertsAndFestivalsPlaylists'
 import { FilmsPlaylists } from 'features/search/pages/ThematicSearch/Films/FilmsPlaylists'
 import { MusicPlaylists } from 'features/search/pages/ThematicSearch/Music/MusicPlaylists'
 import { ThematicSearchBar } from 'features/search/pages/ThematicSearch/ThematicSearchBar'
+import { SearchView } from 'features/search/types'
 import { getShouldDisplayGtlPlaylist } from 'features/venue/pages/Venue/getShouldDisplayGtlPlaylist'
+import { analytics } from 'libs/analytics/provider'
 import { useLocation } from 'libs/location/location'
 import { LocationMode } from 'libs/location/types'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
@@ -47,6 +50,8 @@ export const ThematicSearch: React.FC = () => {
   const {
     hits: { venues },
     venuesUserData,
+    nbHits,
+    isLoading,
   } = useSearchResults()
 
   const { searchState, dispatch } = useSearch()
@@ -76,6 +81,14 @@ export const ThematicSearch: React.FC = () => {
     },
     [pageTracking]
   )
+
+  // Execute log only on search fetch completion (same pattern as SearchResultsContent)
+  const previousIsLoading = usePrevious(isLoading)
+  useEffect(() => {
+    if (previousIsLoading && !isLoading) {
+      void analytics.logPerformSearch(searchState, disabilities, nbHits, SearchView.Thematic)
+    }
+  }, [disabilities, isLoading, nbHits, previousIsLoading, searchState])
 
   const shouldDisplayVenuesPlaylist = !searchState.venue && !!venues?.length
 


### PR DESCRIPTION
…h page

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42552

## Context

Sur la page de Recherche, le clic sur une **catégorie principale seule** (niveau 1) mène à la page
`ThematicSearch`, qui n'émettait jamais l'événement `PerformSearch`. L'événement n'était tracké que
lorsque l'utilisateur sélectionnait au moins une sous-catégorie (niveau 2) ou un genre (niveau 3),
car ces parcours aboutissent sur `SearchResults`, seule page qui émettait l'événement.

### Correctif

- `ThematicSearch.tsx` : émission de `PerformSearch` à la fin du fetch de recherche, en reprenant
  le pattern existant de `SearchResultsContent` (transition `isLoading` via `usePrevious`), avec
  `searchView: 'ThematicSearch'`.
- L'événement contient `searchCategories`, `searchId`, les filtres de localisation/accessibilité et
  `searchNbResults`. **Aucun nouveau champ** n'est introduit → pas d'impact sur le schéma BigQuery,
  pas de ticket Analytics Engineering nécessaire.

Les trois niveaux de profondeur sont désormais tous trackés :

| Scénario | Page d'arrivée | PerformSearch |
| :--- | :--- | :---: |
| Catégorie seule (niveau 1) | `ThematicSearch` | ✅ (corrigé) |
| Catégorie + sous-catégorie (niveau 2) | `SearchResults` | ✅ (existant) |
| Catégorie + sous-catégorie + genre (niveau 3) | `SearchResults` | ✅ (existant) |

### Tests

- `ThematicSearch.native.test.tsx` : nouveau bloc « PerformSearch log » — émission avec les bons
  paramètres, émission unique malgré plusieurs re-renders, non-émission sans exécution de recherche.
- Recette manuelle via la DebugView Firebase (environnement testing) : événement visible avec
  `searchView: "ThematicSearch"` et `searchCategories` renseigné.

