### PR TITLE
(PC-42786) fix(SetAddress): button should not be enabled if their is …

### DIFF
--- a/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
@@ -778,7 +778,7 @@ exports[`<SetAddress/> when ff phoneNumberInProfileStepper is enabled should ren
                   "flexShrink": 0,
                 }
               }
-              nativeID="7"
+              nativeID="8"
               style={
                 [
                   {

--- a/src/features/identityCheck/pages/profile/SetAddress.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.native.test.tsx
@@ -134,6 +134,25 @@ describe('<SetAddress/>', () => {
     })
   })
 
+  it('should disable continue button when address has validation error', async () => {
+    renderSetAddress()
+
+    const input = screen.getByTestId('Entrée pour l’adresse')
+    fireEvent.changeText(input, '%%%')
+
+    expect(input.props.accessibilityLabel).toContain(
+      'Ton adresse ne doit pas contenir de caractères spéciaux ou n’être composée que d’espaces.'
+    )
+
+    const continueButton = screen.getByLabelText('Continuer vers le statut')
+
+    expect(continueButton).toBeDisabled()
+
+    await user.press(screen.getByText('Continuer'))
+
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
   describe('when ff phoneNumberInProfileStepper is enabled', () => {
     beforeEach(() => {
       setFeatureFlags([RemoteStoreFeatureFlags.WIP_PHONE_NUMBER_IN_PROFILE_STEPPER])

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -108,13 +108,13 @@ export const SetAddress = () => {
 
   const isValidAddress = selectedAddress !== null || isAddressValid(query)
 
-  const enabled = query.trim().length > 0
+  const hasError = !isValidAddress && query.length > 0
+
+  const enabled = query.trim().length > 0 && !hasError
 
   const label = idCheckAddressAutocompletion
     ? 'Recherche et sélectionne ton adresse'
     : 'Entre ton adresse'
-
-  const hasError = !isValidAddress && query.length > 0
 
   const getStatusNavigationParams = () => {
     if (origin) {


### PR DESCRIPTION
…an error in input

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42786

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |   <img width="2880" height="1556" alt="Capture d’écran 2026-07-08 à 11 38 22" src="https://github.com/user-attachments/assets/f01fa036-ade1-473f-868c-dbe5f1df4319" /> |  <img width="1440" height="751" alt="Capture d’écran 2026-07-08 à 16 34 56" src="https://github.com/user-attachments/assets/477dc0eb-dc7b-4eb8-bac1-3c239cdda047" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
