### PR TITLE
(PC-42780) feat(artist): send offer_type embedded data to Qualtrics f…

### DIFF
--- a/src/features/artist/components/ArtistBody/ArtistBody.native.test.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.native.test.tsx
@@ -356,13 +356,78 @@ describe('<ArtistBody />', () => {
     expect(screen.queryByLabelText('Suivre cet artiste')).not.toBeOnTheScreen()
   })
 
-  it('should open fake door modal when pressing follow button', async () => {
+  it('should open fake door modal without offer type when the artist has no offer', async () => {
     setFeatureFlags([RemoteStoreFeatureFlags.WIP_ARTIST_FAKE_DOOR])
     render(
       reactQueryProviderHOC(
         <ArtistBody
           artist={mockArtist}
           artistPlaylist={[]}
+          artistTopOffers={[]}
+          onViewableItemsChanged={jest.fn()}
+          onExpandBioPress={jest.fn()}
+        />
+      )
+    )
+
+    await user.press(await screen.findByLabelText('Suivre cet artiste'))
+
+    expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
+      surveyKey: 'has_seen_follow_artist_fake_door_survey',
+      surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU',
+    })
+  })
+
+  it('should open fake door modal with the first displayed playlist category as offer type', async () => {
+    setFeatureFlags([
+      RemoteStoreFeatureFlags.WIP_ARTIST_FAKE_DOOR,
+      RemoteStoreFeatureFlags.WIP_ARTIST_CATEGORY_PLAYLISTS,
+    ])
+    render(
+      reactQueryProviderHOC(
+        <ArtistBody
+          artist={mockArtist}
+          // LIVRES comes before MUSIQUE in ARTIST_CATEGORY_PLAYLISTS, offers order is irrelevant
+          artistPlaylist={[
+            buildArtistOffer({
+              objectID: '1',
+              name: 'Vinyle',
+              subcategoryId: SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE,
+            }),
+            buildArtistOffer({
+              objectID: '2',
+              name: 'Livre papier',
+              subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
+            }),
+          ]}
+          artistTopOffers={[]}
+          onViewableItemsChanged={jest.fn()}
+          onExpandBioPress={jest.fn()}
+        />
+      )
+    )
+
+    await user.press(await screen.findByLabelText('Suivre cet artiste'))
+
+    expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
+      surveyKey: 'has_seen_follow_artist_fake_door_survey',
+      surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?offer_type=LIVRES',
+    })
+  })
+
+  it('should open fake door modal without offer type when wipArtistCategoryPlaylists FF deactivated', async () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_ARTIST_FAKE_DOOR])
+    render(
+      reactQueryProviderHOC(
+        <ArtistBody
+          artist={mockArtist}
+          artistPlaylist={[
+            buildArtistOffer({
+              objectID: '1',
+              name: 'Livre papier',
+              subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
+            }),
+          ]}
           artistTopOffers={[]}
           onViewableItemsChanged={jest.fn()}
           onExpandBioPress={jest.fn()}

--- a/src/features/artist/components/ArtistBody/ArtistBody.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.tsx
@@ -11,6 +11,8 @@ import { ArtistPlaylist } from 'features/artist/components/ArtistPlaylist/Artist
 import { ArtistSimilarArtists } from 'features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists'
 import { ArtistTopOffers } from 'features/artist/components/ArtistTopOffers/ArtistTopOffers'
 import { ArtistWebMetaHeader } from 'features/artist/components/ArtistWebMetaHeader'
+import { buildFollowArtistSurveyUrl } from 'features/artist/helpers/buildFollowArtistSurveyUrl'
+import { getDisplayableArtistPlaylists } from 'features/artist/helpers/getDisplayableArtistPlaylists'
 import { separateTitleAndEmojis } from 'features/home/helpers/separateTitleAndEmojis'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
 import { getSearchHookConfig } from 'features/navigation/navigators/SearchStackNavigator/getSearchHookConfig'
@@ -41,8 +43,6 @@ import { Share } from 'ui/svg/icons/Share'
 import { Typo } from 'ui/theme'
 
 const isWeb = Platform.OS === 'web'
-
-const FOLLOW_ARTIST_SURVEY_URL = 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU'
 
 type Props = {
   artist: ArtistResponse
@@ -109,9 +109,15 @@ export const ArtistBody: FunctionComponent<Props> = ({
   const { navigate } = useNavigation<UseNavigationType>()
 
   const handlePressFollow = () => {
+    // Business rule: report a single offer type, the first playlist category displayed on the page.
+    // Playlists are only rendered when enablePlaylistByCategory is on, so no category is reported otherwise.
+    const [firstArtistPlaylist] = enablePlaylistByCategory
+      ? getDisplayableArtistPlaylists(artistPlaylist)
+      : []
+
     navigate('FakeDoorModal', {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
-      surveyUrl: FOLLOW_ARTIST_SURVEY_URL,
+      surveyUrl: buildFollowArtistSurveyUrl({ offerType: firstArtistPlaylist?.searchGroupName }),
     })
   }
 

--- a/src/features/artist/components/FollowArtistButton/FollowArtistButton.native.test.tsx
+++ b/src/features/artist/components/FollowArtistButton/FollowArtistButton.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
+import { SearchGroupNameEnumv2 } from 'api/gen'
 import { FollowArtistButton } from 'features/artist/components/FollowArtistButton/FollowArtistButton'
 import { render, screen, userEvent } from 'tests/utils'
 
@@ -34,6 +35,24 @@ describe('<FollowArtistButton />', () => {
     expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
       surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU',
+    })
+  })
+
+  it('should open fake door modal with offer type when provided', async () => {
+    render(
+      <FollowArtistButton
+        artistName="Edith Piaf"
+        artistId="1"
+        offerType={SearchGroupNameEnumv2.LIVRES}
+      />
+    )
+
+    await user.press(screen.getByLabelText('Suivre Edith Piaf'))
+
+    expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
+      surveyKey: 'has_seen_follow_artist_fake_door_survey',
+      surveyUrl:
+        'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=1&offer_type=LIVRES',
     })
   })
 })

--- a/src/features/artist/components/FollowArtistButton/FollowArtistButton.tsx
+++ b/src/features/artist/components/FollowArtistButton/FollowArtistButton.tsx
@@ -1,28 +1,29 @@
 import { useNavigation } from '@react-navigation/native'
 import React, { FunctionComponent } from 'react'
 
+import { SearchGroupNameEnumv2 } from 'api/gen'
+import { buildFollowArtistSurveyUrl } from 'features/artist/helpers/buildFollowArtistSurveyUrl'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Bell } from 'ui/svg/icons/Bell'
 
-// Same Qualtrics survey as the artist page follow fake door
-const FOLLOW_ARTIST_SURVEY_URL = 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU'
-
-const buildSurveyUrl = (artistId?: string) =>
-  artistId ? `${FOLLOW_ARTIST_SURVEY_URL}?artistId=${artistId}` : FOLLOW_ARTIST_SURVEY_URL
-
 type Props = {
   artistName: string
   artistId?: string
+  offerType?: SearchGroupNameEnumv2
 }
 
-export const FollowArtistButton: FunctionComponent<Props> = ({ artistName, artistId }) => {
+export const FollowArtistButton: FunctionComponent<Props> = ({
+  artistName,
+  artistId,
+  offerType,
+}) => {
   const { navigate } = useNavigation<UseNavigationType>()
 
   const handlePress = () => {
     navigate('FakeDoorModal', {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
-      surveyUrl: buildSurveyUrl(artistId),
+      surveyUrl: buildFollowArtistSurveyUrl({ artistId, offerType }),
     })
   }
 

--- a/src/features/artist/helpers/buildFollowArtistSurveyUrl.native.test.ts
+++ b/src/features/artist/helpers/buildFollowArtistSurveyUrl.native.test.ts
@@ -1,0 +1,26 @@
+import { SearchGroupNameEnumv2 } from 'api/gen'
+import { buildFollowArtistSurveyUrl } from 'features/artist/helpers/buildFollowArtistSurveyUrl'
+
+const SURVEY_URL = 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU'
+
+describe('buildFollowArtistSurveyUrl', () => {
+  it('should return the bare survey url when no param is provided', () => {
+    expect(buildFollowArtistSurveyUrl()).toEqual(SURVEY_URL)
+  })
+
+  it('should append artistId only', () => {
+    expect(buildFollowArtistSurveyUrl({ artistId: '1' })).toEqual(`${SURVEY_URL}?artistId=1`)
+  })
+
+  it('should append offer_type only', () => {
+    expect(buildFollowArtistSurveyUrl({ offerType: SearchGroupNameEnumv2.LIVRES })).toEqual(
+      `${SURVEY_URL}?offer_type=LIVRES`
+    )
+  })
+
+  it('should append both artistId and offer_type', () => {
+    expect(
+      buildFollowArtistSurveyUrl({ artistId: '1', offerType: SearchGroupNameEnumv2.MUSIQUE })
+    ).toEqual(`${SURVEY_URL}?artistId=1&offer_type=MUSIQUE`)
+  })
+})

--- a/src/features/artist/helpers/buildFollowArtistSurveyUrl.ts
+++ b/src/features/artist/helpers/buildFollowArtistSurveyUrl.ts
@@ -1,0 +1,18 @@
+import { SearchGroupNameEnumv2 } from 'api/gen'
+
+const FOLLOW_ARTIST_SURVEY_URL = 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU'
+
+type Params = {
+  artistId?: string
+  // Qualtrics embedded data: culture category of the offer(s) the survey was triggered from
+  offerType?: SearchGroupNameEnumv2
+}
+
+export const buildFollowArtistSurveyUrl = ({ artistId, offerType }: Params = {}): string => {
+  const searchParams = new URLSearchParams()
+  if (artistId) searchParams.append('artistId', artistId)
+  if (offerType) searchParams.append('offer_type', offerType)
+
+  const query = searchParams.toString()
+  return query ? `${FOLLOW_ARTIST_SURVEY_URL}?${query}` : FOLLOW_ARTIST_SURVEY_URL
+}

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.native.test.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.native.test.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { ArtistType, CategoryIdEnum, OfferArtist, SubcategoryIdEnum } from 'api/gen'
+import {
+  ArtistType,
+  CategoryIdEnum,
+  OfferArtist,
+  SearchGroupNameEnumv2,
+  SubcategoryIdEnum,
+} from 'api/gen'
 import { OfferArtistsSection } from 'features/offer/components/OfferArtistsSection/OfferArtistsSection'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
@@ -28,6 +34,7 @@ const renderOfferArtistsSection = (artists: OfferArtist[]) =>
         artists={artists}
         offerCategoryId={CategoryIdEnum.MUSIQUE_ENREGISTREE}
         offerSubcategoryId={SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}
+        offerSearchGroupName={SearchGroupNameEnumv2.MUSIQUE}
         onPlaylistItemPress={jest.fn()}
         offerId={1}
       />
@@ -220,7 +227,7 @@ describe('<OfferArtistsSection />', () => {
       expect(screen.queryByLabelText('Suivre Edith Piaf')).not.toBeOnTheScreen()
     })
 
-    it('should open fake door modal with artistId when pressing follow button', async () => {
+    it('should open fake door modal with artistId and offer type when pressing follow button', async () => {
       setFeatureFlags([RemoteStoreFeatureFlags.WIP_ARTIST_FAKE_DOOR])
       renderOfferArtistsSection([mockArtist])
 
@@ -228,7 +235,8 @@ describe('<OfferArtistsSection />', () => {
 
       expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
         surveyKey: 'has_seen_follow_artist_fake_door_survey',
-        surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=1',
+        surveyUrl:
+          'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=1&offer_type=MUSIQUE',
       })
     })
 
@@ -240,7 +248,21 @@ describe('<OfferArtistsSection />', () => {
 
       expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
         surveyKey: 'has_seen_follow_artist_fake_door_survey',
-        surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU',
+        surveyUrl:
+          'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?offer_type=MUSIQUE',
+      })
+    })
+
+    it('should open fake door modal with offer type from a multi artists list', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_ARTIST_FAKE_DOOR])
+      renderOfferArtistsSection(mockMultiArtists)
+
+      await user.press(screen.getByLabelText('Suivre Zoe Saldana'))
+
+      expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
+        surveyKey: 'has_seen_follow_artist_fake_door_survey',
+        surveyUrl:
+          'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=2&offer_type=MUSIQUE',
       })
     })
   })

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useState } from 'react'
 import { styled, useTheme } from 'styled-components/native'
 
-import { CategoryIdEnum, OfferArtist, SubcategoryIdEnum } from 'api/gen'
+import { CategoryIdEnum, OfferArtist, SearchGroupNameEnumv2, SubcategoryIdEnum } from 'api/gen'
 import { FollowArtistButton } from 'features/artist/components/FollowArtistButton/FollowArtistButton'
 import { formatArtists } from 'features/artist/helpers/formatArtists'
 import { getArtistRole } from 'features/artist/helpers/getArtistRole'
@@ -29,6 +29,7 @@ interface Props {
   artists: OfferArtist[]
   offerCategoryId: CategoryIdEnum
   offerSubcategoryId: SubcategoryIdEnum
+  offerSearchGroupName: SearchGroupNameEnumv2
   offerId: number
   onPlaylistItemPress: (artistId: string, artistName: string) => void
 }
@@ -37,6 +38,7 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
   artists,
   offerCategoryId,
   offerSubcategoryId,
+  offerSearchGroupName,
   offerId,
   onPlaylistItemPress,
 }) => {
@@ -137,6 +139,7 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
               <FollowArtistButton
                 artistName={soloArtist.name}
                 artistId={soloArtist.id || undefined}
+                offerType={offerSearchGroupName}
               />
             </SoloFollowButtonContainer>
           ) : null}
@@ -171,6 +174,7 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
                     <FollowArtistButton
                       artistName={artist.name}
                       artistId={artist.id || undefined}
+                      offerType={offerSearchGroupName}
                     />
                   )
                 : undefined

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -200,6 +200,7 @@ export const OfferBody: FunctionComponent<Props> = ({
             artists={artists}
             offerCategoryId={subcategory.categoryId}
             offerSubcategoryId={offer.subcategoryId}
+            offerSearchGroupName={subcategory.searchGroupName}
             offerId={offer.id}
             onPlaylistItemPress={handleOnArtistPlaylistItemPress}
           />


### PR DESCRIPTION
…ollow survey

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42780

## Context

La catégorie d'artiste n'existe pas en base : on segmente donc les réponses au questionnaire « Suivre » par **type d'offre**. Cette PR transmet `offer_type` en donnée intégrée (embedded data) Qualtrics au déclenchement du questionnaire, depuis la page offre et depuis la page artiste.

### Valeur envoyée

`SearchGroupNameEnumv2` (`LIVRES`, `MUSIQUE`, `CONCERTS_FESTIVALS`…), retenue plutôt que `CategoryIdEnum` car c'est déjà la clé de regroupement des playlists de la page artiste : la règle « la première catégorie trouvée » s'y applique directement, et la valeur reste cohérente entre les deux pages sans mapping supplémentaire.

### Comportement par point d'entrée

| Origine | Valeur remontée |
| :------ | :-------------- |
| Page offre (section artistes) | Catégorie de l'offre consultée — les offres liées n'étant pas préchargées, léger biais assumé |
| Page artiste (bouton header) | Catégorie de la **première** playlist affichée, même lorsque plusieurs catégories sont présentes |
| Page lieu | Aucune — questionnaire Qualtrics distinct, non modifié |

### Changements

- Nouveau helper `buildFollowArtistSurveyUrl` qui centralise l'URL du questionnaire et la construction des query params. Elle était jusqu'ici dupliquée entre `FollowArtistButton.tsx` et `ArtistBody.tsx`.
- `FollowArtistButton` accepte une prop `offerType`, propagée par `OfferArtistsSection` depuis `subcategory.searchGroupName` fourni par `OfferBody`.
- `ArtistBody` dérive la catégorie via `getDisplayableArtistPlaylists(artistPlaylist)[0]?.searchGroupName`, calculée au clic plutôt qu'au render.
- Si aucune catégorie n'est déterminable, le paramètre est **absent** de l'URL plutôt qu'envoyé vide.

### Points d'attention pour la relecture

- Sur la page artiste, `offer_type` n'est calculé que si `wipArtistCategoryPlaylists` est actif, puisque c'est ce flag qui conditionne l'affichage des playlists par catégorie dont la valeur est dérivée. Le flag est déjà actif en production, cette branche est donc uniquement défensive.
- L'envoi de `artistId` reste inchangé : présent depuis la page offre (règle de gestion de PC-42600), absent depuis la page artiste (PC-42391 spécifiait l'URL nue). Ce n'est pas modifié ici, mais ça vaut sans doute une discussion produit — sans identifiant, une réponse issue de la page artiste ne permet pas de savoir quel artiste l'utilisateur voulait suivre.
- **Avant activation** : le champ `offer_type` doit être déclaré en embedded data côté Qualtrics, sinon la donnée est perdue sans possibilité de réinjection a posteriori. Même vigilance pour `artistId`, envoyé depuis PC-42600.
