### PR TITLE
(PC-42600) feat(offer): add follow artist button to distribution section

### DIFF
--- a/src/features/artist/components/FollowArtistButton/FollowArtistButton.native.test.tsx
+++ b/src/features/artist/components/FollowArtistButton/FollowArtistButton.native.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import { navigate } from '__mocks__/@react-navigation/native'
+import { FollowArtistButton } from 'features/artist/components/FollowArtistButton/FollowArtistButton'
+import { render, screen, userEvent } from 'tests/utils'
+
+const user = userEvent.setup()
+
+jest.useFakeTimers()
+
+describe('<FollowArtistButton />', () => {
+  it('should display the follow button with an accessible label', () => {
+    render(<FollowArtistButton artistName="Edith Piaf" artistId="1" />)
+
+    expect(screen.getByLabelText('Suivre Edith Piaf')).toBeOnTheScreen()
+  })
+
+  it('should open fake door modal with artistId when pressed', async () => {
+    render(<FollowArtistButton artistName="Edith Piaf" artistId="1" />)
+
+    await user.press(screen.getByLabelText('Suivre Edith Piaf'))
+
+    expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
+      surveyKey: 'has_seen_follow_artist_fake_door_survey',
+      surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=1',
+    })
+  })
+
+  it('should open fake door modal without artistId when not provided', async () => {
+    render(<FollowArtistButton artistName="Edith Piaf" />)
+
+    await user.press(screen.getByLabelText('Suivre Edith Piaf'))
+
+    expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
+      surveyKey: 'has_seen_follow_artist_fake_door_survey',
+      surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU',
+    })
+  })
+})

--- a/src/features/artist/components/FollowArtistButton/FollowArtistButton.tsx
+++ b/src/features/artist/components/FollowArtistButton/FollowArtistButton.tsx
@@ -1,0 +1,40 @@
+import { useNavigation } from '@react-navigation/native'
+import React, { FunctionComponent } from 'react'
+
+import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
+import { Button } from 'ui/designSystem/Button/Button'
+import { Bell } from 'ui/svg/icons/Bell'
+
+// Same Qualtrics survey as the artist page follow fake door
+const FOLLOW_ARTIST_SURVEY_URL = 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU'
+
+const buildSurveyUrl = (artistId?: string) =>
+  artistId ? `${FOLLOW_ARTIST_SURVEY_URL}?artistId=${artistId}` : FOLLOW_ARTIST_SURVEY_URL
+
+type Props = {
+  artistName: string
+  artistId?: string
+}
+
+export const FollowArtistButton: FunctionComponent<Props> = ({ artistName, artistId }) => {
+  const { navigate } = useNavigation<UseNavigationType>()
+
+  const handlePress = () => {
+    navigate('FakeDoorModal', {
+      surveyKey: 'has_seen_follow_artist_fake_door_survey',
+      surveyUrl: buildSurveyUrl(artistId),
+    })
+  }
+
+  return (
+    <Button
+      wording="Suivre"
+      icon={Bell}
+      variant="secondary"
+      color="neutral"
+      size="small"
+      accessibilityLabel={`Suivre ${artistName}`}
+      onPress={handlePress}
+    />
+  )
+}

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.native.test.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.native.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { ArtistType, CategoryIdEnum, SubcategoryIdEnum } from 'api/gen'
+import { ArtistType, CategoryIdEnum, OfferArtist, SubcategoryIdEnum } from 'api/gen'
 import { OfferArtistsSection } from 'features/offer/components/OfferArtistsSection/OfferArtistsSection'
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent } from 'tests/utils'
 
 const mockArtist = { id: '1', name: 'Edith Piaf' }
@@ -18,75 +21,52 @@ const user = userEvent.setup()
 
 jest.useFakeTimers()
 
+const renderOfferArtistsSection = (artists: OfferArtist[]) =>
+  render(
+    reactQueryProviderHOC(
+      <OfferArtistsSection
+        artists={artists}
+        offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
+        offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+        onPlaylistItemPress={jest.fn()}
+        offerId={1}
+      />
+    )
+  )
+
 describe('<OfferArtistsSection />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('When single artist', () => {
     it('should display correctly', () => {
-      render(
-        <OfferArtistsSection
-          artists={[mockArtist]}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection([mockArtist])
 
       expect(screen.getByText('Edith Piaf')).toBeOnTheScreen()
     })
 
     it('should display default avatar when image not defined', () => {
-      render(
-        <OfferArtistsSection
-          artists={[mockArtist]}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection([mockArtist])
 
       expect(screen.getByTestId('defaultArtistAvatar')).toBeOnTheScreen()
     })
 
     it('should display artist image when image defined', () => {
-      render(
-        <OfferArtistsSection
-          artists={[{ ...mockArtist, image: 'url' }]}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection([{ ...mockArtist, image: 'url' }])
 
       expect(screen.getByTestId('ArtistImage')).toBeOnTheScreen()
     })
 
     it('should display role as subtitle when role defined', () => {
-      render(
-        <OfferArtistsSection
-          artists={[{ ...mockArtist, role: ArtistType.author }]}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection([{ ...mockArtist, role: ArtistType.author }])
 
       expect(screen.getByText('Auteur')).toBeOnTheScreen()
       expect(screen.getByTestId('subtitleWithTitle')).toBeOnTheScreen()
     })
 
     it('should redirect to artist page when pressing button', async () => {
-      render(
-        <OfferArtistsSection
-          artists={[mockArtist]}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection([mockArtist])
 
       await user.press(screen.getByLabelText('Accéder à la page artiste de Edith Piaf'))
 
@@ -94,15 +74,7 @@ describe('<OfferArtistsSection />', () => {
     })
 
     it('should not have redirection to artist page when artist has not id', () => {
-      render(
-        <OfferArtistsSection
-          artists={[{ ...mockArtist, id: undefined }]}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection([{ ...mockArtist, id: undefined }])
 
       expect(
         screen.queryByLabelText('Accéder à la page artiste de Edith Piaf')
@@ -110,29 +82,13 @@ describe('<OfferArtistsSection />', () => {
     })
 
     it('should display singular section title', () => {
-      render(
-        <OfferArtistsSection
-          artists={[mockArtist]}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection([mockArtist])
 
       expect(screen.getAllByText('Artiste')[0]).toBeOnTheScreen()
     })
 
     it('should not display filter buttons', () => {
-      render(
-        <OfferArtistsSection
-          artists={[mockArtist]}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection([mockArtist])
 
       expect(screen.queryByTestId('filterButtons')).not.toBeOnTheScreen()
     })
@@ -140,15 +96,7 @@ describe('<OfferArtistsSection />', () => {
 
   describe('When multi artists', () => {
     it('should display correctly', () => {
-      render(
-        <OfferArtistsSection
-          artists={mockMultiArtists}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection(mockMultiArtists)
 
       expect(screen.getByText('Sam Worthington')).toBeOnTheScreen()
       expect(screen.getByText('Zoe Saldana')).toBeOnTheScreen()
@@ -156,58 +104,26 @@ describe('<OfferArtistsSection />', () => {
     })
 
     it('should display plural section title', () => {
-      render(
-        <OfferArtistsSection
-          artists={mockMultiArtists}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection(mockMultiArtists)
 
       expect(screen.getByText('Artistes')).toBeOnTheScreen()
     })
 
     it('should not display filter buttons when there are only artists with the same role', () => {
-      render(
-        <OfferArtistsSection
-          artists={mockMultiArtists}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection(mockMultiArtists)
 
       expect(screen.queryByTestId('filterButtons')).not.toBeOnTheScreen()
     })
 
     it('should display filter buttons when there are artists with different roles', () => {
-      render(
-        <OfferArtistsSection
-          artists={[...mockMultiArtists, mockFilmDirector]}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection([...mockMultiArtists, mockFilmDirector])
 
       expect(screen.getByLabelText('Acteurs : Filtre non sélectionné')).toBeOnTheScreen()
       expect(screen.getByLabelText('Réalisateur : Filtre non sélectionné')).toBeOnTheScreen()
     })
 
     it('should display all artists by default', () => {
-      render(
-        <OfferArtistsSection
-          artists={[...mockMultiArtists, mockFilmDirector]}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection([...mockMultiArtists, mockFilmDirector])
 
       expect(screen.getByText('Sam Worthington')).toBeOnTheScreen()
       expect(screen.getByText('Zoe Saldana')).toBeOnTheScreen()
@@ -216,15 +132,7 @@ describe('<OfferArtistsSection />', () => {
     })
 
     it('should filter artists when pressing filter button', async () => {
-      render(
-        <OfferArtistsSection
-          artists={[...mockMultiArtists, mockFilmDirector]}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection([...mockMultiArtists, mockFilmDirector])
 
       await user.press(screen.getByLabelText('Réalisateur : Filtre non sélectionné'))
 
@@ -235,15 +143,7 @@ describe('<OfferArtistsSection />', () => {
     })
 
     it('should display all artists when pressing filter button then deselected', async () => {
-      render(
-        <OfferArtistsSection
-          artists={[...mockMultiArtists, mockFilmDirector]}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection([...mockMultiArtists, mockFilmDirector])
 
       await user.press(screen.getByLabelText('Réalisateur : Filtre non sélectionné'))
 
@@ -261,43 +161,19 @@ describe('<OfferArtistsSection />', () => {
     })
 
     it('should display see all button when there are several artists', () => {
-      render(
-        <OfferArtistsSection
-          artists={mockMultiArtists}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection(mockMultiArtists)
 
       expect(screen.getByText('Voir tout')).toBeOnTheScreen()
     })
 
     it('should not display see all button when there is only one artist', () => {
-      render(
-        <OfferArtistsSection
-          artists={[mockArtist]}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection([mockArtist])
 
       expect(screen.queryByText('Voir tout')).not.toBeOnTheScreen()
     })
 
     it('should trigger ClickSeeAll log when pressing see all button', async () => {
-      render(
-        <OfferArtistsSection
-          artists={mockMultiArtists}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection(mockMultiArtists)
 
       await user.press(screen.getByText('Voir tout'))
 
@@ -309,15 +185,7 @@ describe('<OfferArtistsSection />', () => {
     })
 
     it('should redirect to VerticalPlaylistArtists when pressing see all button', async () => {
-      render(
-        <OfferArtistsSection
-          artists={mockMultiArtists}
-          offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
-          offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
-          onPlaylistItemPress={jest.fn()}
-          offerId={1}
-        />
-      )
+      renderOfferArtistsSection(mockMultiArtists)
 
       await user.press(screen.getByText('Voir tout'))
 
@@ -325,6 +193,54 @@ describe('<OfferArtistsSection />', () => {
         offerId: 1,
         title: 'Artistes',
         originDetails: 'offer',
+      })
+    })
+  })
+
+  describe('Follow artist fake door', () => {
+    it('should display follow button for the single artist when FF activated', () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_ARTIST_FAKE_DOOR])
+      renderOfferArtistsSection([mockArtist])
+
+      expect(screen.getByLabelText('Suivre Edith Piaf')).toBeOnTheScreen()
+    })
+
+    it('should display follow button for each artist when FF activated', () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_ARTIST_FAKE_DOOR])
+      renderOfferArtistsSection(mockMultiArtists)
+
+      expect(screen.getByLabelText('Suivre Sam Worthington')).toBeOnTheScreen()
+      expect(screen.getByLabelText('Suivre Zoe Saldana')).toBeOnTheScreen()
+      expect(screen.getByLabelText('Suivre Sigourney Weaver')).toBeOnTheScreen()
+    })
+
+    it('should not display follow button when FF deactivated', () => {
+      renderOfferArtistsSection([mockArtist])
+
+      expect(screen.queryByLabelText('Suivre Edith Piaf')).not.toBeOnTheScreen()
+    })
+
+    it('should open fake door modal with artistId when pressing follow button', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_ARTIST_FAKE_DOOR])
+      renderOfferArtistsSection([mockArtist])
+
+      await user.press(screen.getByLabelText('Suivre Edith Piaf'))
+
+      expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
+        surveyKey: 'has_seen_follow_artist_fake_door_survey',
+        surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=1',
+      })
+    })
+
+    it('should open fake door modal without artistId when artist has no id', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_ARTIST_FAKE_DOOR])
+      renderOfferArtistsSection([{ ...mockArtist, id: undefined }])
+
+      await user.press(screen.getByLabelText('Suivre Edith Piaf'))
+
+      expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
+        surveyKey: 'has_seen_follow_artist_fake_door_survey',
+        surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU',
       })
     })
   })

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
@@ -2,12 +2,15 @@ import React, { FunctionComponent, useState } from 'react'
 import { styled, useTheme } from 'styled-components/native'
 
 import { CategoryIdEnum, OfferArtist, SubcategoryIdEnum } from 'api/gen'
+import { FollowArtistButton } from 'features/artist/components/FollowArtistButton/FollowArtistButton'
 import { formatArtists } from 'features/artist/helpers/formatArtists'
 import { getArtistRole } from 'features/artist/helpers/getArtistRole'
 import { getArtistSectionTitle } from 'features/artist/helpers/getArtistSectionTitle'
 import { getArtistsFilterButtons } from 'features/offer/helpers/getArtistsFilterButtons/getArtistsFilterButtons'
 import { SingleFilterButton } from 'features/search/components/Buttons/SingleFilterButton/SingleFilterButton'
 import { analytics } from 'libs/analytics/provider'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { FastImage } from 'libs/resizing-image-on-demand/FastImage'
 import { accessibilityRoleInternalNavigation } from 'shared/accessibility/helpers/accessibilityRoleInternalNavigation'
 import { Avatar } from 'ui/components/Avatar/Avatar'
@@ -38,6 +41,7 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
   onPlaylistItemPress,
 }) => {
   const { designSystem } = useTheme()
+  const enableArtistFakeDoor = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ARTIST_FAKE_DOOR)
   const sectionTitle = getArtistSectionTitle(offerSubcategoryId)
   const formattedArtists = formatArtists(artists, offerCategoryId)
   const filterButtons = getArtistsFilterButtons(artists, offerCategoryId)
@@ -126,7 +130,17 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
       </SeeAllButtonContainer>
 
       {artists.length === 1 && soloArtist ? (
-        soloArtistPart()
+        <ViewGap gap={2}>
+          {soloArtistPart()}
+          {enableArtistFakeDoor ? (
+            <SoloFollowButtonContainer>
+              <FollowArtistButton
+                artistName={soloArtist.name}
+                artistId={soloArtist.id || undefined}
+              />
+            </SoloFollowButtonContainer>
+          ) : null}
+        </ViewGap>
       ) : (
         <React.Fragment>
           {filterButtons.length > 1 ? (
@@ -151,12 +165,27 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
             onItemPress={onPlaylistItemPress}
             withMargins={false}
             keyExtractor={(item) => `${item.id}-${item.role ?? ''}`}
+            renderItemFooter={
+              enableArtistFakeDoor
+                ? (artist) => (
+                    <FollowArtistButton
+                      artistName={artist.name}
+                      artistId={artist.id || undefined}
+                    />
+                  )
+                : undefined
+            }
           />
         </React.Fragment>
       )}
     </ViewGap>
   )
 }
+
+// Align the follow button with the avatar image (left edge of the item)
+const SoloFollowButtonContainer = styled.View({
+  alignSelf: 'flex-start',
+})
 
 const ArtistImage = styled(FastImage)(({ theme }) => ({
   width: '100%',

--- a/src/ui/components/Avatar/AvatarList.tsx
+++ b/src/ui/components/Avatar/AvatarList.tsx
@@ -5,7 +5,7 @@ import { FlatList } from 'react-native-gesture-handler'
 
 import { Artist } from 'features/venue/types'
 import { AvatarProps } from 'ui/components/Avatar/Avatar'
-import { AvatarListItem, AvatarListItemProps } from 'ui/components/Avatar/AvatarListItem'
+import { AvatarListItem } from 'ui/components/Avatar/AvatarListItem'
 import { Playlist } from 'ui/components/Playlist'
 import { AVATAR_LARGE } from 'ui/theme/constants'
 
@@ -18,6 +18,7 @@ type AvatarListProps = {
   withMargins?: boolean
   withPush?: boolean
   keyExtractor?: (item: Artist) => string
+  renderItemFooter?: (item: Artist) => React.ReactNode
 }
 
 const AVATAR_DEFAULT_CONFIG = {
@@ -34,6 +35,7 @@ export const AvatarList: FunctionComponent<AvatarListProps> = ({
   withMargins,
   withPush,
   keyExtractor,
+  renderItemFooter,
 }) => {
   const mergedAvatarConfig = mergeWith(
     avatarConfig,
@@ -41,7 +43,7 @@ export const AvatarList: FunctionComponent<AvatarListProps> = ({
     (value, srcValue) => value ?? srcValue
   )
   const renderAvatar = useCallback(
-    ({ item }: { item: AvatarListItemProps }) => (
+    ({ item }: { item: Artist }) => (
       <AvatarListItem
         id={item.id}
         image={item.image}
@@ -50,10 +52,11 @@ export const AvatarList: FunctionComponent<AvatarListProps> = ({
         role={item.role}
         accessibilityLabel={item.accessibilityLabel}
         withPush={withPush}
+        footer={renderItemFooter?.(item)}
         {...mergedAvatarConfig}
       />
     ),
-    [onItemPress, mergedAvatarConfig, withPush]
+    [onItemPress, mergedAvatarConfig, withPush, renderItemFooter]
   )
 
   const size = mergedAvatarConfig.size

--- a/src/ui/components/Avatar/AvatarListItem.tsx
+++ b/src/ui/components/Avatar/AvatarListItem.tsx
@@ -9,7 +9,7 @@ import { DefaultAvatar } from 'ui/components/Avatar/DefaultAvatar'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-export type AvatarListItemProps = {
+type AvatarListItemProps = {
   id: number | string
   name: string
   onItemPress: (id: string, name: string) => void
@@ -18,6 +18,7 @@ export type AvatarListItemProps = {
   role?: string
   accessibilityLabel?: string
   withPush?: boolean
+  footer?: React.ReactNode
 } & AvatarProps
 
 export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
@@ -30,6 +31,7 @@ export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
   role,
   accessibilityLabel,
   withPush,
+  footer,
   ...props
 }) => {
   const numberOfLines = useNumberOfLine(2)
@@ -59,19 +61,35 @@ export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
     </StyledView>
   )
 
-  if (!id) {
-    return content
-  }
-
-  return (
+  // The footer is rendered as a sibling of the navigation link (never nested inside it),
+  // because InternalTouchableLink renders an <a> on web and interactive elements
+  // must not be nested inside anchors.
+  const wrapped = id ? (
     <InternalTouchableLink
       accessibilityLabel={accessibilityLabel ?? name}
       navigateTo={{ screen: 'Artist', params: { id: id.toString() }, withPush }}
       onBeforeNavigate={() => onItemPress(id.toString(), name)}>
       {content}
     </InternalTouchableLink>
+  ) : (
+    content
+  )
+
+  if (!footer) {
+    return wrapped
+  }
+
+  return (
+    <ItemWithFooter gap={2}>
+      {wrapped}
+      {footer}
+    </ItemWithFooter>
   )
 }
+
+const ItemWithFooter = styled(ViewGap)({
+  alignItems: 'center',
+})
 
 const ArtistName = styled(Typo.BodyAccentS)<{
   maxWidth: number


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42600

## Context

Extension du point d'entrée de la fake door « Suivre » à la page offre. Un bouton « Suivre » est ajouté pour chaque artiste de la section **Distribution**, qui ouvre la même modale fake door que sur la page artiste.

Même fake door, nouveau point d'entrée : réutilisation du composant `FakeDoorModal`, du même questionnaire Qualtrics artiste, du même feature flag (`WIP_ARTIST_FAKE_DOOR`) et de la même clé `AsyncStorage` (`has_seen_follow_artist_fake_door_survey`).

**Ce que contient la PR :**

- Nouveau composant réutilisable `FollowArtistButton` (bouton `secondary` / `neutral` / `small` + icône cloche) qui ouvre la `FakeDoorModal`.
- **Cas solo** (un seul artiste) : bouton « Suivre » sous l'item, aligné avec l'avatar ; la cellule reste entièrement cliquable vers la page artiste.
- **Cas multi** : bouton « Suivre » sous chaque avatar, via une prop `renderItemFooter` optionnelle ajoutée à `AvatarList` / `AvatarListItem` (rétrocompatible, sans impact sur les autres écrans).
- Le bouton est affiché pour tous les artistes, y compris ceux sans `artistId`, et uniquement quand le feature flag est actif.
- L'`artistId` de l'artiste cliqué est transmis au questionnaire Qualtrics via `?artistId=<id>` (absent si le profil n'a pas d'`artistId`).

### Screenshots

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-07-16 at 11 39 59" src="https://github.com/user-attachments/assets/a5a7635c-b908-4ab1-a2ac-d50ae2740278" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-07-16 at 11 39 45" src="https://github.com/user-attachments/assets/d0bffa68-f68a-416a-986a-5375b2d30d36" />
