### PR TITLE
(PC-42740) fix(location): update url params only when on search results

### DIFF
--- a/__mocks__/@react-navigation/native.ts
+++ b/__mocks__/@react-navigation/native.ts
@@ -28,6 +28,7 @@ export const createPathConfigForStaticNavigation = jest.fn((staticNavigatorDefin
 export const addListener = jest.fn()
 export const canGoBack = jest.fn()
 export const dispatch = jest.fn()
+export const getCurrentRoute = jest.fn()
 export const getParent = jest.fn()
 export const getState = jest.fn()
 export const goBack = jest.fn()
@@ -48,6 +49,7 @@ export const navigation = {
   addListener,
   canGoBack,
   dispatch,
+  getCurrentRoute,
   getParent,
   getState,
   goBack,

--- a/src/features/search/store/search.store.test.ts
+++ b/src/features/search/store/search.store.test.ts
@@ -1,5 +1,9 @@
 jest.mock('features/navigation/navigationRef', () => ({
-  navigationRef: { setParams: jest.fn() },
+  navigationRef: {
+    getCurrentRoute: jest.fn(),
+    isReady: jest.fn().mockReturnValue(true),
+    setParams: jest.fn(),
+  },
 }))
 
 import { navigationRef } from 'features/navigation/navigationRef'
@@ -11,13 +15,28 @@ describe('searchStore', () => {
   beforeEach(() => {
     searchStore.actions.reset()
     jest.mocked(navigationRef.setParams).mockClear()
+    jest.mocked(navigationRef.getCurrentRoute).mockReturnValue({
+      key: 'SearchResults',
+      name: 'SearchResults',
+    } as unknown as ReturnType<typeof navigationRef.getCurrentRoute>)
   })
 
-  it('should sync params with navigation ref', () => {
+  it('should sync params with navigation ref when on SearchResults', () => {
     const params = { ...initialSearchState, query: 'cinema' }
 
     searchStore.actions.setParams(params)
 
     expect(navigationRef.setParams).toHaveBeenCalledWith(params)
+  })
+
+  it('should not sync params with navigation ref when not on SearchResults', () => {
+    jest.mocked(navigationRef.getCurrentRoute).mockReturnValueOnce({
+      key: 'LocationModal',
+      name: 'SearchLocationModal',
+    })
+
+    searchStore.actions.setParams({ ...initialSearchState, query: 'cinema' })
+
+    expect(navigationRef.setParams).not.toHaveBeenCalled()
   })
 })

--- a/src/features/search/store/search.store.ts
+++ b/src/features/search/store/search.store.ts
@@ -1,4 +1,5 @@
 import { navigationRef } from 'features/navigation/navigationRef'
+import { SearchStackRouteName } from 'features/navigation/navigators/SearchStackNavigator/types'
 import { initialSearchState } from 'features/search/context/reducer'
 import { SearchState } from 'features/search/types'
 import { createStore } from 'libs/store/createStore'
@@ -24,5 +25,12 @@ export const searchStore = createStore({
 })
 
 searchStore.store.subscribe(searchStore.selectors.selectParams, (params) => {
-  navigationRef.setParams(params)
+  if (!navigationRef.isReady()) return
+
+  const currentScreenName = navigationRef.getCurrentRoute()?.name as
+    | SearchStackRouteName
+    | undefined
+  if (currentScreenName === 'SearchResults') {
+    navigationRef.setParams(params)
+  }
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42740

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
