### PR TITLE
(PC-42828) fix(ios): fix react-native-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,6 @@ coverage/
 
 # @react-native-config codegen
 ios/react-native-config.xcconfig
-ios/envfile
 
 # Deploy
 android/keystores/*

--- a/ios/AppDelegate.mm
+++ b/ios/AppDelegate.mm
@@ -13,7 +13,7 @@
 #import <Firebase.h>
 #import <React/RCTLinkingManager.h>
 #import "BatchFirebaseDispatcher.h"
-#import "ReactNativeConfig.h"
+#import "RNCConfig.h"
 
 #import <PassCulture-Swift.h>
 
@@ -56,8 +56,10 @@
   }
 
   // Setup Batch
-  NSString* AssociatedDomain = [ReactNativeConfig envFor:@"WEBAPP_V2_DOMAIN"];
-  [BatchSDK setAssociatedDomains:@[AssociatedDomain]];
+  NSString* AssociatedDomain = [RNCConfig envFor:@"WEBAPP_V2_DOMAIN"];
+  if (AssociatedDomain != nil) {
+    [BatchSDK setAssociatedDomains:@[AssociatedDomain]];
+  }
   [BatchEventDispatcher addDispatcher:[BatchFirebaseDispatcher instance]];
   [RNBatch start];
   [BatchUNUserNotificationCenterDelegate registerAsDelegate];

--- a/ios/PassCulture-Bridging-Header.h
+++ b/ios/PassCulture-Bridging-Header.h
@@ -5,7 +5,7 @@
 #define PassCulture_Bridging_Header_h
 
 #import "RNSplashScreen.h" // react-native-lottie-splash-screen
-#import "ReactNativeConfig.h"
+#import "RNCConfig.h"
 #import "Orientation.h"
 #import "BatchFirebaseDispatcher.h"
 

--- a/ios/PassCulture.xcodeproj/xcshareddata/xcschemes/PassCulture-Production.xcscheme
+++ b/ios/PassCulture.xcodeproj/xcshareddata/xcschemes/PassCulture-Production.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Load env file"
-               scriptText = "echo &quot;.env.production&quot; &gt;  ${SRCROOT}/envfile&#10;ENVFILE=.env.production ${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb ${SRCROOT}/.. ${SRCROOT}/react-native-config.xcconfig&#10;&#10;${SRCROOT}/../scripts/print_project_version.sh ${SRCROOT}/..&#10;">
+               scriptText = "echo &quot;.env.production&quot; &gt; /tmp/envfile&#10;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb ${SRCROOT}/.. ${SRCROOT}/react-native-config.xcconfig&#10;&#10;${SRCROOT}/../scripts/print_project_version.sh ${SRCROOT}/..&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/PassCulture.xcodeproj/xcshareddata/xcschemes/PassCulture-Staging.xcscheme
+++ b/ios/PassCulture.xcodeproj/xcshareddata/xcschemes/PassCulture-Staging.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Load env file"
-               scriptText = "echo &quot;.env.staging&quot; &gt;  ${SRCROOT}/envfile&#10;ENVFILE=.env.staging ${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb ${SRCROOT}/.. ${SRCROOT}/react-native-config.xcconfig&#10;&#10;${SRCROOT}/../scripts/print_project_version.sh ${SRCROOT}/..&#10;">
+               scriptText = "echo &quot;.env.staging&quot; &gt; /tmp/envfile&#10;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb ${SRCROOT}/.. ${SRCROOT}/react-native-config.xcconfig&#10;&#10;${SRCROOT}/../scripts/print_project_version.sh ${SRCROOT}/..&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/PassCulture.xcodeproj/xcshareddata/xcschemes/PassCulture-Testing.xcscheme
+++ b/ios/PassCulture.xcodeproj/xcshareddata/xcschemes/PassCulture-Testing.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Load env file"
-               scriptText = "echo &quot;.env.testing&quot; &gt;  ${SRCROOT}/envfile&#10;ENVFILE=.env.testing ${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb ${SRCROOT}/.. ${SRCROOT}/react-native-config.xcconfig&#10;&#10;${SRCROOT}/../scripts/print_project_version.sh ${SRCROOT}/..&#10;">
+               scriptText = "echo &quot;.env.testing&quot; &gt; /tmp/envfile&#10;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb ${SRCROOT}/.. ${SRCROOT}/react-native-config.xcconfig&#10;&#10;${SRCROOT}/../scripts/print_project_version.sh ${SRCROOT}/..&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/PassCulture/AppDelegate.swift
+++ b/ios/PassCulture/AppDelegate.swift
@@ -45,7 +45,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     // Setup Batch
-    let associatedDomain = ReactNativeConfig.env(for: "WEBAPP_V2_DOMAIN")
+    let associatedDomain = RNCConfig.env(for: "WEBAPP_V2_DOMAIN")
     BatchSDK.associatedDomains = associatedDomain.map { [$0] } ?? []
     BatchEventDispatcher.add(BatchFirebaseDispatcher.instance())
     RNBatch.start()


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42828

## Context

Cette PR fait suite à un oubli de configuration sur la partie IOS

```ts
# node_modules/react-native-config/ios/ReactNativeConfig/ReadDotEnv.rb

def read_dot_env(envs_root)
  defaultEnvFile = '.env'
  puts "going to read env file from root folder #{envs_root}"

  # pick a custom env file if set
  if File.exist?('/tmp/envfile')
    custom_env = true
    file = File.read('/tmp/envfile').strip
  else
    custom_env = false
    file = ENV['ENVFILE'] || defaultEnvFile
  end
```

C'est ainsi que `react-native-config` récupère le fichier d'environnement pour l'intégrer au build:
- dans `/tmp`
- dans une variable d'environnement `$ENVFILE`
- dans un `.env` à la racine du projet

Dans cette PR le choix est porté sur `/tmp`, on peut donc supprimer l'`envfile` du `.gitignore`
