### PR TITLE
(PC-42768) fix(e2e): update wording and enhance digital booking steps

### DIFF
--- a/.maestro/testsV3/booking/BookDigitalOffer.yml
+++ b/.maestro/testsV3/booking/BookDigitalOffer.yml
@@ -17,23 +17,11 @@ onFlowStart:
 - runFlow: ../common/navigation/GoToSearchFromTabBar.yml
 
 - assertVisible: 'Rechercher'
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - scrollUntilVisible:
-          element:
-            text: 'Catégorie Médias et presse'
-      - tapOn: 'Catégorie Médias et presse'
 
-- runFlow:
-    when:
-      platform: Android
-    commands:
-      - scrollUntilVisible:
-          element:
-            text: 'MÉDIAS ET PRESSE'
-      - tapOn: 'MÉDIAS ET PRESSE'
+- scrollUntilVisible:
+    element:
+      text: 'Catégorie Médias et presse'
+- tapOn: 'Catégorie Médias et presse'
 
 - tapOn: 'Voir tous les filtres : 1 filtre actif'
 - tapOn: '.*Catégorie.*'
@@ -56,6 +44,50 @@ onFlowStart:
       visible: "Réserver l’offre"
     commands:
       - tapOn: "Réserver l’offre"
+      - assertVisible: 'Détails de la réservation'
+      - tapOn: 'J’ai lu et j’accepte les conditions générales d’utilisation - obligatoire'
+      - runFlow:
+          when:
+            platform: Android
+          commands:
+            - scrollUntilVisible:
+                element: 'Confirmer la réservation'
+      - runFlow:
+          when:
+            platform: iOS
+          commands:
+            - scroll
+
+      - tapOn:
+          text: '.*Confirmer la réservation.*'
+          retryTapIfNoChange: false
+
+      - assertVisible: "Réservation confirmée\_!"
+      - runFlow:
+          when:
+            platform: iOS
+            visible: 'Plus tard'
+          commands:
+            - tapOn: 'Plus tard'
+
+      - tapOn: 'Voir ma réservation'
+
+      - scrollUntilVisible:
+          element: 'Annuler ma réservation'
+      - tapOn: 'Annuler ma réservation'
+
+      - runFlow:
+          when:
+            platform: Android
+          commands:
+            - tapOn: 'Annuler ma réservation'
+
+      - runFlow: # iOS has an accessibility issue with the "Annuler ma réservation" button, so we need to tap on it with coordinates
+          when:
+            platform: iOS
+          commands:
+            - tapOn:
+                point: 50%,87%
 
 - runFlow:
     when:


### PR DESCRIPTION
## 🎯 Related Ticket

[PC-42768](https://passculture.atlassian.net/browse/PC-42768)

> Le test E2E Maestro de réservation d'une offre digitale (`BookDigitalOffer`) était incomplet (il s'arrêtait après le tap sur "Réserver l'offre") et contenait une gestion iOS/Android inutile pour la navigation dans les catégories. Cette PR complète le parcours de réservation et simplifie le code du test.

### 🔧 Changements

- **Simplification de la navigation catégorie** : suppression des blocs `runFlow` conditionnels iOS/Android pour scroller et taper sur « Catégorie Médias et presse » — remplacé par un seul bloc unifié qui fonctionne sur les deux plateformes.
- **Ajout du parcours complet de réservation** : le test couvre désormais toute la chaîne après le tap sur "Réserver l'offre" :
  - Vérification de l'écran « Détails de la réservation »
  - Acceptation des CGU
  - Scroll + tap sur « Confirmer la réservation » (gestion plateforme spécifique pour le scroll)
  - Assertion de « Réservation confirmée ! »
  - Dismiss de la modale iOS « Plus tard » si visible
  - Navigation vers « Voir ma réservation »
  - **Annulation de la réservation** (avec workaround iOS par coordonnées pour un problème d'accessibilité sur le bouton)

### 🧪 Comment tester

- [Voir la run Maestro Cloud](https://app.maestro.dev/project/proj_01javz1ncreqb9dcshv3y4da44/maestro-test/flow/run_01kwyewsghetqrv9a4gxc7jj1c)

---

**🧭 Review effort : 1/5** — _Un seul fichier Maestro modifié, logique linéaire de test E2E, pas d'impact sur le code applicatif._

**🗂️ Walkthrough**

| Fichier | Résumé |
|---|---|
| `.maestro/testsV3/booking/BookDigitalOffer.yml` | Simplifie la navigation catégorie (plus de split iOS/Android) et ajoute les étapes de confirmation, consultation et annulation de réservation. |

**⚠️ Points d'attention**
- Le tap par coordonnées (`point: 50%,87%`) sur iOS pour « Annuler ma réservation » est un workaround fragile — si le layout change, ce point pourrait rater la cible.

[PC-42768]: https://passculture.atlassian.net/browse/PC-42768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