### PR TITLE
(PC-42537) feat(venue): track follow venue fake door clicks and surve…

### DIFF
--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -27,6 +27,7 @@ exports[`<Venue /> should match snapshot 1`] = `
         "overflow": "visible",
       }
     }
+    testID="venue-container"
   >
     <View>
       <View
@@ -3379,6 +3380,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
         "overflow": "visible",
       }
     }
+    testID="venue-container"
   >
     <View>
       <View
@@ -6731,6 +6733,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
         "overflow": "visible",
       }
     }
+    testID="venue-container"
   >
     <View>
       <View

--- a/src/features/artist/components/ArtistBody/ArtistBody.native.test.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.native.test.tsx
@@ -376,7 +376,7 @@ describe('<ArtistBody />', () => {
 
     expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
-      surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU',
+      surveyUrl: `https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artist_id=${mockArtist.id}`,
       analyticsParams: {
         featureName: 'follow_artist',
         from: 'artist',
@@ -417,7 +417,7 @@ describe('<ArtistBody />', () => {
 
     expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
-      surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?offer_type=LIVRES',
+      surveyUrl: `https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artist_id=${mockArtist.id}&offer_type=LIVRES`,
       analyticsParams: {
         featureName: 'follow_artist',
         from: 'artist',
@@ -497,7 +497,7 @@ describe('<ArtistBody />', () => {
 
     expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
-      surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU',
+      surveyUrl: `https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artist_id=${mockArtist.id}`,
       analyticsParams: {
         featureName: 'follow_artist',
         from: 'artist',

--- a/src/features/artist/components/ArtistBody/ArtistBody.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.tsx
@@ -118,7 +118,22 @@ export const ArtistBody: FunctionComponent<Props> = ({
       ? getDisplayableArtistPlaylists(artistPlaylist)
       : []
 
-    const hasSeenSurvey = await getHasSeenFakeDoorSurvey(FOLLOW_ARTIST_SURVEY_KEY)
+    const hasSeenSurveyPromise = getHasSeenFakeDoorSurvey(FOLLOW_ARTIST_SURVEY_KEY)
+
+    navigate('FakeDoorModal', {
+      surveyKey: FOLLOW_ARTIST_SURVEY_KEY,
+      surveyUrl: buildFollowArtistSurveyUrl({
+        artistId: artist.id,
+        offerType: firstArtistPlaylist?.searchGroupName,
+      }),
+      analyticsParams: {
+        featureName: FOLLOW_ARTIST_FEATURE_NAME,
+        from: 'artist',
+        artistId: artist.id,
+      },
+    })
+
+    const hasSeenSurvey = await hasSeenSurveyPromise
 
     void analytics.logHasClickedFakeDoorCTA({
       featureName: FOLLOW_ARTIST_FEATURE_NAME,
@@ -126,16 +141,6 @@ export const ArtistBody: FunctionComponent<Props> = ({
       artistId: artist.id,
       hasSeenSurvey,
       originDetails: 'artistHeader',
-    })
-
-    navigate('FakeDoorModal', {
-      surveyKey: FOLLOW_ARTIST_SURVEY_KEY,
-      surveyUrl: buildFollowArtistSurveyUrl({ offerType: firstArtistPlaylist?.searchGroupName }),
-      analyticsParams: {
-        featureName: FOLLOW_ARTIST_FEATURE_NAME,
-        from: 'artist',
-        artistId: artist.id,
-      },
     })
   }
 

--- a/src/features/artist/components/FollowArtistButton/FollowArtistButton.native.test.tsx
+++ b/src/features/artist/components/FollowArtistButton/FollowArtistButton.native.test.tsx
@@ -31,7 +31,7 @@ describe('<FollowArtistButton />', () => {
 
     expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
-      surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=1',
+      surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artist_id=1',
       analyticsParams: { featureName: 'follow_artist', from: 'offer', artistId: '1' },
     })
   })
@@ -62,7 +62,7 @@ describe('<FollowArtistButton />', () => {
     expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
       surveyKey: 'has_seen_follow_artist_fake_door_survey',
       surveyUrl:
-        'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=1&offer_type=LIVRES',
+        'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artist_id=1&offer_type=LIVRES',
       analyticsParams: { featureName: 'follow_artist', from: 'offer', artistId: '1' },
     })
   })

--- a/src/features/artist/components/FollowArtistButton/FollowArtistButton.tsx
+++ b/src/features/artist/components/FollowArtistButton/FollowArtistButton.tsx
@@ -27,19 +27,21 @@ export const FollowArtistButton: FunctionComponent<Props> = ({
   const { navigate } = useNavigation<UseNavigationType>()
 
   const handlePress = async () => {
-    const hasSeenSurvey = await getHasSeenFakeDoorSurvey(FOLLOW_ARTIST_SURVEY_KEY)
+    const hasSeenSurveyPromise = getHasSeenFakeDoorSurvey(FOLLOW_ARTIST_SURVEY_KEY)
+
+    navigate('FakeDoorModal', {
+      surveyKey: FOLLOW_ARTIST_SURVEY_KEY,
+      surveyUrl: buildFollowArtistSurveyUrl({ artistId, offerType }),
+      analyticsParams: { featureName: FOLLOW_ARTIST_FEATURE_NAME, from: 'offer', artistId },
+    })
+
+    const hasSeenSurvey = await hasSeenSurveyPromise
 
     void analytics.logHasClickedFakeDoorCTA({
       featureName: FOLLOW_ARTIST_FEATURE_NAME,
       from: 'offer',
       artistId,
       hasSeenSurvey,
-    })
-
-    navigate('FakeDoorModal', {
-      surveyKey: FOLLOW_ARTIST_SURVEY_KEY,
-      surveyUrl: buildFollowArtistSurveyUrl({ artistId, offerType }),
-      analyticsParams: { featureName: FOLLOW_ARTIST_FEATURE_NAME, from: 'offer', artistId },
     })
   }
 

--- a/src/features/artist/helpers/buildFollowArtistSurveyUrl.native.test.ts
+++ b/src/features/artist/helpers/buildFollowArtistSurveyUrl.native.test.ts
@@ -8,8 +8,8 @@ describe('buildFollowArtistSurveyUrl', () => {
     expect(buildFollowArtistSurveyUrl()).toEqual(SURVEY_URL)
   })
 
-  it('should append artistId only', () => {
-    expect(buildFollowArtistSurveyUrl({ artistId: '1' })).toEqual(`${SURVEY_URL}?artistId=1`)
+  it('should append artist_id only', () => {
+    expect(buildFollowArtistSurveyUrl({ artistId: '1' })).toEqual(`${SURVEY_URL}?artist_id=1`)
   })
 
   it('should append offer_type only', () => {
@@ -18,9 +18,9 @@ describe('buildFollowArtistSurveyUrl', () => {
     )
   })
 
-  it('should append both artistId and offer_type', () => {
+  it('should append both artist_id and offer_type', () => {
     expect(
       buildFollowArtistSurveyUrl({ artistId: '1', offerType: SearchGroupNameEnumv2.MUSIQUE })
-    ).toEqual(`${SURVEY_URL}?artistId=1&offer_type=MUSIQUE`)
+    ).toEqual(`${SURVEY_URL}?artist_id=1&offer_type=MUSIQUE`)
   })
 })

--- a/src/features/artist/helpers/buildFollowArtistSurveyUrl.ts
+++ b/src/features/artist/helpers/buildFollowArtistSurveyUrl.ts
@@ -13,7 +13,7 @@ type Params = {
 
 export const buildFollowArtistSurveyUrl = ({ artistId, offerType }: Params = {}): string => {
   const searchParams = new URLSearchParams()
-  if (artistId) searchParams.append('artistId', artistId)
+  if (artistId) searchParams.append('artist_id', artistId)
   if (offerType) searchParams.append('offer_type', offerType)
 
   const query = searchParams.toString()

--- a/src/features/navigation/navigators/RootNavigator/types.ts
+++ b/src/features/navigation/navigators/RootNavigator/types.ts
@@ -19,7 +19,10 @@ import { TabParamList } from 'features/navigation/navigators/TabNavigator/types'
 import { PlaylistType } from 'features/offer/enums'
 import { SearchState } from 'features/search/types'
 import { Venue } from 'features/venue/types'
-import { ConsultArtistOriginDetails } from 'libs/analytics/logEventAnalytics'
+import {
+  ConsultArtistOriginDetails,
+  FakeDoorAnalyticsParams,
+} from 'libs/analytics/logEventAnalytics'
 import { ContentfulLabelCategories } from 'libs/contentful/types'
 import { SuggestedPlace } from 'libs/place/types'
 import { StorageKey } from 'libs/storage'
@@ -240,16 +243,10 @@ type LoginParams = {
   from?: StepperOrigin
 }
 
-type FakeDoorModalAnalyticsParams = {
-  featureName: string
-  from: Referrals
-  artistId?: string
-}
-
 type FakeDoorModalParams = {
   surveyKey: StorageKey
   surveyUrl: string
-  analyticsParams?: FakeDoorModalAnalyticsParams
+  analyticsParams?: FakeDoorAnalyticsParams
 }
 
 /**

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.native.test.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.native.test.tsx
@@ -236,7 +236,7 @@ describe('<OfferArtistsSection />', () => {
       expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
         surveyKey: 'has_seen_follow_artist_fake_door_survey',
         surveyUrl:
-          'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=1&offer_type=MUSIQUE',
+          'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artist_id=1&offer_type=MUSIQUE',
         analyticsParams: { featureName: 'follow_artist', from: 'offer', artistId: '1' },
       })
     })
@@ -264,7 +264,7 @@ describe('<OfferArtistsSection />', () => {
       expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
         surveyKey: 'has_seen_follow_artist_fake_door_survey',
         surveyUrl:
-          'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artistId=2&offer_type=MUSIQUE',
+          'https://passculture.qualtrics.com/jfe/form/SV_0wafZvbQ06UrZnU?artist_id=2&offer_type=MUSIQUE',
         analyticsParams: { featureName: 'follow_artist', from: 'offer', artistId: '2' },
       })
     })

--- a/src/features/venue/components/VenueContent/OldVenueContent.tsx
+++ b/src/features/venue/components/VenueContent/OldVenueContent.tsx
@@ -112,6 +112,7 @@ export const OldVenueContent: React.FunctionComponent<Props> = ({
             />
           }>
           <ContentContainer
+            testID="venue-container"
             onScroll={handleScroll}
             scrollEventThrottle={16}
             bounces={false}

--- a/src/features/venue/components/VenueContent/VenueContent.tsx
+++ b/src/features/venue/components/VenueContent/VenueContent.tsx
@@ -110,6 +110,7 @@ export const VenueContent: React.FunctionComponent<Props> = ({
             />
           }>
           <ContentContainer
+            testID="venue-container"
             rightNootch={isLandscape ? right : 0}
             leftNootch={isLandscape ? left : 0}
             onScroll={handleScroll}

--- a/src/features/venue/helpers/buildFollowVenueSurveyUrl.ts
+++ b/src/features/venue/helpers/buildFollowVenueSurveyUrl.ts
@@ -1,7 +1,11 @@
 import { Activity } from 'api/gen'
+import { StorageKey } from 'libs/storage'
 
 export const FOLLOW_VENUE_SURVEY_URL =
   'https://passculture.qualtrics.com/jfe/form/SV_b3novwqFYApLUDY'
+
+export const FOLLOW_VENUE_SURVEY_KEY: StorageKey = 'has_seen_follow_venue_fake_door_survey'
+export const FOLLOW_VENUE_FEATURE_NAME = 'follow_venue'
 
 // venue_type is declared as embedded data on the Qualtrics side, so responses
 // can be filtered by venue activity. Omitted when the venue has no activity.

--- a/src/features/venue/pages/Venue/Venue.native.test.tsx
+++ b/src/features/venue/pages/Venue/Venue.native.test.tsx
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { SearchResponse } from 'algoliasearch/lite'
 import mockdate from 'mockdate'
 import React from 'react'
+import { ReactTestInstance } from 'react-test-renderer'
 
 import { navigate, useRoute } from '__mocks__/@react-navigation/native'
 import {
@@ -39,10 +40,8 @@ import { abTestOverridesActions } from 'shared/useABSegment/abTestOverrideStore'
 import { AB_TESTS } from 'shared/useABSegment/abTests'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render, screen, userEvent, waitFor } from 'tests/utils'
+import { fireEvent, render, screen, userEvent, waitFor } from 'tests/utils'
 import * as AnchorContextModule from 'ui/components/anchor/AnchorContext'
-
-const getItemSpy = jest.spyOn(AsyncStorage, 'getItem')
 
 jest.useFakeTimers()
 
@@ -108,9 +107,15 @@ jest.mock('libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog'
   triggerConsultOfferLog: jest.fn(),
 }))
 
-const asyncStorageSpyOn = jest.spyOn(AsyncStorage, 'getItem')
-
 const user = userEvent.setup()
+
+const scrollEvent = {
+  nativeEvent: {
+    contentOffset: { y: 200 },
+    layoutMeasurement: { height: 1000 },
+    contentSize: { height: 1900 },
+  },
+}
 
 describe('<Venue />', () => {
   beforeAll(() => {
@@ -120,10 +125,10 @@ describe('<Venue />', () => {
     })
   })
 
-  beforeEach(() => {
+  beforeEach(async () => {
     useLocationV2.setState(defaultLocationState)
     setFeatureFlags()
-    getItemSpy.mockReset()
+    await AsyncStorage.clear()
     mockServer.postApi<OffersStocksResponseV2>('/v2/offers/stocks', {})
     mockServer.patchApi<UserProfile>('/v1/profile', {})
     mockServer.getApi<VenueResponse>(`/v2/venue/${venueId}`, {
@@ -510,7 +515,6 @@ describe('<Venue />', () => {
     })
 
     it('should open fake door modal when pressing follow button', async () => {
-      asyncStorageSpyOn.mockResolvedValueOnce('false')
       renderVenue(venueId)
 
       await user.press(await screen.findByLabelText('Suivre le lieu'))
@@ -518,7 +522,54 @@ describe('<Venue />', () => {
       expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
         surveyKey: 'has_seen_follow_venue_fake_door_survey',
         surveyUrl: `https://passculture.qualtrics.com/jfe/form/SV_b3novwqFYApLUDY?venue_type=${Activity.BOOKSTORE}`,
