### PR TITLE
(PC-42392) feat(artist): track follow artist fake door clicks and sur…

### DIFF
--- a/src/features/artist/components/ArtistBody/ArtistBody.native.test.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.native.test.tsx
@@ -1,3 +1,4 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import React from 'react'
 import { Share } from 'react-native'
 
@@ -46,8 +47,9 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('<ArtistBody />', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     setFeatureFlags()
+    await AsyncStorage.clear()
   })
 
   it('should display only the main artist when there are several artists on header title', async () => {
@@ -375,6 +377,11 @@ describe('<ArtistBody />', () => {
     expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
       surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU',
+      analyticsParams: {
+        featureName: 'follow_artist',
+        from: 'artist',
+        artistId: mockArtist.id,
+      },
     })
   })
 
@@ -387,7 +394,6 @@ describe('<ArtistBody />', () => {
       reactQueryProviderHOC(
         <ArtistBody
           artist={mockArtist}
-          // LIVRES comes before MUSIQUE in ARTIST_CATEGORY_PLAYLISTS, offers order is irrelevant
           artistPlaylist={[
             buildArtistOffer({
               objectID: '1',
@@ -412,7 +418,59 @@ describe('<ArtistBody />', () => {
     expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
       surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?offer_type=LIVRES',
+      analyticsParams: {
+        featureName: 'follow_artist',
+        from: 'artist',
+        artistId: mockArtist.id,
+      },
     })
+  })
+
+  it('should log HasClickedFakeDoorCTA when pressing the header follow button', async () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_ARTIST_FAKE_DOOR])
+    render(
+      reactQueryProviderHOC(
+        <ArtistBody
+          artist={mockArtist}
+          artistPlaylist={[]}
+          artistTopOffers={[]}
+          onViewableItemsChanged={jest.fn()}
+          onExpandBioPress={jest.fn()}
+        />
+      )
+    )
+
+    await user.press(await screen.findByLabelText('Suivre cet artiste'))
+
+    expect(analytics.logHasClickedFakeDoorCTA).toHaveBeenCalledWith({
+      featureName: 'follow_artist',
+      from: 'artist',
+      artistId: mockArtist.id,
+      hasSeenSurvey: false,
+      originDetails: 'artistHeader',
+    })
+  })
+
+  it('should log HasClickedFakeDoorCTA with hasSeenSurvey when the survey has already been accessed', async () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_ARTIST_FAKE_DOOR])
+    await AsyncStorage.setItem('has_seen_follow_artist_fake_door_survey', 'true')
+    render(
+      reactQueryProviderHOC(
+        <ArtistBody
+          artist={mockArtist}
+          artistPlaylist={[]}
+          artistTopOffers={[]}
+          onViewableItemsChanged={jest.fn()}
+          onExpandBioPress={jest.fn()}
+        />
+      )
+    )
+
+    await user.press(await screen.findByLabelText('Suivre cet artiste'))
+
+    expect(analytics.logHasClickedFakeDoorCTA).toHaveBeenCalledWith(
+      expect.objectContaining({ hasSeenSurvey: true })
+    )
   })
 
   it('should open fake door modal without offer type when wipArtistCategoryPlaylists FF deactivated', async () => {
@@ -440,6 +498,11 @@ describe('<ArtistBody />', () => {
     expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
       surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU',
+      analyticsParams: {
+        featureName: 'follow_artist',
+        from: 'artist',
+        artistId: mockArtist.id,
+      },
     })
   })
 

--- a/src/features/artist/components/ArtistBody/ArtistBody.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.tsx
@@ -11,7 +11,11 @@ import { ArtistPlaylist } from 'features/artist/components/ArtistPlaylist/Artist
 import { ArtistSimilarArtists } from 'features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists'
 import { ArtistTopOffers } from 'features/artist/components/ArtistTopOffers/ArtistTopOffers'
 import { ArtistWebMetaHeader } from 'features/artist/components/ArtistWebMetaHeader'
-import { buildFollowArtistSurveyUrl } from 'features/artist/helpers/buildFollowArtistSurveyUrl'
+import {
+  buildFollowArtistSurveyUrl,
+  FOLLOW_ARTIST_FEATURE_NAME,
+  FOLLOW_ARTIST_SURVEY_KEY,
+} from 'features/artist/helpers/buildFollowArtistSurveyUrl'
 import { getDisplayableArtistPlaylists } from 'features/artist/helpers/getDisplayableArtistPlaylists'
 import { separateTitleAndEmojis } from 'features/home/helpers/separateTitleAndEmojis'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
@@ -25,6 +29,7 @@ import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureF
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { capitalize } from 'libs/formatter/capitalize'
 import { ensureEndingDot } from 'libs/parsers/ensureEndingDot'
+import { getHasSeenFakeDoorSurvey } from 'shared/FakeDoorModal/helpers/getHasSeenFakeDoorSurvey'
 import { AB_TESTS } from 'shared/useABSegment/abTests'
 import { useABSegment } from 'shared/useABSegment/useABSegment'
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
@@ -108,16 +113,29 @@ export const ArtistBody: FunctionComponent<Props> = ({
 
   const { navigate } = useNavigation<UseNavigationType>()
 
-  const handlePressFollow = () => {
-    // Business rule: report a single offer type, the first playlist category displayed on the page.
-    // Playlists are only rendered when enablePlaylistByCategory is on, so no category is reported otherwise.
+  const handlePressFollow = async () => {
     const [firstArtistPlaylist] = enablePlaylistByCategory
       ? getDisplayableArtistPlaylists(artistPlaylist)
       : []
 
+    const hasSeenSurvey = await getHasSeenFakeDoorSurvey(FOLLOW_ARTIST_SURVEY_KEY)
+
+    void analytics.logHasClickedFakeDoorCTA({
+      featureName: FOLLOW_ARTIST_FEATURE_NAME,
+      from: 'artist',
+      artistId: artist.id,
+      hasSeenSurvey,
+      originDetails: 'artistHeader',
+    })
+
     navigate('FakeDoorModal', {
-      surveyKey: 'has_seen_follow_artist_fake_door_survey',
+      surveyKey: FOLLOW_ARTIST_SURVEY_KEY,
       surveyUrl: buildFollowArtistSurveyUrl({ offerType: firstArtistPlaylist?.searchGroupName }),
+      analyticsParams: {
+        featureName: FOLLOW_ARTIST_FEATURE_NAME,
+        from: 'artist',
+        artistId: artist.id,
+      },
     })
   }
 

--- a/src/features/artist/components/FollowArtistButton/FollowArtistButton.native.test.tsx
+++ b/src/features/artist/components/FollowArtistButton/FollowArtistButton.native.test.tsx
@@ -1,15 +1,23 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { SearchGroupNameEnumv2 } from 'api/gen'
 import { FollowArtistButton } from 'features/artist/components/FollowArtistButton/FollowArtistButton'
+import { analytics } from 'libs/analytics/provider'
 import { render, screen, userEvent } from 'tests/utils'
+
+jest.mock('libs/firebase/analytics/analytics')
 
 const user = userEvent.setup()
 
 jest.useFakeTimers()
 
 describe('<FollowArtistButton />', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear()
+  })
+
   it('should display the follow button with an accessible label', () => {
     render(<FollowArtistButton artistName="Edith Piaf" artistId="1" />)
 
@@ -24,6 +32,7 @@ describe('<FollowArtistButton />', () => {
     expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
       surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=1',
+      analyticsParams: { featureName: 'follow_artist', from: 'offer', artistId: '1' },
     })
   })
 
@@ -35,6 +44,7 @@ describe('<FollowArtistButton />', () => {
     expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
       surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU',
+      analyticsParams: { featureName: 'follow_artist', from: 'offer', artistId: undefined },
     })
   })
 
@@ -53,6 +63,31 @@ describe('<FollowArtistButton />', () => {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
       surveyUrl:
         'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=1&offer_type=LIVRES',
+      analyticsParams: { featureName: 'follow_artist', from: 'offer', artistId: '1' },
     })
+  })
+
+  it('should log HasClickedFakeDoorCTA when pressed', async () => {
+    render(<FollowArtistButton artistName="Edith Piaf" artistId="1" />)
+
+    await user.press(screen.getByLabelText('Suivre Edith Piaf'))
+
+    expect(analytics.logHasClickedFakeDoorCTA).toHaveBeenCalledWith({
+      featureName: 'follow_artist',
+      from: 'offer',
+      artistId: '1',
+      hasSeenSurvey: false,
+    })
+  })
+
+  it('should log HasClickedFakeDoorCTA with hasSeenSurvey when the survey has already been accessed', async () => {
+    await AsyncStorage.setItem('has_seen_follow_artist_fake_door_survey', 'true')
+    render(<FollowArtistButton artistName="Edith Piaf" artistId="1" />)
+
+    await user.press(screen.getByLabelText('Suivre Edith Piaf'))
+
+    expect(analytics.logHasClickedFakeDoorCTA).toHaveBeenCalledWith(
+      expect.objectContaining({ hasSeenSurvey: true })
+    )
   })
 })

--- a/src/features/artist/components/FollowArtistButton/FollowArtistButton.tsx
+++ b/src/features/artist/components/FollowArtistButton/FollowArtistButton.tsx
@@ -2,8 +2,14 @@ import { useNavigation } from '@react-navigation/native'
 import React, { FunctionComponent } from 'react'
 
 import { SearchGroupNameEnumv2 } from 'api/gen'
-import { buildFollowArtistSurveyUrl } from 'features/artist/helpers/buildFollowArtistSurveyUrl'
+import {
+  buildFollowArtistSurveyUrl,
+  FOLLOW_ARTIST_FEATURE_NAME,
+  FOLLOW_ARTIST_SURVEY_KEY,
+} from 'features/artist/helpers/buildFollowArtistSurveyUrl'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
+import { analytics } from 'libs/analytics/provider'
+import { getHasSeenFakeDoorSurvey } from 'shared/FakeDoorModal/helpers/getHasSeenFakeDoorSurvey'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Bell } from 'ui/svg/icons/Bell'
 
@@ -20,10 +26,20 @@ export const FollowArtistButton: FunctionComponent<Props> = ({
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
 
-  const handlePress = () => {
+  const handlePress = async () => {
+    const hasSeenSurvey = await getHasSeenFakeDoorSurvey(FOLLOW_ARTIST_SURVEY_KEY)
+
+    void analytics.logHasClickedFakeDoorCTA({
+      featureName: FOLLOW_ARTIST_FEATURE_NAME,
+      from: 'offer',
+      artistId,
+      hasSeenSurvey,
+    })
+
     navigate('FakeDoorModal', {
-      surveyKey: 'has_seen_follow_artist_fake_door_survey',
+      surveyKey: FOLLOW_ARTIST_SURVEY_KEY,
       surveyUrl: buildFollowArtistSurveyUrl({ artistId, offerType }),
+      analyticsParams: { featureName: FOLLOW_ARTIST_FEATURE_NAME, from: 'offer', artistId },
     })
   }
 

--- a/src/features/artist/helpers/buildFollowArtistSurveyUrl.ts
+++ b/src/features/artist/helpers/buildFollowArtistSurveyUrl.ts
@@ -1,10 +1,13 @@
 import { SearchGroupNameEnumv2 } from 'api/gen'
+import { StorageKey } from 'libs/storage'
 
 const FOLLOW_ARTIST_SURVEY_URL = 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU'
 
+export const FOLLOW_ARTIST_SURVEY_KEY: StorageKey = 'has_seen_follow_artist_fake_door_survey'
+export const FOLLOW_ARTIST_FEATURE_NAME = 'follow_artist'
+
 type Params = {
   artistId?: string
-  // Qualtrics embedded data: culture category of the offer(s) the survey was triggered from
   offerType?: SearchGroupNameEnumv2
 }
 

--- a/src/features/navigation/navigators/RootNavigator/types.ts
+++ b/src/features/navigation/navigators/RootNavigator/types.ts
@@ -240,9 +240,16 @@ type LoginParams = {
   from?: StepperOrigin
 }
 
+type FakeDoorModalAnalyticsParams = {
+  featureName: string
+  from: Referrals
+  artistId?: string
+}
+
 type FakeDoorModalParams = {
   surveyKey: StorageKey
   surveyUrl: string
+  analyticsParams?: FakeDoorModalAnalyticsParams
 }
 
 /**

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.native.test.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.native.test.tsx
@@ -237,6 +237,7 @@ describe('<OfferArtistsSection />', () => {
         surveyKey: 'has_seen_follow_artist_fake_door_survey',
         surveyUrl:
           'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=1&offer_type=MUSIQUE',
+        analyticsParams: { featureName: 'follow_artist', from: 'offer', artistId: '1' },
       })
     })
 
@@ -250,6 +251,7 @@ describe('<OfferArtistsSection />', () => {
         surveyKey: 'has_seen_follow_artist_fake_door_survey',
         surveyUrl:
           'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?offer_type=MUSIQUE',
+        analyticsParams: { featureName: 'follow_artist', from: 'offer', artistId: undefined },
       })
     })
 
@@ -263,6 +265,7 @@ describe('<OfferArtistsSection />', () => {
         surveyKey: 'has_seen_follow_artist_fake_door_survey',
         surveyUrl:
           'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=2&offer_type=MUSIQUE',
+        analyticsParams: { featureName: 'follow_artist', from: 'offer', artistId: '2' },
       })
     })
   })

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
@@ -186,7 +186,6 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
   )
 }
 
-// Align the follow button with the avatar image (left edge of the item)
 const SoloFollowButtonContainer = styled.View({
   alignSelf: 'flex-start',
 })

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -54,6 +54,7 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logConsultDescriptionDetails: jest.fn(),
   logConsultDisclaimerValidationMail: jest.fn(),
   logConsultErrorApplicationModal: jest.fn(),
+  logConsultFakeDoorSurvey: jest.fn(),
   logConsultFinishSubscriptionModal: jest.fn(),
   logConsultHome: jest.fn(),
   logConsultItinerary: jest.fn(),

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -297,6 +297,8 @@ export const logEventAnalytics = {
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_DISCLAIMER_VALIDATION_MAIL }),
   logConsultErrorApplicationModal: (offerId: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_ERROR_APPLICATION_MODAL }, { offerId }),
+  logConsultFakeDoorSurvey: (params: { featureName: string; from: Referrals; artistId?: string }) =>
+    analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_FAKE_DOOR_SURVEY }, params),
   logConsultFinishSubscriptionModal: (offerId: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_FINISH_SUBSCRIPTION_MODAL }, { offerId }),
   logConsultHome: (params: ConsultHomeParams) =>
@@ -438,15 +440,21 @@ export const logEventAnalytics = {
     from,
     searchId,
     homeEntryId,
+    artistId,
+    hasSeenSurvey,
+    originDetails,
   }: {
     featureName: string
     from: Referrals
     searchId?: string
     homeEntryId?: string
+    artistId?: string
+    hasSeenSurvey?: boolean
+    originDetails?: string
   }) =>
     analytics.logEvent(
       { firebase: AnalyticsEvent.HAS_CLICKED_FAKE_DOOR_CTA },
-      { featureName, from, homeEntryId, searchId }
+      { artistId, featureName, from, hasSeenSurvey, homeEntryId, originDetails, searchId }
     ),
   logHasClickedGridListToggle: ({ fromLayout }: { fromLayout: GridListLayout }) =>
     analytics.logEvent({ firebase: AnalyticsEvent.HAS_CLICKED_GRID_LIST_TOGGLE }, { fromLayout }),

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -56,6 +56,7 @@ export enum AnalyticsEvent {
   CONSULT_DESCRIPTION_DETAILS = 'ConsultDescriptionDetails',
   CONSULT_DISCLAIMER_VALIDATION_MAIL = 'ConsultDisclaimerValidationMail',
   CONSULT_ERROR_APPLICATION_MODAL = 'ConsultErrorApplicationModal',
+  CONSULT_FAKE_DOOR_SURVEY = 'ConsultFakeDoorSurvey',
   CONSULT_FINISH_SUBSCRIPTION_MODAL = 'ConsultFinishSubscriptionModal',
   CONSULT_HOME = 'ConsultHome',
   CONSULT_ITINERARY = 'ConsultLocationItinerary',

--- a/src/shared/FakeDoorModal/FakeDoorModal.native.test.tsx
+++ b/src/shared/FakeDoorModal/FakeDoorModal.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { goBack, useRoute } from '__mocks__/@react-navigation/native'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
+import { analytics } from 'libs/analytics/provider'
 import { FakeDoorModal } from 'shared/FakeDoorModal/FakeDoorModal'
 import { render, screen, userEvent } from 'tests/utils'
 import { theme } from 'theme'
@@ -106,6 +107,53 @@ describe('FakeDoorModal', () => {
       render(<FakeDoorModal />)
 
       expect(await screen.findByText('Fermer')).toBeOnTheScreen()
+    })
+  })
+
+  describe('Analytics', () => {
+    it('should not log ConsultFakeDoorSurvey when no analytics params are provided', async () => {
+      render(<FakeDoorModal />)
+
+      await user.press(screen.getByLabelText('Donner mon avis'))
+
+      expect(analytics.logConsultFakeDoorSurvey).not.toHaveBeenCalled()
+    })
+
+    describe('When analytics params are provided', () => {
+      beforeEach(() => {
+        useRoute.mockReturnValue({
+          params: {
+            surveyKey: 'has_seen_follow_artist_fake_door_survey',
+            surveyUrl: 'https://passculture.qualtrics.com/',
+            analyticsParams: { featureName: 'follow_artist', from: 'artist', artistId: '1' },
+          },
+        })
+      })
+
+      it('should log ConsultFakeDoorSurvey when pressing "Donner mon avis" button', async () => {
+        render(<FakeDoorModal />)
+
+        await user.press(screen.getByLabelText('Donner mon avis'))
+
+        expect(analytics.logConsultFakeDoorSurvey).toHaveBeenCalledWith({
+          featureName: 'follow_artist',
+          from: 'artist',
+          artistId: '1',
+        })
+      })
+
+      it('should log ConsultFakeDoorSurvey when the survey has already been seen', async () => {
+        asyncStorageSpyOn.mockResolvedValueOnce('true')
+        render(<FakeDoorModal />)
+
+        await user.press(await screen.findByLabelText('Répondre au questionnaire'))
+
+        expect(analytics.logConsultFakeDoorSurvey).toHaveBeenCalledWith({
+          featureName: 'follow_artist',
+          from: 'artist',
+          artistId: '1',
+        })
+      })
     })
   })
 })

--- a/src/shared/FakeDoorModal/FakeDoorModal.tsx
+++ b/src/shared/FakeDoorModal/FakeDoorModal.tsx
@@ -5,6 +5,7 @@ import { TouchableWithoutFeedback } from 'react-native'
 import { styled } from 'styled-components/native'
 
 import { UseNavigationType, UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
+import { analytics } from 'libs/analytics/provider'
 import { ModalHeader } from 'ui/components/modals/ModalHeader'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -20,7 +21,7 @@ const OVERLAY_COLOR = 'rgba(0, 0, 0, 0.7)'
 export const FakeDoorModal = () => {
   const { goBack } = useNavigation<UseNavigationType>()
   const { params } = useRoute<UseRouteType<'FakeDoorModal'>>()
-  const { surveyKey, surveyUrl } = params
+  const { surveyKey, surveyUrl, analyticsParams } = params
   const [hasSeenSurvey, setHasSeenSurvey] = useState(false)
 
   useEffect(() => {
@@ -33,6 +34,11 @@ export const FakeDoorModal = () => {
     setHasSeenSurvey(true)
     await AsyncStorage.setItem(surveyKey, 'true')
     goBack()
+  }
+
+  const onSurveyAccess = () => {
+    if (analyticsParams) void analytics.logConsultFakeDoorSurvey(analyticsParams)
+    return hasSeenSurvey ? goBack() : markHasSeen()
   }
 
   const content = hasSeenSurvey
@@ -90,7 +96,7 @@ export const FakeDoorModal = () => {
             fullWidth
             icon={ExternalSiteFilled}
             variant={content.buttonVariant}
-            onBeforeNavigate={hasSeenSurvey ? goBack : markHasSeen}
+            onBeforeNavigate={onSurveyAccess}
           />
         </ButtonContainer>
 

--- a/src/shared/FakeDoorModal/FakeDoorModal.web.tsx
+++ b/src/shared/FakeDoorModal/FakeDoorModal.web.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react'
 import { styled } from 'styled-components/native'
 
 import { UseNavigationType, UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
+import { analytics } from 'libs/analytics/provider'
 import { ModalScreenWrapper } from 'shared/ModalScreenWrapper/ModalScreenWrapper'
 import { ModalHeader } from 'ui/components/modals/ModalHeader'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
@@ -18,7 +19,7 @@ import { Typo } from 'ui/theme'
 export const FakeDoorModal = () => {
   const { goBack } = useNavigation<UseNavigationType>()
   const { params } = useRoute<UseRouteType<'FakeDoorModal'>>()
-  const { surveyKey, surveyUrl } = params
+  const { surveyKey, surveyUrl, analyticsParams } = params
   const [hasSeenSurvey, setHasSeenSurvey] = useState(false)
 
   useEffect(() => {
@@ -31,6 +32,11 @@ export const FakeDoorModal = () => {
     setHasSeenSurvey(true)
     await AsyncStorage.setItem(surveyKey, 'true')
     goBack()
+  }
+
+  const onSurveyAccess = () => {
+    if (analyticsParams) void analytics.logConsultFakeDoorSurvey(analyticsParams)
+    return hasSeenSurvey ? goBack() : markHasSeen()
   }
 
   const content = hasSeenSurvey
@@ -83,7 +89,7 @@ export const FakeDoorModal = () => {
               fullWidth
               icon={ExternalSiteFilled}
               variant={content.buttonVariant}
-              onBeforeNavigate={hasSeenSurvey ? goBack : markHasSeen}
+              onBeforeNavigate={onSurveyAccess}
             />
           </ButtonContainer>
 

--- a/src/shared/FakeDoorModal/helpers/getHasSeenFakeDoorSurvey.ts
+++ b/src/shared/FakeDoorModal/helpers/getHasSeenFakeDoorSurvey.ts
@@ -1,0 +1,4 @@
+import { storage, StorageKey } from 'libs/storage'
+
+export const getHasSeenFakeDoorSurvey = async (surveyKey: StorageKey): Promise<boolean> =>
+  (await storage.readString(surveyKey)) === 'true'


### PR DESCRIPTION
…vey access

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42392

## Context

Ajoute le tracking de la fake door « Suivre un artiste » pour permettre à la squad Découverte de mesurer l'appétence des utilisateurs et de recroiser les données avec les réponses Qualtrics (décision go/no-go sur la fonctionnalité réelle).

### `HasClickedFakeDoorCTA` — clic sur « Suivre »

| Point d'entrée | `featureName` | `from` | Autres params |
|---|---|---|---|
| Page artiste — bouton header | `follow_artist` | `artist` | `artistId`, `hasSeenSurvey`, `originDetails: 'artistHeader'` |
| Page offre — section Distribution | `follow_artist` | `offer` | `artistId`, `hasSeenSurvey` |

### `ConsultFakeDoorSurvey` — accès au questionnaire

Nouvel event envoyé au clic sur le bouton menant au questionnaire Qualtrics depuis la modale, avec `featureName`, `from` (repris du point d'entrée) et `artistId`.

### Notes d'implémentation

- **`hasSeenSurvey`** est lu au moment du clic (et non au montage du composant) : le flag est global à la fake door artiste et peut être posé depuis une autre surface durant la même session.
- **La modale `FakeDoorModal` reste générique** (elle sert aussi à la fake door venue) : les paramètres analytics sont passés en paramètres de navigation via `analyticsParams`, optionnels. La fake door venue n'envoie donc aucun event — pas de régression.
- **`ConsultFakeDoorSurvey` est envoyé sur les deux variantes** de la modale (« Donner mon avis » et « Répondre au questionnaire ») : le KR mesure l'accès effectif au questionnaire. Le paramètre `hasSeenSurvey` porté par `HasClickedFakeDoorCTA` permet de segmenter les deux populations côté Firebase.
