### PR TITLE
(PC-42779) feat(venue): send venue_type to qualtrics follow survey

### DIFF
--- a/src/features/venue/helpers/buildFollowVenueSurveyUrl.test.ts
+++ b/src/features/venue/helpers/buildFollowVenueSurveyUrl.test.ts
@@ -1,0 +1,31 @@
+import { Activity } from 'api/gen'
+import {
+  buildFollowVenueSurveyUrl,
+  FOLLOW_VENUE_SURVEY_URL,
+} from 'features/venue/helpers/buildFollowVenueSurveyUrl'
+
+describe('buildFollowVenueSurveyUrl', () => {
+  it('should add the venue activity as venue_type query param', () => {
+    const result = buildFollowVenueSurveyUrl(Activity.MUSEUM)
+
+    expect(result).toEqual(`${FOLLOW_VENUE_SURVEY_URL}?venue_type=MUSEUM`)
+  })
+
+  it('should add the venue activity as venue_type query param for another activity', () => {
+    const result = buildFollowVenueSurveyUrl(Activity.CINEMA)
+
+    expect(result).toEqual(`${FOLLOW_VENUE_SURVEY_URL}?venue_type=CINEMA`)
+  })
+
+  it('should not add the venue_type query param when activity is null', () => {
+    const result = buildFollowVenueSurveyUrl(null)
+
+    expect(result).toEqual(FOLLOW_VENUE_SURVEY_URL)
+  })
+
+  it('should not add the venue_type query param when activity is undefined', () => {
+    const result = buildFollowVenueSurveyUrl(undefined)
+
+    expect(result).toEqual(FOLLOW_VENUE_SURVEY_URL)
+  })
+})

--- a/src/features/venue/helpers/buildFollowVenueSurveyUrl.ts
+++ b/src/features/venue/helpers/buildFollowVenueSurveyUrl.ts
@@ -1,0 +1,9 @@
+import { Activity } from 'api/gen'
+
+export const FOLLOW_VENUE_SURVEY_URL =
+  'https://passculture.qualtrics.com/jfe/form/SV_b3novwqFYApLUDY'
+
+// venue_type is declared as embedded data on the Qualtrics side, so responses
+// can be filtered by venue activity. Omitted when the venue has no activity.
+export const buildFollowVenueSurveyUrl = (activity?: Activity | null): string =>
+  activity ? `${FOLLOW_VENUE_SURVEY_URL}?venue_type=${activity}` : FOLLOW_VENUE_SURVEY_URL

--- a/src/features/venue/pages/Venue/Venue.native.test.tsx
+++ b/src/features/venue/pages/Venue/Venue.native.test.tsx
@@ -517,6 +517,24 @@ describe('<Venue />', () => {
 
       expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
         surveyKey: 'has_seen_follow_venue_fake_door_survey',
+        surveyUrl: `https://passculture.qualtrics.com/jfe/form/SV_b3novwqFYApLUDY?venue_type=${Activity.BOOKSTORE}`,
+      })
+    })
+
+    it('should not send venue_type to the survey when venue has no activity', async () => {
+      mockServer.getApi<VenueResponse>(`/v2/venue/${venueId}`, {
+        ...venueDataTest,
+        isOpenToPublic: true,
+        bannerUrl: 'url_image',
+        activity: null,
+      })
+      asyncStorageSpyOn.mockResolvedValueOnce('false')
+      renderVenue(venueId)
+
+      await user.press(await screen.findByLabelText('Suivre le lieu'))
+
+      expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
+        surveyKey: 'has_seen_follow_venue_fake_door_survey',
         surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_b3novwqFYApLUDY',
       })
     })

--- a/src/features/venue/pages/Venue/Venue.tsx
+++ b/src/features/venue/pages/Venue/Venue.tsx
@@ -21,6 +21,7 @@ import { VenueContent } from 'features/venue/components/VenueContent/VenueConten
 import { VenueMessagingApps } from 'features/venue/components/VenueMessagingApps/VenueMessagingApps'
 import { VenueThematicSection } from 'features/venue/components/VenueThematicSection/VenueThematicSection'
 import { VenueTopComponent } from 'features/venue/components/VenueTopComponent/VenueTopComponent'
+import { buildFollowVenueSurveyUrl } from 'features/venue/helpers/buildFollowVenueSurveyUrl'
 import { getVenueOffersArtists } from 'features/venue/helpers/getVenueOffersArtists'
 import { useVenueSearchParameters } from 'features/venue/helpers/useVenueSearchParameters'
 import { getAdvicesWithoutHeadline, getHeadlineAdvice } from 'features/venue/helpers/venueAdvices'
@@ -179,7 +180,7 @@ export const Venue: FunctionComponent = () => {
   const handleOnPressFollowButton = () => {
     navigate('FakeDoorModal', {
       surveyKey: 'has_seen_follow_venue_fake_door_survey',
-      surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_b3novwqFYApLUDY',
+      surveyUrl: buildFollowVenueSurveyUrl(venue?.activity),
     })
   }
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42779

## Context

Pour permettre de trier les réponses Qualtrics par type de lieu, on transmet désormais le type du lieu consulté en donnée intégrée (embedded data) lors du déclenchement du questionnaire depuis le bouton « Suivre » de la page lieu.

Le paramètre est ajouté en query param à l'URL du questionnaire, sur le même modèle que `?artistId=` déjà en place sur le fake door « Suivre » de la page artiste.

**Source de la donnée** : `venue.activity`, déjà présent dans la réponse de `/v2/venue/{id}` et utilisé dans `Venue.tsx`. Aucun appel supplémentaire n'est nécessaire.

**Valeurs transmises** : la valeur brute de l'enum `Activity` (`MUSEUM`, `CINEMA`, `LIBRARY`, `BOOKSTORE`, `PERFORMANCE_HALL`…). Choix retenu plutôt qu'un mapping vers des libellés français, pour rester aligné avec le backend et éviter une table de correspondance à maintenir.

**Cas sans activité** : si `venue.activity` est `null` (le champ est nullable côté API), le paramètre est simplement omis de l'URL — Qualtrics enregistre une valeur vide, pas une valeur erronée.

### Modifications

- Nouveau helper `buildFollowVenueSurveyUrl` (`src/features/venue/helpers/`) qui construit l'URL du questionnaire avec le paramètre `venue_type`
- `Venue.tsx` : `handleOnPressFollowButton` utilise ce helper à la place de l'URL codée en dur

`handleOnPressFollowButton` est le point d'entrée unique du fake door : les boutons « Suivre » de `VenueBanner` et de `VenueHeader` reçoivent tous les deux ce callback, aucun autre composant n'est à modifier.

### Hors scope

- `offer_type` (ticket dédié)
- Le fake door « Suivre » de la page artiste