+        analyticsParams: {
+          featureName: 'follow_venue',
+          from: 'venue',
+          venueId: venueId.toString(),
+        },
       })
+    })
+
+    it('should log HasClickedFakeDoorCTA with the banner origin when pressing the banner follow button', async () => {
+      renderVenue(venueId)
+
+      await user.press(await screen.findByLabelText('Suivre le lieu'))
+
+      expect(analytics.logHasClickedFakeDoorCTA).toHaveBeenCalledWith({
+        featureName: 'follow_venue',
+        from: 'venue',
+        venueId: venueId.toString(),
+        originDetails: 'venueBanner',
+        hasSeenSurvey: false,
+      })
+    })
+
+    it('should log HasClickedFakeDoorCTA with the header origin when pressing the sticky header follow button', async () => {
+      renderVenue(venueId)
+
+      await screen.findByLabelText('Suivre le lieu')
+      fireEvent.scroll(screen.getByTestId('venue-container'), scrollEvent)
+
+      const headerFollowButton = screen.getAllByLabelText('Suivre le lieu')[1]
+
+      expect(headerFollowButton).toBeDefined()
+
+      await user.press(headerFollowButton as ReactTestInstance)
+
+      expect(analytics.logHasClickedFakeDoorCTA).toHaveBeenCalledWith(
+        expect.objectContaining({ originDetails: 'venueHeader' })
+      )
+    })
+
+    it('should log HasClickedFakeDoorCTA with hasSeenSurvey when the survey has already been accessed', async () => {
+      await AsyncStorage.setItem('has_seen_follow_venue_fake_door_survey', 'true')
+      renderVenue(venueId)
+
+      await user.press(await screen.findByLabelText('Suivre le lieu'))
+
+      expect(analytics.logHasClickedFakeDoorCTA).toHaveBeenCalledWith(
+        expect.objectContaining({ hasSeenSurvey: true })
+      )
     })
 
     it('should not send venue_type to the survey when venue has no activity', async () => {
@@ -528,7 +579,6 @@ describe('<Venue />', () => {
         bannerUrl: 'url_image',
         activity: null,
       })
-      asyncStorageSpyOn.mockResolvedValueOnce('false')
       renderVenue(venueId)
 
       await user.press(await screen.findByLabelText('Suivre le lieu'))
@@ -536,6 +586,11 @@ describe('<Venue />', () => {
       expect(navigate).toHaveBeenCalledWith('FakeDoorModal', {
         surveyKey: 'has_seen_follow_venue_fake_door_survey',
         surveyUrl: 'https://passculture.qualtrics.com/jfe/form/SV_b3novwqFYApLUDY',
+        analyticsParams: {
+          featureName: 'follow_venue',
+          from: 'venue',
+          venueId: venueId.toString(),
+        },
       })
     })
   })

--- a/src/features/venue/pages/Venue/Venue.tsx
+++ b/src/features/venue/pages/Venue/Venue.tsx
@@ -21,7 +21,11 @@ import { VenueContent } from 'features/venue/components/VenueContent/VenueConten
 import { VenueMessagingApps } from 'features/venue/components/VenueMessagingApps/VenueMessagingApps'
 import { VenueThematicSection } from 'features/venue/components/VenueThematicSection/VenueThematicSection'
 import { VenueTopComponent } from 'features/venue/components/VenueTopComponent/VenueTopComponent'
-import { buildFollowVenueSurveyUrl } from 'features/venue/helpers/buildFollowVenueSurveyUrl'
+import {
+  buildFollowVenueSurveyUrl,
+  FOLLOW_VENUE_FEATURE_NAME,
+  FOLLOW_VENUE_SURVEY_KEY,
+} from 'features/venue/helpers/buildFollowVenueSurveyUrl'
 import { getVenueOffersArtists } from 'features/venue/helpers/getVenueOffersArtists'
 import { useVenueSearchParameters } from 'features/venue/helpers/useVenueSearchParameters'
 import { getAdvicesWithoutHeadline, getHeadlineAdvice } from 'features/venue/helpers/venueAdvices'
@@ -43,6 +47,7 @@ import {
 import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
 import { useVenueOffersQuery } from 'queries/venue/useVenueOffersQuery'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
+import { getHasSeenFakeDoorSurvey } from 'shared/FakeDoorModal/helpers/getHasSeenFakeDoorSurvey'
 import { usePageTracking } from 'shared/tracking/usePageTracking'
 import { AB_TESTS } from 'shared/useABSegment/abTests'
 import { useABSegment } from 'shared/useABSegment/useABSegment'
@@ -51,6 +56,8 @@ import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 
 const VENUE_CTA_HEIGHT_IN_SPACES = 6 + 10 + 6
+
+type FollowVenueButtonOrigin = 'venueBanner' | 'venueHeader'
 
 export const Venue: FunctionComponent = () => {
   const { params } = useRoute<UseRouteType<'Venue'>>()
@@ -177,11 +184,26 @@ export const Venue: FunctionComponent = () => {
     }
   }, [params.from, proAdvicesSegment, venue?.id])
 
-  const handleOnPressFollowButton = () => {
+  const handleOnPressFollowButton = async (originDetails: FollowVenueButtonOrigin) => {
+    if (!venue) return
+
+    const analyticsParams = {
+      featureName: FOLLOW_VENUE_FEATURE_NAME,
+      from: 'venue' as const,
+      venueId: venue.id.toString(),
+    }
+
+    const hasSeenSurveyPromise = getHasSeenFakeDoorSurvey(FOLLOW_VENUE_SURVEY_KEY)
+
     navigate('FakeDoorModal', {
-      surveyKey: 'has_seen_follow_venue_fake_door_survey',
-      surveyUrl: buildFollowVenueSurveyUrl(venue?.activity),
+      surveyKey: FOLLOW_VENUE_SURVEY_KEY,
+      surveyUrl: buildFollowVenueSurveyUrl(venue.activity),
+      analyticsParams,
     })
+
+    const hasSeenSurvey = await hasSeenSurveyPromise
+
+    void analytics.logHasClickedFakeDoorCTA({ ...analyticsParams, originDetails, hasSeenSurvey })
   }
 
   const isCTADisplayed =
@@ -195,7 +217,7 @@ export const Venue: FunctionComponent = () => {
         enableVolunteer={enableVolunteer}
         enableVolunteerFeedback={enableVolunteerFeedback}
         enableVenueFakeDoor={enableVenueFakeDoor}
-        onPressFollowButton={handleOnPressFollowButton}
+        onPressFollowButton={() => handleOnPressFollowButton('venueBanner')}
       />
       <ViewGap gap={isDesktopViewport ? 10 : 6}>
         <Animated.View layout={Layout.duration(200)}>
@@ -252,7 +274,7 @@ export const Venue: FunctionComponent = () => {
             isCTADisplayed={isCTADisplayed}
             showSearchInVenueModal={showSearchInVenueModal}
             enableVenueFakeDoor={enableVenueFakeDoor}
-            onPressFollowButton={handleOnPressFollowButton}>
+            onPressFollowButton={() => handleOnPressFollowButton('venueHeader')}>
             {VenueContentChildren}
           </VenueContent>
           <SearchInVenueModal
@@ -267,7 +289,7 @@ export const Venue: FunctionComponent = () => {
           venue={venue}
           isCTADisplayed={isCTADisplayed}
           enableVenueFakeDoor={enableVenueFakeDoor}
-          onPressFollowButton={handleOnPressFollowButton}>
+          onPressFollowButton={() => handleOnPressFollowButton('venueHeader')}>
           {VenueContentChildren}
         </OldVenueContent>
       )}

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -116,6 +116,11 @@ export type ConsultArtistOriginDetails =
   | 'searchResults'
   | 'artistRecommendation'
 
+export type FakeDoorAnalyticsParams = {
+  featureName: string
+  from: Referrals
+} & ({ artistId?: string; venueId?: never } | { venueId?: string; artistId?: never })
+
 /* eslint sort-keys-fix/sort-keys-fix: "error" */
 export const logEventAnalytics = {
   logAcceptNotifications: () =>
@@ -297,7 +302,7 @@ export const logEventAnalytics = {
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_DISCLAIMER_VALIDATION_MAIL }),
   logConsultErrorApplicationModal: (offerId: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_ERROR_APPLICATION_MODAL }, { offerId }),
-  logConsultFakeDoorSurvey: (params: { featureName: string; from: Referrals; artistId?: string }) =>
+  logConsultFakeDoorSurvey: (params: FakeDoorAnalyticsParams) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_FAKE_DOOR_SURVEY }, params),
   logConsultFinishSubscriptionModal: (offerId: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_FINISH_SUBSCRIPTION_MODAL }, { offerId }),
@@ -441,20 +446,18 @@ export const logEventAnalytics = {
     searchId,
     homeEntryId,
     artistId,
+    venueId,
     hasSeenSurvey,
     originDetails,
-  }: {
-    featureName: string
-    from: Referrals
+  }: FakeDoorAnalyticsParams & {
     searchId?: string
     homeEntryId?: string
-    artistId?: string
     hasSeenSurvey?: boolean
     originDetails?: string
   }) =>
     analytics.logEvent(
       { firebase: AnalyticsEvent.HAS_CLICKED_FAKE_DOOR_CTA },
-      { artistId, featureName, from, hasSeenSurvey, homeEntryId, originDetails, searchId }
+      { artistId, featureName, from, hasSeenSurvey, homeEntryId, originDetails, searchId, venueId }
     ),
   logHasClickedGridListToggle: ({ fromLayout }: { fromLayout: GridListLayout }) =>
     analytics.logEvent({ firebase: AnalyticsEvent.HAS_CLICKED_GRID_LIST_TOGGLE }, { fromLayout }),

--- a/src/shared/FakeDoorModal/FakeDoorModal.tsx
+++ b/src/shared/FakeDoorModal/FakeDoorModal.tsx
@@ -1,11 +1,11 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import { useNavigation, useRoute } from '@react-navigation/native'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { TouchableWithoutFeedback } from 'react-native'
 import { styled } from 'styled-components/native'
 
 import { UseNavigationType, UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
+import { useHasSeenFakeDoorSurvey } from 'shared/FakeDoorModal/helpers/useHasSeenFakeDoorSurvey'
 import { ModalHeader } from 'ui/components/modals/ModalHeader'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -22,17 +22,10 @@ export const FakeDoorModal = () => {
   const { goBack } = useNavigation<UseNavigationType>()
   const { params } = useRoute<UseRouteType<'FakeDoorModal'>>()
   const { surveyKey, surveyUrl, analyticsParams } = params
-  const [hasSeenSurvey, setHasSeenSurvey] = useState(false)
-
-  useEffect(() => {
-    void AsyncStorage.getItem(surveyKey).then((val) => {
-      setHasSeenSurvey(val === 'true')
-    })
-  }, [surveyKey])
+  const { hasSeenSurvey, markHasSeenSurvey } = useHasSeenFakeDoorSurvey(surveyKey)
 
   const markHasSeen = async () => {
-    setHasSeenSurvey(true)
-    await AsyncStorage.setItem(surveyKey, 'true')
+    await markHasSeenSurvey()
     goBack()
   }
 

--- a/src/shared/FakeDoorModal/FakeDoorModal.web.tsx
+++ b/src/shared/FakeDoorModal/FakeDoorModal.web.tsx
@@ -1,10 +1,10 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import { useNavigation, useRoute } from '@react-navigation/native'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { styled } from 'styled-components/native'
 
 import { UseNavigationType, UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
+import { useHasSeenFakeDoorSurvey } from 'shared/FakeDoorModal/helpers/useHasSeenFakeDoorSurvey'
 import { ModalScreenWrapper } from 'shared/ModalScreenWrapper/ModalScreenWrapper'
 import { ModalHeader } from 'ui/components/modals/ModalHeader'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
@@ -20,17 +20,10 @@ export const FakeDoorModal = () => {
   const { goBack } = useNavigation<UseNavigationType>()
   const { params } = useRoute<UseRouteType<'FakeDoorModal'>>()
   const { surveyKey, surveyUrl, analyticsParams } = params
-  const [hasSeenSurvey, setHasSeenSurvey] = useState(false)
-
-  useEffect(() => {
-    void AsyncStorage.getItem(surveyKey).then((val) => {
-      setHasSeenSurvey(val === 'true')
-    })
-  }, [surveyKey])
+  const { hasSeenSurvey, markHasSeenSurvey } = useHasSeenFakeDoorSurvey(surveyKey)
 
   const markHasSeen = async () => {
-    setHasSeenSurvey(true)
-    await AsyncStorage.setItem(surveyKey, 'true')
+    await markHasSeenSurvey()
     goBack()
   }
 

--- a/src/shared/FakeDoorModal/helpers/useHasSeenFakeDoorSurvey.ts
+++ b/src/shared/FakeDoorModal/helpers/useHasSeenFakeDoorSurvey.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+import { storage, StorageKey } from 'libs/storage'
+import { getHasSeenFakeDoorSurvey } from 'shared/FakeDoorModal/helpers/getHasSeenFakeDoorSurvey'
+
+export const useHasSeenFakeDoorSurvey = (surveyKey: StorageKey) => {
+  const [hasSeenSurvey, setHasSeenSurvey] = useState(false)
+
+  useEffect(() => {
+    void getHasSeenFakeDoorSurvey(surveyKey).then(setHasSeenSurvey)
+  }, [surveyKey])
+
+  const markHasSeenSurvey = async () => {
+    setHasSeenSurvey(true)
+    await storage.saveString(surveyKey, 'true')
+  }
+
+  return { hasSeenSurvey, markHasSeenSurvey }
+}


### PR DESCRIPTION
…y access

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42537

## Context

Dans la continuité du tracking de la fake door « Suivre un artiste » (PC-42392), cette PR enrichit le tracking de la fake door « Suivre un lieu » :

- L'event `HasClickedFakeDoorCTA` envoie désormais le `venueId`, un `originDetails` distinguant le bouton du bandeau (`venueBanner`) de celui du header sticky (`venueHeader`), ainsi que `hasSeenSurvey` indiquant si l'utilisateur a déjà accédé au questionnaire.
- Les `analyticsParams` sont transmis à la `FakeDoorModal`, permettant à l'event `ConsultFakeDoorSurvey` d'inclure le `venueId` lors de l'accès au questionnaire.
- Le type `FakeDoorAnalyticsParams` est mutualisé dans `logEventAnalytics` (avec `artistId`/`venueId` mutuellement exclusifs) et réutilisé par les params de navigation de la modale.
- La logique `hasSeenSurvey` (lecture + écriture storage) est centralisée dans un hook partagé `useHasSeenFakeDoorSurvey`, utilisé par les versions native et web de la `FakeDoorModal`.
