### PR TITLE
(PC-42707) feat(home): prepare category headers Contentful migration

### DIFF
--- a/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
@@ -679,7 +679,7 @@ exports[`ThematicHome should render correctly 1`] = `
                   "maxWidth": "100%",
                   "transform": [
                     {
-                      "rotate": "-2deg",
+                      "rotate": "-3deg",
                     },
                   ],
                 }

--- a/src/features/home/components/headers/CategoryThematicHomeHeaderContent.tsx
+++ b/src/features/home/components/headers/CategoryThematicHomeHeaderContent.tsx
@@ -102,7 +102,7 @@ const TitleContainer = styled.View(({ theme }) => ({
   alignItems: 'flex-start',
   gap: theme.designSystem.size.spacing.xs,
   maxWidth: '100%',
-  transform: 'rotate(-2deg)',
+  transform: 'rotate(-3deg)',
 }))
 
 const Title = styled(Typo.Title3)(({ theme }) => ({

--- a/src/features/home/components/modules/categories/CategoryListModule.tsx
+++ b/src/features/home/components/modules/categories/CategoryListModule.tsx
@@ -97,7 +97,7 @@ export const CategoryListModule = ({
                   moduleListId: id,
                 },
               }}
-              labelParts={getCategoryLabelParts(item.title)}
+              labelParts={item.titleParts ?? getCategoryLabelParts(item.title)}
               illustrationUrl={
                 item.illustrationCategoryBlock
                   ? categoryButtonIllustrationUrls[item.illustrationCategoryBlock]

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -262,6 +262,7 @@ export type CategoryListModule = {
 export type CategoryBlock = {
   id: string
   title: string
+  titleParts?: string[]
   homeEntryId: string
   image?: string
   color: Color | CategoryHeaderColor

--- a/src/libs/contentful/adapters/adaptHomepageEntries.native.test.ts
+++ b/src/libs/contentful/adapters/adaptHomepageEntries.native.test.ts
@@ -23,11 +23,42 @@ describe('adaptHomepageEntries', () => {
 
     expect(adaptedHomepageWithCategoryHeader.thematicHeader).toEqual({
       type: ThematicHeaderType.Category,
-      title: 'Cinéma',
+      title: 'vos cinéma',
       titleParts: ['vos', 'cinéma'],
       subtitle: 'Sous-titre cinéma',
       color: 'Lilac',
       imageUrl: `${env.ILLUSTRATIONS_BASE_URL}/cinema.png`,
     })
+  })
+
+  it('should adapt category header title from title parts when displayed title is missing', () => {
+    const thematicCategoryInfoFields = thematicCategoryInfoFixture.fields
+    if (!thematicCategoryInfoFields)
+      throw new Error('Missing thematic category info fixture fields')
+
+    const { displayedTitle: _displayedTitle, ...thematicCategoryInfoFieldsWithoutDisplayedTitle } =
+      thematicCategoryInfoFields
+
+    const adaptedHomepageWithCategoryHeader = adaptHomepageEntry({
+      ...homepageNatifEntryFixture,
+      fields: {
+        ...homepageNatifEntryFixture.fields,
+        thematicHeader: {
+          ...thematicCategoryInfoFixture,
+          fields: {
+            ...thematicCategoryInfoFieldsWithoutDisplayedTitle,
+            titleParts: ['vos', 'recommandations'],
+          },
+        },
+      },
+    })
+
+    expect(adaptedHomepageWithCategoryHeader.thematicHeader).toEqual(
+      expect.objectContaining({
+        type: ThematicHeaderType.Category,
+        title: 'vos recommandations',
+        titleParts: ['vos', 'recommandations'],
+      })
+    )
   })
 })

--- a/src/libs/contentful/adapters/adaptHomepageEntries.ts
+++ b/src/libs/contentful/adapters/adaptHomepageEntries.ts
@@ -41,10 +41,14 @@ const adaptThematicHeader = (homepageEntry: HomepageNatifEntry) => {
     if (thematicHeaderFields === undefined) return
 
     const legacyImageUrl = buildImageUrl(thematicHeaderFields.image?.fields?.file.url)
+    const title =
+      thematicHeaderFields.titleParts?.join(' ') ??
+      thematicHeaderFields.displayedTitle ??
+      thematicHeaderFields.title
 
     const categoryThematicHeader: CategoryThematicHeader = {
       type: ThematicHeaderType.Category,
-      title: thematicHeaderFields.displayedTitle,
+      title,
       titleParts: thematicHeaderFields.titleParts,
       subtitle: thematicHeaderFields.displayedSubtitle,
       imageUrl: thematicHeaderFields.illustrationFilename

--- a/src/libs/contentful/adapters/modules/adaptCategoryListModule.native.test.ts
+++ b/src/libs/contentful/adapters/modules/adaptCategoryListModule.native.test.ts
@@ -10,4 +10,42 @@ describe('adaptCategoryListModule', () => {
     expect(isCategoryListContentModel(rawCategoryListModule)).toBe(true)
     expect(adaptCategoryListModule(rawCategoryListModule)).toEqual(formattedCategoryListModule)
   })
+
+  it('should adapt category block title parts when they are defined', () => {
+    const categoryListFields = categoryListFixture.fields
+    const categoryBlock = categoryListFields?.categoryBlockList[0]
+    const thematicCategoryInfo = categoryBlock?.fields?.thematicCategoryInfo
+
+    if (!categoryListFields || !categoryBlock?.fields || !thematicCategoryInfo?.fields)
+      throw new Error('Missing category list fixture fields')
+
+    const rawCategoryListModule = {
+      ...categoryListFixture,
+      fields: {
+        ...categoryListFields,
+        categoryBlockList: [
+          {
+            ...categoryBlock,
+            fields: {
+              ...categoryBlock.fields,
+              thematicCategoryInfo: {
+                ...thematicCategoryInfo,
+                fields: {
+                  ...thematicCategoryInfo.fields,
+                  titleParts: ['vos', 'livres'],
+                },
+              },
+            },
+          },
+        ],
+      },
+    }
+
+    expect(adaptCategoryListModule(rawCategoryListModule)?.categoryBlockList[0]).toEqual(
+      expect.objectContaining({
+        title: 'Livres',
+        titleParts: ['vos', 'livres'],
+      })
+    )
+  })
 })

--- a/src/libs/contentful/adapters/modules/adaptCategoryListModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptCategoryListModule.ts
@@ -26,17 +26,15 @@ const categoryBlockListHaveFields = (
 
 const adaptCategoryBlock = (CategoryBlockList: CategoryBlockContentModel[]): CategoryBlock[] =>
   CategoryBlockList.filter(categoryBlockListHaveFields).map((bloc) => {
-    const {
-      displayedTitle: title,
-      image,
-      color,
-      illustrationCategoryBlock,
-    } = bloc.fields.thematicCategoryInfo.fields
+    const { title, displayedTitle, titleParts, image, color, illustrationCategoryBlock } =
+      bloc.fields.thematicCategoryInfo.fields
+
     return {
       id: bloc.sys.id,
       image: buildImageUrl(image?.fields?.file.url),
       homeEntryId: bloc.fields.homeEntryId,
-      title,
+      title: displayedTitle ?? title,
+      ...(titleParts ? { titleParts } : {}),
       color,
       illustrationCategoryBlock,
     }

--- a/src/libs/contentful/types.ts
+++ b/src/libs/contentful/types.ts
@@ -362,7 +362,7 @@ type BookTypesFields = {
 
 type ThematicCategoryInfoFields = {
   title: string
-  displayedTitle: string
+  displayedTitle?: string
   titleParts?: string[]
   displayedSubtitle?: string
   image?: Image


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42707

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

<img width="1077" height="192" alt="Capture d’écran 2026-07-03 à 11 42 12" src="https://github.com/user-attachments/assets/231d39c0-8ec3-4671-8a94-26a84082ae85" />


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
