### PR TITLE
(PC-42902) fix(venue): gate header follow button behind wipVenueFakeD…

### DIFF
--- a/src/features/navigation/helpers/screenParamsUtils.ts
+++ b/src/features/navigation/helpers/screenParamsUtils.ts
@@ -12,7 +12,6 @@ type ScreensRequiringParsing = Extract<
   | 'BookingDetails'
   | 'BookingConfirmation'
   | 'ClubAdvices'
-  | 'FakeDoorModal'
   | 'Home'
   | 'Login'
   | 'LoginMethods'
@@ -210,10 +209,6 @@ export const screenParamsParser: ParamsParsers = {
     transcription: identityFn,
     thematicHomeEntryId: identityFn,
     thematicHomeTitle: identityFn,
-  },
-  FakeDoorModal: {
-    surveyKey: identityFn,
-    surveyUrl: identityFn,
   },
 }
 

--- a/src/features/venue/components/VenueContent/OldVenueContent.tsx
+++ b/src/features/venue/components/VenueContent/OldVenueContent.tsx
@@ -24,6 +24,7 @@ type Props = {
   venue: VenueResponse
   isCTADisplayed?: boolean
   children: React.ReactNode
+  enableVenueFakeDoor?: boolean
   onPressFollowButton: () => void
 }
 
@@ -34,6 +35,7 @@ export const OldVenueContent: React.FunctionComponent<Props> = ({
   venue,
   isCTADisplayed,
   children,
+  enableVenueFakeDoor,
   onPressFollowButton,
 }) => {
   const triggerBatch = useFunctionOnce(trackEventHasSeenVenueForSurvey)
@@ -105,6 +107,7 @@ export const OldVenueContent: React.FunctionComponent<Props> = ({
             <VenueHeader
               headerTransition={headerTransition}
               venue={venue}
+              enableVenueFakeDoor={enableVenueFakeDoor}
               onPressFollowButton={onPressFollowButton}
             />
           }>

--- a/src/features/venue/components/VenueContent/VenueContent.tsx
+++ b/src/features/venue/components/VenueContent/VenueContent.tsx
@@ -25,6 +25,7 @@ type Props = {
   isCTADisplayed?: boolean
   children: React.ReactNode
   showSearchInVenueModal: () => void
+  enableVenueFakeDoor?: boolean
   onPressFollowButton: () => void
 }
 
@@ -36,6 +37,7 @@ export const VenueContent: React.FunctionComponent<Props> = ({
   isCTADisplayed,
   children,
   showSearchInVenueModal,
+  enableVenueFakeDoor,
   onPressFollowButton,
 }) => {
   const triggerBatch = useFunctionOnce(trackEventHasSeenVenueForSurvey)
@@ -103,6 +105,7 @@ export const VenueContent: React.FunctionComponent<Props> = ({
             <VenueHeader
               headerTransition={headerTransition}
               venue={venue}
+              enableVenueFakeDoor={enableVenueFakeDoor}
               onPressFollowButton={onPressFollowButton}
             />
           }>

--- a/src/features/venue/components/VenueHeader/VenueHeader.native.test.tsx
+++ b/src/features/venue/components/VenueHeader/VenueHeader.native.test.tsx
@@ -72,18 +72,44 @@ describe('<VenueHeader />', () => {
       venueId: venueDataTest.id,
     })
   })
+
+  it('should display follow button when scrolling and wipVenueFakeDoor FF activated', () => {
+    const { animatedValue } = renderVenueHeader({ enableVenueFakeDoor: true })
+    scrollToDisplaySmallHeader(animatedValue)
+
+    expect(screen.getByLabelText('Suivre le lieu')).toBeOnTheScreen()
+  })
+
+  it('should not display follow button when scrolling and wipVenueFakeDoor FF deactivated', () => {
+    const { animatedValue } = renderVenueHeader()
+    scrollToDisplaySmallHeader(animatedValue)
+
+    expect(screen.queryByLabelText('Suivre le lieu')).not.toBeOnTheScreen()
+  })
 })
 
-const renderVenueHeader = () => {
+const renderVenueHeader = ({ enableVenueFakeDoor }: { enableVenueFakeDoor?: boolean } = {}) => {
   const animatedValue = new Animated.Value(0)
   render(
     reactQueryProviderHOC(
       <VenueHeader
         headerTransition={animatedValue}
         venue={venueDataTest}
+        enableVenueFakeDoor={enableVenueFakeDoor}
         onPressFollowButton={jest.fn()}
       />
     )
   )
   return { animatedValue }
+}
+
+const scrollToDisplaySmallHeader = (animatedValue: Animated.Value) => {
+  act(() => {
+    Animated.timing(animatedValue, {
+      duration: 100,
+      toValue: 1,
+      useNativeDriver: false,
+    }).start()
+    jest.runAllTimers()
+  })
 }

--- a/src/features/venue/components/VenueHeader/VenueHeader.tsx
+++ b/src/features/venue/components/VenueHeader/VenueHeader.tsx
@@ -18,13 +18,19 @@ import { Share } from 'ui/svg/icons/Share'
 interface Props {
   headerTransition: Animated.AnimatedInterpolation<string | number>
   venue: VenueResponse
+  enableVenueFakeDoor?: boolean
   onPressFollowButton: () => void
 }
 
 /**
  * @param props.headerTransition should be between animated between 0 and 1
  */
-export const VenueHeader: React.FC<Props> = ({ headerTransition, venue, onPressFollowButton }) => {
+export const VenueHeader: React.FC<Props> = ({
+  headerTransition,
+  venue,
+  enableVenueFakeDoor,
+  onPressFollowButton,
+}) => {
   const { goBack } = useGoBack(...getSearchHookConfig('SearchLanding'))
   const [showSmallSubscriptionButton, setShowSmallSubscriptionButton] = useState(false)
 
@@ -65,7 +71,7 @@ export const VenueHeader: React.FC<Props> = ({ headerTransition, venue, onPressF
         titleTestID="venueHeaderName"
         RightElement={
           <ButtonsContainer gap={3}>
-            {showSmallSubscriptionButton ? (
+            {enableVenueFakeDoor && showSmallSubscriptionButton ? (
               <Animated.View style={{ opacity: smallSubscribeButtonOpacity }}>
                 <Button
                   iconButton

--- a/src/features/venue/pages/Venue/Venue.tsx
+++ b/src/features/venue/pages/Venue/Venue.tsx
@@ -250,6 +250,7 @@ export const Venue: FunctionComponent = () => {
             venue={venue}
             isCTADisplayed={isCTADisplayed}
             showSearchInVenueModal={showSearchInVenueModal}
+            enableVenueFakeDoor={enableVenueFakeDoor}
             onPressFollowButton={handleOnPressFollowButton}>
             {VenueContentChildren}
           </VenueContent>
@@ -264,6 +265,7 @@ export const Venue: FunctionComponent = () => {
         <OldVenueContent
           venue={venue}
           isCTADisplayed={isCTADisplayed}
+          enableVenueFakeDoor={enableVenueFakeDoor}
           onPressFollowButton={handleOnPressFollowButton}>
           {VenueContentChildren}
         </OldVenueContent>


### PR DESCRIPTION
…oor FF

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42902

## Context

Suite à la PR #9918 (PC-42797) qui a ajouté le bouton « Suivre » avec une fake door
sur la page lieu, le feature flag `wipVenueFakeDoor` ne protégeait qu'un seul des
deux points d'entrée.

La prop `enableVenueFakeDoor` était bien passée jusqu'à `VenueBanner`, mais pas
jusqu'à `VenueHeader`. Résultat : avec le flag désactivé, le bouton de la bannière
était bien masqué, mais dès que l'utilisateur scrollait, la cloche « Suivre le lieu »
apparaissait dans le header réduit et ouvrait la `FakeDoorModal` avec le
questionnaire Qualtrics.

Cette PR :

- Fait descendre `enableVenueFakeDoor` de `Venue` jusqu'à `VenueHeader`, via
  `VenueContent` et `OldVenueContent`, et conditionne l'affichage de la cloche
- Ajoute deux tests de non-régression sur `VenueHeader` (flag ON / flag OFF après
  scroll). J'ai vérifié qu'ils ne sont pas tautologiques : en retirant le gating,
  le test « flag OFF » échoue bien
- Supprime l'entrée morte `FakeDoorModal` de `screenParamsParser` : l'écran n'a pas
  de path de deeplink dans `rootStackNavigatorPathConfig`, donc le parser n'était
  jamais appelé
