### PR TITLE
(PC-42461) fix(rotation): rotation should not be possible if system r…

### DIFF
--- a/src/shared/hook/useOrientationLocked.native.test.ts
+++ b/src/shared/hook/useOrientationLocked.native.test.ts
@@ -18,6 +18,7 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 jest.mock('react-native-orientation-locker', () => ({
   lockToPortrait: jest.fn(),
   unlockAllOrientations: jest.fn(),
+  getAutoRotateState: jest.fn((callback: (state: boolean) => void) => callback(true)),
 
   addOrientationListener: jest.fn(),
   removeOrientationListener: jest.fn(),
@@ -71,7 +72,7 @@ describe('useOrientationLocked', () => {
 
     expect(AsyncStorage.setItem).toHaveBeenCalledWith('orientationLocked', 'true')
 
-    expect(Orientation.lockToPortrait).toHaveBeenCalledTimes(1)
+    expect(Orientation.lockToPortrait).toHaveBeenCalledTimes(2) // 1 for initial unlock, 1 for toggle
   })
 
   it('should unlock orientation when toggling from locked state', async () => {
@@ -90,6 +91,22 @@ describe('useOrientationLocked', () => {
     expect(AsyncStorage.setItem).toHaveBeenCalledWith('orientationLocked', 'false')
 
     expect(Orientation.unlockAllOrientations).toHaveBeenCalledTimes(1)
+  })
+
+  it('should keep portrait when app allows rotation but system auto-rotate is disabled', async () => {
+    ;(Orientation.getAutoRotateState as jest.Mock).mockImplementationOnce(
+      (callback: (state: boolean) => void) => callback(false)
+    )
+
+    storage.orientationLocked = 'false'
+
+    renderHook(() => useOrientationLocked())
+
+    await waitFor(() => {
+      expect(Orientation.lockToPortrait).toHaveBeenCalledTimes(1)
+    })
+
+    expect(Orientation.unlockAllOrientations).not.toHaveBeenCalled()
   })
 
   it('should clean up listeners on unmount', () => {

--- a/src/shared/hook/useOrientationLocked.ts
+++ b/src/shared/hook/useOrientationLocked.ts
@@ -11,13 +11,29 @@ export const useOrientationLocked = () => {
   const applyOrientationLock = useCallback((locked: boolean) => {
     if (locked) {
       Orientation.lockToPortrait()
-    } else {
-      Orientation.unlockAllOrientations()
+      return
     }
+
+    if (typeof Orientation.getAutoRotateState !== 'function') {
+      Orientation.unlockAllOrientations()
+      return
+    }
+
+    Orientation.getAutoRotateState((canRotate: boolean) => {
+      if (canRotate) {
+        Orientation.unlockAllOrientations()
+        return
+      }
+
+      Orientation.lockToPortrait()
+    })
   }, [])
 
   useEffect(() => {
     let mounted = true
+
+    // Lock immediately to avoid a landscape flash while async preference is loading.
+    Orientation.lockToPortrait()
 
     const init = async () => {
       const storedValue = await AsyncStorage.getItem(STORAGE_KEY)
@@ -38,13 +54,13 @@ export const useOrientationLocked = () => {
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (state: AppStateStatus) => {
-      if (state === 'active' && isOrientationLocked) {
-        Orientation.lockToPortrait()
+      if (state === 'active') {
+        void applyOrientationLock(isOrientationLocked)
       }
     })
 
     return () => subscription.remove()
-  }, [isOrientationLocked])
+  }, [applyOrientationLock, isOrientationLocked])
 
   useEffect(() => {
     const handler = (orientation: string) => {


### PR DESCRIPTION
…otation is locked

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42461

## Context

ios & android :
System rotation locked - app unlocked -> no rotation ✅
System rotation locked - app locked -> no rotation ✅
System rotation unlocked - app unlocked -> rotation ✅
System rotation unlocked - app locked -> no rotation ✅

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
