### PR TITLE
(PC-42755) feat(analytics): add missing param

### DIFF
--- a/src/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx
+++ b/src/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx
@@ -153,7 +153,8 @@ describe('ReinitializePassword Page', () => {
         refreshToken: 'refreshToken',
         accountState: AccountState.ACTIVE,
       },
-      'fromReinitializePassword'
+      'fromReinitializePassword',
+      'email_reinitialize'
     )
   })
 

--- a/src/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
+++ b/src/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
@@ -83,7 +83,8 @@ export const ReinitializePassword = () => {
           refreshToken: response.refreshToken,
           accountState: AccountState.ACTIVE,
         },
-        'fromReinitializePassword'
+        'fromReinitializePassword',
+        'email_reinitialize'
       )
       navigateToHome()
     },

--- a/src/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx
+++ b/src/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx
@@ -4,6 +4,7 @@ import { navigate, replace, reset, useRoute } from '__mocks__/@react-navigation/
 import { EmailChangeConfirmationResponse } from 'api/gen'
 import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { ConfirmChangeEmail } from 'features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail'
+import { analytics } from 'libs/analytics/provider'
 import { EmptyResponse } from 'libs/fetch'
 import { getRefreshToken } from 'libs/keychain/keychain'
 import { storage } from 'libs/storage'
@@ -27,8 +28,6 @@ jest.mock('features/search/context/SearchWrapper', () => ({
     resetSearch: jest.fn(),
   }),
 }))
-
-jest.mock('libs/firebase/analytics/analytics')
 
 jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   return function createAnimatedComponent(Component: unknown) {
@@ -110,6 +109,20 @@ describe('<ConfirmChangeEmail />', () => {
 
     expect(await storage.readString('access_token')).toEqual('accessToken')
     expect(await getRefreshToken()).toEqual('refreshToken')
+  })
+
+  it('should log login analytics with email_change type on change email confirmation success', async () => {
+    mockServer.postApi<EmailChangeConfirmationResponse>('/v2/profile/email_update/confirm', {
+      responseOptions: { statusCode: 200, data: confirmationSuccessResponse },
+    })
+    await renderAsync(reactQueryProviderHOC(<ConfirmChangeEmail />))
+
+    await userEvent.press(screen.getByText('Confirmer la demande'))
+
+    expect(analytics.logLogin).toHaveBeenCalledWith({
+      method: 'fromConfirmChangeEmail',
+      type: 'email_change',
+    })
   })
 
   it('should redirect to change email expired when change email confirmation fails because the link expired', async () => {

--- a/src/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.tsx
+++ b/src/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.tsx
@@ -28,7 +28,8 @@ export function ConfirmChangeEmail() {
     }) => {
       await loginRoutine(
         { accessToken, refreshToken, accountState: AccountState.ACTIVE },
-        'fromConfirmChangeEmail'
+        'fromConfirmChangeEmail',
+        'email_change'
       )
 
       if (resetPasswordToken) {

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -85,7 +85,7 @@ export type LoginRoutineMethod =
   | 'fromConfirmChangeEmail'
 
 type SSOType = 'SSO_login' | 'SSO_signup'
-type EmailType = 'email_login' | 'email_signup'
+type EmailType = 'email_login' | 'email_signup' | 'email_reinitialize' | 'email_change'
 export type LoginType = SSOType | EmailType
 
 type SSOProvider = 'apple' | 'google'


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42755
## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

<img width="523" height="83" alt="Capture d’écran 2026-07-08 à 09 06 52" src="https://github.com/user-attachments/assets/c17eeb72-e617-4058-ba07-b11cab033db4" />

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
