### PR TITLE
(PC-42647) feat(bonification): remove bonif tracking

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -12,5 +12,8 @@
         "destination": "/index.html"
       }
     ]
+  },
+  "react-native": {
+    "google_analytics_automatic_screen_reporting_enabled": false
   }
 }

--- a/src/libs/analytics/provider.test.ts
+++ b/src/libs/analytics/provider.test.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import { resetDedupCache } from 'libs/analytics/eventDeduplication'
 // eslint-disable-next-line no-restricted-imports
-import { analytics } from 'libs/analytics/provider'
+import { SENSITIVE_SCREEN_NAMES, analytics } from 'libs/analytics/provider'
 import { LocationType } from 'libs/analytics/types'
 // eslint-disable-next-line no-restricted-imports
 import { firebaseAnalytics } from 'libs/firebase/analytics/analytics'
@@ -55,6 +55,16 @@ describe('analyticsProvider - logEvent', () => {
 
       expect(firebaseAnalytics.logScreenView).toHaveBeenCalledWith(SCREEN_NAME, 'undefined')
     })
+
+    it.each(SENSITIVE_SCREEN_NAMES)(
+      'should not log screen view when logScreenView is called with screen %s',
+      async (sensitive_screen_name) => {
+        await analytics.logScreenView(sensitive_screen_name)
+        await act(() => {})
+
+        expect(firebaseAnalytics.logScreenView).not.toHaveBeenCalled()
+      }
+    )
   })
 
   describe('deduplication', () => {

--- a/src/libs/analytics/provider.ts
+++ b/src/libs/analytics/provider.ts
@@ -1,3 +1,4 @@
+import { ScreenNames } from 'features/navigation/navigators/RootNavigator/types'
 // eslint-disable-next-line no-restricted-imports
 import { isDuplicateEvent } from 'libs/analytics/eventDeduplication'
 // eslint-disable-next-line no-restricted-imports
@@ -6,6 +7,19 @@ import { AnalyticsProvider } from 'libs/analytics/types'
 // eslint-disable-next-line no-restricted-imports
 import { firebaseAnalytics } from 'libs/firebase/analytics/analytics'
 import { locationSelectors } from 'libs/locationV2/location.store'
+
+export const SENSITIVE_SCREEN_NAMES: ScreenNames[] = [
+  'BonificationBirthDate',
+  'BonificationBirthPlace',
+  'BonificationDisabilityRefused',
+  'BonificationError',
+  'BonificationExplanations',
+  'BonificationFamilyQuotientRefused',
+  'BonificationNames',
+  'BonificationRecap',
+  'BonificationRequiredInformation',
+  'BonificationTitle',
+]
 
 export const analytics: AnalyticsProvider = {
   enableCollection: async () => {
@@ -17,6 +31,7 @@ export const analytics: AnalyticsProvider = {
 
   logScreenView: async (screenName) => {
     if (isDuplicateEvent('screen_view', { screenName })) return
+    if (SENSITIVE_SCREEN_NAMES.includes(screenName)) return
     const locationType = locationSelectors.selectLocationType()
     await firebaseAnalytics.logScreenView(screenName, locationType)
   },


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42647


j'ai mis `"google_analytics_automatic_screen_reporting_enabled": false"` car le tracking auto envoie en doublons les event screen_view mais le screen indiqué est toujours `RNScreen` ce qui ne sert à rien. Ça fait ça car ça détecte les changement au niveau natif ce qui ne fonctionne pas avec React Native. 
Voir ici : https://rnfirebase.io/analytics/usage#disable-screenview-tracking
et première phrase ici : https://rnfirebase.io/analytics/screen-tracking
Je vais quand même valider le changement avec la data.

