### PR TITLE
(PC-42368) feat(search): add see all button on thematic search subcat…

### DIFF
--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -634,7 +634,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
           }
         >
           <View
-            accessibilityLabel="Voir toutes les catégories"
+            accessibilityLabel="Voir tout pour la sélection Tout parcourir"
             accessibilityRole="button"
             accessibilityState={
               {
@@ -686,7 +686,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                 },
               ]
             }
-            testID="Voir toutes les catégories"
+            testID="Voir tout pour la sélection Tout parcourir"
           >
             <View
               gap={8}

--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -594,6 +594,139 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
     scrollEventThrottle={16}
   >
     <View>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "paddingHorizontal": 24,
+            "paddingTop": 24,
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "flexShrink": 1,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="header"
+            style={
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 19,
+                "lineHeight": 30.4,
+              }
+            }
+          >
+            Tout parcourir
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "flexShrink": 1,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Voir toutes les catégories"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "paddingBottom": 2,
+                    "paddingLeft": 2,
+                    "paddingRight": 2,
+                    "paddingTop": 2,
+                    "width": "auto",
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Voir toutes les catégories"
+          >
+            <View
+              gap={8}
+              hasIcon={false}
+              isMultiline={false}
+              style={
+                {
+                  "alignItems": "center",
+                  "columnGap": 8,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-SemiBold",
+                      "fontSize": 14,
+                      "lineHeight": 14,
+                    },
+                    {
+                      "color": "#6123df",
+                      "flexBasis": undefined,
+                      "flexGrow": undefined,
+                      "flexShrink": 1,
+                      "maxWidth": "100%",
+                      "minWidth": 0,
+                      "textAlign": undefined,
+                    },
+                  ]
+                }
+              >
+                Voir tout
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
       <RCTScrollView
         horizontal={true}
         showsHorizontalScrollIndicator={false}

--- a/doc/accessibility/audits/following.md
+++ b/doc/accessibility/audits/following.md
@@ -24,14 +24,16 @@ Texte
 <summary> ⏳ Critère 11.10 - Dans chaque écran, les fonctionnalités activables au moyen d’un geste complexe sont-elles activables au moyen d’un geste simple ?</summary>
 
 **RAAM** : [Critère 11.10](https://accessibilite.public.lu/fr/raam1.1/referentiel-technique.html#crit-11-1)  
-**Ticket** : [PC-42367](https://passculture.atlassian.net/browse/PC-42367)  
-**PR** : [#9877](https://github.com/pass-culture/pass-culture-app-native/pull/9877)
+**Ticket** : [PC-42367](https://passculture.atlassian.net/browse/PC-42367), [PC-42368](https://passculture.atlassian.net/browse/PC-42368)  
+**PR** : [#9877](https://github.com/pass-culture/pass-culture-app-native/pull/9877), [#9886](https://github.com/pass-culture/pass-culture-app-native/pull/9886)
 
 **Problème** 😱  
-E02 - Dans le module vidéo, lorsqu'il y a plus de 3 offres associées il faut scroller horizontalement pour y accéder. Il faudrait une alternative à ce geste complexe
+- E02 : Dans le module vidéo, lorsqu'il y a plus de 3 offres associées il faut scroller horizontalement pour y accéder. Il faudrait une alternative à ce geste complexe.
+- E14 : Sur les pages de recherche thématique (ex. « Livres »), les sous-catégories sont présentées dans un carrousel à défilement horizontal, un geste complexe sans alternative.
 
 **Correction** 💡  
-E02 : ajout du bouton “Voir tout” pour accéder à une page avec les offres disposées verticalement
+- E02 : Ajout du bouton “Voir tout” pour accéder à une page avec les offres disposées verticalement
+- E14 : Ajout d'un bouton « Voir tout » au-dessus de la liste horizontale des sous-catégories qui redirige vers une page avec la liste des sous-catégories au format vertical.
 
 **Retours audit** 🔥  
 Texte

--- a/src/features/navigation/helpers/screenParamsUtils.ts
+++ b/src/features/navigation/helpers/screenParamsUtils.ts
@@ -29,6 +29,7 @@ type ScreensRequiringParsing = Extract<
   | 'SearchLanding'
   | 'SearchResults'
   | 'ThematicSearch'
+  | 'ThematicSearchSubcategories'
   | 'ProAdvicesOffer'
   | 'ProAdvicesVenue'
   | 'VideoModulePage'
@@ -163,6 +164,7 @@ export const screenParamsParser: ParamsParsers = {
   SearchResults: searchParamsParser,
   SearchLanding: searchParamsParser,
   ThematicSearch: searchParamsParser,
+  ThematicSearchSubcategories: searchParamsParser,
   SearchFilter: searchParamsParser,
   LocationFilter: {
     selectedVenue: JSON.parse,
@@ -240,7 +242,12 @@ function parseDataWithISODates(data: any) {
 
 type ScreensRequiringStringifying = Extract<
   ScreenNames,
-  'SearchFilter' | 'LocationFilter' | 'SearchLanding' | 'SearchResults' | 'ThematicSearch'
+  | 'SearchFilter'
+  | 'LocationFilter'
+  | 'SearchLanding'
+  | 'SearchResults'
+  | 'ThematicSearch'
+  | 'ThematicSearchSubcategories'
 >
 type ParamsStringifiers = {
   [Screen in ScreensRequiringStringifying]: {
@@ -288,6 +295,7 @@ export const screenParamsStringifier: ParamsStringifiers = {
   SearchLanding: searchParamsStringifier,
   SearchResults: searchParamsStringifier,
   ThematicSearch: searchParamsStringifier,
+  ThematicSearchSubcategories: searchParamsStringifier,
   LocationFilter: {
     selectedVenue: JSON.stringify,
     selectedPlace: JSON.stringify,

--- a/src/features/navigation/navigators/SearchStackNavigator/SearchStackNavigator.tsx
+++ b/src/features/navigation/navigators/SearchStackNavigator/SearchStackNavigator.tsx
@@ -12,6 +12,7 @@ import { SEARCH_STACK_NAVIGATOR_SCREEN_OPTIONS } from 'features/navigation/navig
 import { SearchLanding } from 'features/search/pages/SearchLanding/SearchLanding'
 import { SearchResultsContainer } from 'features/search/pages/SearchResults/SearchResultsContainer'
 import { ThematicSearch } from 'features/search/pages/ThematicSearch/ThematicSearch'
+import { ThematicSearchSubcategories } from 'features/search/pages/ThematicSearch/ThematicSearchSubcategories'
 import { SearchView } from 'features/search/types'
 
 const searchStackNavigatorConfig = {
@@ -40,6 +41,14 @@ const searchStackNavigatorConfig = {
         path: 'recherche/thematique',
         parse: screenParamsParser[SearchView.Thematic],
         stringify: screenParamsStringifier[SearchView.Thematic],
+      },
+    },
+    ThematicSearchSubcategories: {
+      screen: ThematicSearchSubcategories,
+      linking: {
+        path: 'recherche/thematique/toutes-les-categories',
+        parse: screenParamsParser.ThematicSearchSubcategories,
+        stringify: screenParamsStringifier.ThematicSearchSubcategories,
       },
     },
   },

--- a/src/features/navigation/navigators/SearchStackNavigator/types.ts
+++ b/src/features/navigation/navigators/SearchStackNavigator/types.ts
@@ -9,6 +9,7 @@ const screensSearch = [
   'SearchLanding',
   'SearchResults',
   'ThematicSearch',
+  'ThematicSearchSubcategories',
 ] as const satisfies ReadonlyDeep<ScreenNames[]>
 
 export type SearchStackRouteName = (typeof screensSearch)[number]
@@ -22,12 +23,18 @@ export const hasAThematicSearch = [
 
 type HasAThematicSearch = typeof hasAThematicSearch
 
-type ThematicSearchCategories = Extract<SearchGroupNameEnumv2, HasAThematicSearch[number]>
+export type ThematicSearchCategories = Extract<SearchGroupNameEnumv2, HasAThematicSearch[number]>
 
 export type SearchStackParamList = {
   SearchLanding?: Partial<SearchState & { accessibilityFilter: Partial<DisabilitiesProperties> }>
   SearchResults?: Partial<SearchState & { accessibilityFilter: Partial<DisabilitiesProperties> }>
   ThematicSearch?: Partial<
+    SearchState & {
+      offerCategories: ThematicSearchCategories[]
+      accessibilityFilter: Partial<DisabilitiesProperties>
+    }
+  >
+  ThematicSearchSubcategories?: Partial<
     SearchState & {
       offerCategories: ThematicSearchCategories[]
       accessibilityFilter: Partial<DisabilitiesProperties>

--- a/src/features/search/pages/ThematicSearch/ThematicSearch.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearch.tsx
@@ -7,7 +7,10 @@ import { v4 as uuidv4 } from 'uuid'
 import { SearchGroupNameEnumv2 } from 'api/gen'
 import { useAccessibilityFiltersContext } from 'features/accessibility/context/AccessibilityFiltersWrapper'
 import { UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
-import { SearchStackRouteName } from 'features/navigation/navigators/SearchStackNavigator/types'
+import {
+  SearchStackRouteName,
+  ThematicSearchCategories,
+} from 'features/navigation/navigators/SearchStackNavigator/types'
 import { useSearchResults } from 'features/search/api/useSearchResults/useSearchResults'
 import { VenuePlaylist } from 'features/search/components/VenuePlaylist/VenuePlaylist'
 import { useSearch } from 'features/search/context/SearchWrapper'
@@ -93,7 +96,7 @@ export const ThematicSearch: React.FC = () => {
     }
   }, [dispatch, isWeb, params?.offerCategories])
 
-  const offerCategories = (params?.offerCategories ?? []) as SearchGroupNameEnumv2[]
+  const offerCategories = (params?.offerCategories ?? []) as ThematicSearchCategories[]
   const offerCategory = offerCategories[0]
   const isZoomedAt200 = useMobileFontScaleToDisplay({ default: false, at200PercentZoom: true })
 

--- a/src/features/search/pages/ThematicSearch/ThematicSearchSubcategories.native.test.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearchSubcategories.native.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+
+import { goBack, useRoute } from '__mocks__/@react-navigation/native'
+import { SearchGroupNameEnumv2 } from 'api/gen'
+import { initialSearchState } from 'features/search/context/reducer'
+import { ThematicSearchSubcategories } from 'features/search/pages/ThematicSearch/ThematicSearchSubcategories'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { renderAsync, screen, userEvent } from 'tests/utils'
+
+const mockSearchState = initialSearchState
+const mockDispatch = jest.fn()
+jest.mock('features/search/context/SearchWrapper', () => ({
+  useSearch: () => ({
+    searchState: mockSearchState,
+    dispatch: mockDispatch,
+  }),
+}))
+
+jest.mock('libs/firebase/analytics/analytics')
+
+const user = userEvent.setup()
+jest.useFakeTimers()
+
+describe('<ThematicSearchSubcategories/>', () => {
+  beforeEach(() => {
+    useRoute.mockReturnValue({ params: { offerCategories: [SearchGroupNameEnumv2.LIVRES] } })
+  })
+
+  it('should display the page title', async () => {
+    await renderThematicSearchSubcategories()
+
+    expect(await screen.findAllByText('Tout parcourir')).not.toHaveLength(0)
+  })
+
+  it('should display the subcategories of the offer category', async () => {
+    await renderThematicSearchSubcategories()
+
+    expect(await screen.findByText('Romans et littérature')).toBeOnTheScreen()
+    expect(await screen.findByText('Mangas')).toBeOnTheScreen()
+  })
+
+  it('should go back when pressing back button', async () => {
+    await renderThematicSearchSubcategories()
+
+    await user.press(await screen.findByLabelText('Revenir en arrière'))
+
+    expect(goBack).toHaveBeenCalledTimes(1)
+  })
+
+  it('should update searchState when pressing a subcategory button', async () => {
+    await renderThematicSearchSubcategories()
+
+    await user.press(await screen.findByText('Romans et littérature'))
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'SET_STATE',
+      payload: expect.objectContaining({
+        offerCategories: [SearchGroupNameEnumv2.LIVRES],
+      }),
+    })
+  })
+})
+
+const renderThematicSearchSubcategories = () =>
+  renderAsync(reactQueryProviderHOC(<ThematicSearchSubcategories />))

--- a/src/features/search/pages/ThematicSearch/ThematicSearchSubcategories.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearchSubcategories.tsx
@@ -1,0 +1,93 @@
+import { useNavigation, useRoute } from '@react-navigation/native'
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { UseNavigationType, UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
+import { ThematicSearchCategories } from 'features/navigation/navigators/SearchStackNavigator/types'
+import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
+import { useGetHeaderHeight } from 'shared/header/useGetHeaderHeight'
+import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
+import { SubcategoryButton } from 'ui/components/buttons/SubcategoryButton/SubcategoryButton'
+import { useSubcategoryButtonContent } from 'ui/components/buttons/SubcategoryButton/useSubcategoryButtonContent'
+import { ContentHeader } from 'ui/components/headers/ContentHeader'
+import { Page } from 'ui/pages/Page'
+import { Spacer, Typo } from 'ui/theme'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+
+const TITLE = 'Tout parcourir'
+const MOBILE_MIN_WIDTH = '40%'
+const MOBILE_MIN_WIDTH_WHEN_FONT_ZOOMED = '100%'
+const MOBILE_MAX_WIDTH = '49%'
+const MOBILE_MAX_WIDTH_WHEN_FONT_ZOOMED = '100%'
+
+export const ThematicSearchSubcategories = () => {
+  const headerHeight = useGetHeaderHeight()
+  const { params } = useRoute<UseRouteType<'ThematicSearchSubcategories'>>()
+  const { goBack } = useNavigation<UseNavigationType>()
+  const { headerTransition, onScroll } = useOpacityTransition()
+
+  const offerCategories = (params?.offerCategories ?? []) as ThematicSearchCategories[]
+  const offerCategory = offerCategories[0]
+  const subcategoryButtonContent = useSubcategoryButtonContent(offerCategory)
+
+  const mobileMinWidth = useMobileFontScaleToDisplay({
+    default: MOBILE_MIN_WIDTH,
+    at200PercentZoom: MOBILE_MIN_WIDTH_WHEN_FONT_ZOOMED,
+  })
+  const mobileMaxWidth = useMobileFontScaleToDisplay({
+    default: MOBILE_MAX_WIDTH,
+    at200PercentZoom: MOBILE_MAX_WIDTH_WHEN_FONT_ZOOMED,
+  })
+
+  return (
+    <Page>
+      <StyledScrollView onScroll={onScroll} scrollEventThrottle={16}>
+        <Placeholder height={headerHeight} />
+        <Typo.Title2 {...getHeadingAttrs(1)}>{TITLE}</Typo.Title2>
+        <SubcategoryButtonsContainer>
+          {subcategoryButtonContent.map((item) => (
+            <StyledSubcategoryButton
+              key={item.label}
+              {...item}
+              mobileMinWidth={mobileMinWidth}
+              mobileMaxWidth={mobileMaxWidth}
+            />
+          ))}
+        </SubcategoryButtonsContainer>
+        <Spacer.BottomScreen />
+      </StyledScrollView>
+      {/* On native header is called after Body to implement the BlurView for iOS */}
+      <ContentHeader headerTitle={TITLE} onBackPress={goBack} headerTransition={headerTransition} />
+    </Page>
+  )
+}
+
+const StyledScrollView = styled.ScrollView.attrs(({ theme }) => ({
+  contentContainerStyle: {
+    paddingHorizontal: theme.contentPage.marginHorizontal,
+    paddingVertical: theme.contentPage.marginVertical,
+  },
+}))``
+
+const Placeholder = styled.View<{ height: number }>(({ height }) => ({
+  height,
+}))
+
+const SubcategoryButtonsContainer = styled.View(({ theme }) => ({
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  gap: theme.designSystem.size.spacing.l,
+  paddingVertical: theme.designSystem.size.spacing.xl,
+}))
+
+const StyledSubcategoryButton = styled(SubcategoryButton)<{
+  mobileMinWidth: string
+  mobileMaxWidth: string
+}>(({ mobileMinWidth, mobileMaxWidth }) => ({
+  flexGrow: 1,
+  flexShrink: 0,
+  flexBasis: 0,
+  width: 'auto',
+  minWidth: mobileMinWidth,
+  maxWidth: mobileMaxWidth,
+}))

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -230,7 +230,7 @@ export const logEventAnalytics = {
     void analytics.logEvent({ firebase: AnalyticsEvent.CLICK_MAIL_DEBUG_INFO }, { userId })
   },
   logClickSeeAll: (params: {
-    type: 'offers' | 'venues' | 'artists'
+    type: 'offers' | 'venues' | 'artists' | 'categories'
     moduleName: string
     moduleId?: string
     homeEntryId?: string

--- a/src/ui/components/SeeAllButton/SeeAllInVerticalPlaylistButton.tsx
+++ b/src/ui/components/SeeAllButton/SeeAllInVerticalPlaylistButton.tsx
@@ -6,7 +6,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 
 type Props = {
   accessibilityLabel: string
-  onBeforeNavigate?: () => void
+  onBeforeNavigate: () => void
   navigateTo: InternalNavigationProps['navigateTo']
 }
 

--- a/src/ui/components/SeeAllButton/SeeAllInVerticalPlaylistButton.tsx
+++ b/src/ui/components/SeeAllButton/SeeAllInVerticalPlaylistButton.tsx
@@ -6,7 +6,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 
 type Props = {
   accessibilityLabel: string
-  onBeforeNavigate: () => void
+  onBeforeNavigate?: () => void
   navigateTo: InternalNavigationProps['navigateTo']
 }
 

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButton.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { LayoutChangeEvent, Platform } from 'react-native'
+import { LayoutChangeEvent, Platform, StyleProp, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
 import { getSearchPropConfig } from 'features/navigation/navigators/SearchStackNavigator/getSearchPropConfig'
@@ -28,6 +28,7 @@ type SubcategoryButtonProps = {
   onBeforeNavigate: VoidFunction
   onLayout?: (event: LayoutChangeEvent) => void
   uniformHeight?: number
+  style?: StyleProp<ViewStyle>
 }
 
 export const SubcategoryButton = ({
@@ -38,6 +39,7 @@ export const SubcategoryButton = ({
   onBeforeNavigate,
   onLayout,
   uniformHeight,
+  style,
 }: SubcategoryButtonProps) => {
   const focusProps = useHandleFocus()
   const hoverProps = useHandleHover()
@@ -54,7 +56,8 @@ export const SubcategoryButton = ({
       backgroundColor={backgroundColor}
       borderColor={borderColor}
       onLayout={onLayout}
-      uniformHeight={uniformHeight}>
+      uniformHeight={uniformHeight}
+      style={style}>
       <StyledText>{label}</StyledText>
     </StyledInternalTouchable>
   )

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper.native.test.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper.native.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
+import { navigate } from '__mocks__/@react-navigation/native'
 import { SearchGroupNameEnumv2 } from 'api/gen'
+import { ThematicSearchCategories } from 'features/navigation/navigators/SearchStackNavigator/types'
 import { initialSearchState } from 'features/search/context/reducer'
 import { BooksNativeCategoriesEnum } from 'features/search/types'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -34,6 +36,23 @@ describe('<SubcategoryButtonListWrapper/>', () => {
     expect(await screen.findByText('Romans et littérature')).toBeOnTheScreen()
   })
 
+  it('should display "Tout parcourir" header with a "Voir tout" button', async () => {
+    await renderSubcategoryButtonListWrapper(SearchGroupNameEnumv2.LIVRES)
+
+    expect(await screen.findByText('Tout parcourir')).toBeOnTheScreen()
+    expect(screen.getByText('Voir tout')).toBeOnTheScreen()
+  })
+
+  it('should navigate directly to ThematicSearchSubcategories when pressing "Voir tout"', async () => {
+    await renderSubcategoryButtonListWrapper(SearchGroupNameEnumv2.LIVRES)
+
+    await user.press(await screen.findByText('Voir tout'))
+
+    expect(navigate).toHaveBeenCalledWith('ThematicSearchSubcategories', {
+      offerCategories: [SearchGroupNameEnumv2.LIVRES],
+    })
+  })
+
   it.skip('should update searchState with correct params', async () => {
     await renderSubcategoryButtonListWrapper(SearchGroupNameEnumv2.LIVRES)
 
@@ -51,5 +70,5 @@ describe('<SubcategoryButtonListWrapper/>', () => {
   })
 })
 
-const renderSubcategoryButtonListWrapper = (offerCategory: SearchGroupNameEnumv2) =>
+const renderSubcategoryButtonListWrapper = (offerCategory: ThematicSearchCategories) =>
   renderAsync(reactQueryProviderHOC(<SubcategoryButtonListWrapper offerCategory={offerCategory} />))

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper.native.test.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper.native.test.tsx
@@ -5,6 +5,7 @@ import { SearchGroupNameEnumv2 } from 'api/gen'
 import { ThematicSearchCategories } from 'features/navigation/navigators/SearchStackNavigator/types'
 import { initialSearchState } from 'features/search/context/reducer'
 import { BooksNativeCategoriesEnum } from 'features/search/types'
+import { analytics } from 'libs/analytics/provider'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { renderAsync, screen, userEvent } from 'tests/utils'
 import { SubcategoryButtonListWrapper } from 'ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper'
@@ -50,6 +51,18 @@ describe('<SubcategoryButtonListWrapper/>', () => {
 
     expect(navigate).toHaveBeenCalledWith('ThematicSearchSubcategories', {
       offerCategories: [SearchGroupNameEnumv2.LIVRES],
+    })
+  })
+
+  it('should log ClickSeeAll event when pressing "Voir tout"', async () => {
+    await renderSubcategoryButtonListWrapper(SearchGroupNameEnumv2.LIVRES)
+
+    await user.press(await screen.findByText('Voir tout'))
+
+    expect(analytics.logClickSeeAll).toHaveBeenCalledWith({
+      type: 'categories',
+      moduleName: 'Tout parcourir',
+      from: 'thematicsearch',
     })
   })
 

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper.tsx
@@ -1,72 +1,53 @@
-import React, { useMemo } from 'react'
-import { useTheme } from 'styled-components/native'
+import React from 'react'
+import styled, { useTheme } from 'styled-components/native'
 
-import { SearchGroupNameEnumv2 } from 'api/gen'
-import { useSearch } from 'features/search/context/SearchWrapper'
-import { CATEGORY_CRITERIA } from 'features/search/enums'
-import {
-  sortCategoriesPredicate,
-  useNativeCategories,
-} from 'features/search/helpers/categoriesHelpers/categoriesHelpers'
-import { NativeCategoryEnum } from 'features/search/types'
-import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
-import { useSubcategoriesQuery } from 'queries/subcategories/useSubcategoriesQuery'
-import { getSearchParams } from 'ui/components/buttons/SubcategoryButton/helpers'
-import { SubcategoryButtonItem } from 'ui/components/buttons/SubcategoryButton/SubcategoryButton'
+import { ThematicSearchCategories } from 'features/navigation/navigators/SearchStackNavigator/types'
 import { SubcategoryButtonList } from 'ui/components/buttons/SubcategoryButton/SubcategoryButtonList'
+import { useSubcategoryButtonContent } from 'ui/components/buttons/SubcategoryButton/useSubcategoryButtonContent'
+import { SeeAllButtonWrapper } from 'ui/components/SeeAllButton/SeeAllButtonWrapper'
+import { SeeAllInVerticalPlaylistButton } from 'ui/components/SeeAllButton/SeeAllInVerticalPlaylistButton'
+import { Typo } from 'ui/theme'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type Props = {
-  offerCategory: SearchGroupNameEnumv2
+  offerCategory: ThematicSearchCategories
 }
 
 export const SubcategoryButtonListWrapper: React.FC<Props> = ({ offerCategory }) => {
-  const { data: subcategories = PLACEHOLDER_DATA } = useSubcategoriesQuery()
-  const { searchState, dispatch } = useSearch()
+  const { isMobileViewport } = useTheme()
+  const subcategoryButtonContent = useSubcategoryButtonContent(offerCategory)
 
-  const { designSystem } = useTheme()
-  const nativeCategories = useNativeCategories(offerCategory)
-  const offerCategoryTheme = useMemo(
-    () => ({
-      backgroundColor: CATEGORY_CRITERIA[offerCategory]?.fillColor,
-      borderColor: CATEGORY_CRITERIA[offerCategory]?.borderColor,
-    }),
-    [offerCategory]
+  return (
+    <React.Fragment>
+      {isMobileViewport ? (
+        <HeaderContainer>
+          <TitleContainer>
+            <Typo.Title3 {...getHeadingAttrs(2)}>Tout parcourir</Typo.Title3>
+          </TitleContainer>
+          <SeeAllButtonWrapper>
+            <SeeAllInVerticalPlaylistButton
+              accessibilityLabel="Voir toutes les catégories"
+              navigateTo={{
+                screen: 'ThematicSearchSubcategories',
+                params: { offerCategories: [offerCategory] },
+              }}
+            />
+          </SeeAllButtonWrapper>
+        </HeaderContainer>
+      ) : null}
+      <SubcategoryButtonList subcategoryButtonContent={subcategoryButtonContent} />
+    </React.Fragment>
   )
-  const subcategoryButtonContent = useMemo(
-    () =>
-      nativeCategories
-        .map((nativeCategory): SubcategoryButtonItem => {
-          const searchParams = getSearchParams(
-            nativeCategory[0] as NativeCategoryEnum,
-            offerCategory,
-            subcategories,
-            searchState
-          )
-
-          return {
-            label: nativeCategory[1].label,
-            backgroundColor:
-              designSystem.color.background[offerCategoryTheme.backgroundColor ?? 'default'],
-            borderColor: designSystem.color.border[offerCategoryTheme.borderColor ?? 'default'],
-            nativeCategory: nativeCategory[0] as NativeCategoryEnum,
-            position: nativeCategory[1].position,
-            searchParams,
-            onBeforeNavigate: () => dispatch({ type: 'SET_STATE', payload: searchParams }),
-          }
-        })
-        .sort((a, b) => sortCategoriesPredicate(a, b)),
-    [
-      dispatch,
-      nativeCategories,
-      offerCategory,
-      offerCategoryTheme.backgroundColor,
-      offerCategoryTheme.borderColor,
-      searchState,
-      subcategories,
-      designSystem.color.background,
-      designSystem.color.border,
-    ]
-  )
-
-  return <SubcategoryButtonList subcategoryButtonContent={subcategoryButtonContent} />
 }
+
+const HeaderContainer = styled.View(({ theme }) => ({
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  paddingHorizontal: theme.designSystem.size.spacing.xl,
+  paddingTop: theme.designSystem.size.spacing.xl,
+}))
+
+const TitleContainer = styled.View({
+  flexShrink: 1,
+})

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
 import { ThematicSearchCategories } from 'features/navigation/navigators/SearchStackNavigator/types'
+import { analytics } from 'libs/analytics/provider'
 import { SubcategoryButtonList } from 'ui/components/buttons/SubcategoryButton/SubcategoryButtonList'
 import { useSubcategoryButtonContent } from 'ui/components/buttons/SubcategoryButton/useSubcategoryButtonContent'
-import { SeeAllButtonWrapper } from 'ui/components/SeeAllButton/SeeAllButtonWrapper'
-import { SeeAllInVerticalPlaylistButton } from 'ui/components/SeeAllButton/SeeAllInVerticalPlaylistButton'
+import { SeeAllButton } from 'ui/components/SeeAllButton/SeeAllButton'
 import { Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
@@ -17,6 +17,14 @@ export const SubcategoryButtonListWrapper: React.FC<Props> = ({ offerCategory })
   const { isMobileViewport } = useTheme()
   const subcategoryButtonContent = useSubcategoryButtonContent(offerCategory)
 
+  const onBeforeNavigate = () => {
+    void analytics.logClickSeeAll({
+      type: 'categories',
+      moduleName: 'Tout parcourir',
+      from: 'thematicsearch',
+    })
+  }
+
   return (
     <React.Fragment>
       {isMobileViewport ? (
@@ -24,15 +32,17 @@ export const SubcategoryButtonListWrapper: React.FC<Props> = ({ offerCategory })
           <TitleContainer>
             <Typo.Title3 {...getHeadingAttrs(2)}>Tout parcourir</Typo.Title3>
           </TitleContainer>
-          <SeeAllButtonWrapper>
-            <SeeAllInVerticalPlaylistButton
-              accessibilityLabel="Voir toutes les catégories"
-              navigateTo={{
+          <SeeAllButton
+            playlistTitle="Tout parcourir"
+            data={{
+              onBeforeNavigate,
+              navigateToVerticalPlaylist: {
                 screen: 'ThematicSearchSubcategories',
                 params: { offerCategories: [offerCategory] },
-              }}
-            />
-          </SeeAllButtonWrapper>
+              },
+              hideSearchSeeAll: true,
+            }}
+          />
         </HeaderContainer>
       ) : null}
       <SubcategoryButtonList subcategoryButtonContent={subcategoryButtonContent} />

--- a/src/ui/components/buttons/SubcategoryButton/useSubcategoryButtonContent.ts
+++ b/src/ui/components/buttons/SubcategoryButton/useSubcategoryButtonContent.ts
@@ -1,0 +1,67 @@
+import { useMemo } from 'react'
+import { useTheme } from 'styled-components/native'
+
+import { SearchGroupNameEnumv2 } from 'api/gen'
+import { useSearch } from 'features/search/context/SearchWrapper'
+import { CATEGORY_CRITERIA } from 'features/search/enums'
+import {
+  sortCategoriesPredicate,
+  useNativeCategories,
+} from 'features/search/helpers/categoriesHelpers/categoriesHelpers'
+import { NativeCategoryEnum } from 'features/search/types'
+import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
+import { useSubcategoriesQuery } from 'queries/subcategories/useSubcategoriesQuery'
+import { getSearchParams } from 'ui/components/buttons/SubcategoryButton/helpers'
+import { SubcategoryButtonItem } from 'ui/components/buttons/SubcategoryButton/SubcategoryButton'
+
+export const useSubcategoryButtonContent = (
+  offerCategory?: SearchGroupNameEnumv2
+): SubcategoryButtonItem[] => {
+  const { data: subcategories = PLACEHOLDER_DATA } = useSubcategoriesQuery()
+  const { searchState, dispatch } = useSearch()
+
+  const { designSystem } = useTheme()
+  const nativeCategories = useNativeCategories(offerCategory)
+  const offerCategoryTheme = useMemo(
+    () => ({
+      backgroundColor: offerCategory ? CATEGORY_CRITERIA[offerCategory]?.fillColor : undefined,
+      borderColor: offerCategory ? CATEGORY_CRITERIA[offerCategory]?.borderColor : undefined,
+    }),
+    [offerCategory]
+  )
+
+  return useMemo(() => {
+    if (!offerCategory) return []
+    return nativeCategories
+      .map((nativeCategory): SubcategoryButtonItem => {
+        const searchParams = getSearchParams(
+          nativeCategory[0] as NativeCategoryEnum,
+          offerCategory,
+          subcategories,
+          searchState
+        )
+
+        return {
+          label: nativeCategory[1].label,
+          backgroundColor:
+            designSystem.color.background[offerCategoryTheme.backgroundColor ?? 'default'],
+          borderColor: designSystem.color.border[offerCategoryTheme.borderColor ?? 'default'],
+          nativeCategory: nativeCategory[0] as NativeCategoryEnum,
+          position: nativeCategory[1].position,
+          searchParams,
+          onBeforeNavigate: () => dispatch({ type: 'SET_STATE', payload: searchParams }),
+        }
+      })
+      .sort((a, b) => sortCategoriesPredicate(a, b))
+  }, [
+    dispatch,
+    nativeCategories,
+    offerCategory,
+    offerCategoryTheme.backgroundColor,
+    offerCategoryTheme.borderColor,
+    searchState,
+    subcategories,
+    designSystem.color.background,
+    designSystem.color.border,
+  ])
+}


### PR DESCRIPTION
…egories

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42368

## Context

**RETOUR AUDIT - Critère RGAA 11.10** : dans chaque écran, les fonctionnalités activables au moyen d'un geste complexe doivent également être activables au moyen d'un geste simple.

Sur les pages de recherche thématique (ex. « Livres »), les sous-catégories sont présentées dans un carrousel à défilement horizontal — un geste complexe sans alternative.

Cette PR ajoute, sur le modèle des boutons « Voir tout » des playlists :

- Un en-tête **« Tout parcourir »** avec un bouton **« Voir tout »** au-dessus de la liste horizontale des sous-catégories (mobile uniquement — sur desktop la grille est déjà affichée en entier, sans défilement)
- Une nouvelle page **`ThematicSearchSubcategories`** (deeplink `recherche/thematique/toutes-les-categories`) affichant toutes les sous-catégories en liste verticale sur 2 colonnes (1 colonne pleine largeur avec une police zoomée à 200 %), avec bouton retour

Détails techniques :

- Le bouton « Voir tout » réutilise les composants existants `SeeAllButtonWrapper` et `SeeAllInVerticalPlaylistButton` (dont la prop `onBeforeNavigate` devient optionnelle, aucun tracking n'étant branché sur ce lien pour l'instant)
- La construction des boutons de sous-catégories est extraite dans un hook partagé `useSubcategoryButtonContent`, utilisé par la liste horizontale existante et la nouvelle page
- `SubcategoryButton` accepte désormais une prop `style` pour permettre une largeur flexible en grille
- Le bouton « Voir tout » navigue directement vers l'écran du SearchStack (sans config imbriquée `TabNavigator`), afin que la navigation fonctionne aussi après un retour arrière

## Screenshots

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-07-06 at 10 09 46" src="https://github.com/user-attachments/assets/22ceb309-bfcf-45ab-b547-064aefc0816c" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-07-06 at 10 09 53" src="https://github.com/user-attachments/assets/46401df4-0fa0-4499-b8ee-0ac5baa1fc43" />

