### PR TITLE
(PC-42910) fix(ci): use correct hermesc path for sentry sourcemaps

### DIFF
--- a/scripts/upload_sourcemaps_to_sentry.sh
+++ b/scripts/upload_sourcemaps_to_sentry.sh
@@ -19,7 +19,7 @@ create_sourcemaps() {
     HERMES_OS_BIN="osx-bin"
   fi
 
-  HERMES_BIN="node_modules/react-native/sdks/hermesc/${HERMES_OS_BIN}/hermesc"
+  HERMES_BIN="node_modules/hermes-compiler/hermesc/${HERMES_OS_BIN}/hermesc"
 
   if [[ "${APP_OS}" = "android" ]]; then
     npx react-native bundle \


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42910

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
