### PR TITLE
(PC-42719) chore(deps): bump react native maps to 1.26.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3307,9 +3307,9 @@ PODS:
     - React-Core
   - react-native-lottie-splash-screen (1.1.2):
     - React
-  - react-native-maps (1.24.2):
-    - react-native-maps/Maps (= 1.24.2)
-  - react-native-maps/Generated (1.24.2):
+  - react-native-maps (1.26.0):
+    - react-native-maps/Maps (= 1.26.0)
+  - react-native-maps/Generated (1.26.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3338,7 +3338,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-maps/Maps (1.24.2):
+  - react-native-maps/Maps (1.26.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -5197,7 +5197,7 @@ SPEC CHECKSUMS:
   react-native-get-random-values: d40be1625939a24442f7d1abf96c4846db8eab71
   react-native-in-app-review: b3d1eed3d1596ebf6539804778272c4c65e4a400
   react-native-lottie-splash-screen: 2d84b1c81c176981d3e5e17df14da5a99a2f5082
-  react-native-maps: 4c7d10c22273b626135f7df3e9b26cd5f76096d7
+  react-native-maps: 3793b1682de6d6c5d8e225dc877eb435b5090e80
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-orientation-locker: cc6f357b289a2e0dd2210fea0c52cb8e0727fdaa
   react-native-performance: 7086e7ef93c6550ea39f2f9ae321313118c9d347

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "react-native-lottie-splash-screen": "^1.1.2",
     "react-native-map-clustering": "^4.0.0",
     "react-native-map-link": "^3.10.1",
-    "react-native-maps": "1.24.2",
+    "react-native-maps": "1.26.0",
     "react-native-modal": "13.0.1",
     "react-native-orientation-locker": "^1.7.0",
     "react-native-performance": "^5.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11424,7 +11424,7 @@ __metadata:
     react-native-lottie-splash-screen: "npm:^1.1.2"
     react-native-map-clustering: "npm:^4.0.0"
     react-native-map-link: "npm:^3.10.1"
-    react-native-maps: "npm:1.24.2"
+    react-native-maps: "npm:1.26.0"
     react-native-modal: "npm:13.0.1"
     react-native-orientation-locker: "npm:^1.7.0"
     react-native-performance: "npm:^5.1.4"
@@ -23688,9 +23688,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-maps@npm:1.24.2":
-  version: 1.24.2
-  resolution: "react-native-maps@npm:1.24.2"
+"react-native-maps@npm:1.26.0":
+  version: 1.26.0
+  resolution: "react-native-maps@npm:1.26.0"
   dependencies:
     "@types/geojson": "npm:^7946.0.13"
   peerDependencies:
@@ -23700,23 +23700,7 @@ __metadata:
   peerDependenciesMeta:
     react-native-web:
       optional: true
-  checksum: 10/84565e7be4e8f10f681b082174047b13fb255ab3db250fdb6d728e308e613dc6456204025234a04c3b28c10222e9c8a888d3625c26246c68d2ff9160d68af919
-  languageName: node
-  linkType: hard
-
-"react-native-maps@patch:react-native-maps@npm%3A1.24.2#./.yarn/patches/react-native-maps-npm-1.24.2-83a01f59cc.patch::locator=PassCulture%40workspace%3A.":
-  version: 1.24.2
-  resolution: "react-native-maps@patch:react-native-maps@npm%3A1.24.2#./.yarn/patches/react-native-maps-npm-1.24.2-83a01f59cc.patch::version=1.24.2&hash=22e8b6&locator=PassCulture%40workspace%3A."
-  dependencies:
-    "@types/geojson": "npm:^7946.0.13"
-  peerDependencies:
-    react: ">= 18.3.1"
-    react-native: ">= 0.76.0"
-    react-native-web: ">= 0.11"
-  peerDependenciesMeta:
-    react-native-web:
-      optional: true
-  checksum: 10/92097d66bf4b0e32878235622ed80a4f15fd16421c92746b20a10c43a4e1e428806216f41c05265a95764a23052d5856a91be5fef6ffc0cdfa872102c821d874
+  checksum: 10/08464e05468f9c4e79f9e061ca472f5d1d90ea00bcb30093ddf6716cba9f089fb3366e08a8d99e9d6940d041ae323c46e591e29d2bbfa08c9ee6d28fb34f864a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42719

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
