### PR TITLE
(PC-42673) feat(home): remove contentful general homeentryid

### DIFF
--- a/src/features/home/api/useHomepageData.native.test.ts
+++ b/src/features/home/api/useHomepageData.native.test.ts
@@ -21,7 +21,6 @@ jest.mock('features/auth/context/AuthContext', () => ({
 describe('getHomepageId', () => {
   const mockConfig: CustomRemoteConfig = {
     ...DEFAULT_REMOTE_CONFIG,
-    homeEntryIdGeneral: 'general-id',
     homeEntryIdBeneficiary: 'beneficiary-id',
     homeEntryIdFreeBeneficiary: 'free-beneficiary-id',
     homeEntryIdWithoutBooking: 'without-booking-id',
@@ -42,8 +41,8 @@ describe('getHomepageId', () => {
     ${true}    | ${false}                    | ${true}       | ${false}    | ${UserOnboardingRole.UNKNOWN}  | ${mockConfig.homeEntryIdWithoutBooking}
     ${false}   | ${false}                    | ${false}      | ${false}    | ${UserOnboardingRole.UNDERAGE} | ${mockConfig.homeEntryIdFreeBeneficiary}
     ${true}    | ${true}                     | ${false}      | ${false}    | ${UserOnboardingRole.UNKNOWN}  | ${mockConfig.homeEntryIdFreeBeneficiary}
-    ${false}   | ${false}                    | ${false}      | ${false}    | ${UserOnboardingRole.UNKNOWN}  | ${mockConfig.homeEntryIdGeneral}
-    ${true}    | ${false}                    | ${false}      | ${false}    | ${UserOnboardingRole.UNKNOWN}  | ${mockConfig.homeEntryIdGeneral}
+    ${false}   | ${false}                    | ${false}      | ${false}    | ${UserOnboardingRole.UNKNOWN}  | ${mockConfig.homeEntryIdBeneficiary}
+    ${true}    | ${false}                    | ${false}      | ${false}    | ${UserOnboardingRole.UNKNOWN}  | ${mockConfig.homeEntryIdBeneficiary}
   `(
     `should return remote config $expectedHomeEntry when isLoggedIn=$isLoggedIn, isFreeBeneficiaryOrEligible=$isFreeBeneficiaryOrEligible, isBeneficiary, hasBookings=$hasBookings, onboardingRole=$onboardingRole`,
     ({

--- a/src/features/home/api/useHomepageData.ts
+++ b/src/features/home/api/useHomepageData.ts
@@ -10,7 +10,6 @@ import { useUserHasBookingsQueryV2 } from 'queries/bookings/useUserHasBookingsQu
 import { isUserFreeBeneficiaryOrEligible } from 'shared/user/isUserFreeBeneficiaryOrEligible'
 
 enum HomepageType {
-  GENERAL,
   BENEFICIARY,
   FREE_BENEFICIARY,
   WITHOUT_BOOKING,
@@ -39,19 +38,16 @@ const getHomepageType = ({
   onboardingRole,
 }: HomeCriterias): HomepageType => {
   if (!isLoggedIn) {
-    if (onboardingRole === UserOnboardingRole.EIGHTEEN) {
-      return HomepageType.BENEFICIARY
-    }
     if (onboardingRole === UserOnboardingRole.UNDERAGE) {
       return HomepageType.FREE_BENEFICIARY
     }
-    return HomepageType.GENERAL
+    return HomepageType.BENEFICIARY
   }
 
   if (isFreeBeneficiaryOrEligible) return HomepageType.FREE_BENEFICIARY
   if (isBeneficiary) return hasBookings ? HomepageType.BENEFICIARY : HomepageType.WITHOUT_BOOKING
 
-  return HomepageType.GENERAL
+  return HomepageType.BENEFICIARY
 }
 
 export const getHomepageId = (
@@ -67,7 +63,6 @@ export const getHomepageId = (
   const homePageRemoteConfig: Record<HomepageType, string> = {
     [HomepageType.BENEFICIARY]: remoteConfig.homeEntryIdBeneficiary,
     [HomepageType.FREE_BENEFICIARY]: remoteConfig.homeEntryIdFreeBeneficiary,
-    [HomepageType.GENERAL]: remoteConfig.homeEntryIdGeneral,
     [HomepageType.WITHOUT_BOOKING]: remoteConfig.homeEntryIdWithoutBooking,
   }
   const homepageType = getHomepageType({

--- a/src/libs/firebase/remoteConfig/helpers/getRemoteConfigFromConfigValues.ts
+++ b/src/libs/firebase/remoteConfig/helpers/getRemoteConfigFromConfigValues.ts
@@ -14,7 +14,6 @@ export const getRemoteConfigFromConfigValues = (
   homeEntryIdBeneficiary: getConfigValue(parameters.homeEntryIdBeneficiary).asString(),
   homeEntryIdFreeBeneficiary: getConfigValue(parameters.homeEntryIdFreeBeneficiary).asString(),
   homeEntryIdFreeOffers: getConfigValue(parameters.homeEntryIdFreeOffers).asString(),
-  homeEntryIdGeneral: getConfigValue(parameters.homeEntryIdGeneral).asString(),
   homeEntryIdWithoutBooking: getConfigValue(parameters.homeEntryIdWithoutBooking).asString(),
   reactionFakeDoorCategories: JSON.parse(
     getConfigValue(parameters.reactionFakeDoorCategories).asString()

--- a/src/libs/firebase/remoteConfig/remoteConfig.constants.ts
+++ b/src/libs/firebase/remoteConfig/remoteConfig.constants.ts
@@ -9,7 +9,6 @@ export const DEFAULT_REMOTE_CONFIG: CustomRemoteConfig = {
   homeEntryIdBeneficiary: '',
   homeEntryIdFreeBeneficiary: '',
   homeEntryIdFreeOffers: '',
-  homeEntryIdGeneral: '',
   homeEntryIdWithoutBooking: '',
   reactionFakeDoorCategories: { categories: [] },
   sameAuthorPlaylist: '',

--- a/src/libs/firebase/remoteConfig/remoteConfig.types.ts
+++ b/src/libs/firebase/remoteConfig/remoteConfig.types.ts
@@ -8,7 +8,6 @@ export type CustomRemoteConfig = {
   homeEntryIdBeneficiary: string
   homeEntryIdFreeBeneficiary: string
   homeEntryIdFreeOffers: string
-  homeEntryIdGeneral: string
   homeEntryIdWithoutBooking: string
   reactionFakeDoorCategories: Record<'categories', NativeCategoryIdEnumv2[]>
   sameAuthorPlaylist: string


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42673

## Context

After the fusion of two Contenful homes we cleaned the code to remove the reference to a deprecated home.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.
