### PR TITLE
(PC-42908) fix(offer): align follow artist buttons in artists playlist

### DIFF
--- a/src/ui/components/Avatar/AvatarListItem.tsx
+++ b/src/ui/components/Avatar/AvatarListItem.tsx
@@ -89,6 +89,7 @@ export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
 
 const ItemWithFooter = styled(ViewGap)({
   alignItems: 'center',
+  justifyContent: 'space-between',
 })
 
 const ArtistName = styled(Typo.BodyAccentS)<{


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42908

## Context

Dans la section artistes de la page Offre (« Distribution », « Artistes »…), les boutons « Suivre » n'étaient pas alignés verticalement entre eux : chaque bouton était simplement empilé sous le bloc nom + rôle de son artiste, dont la hauteur varie selon que le nom et le rôle tiennent sur une ou deux lignes.

Le correctif s'appuie sur le comportement natif des listes horizontales : le `contentContainer` étant une ligne en `align-items: stretch`, toutes les cellules prennent la hauteur de la plus haute. `ItemWithFooter` remplit donc cette hauteur commune, et `justifyContent: 'space-between'` plaque le bouton en bas — tous les boutons se retrouvent sur la même ligne de base.

Le style ne s'applique que lorsqu'un `footer` est fourni à `AvatarListItem`. Les autres playlists d'avatars (artistes similaires, lieu, résultats de recherche, mode `isFullWidth`) n'en passent pas et retournent directement le contenu sans ce conteneur : aucun impact.

### Limite connue

La hauteur commune est calculée sur les cellules montées. Avec la virtualisation (`initialNumToRender={4}`, `removeClippedSubviews`), l'arrivée au scroll d'un artiste au nom plus long peut faire descendre le bloc de boutons d'un cran. Les boutons restent alignés entre eux à tout instant. Sur une section Distribution (peu d'artistes, généralement tous rendus d'emblée) l'impact attendu est nul à faible.

### Screenshot

<img width="1228" height="902" alt="image" src="https://github.com/user-attachments/assets/514cdc3c-5c98-45e0-871c-540e58246db0" />
