### PR TITLE
(PC-42925) fix(build): fix xcode build

### DIFF
--- a/ios/PassCulture.xcodeproj/project.pbxproj
+++ b/ios/PassCulture.xcodeproj/project.pbxproj
@@ -279,7 +279,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n. .xcode.env\n../node_modules/@sentry/cli/bin/sentry-cli debug-files upload \"$DWARF_DSYM_FOLDER_PATH\"\n";
+			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n. .xcode.env\n[ -f .xcode.env.local ] && . .xcode.env.local\nexport PATH=\"$(dirname \"$NODE_BINARY\"):$PATH\"\n../node_modules/@sentry/cli/bin/sentry-cli debug-files upload \"$DWARF_DSYM_FOLDER_PATH\"\n";
 		};
 		689C89BA042982264FB82CFE /* [CP-User] [RNFB] Core Configuration */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/PassCulture.xcodeproj/xcshareddata/xcschemes/PassCulture-Production.xcscheme
+++ b/ios/PassCulture.xcodeproj/xcshareddata/xcschemes/PassCulture-Production.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Load env file"
-               scriptText = "python ${SRCROOT}/../scripts/build_ios_env_files.py --dir=${SRCROOT}/.. --env=production&#10;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb ${SRCROOT}/.. ${SRCROOT}/react-native-config.xcconfig&#10;">
+               scriptText = "python3 ${SRCROOT}/../scripts/build_ios_env_files.py --dir=${SRCROOT}/.. --env=production&#10;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb ${SRCROOT}/.. ${SRCROOT}/react-native-config.xcconfig&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/PassCulture.xcodeproj/xcshareddata/xcschemes/PassCulture-Staging.xcscheme
+++ b/ios/PassCulture.xcodeproj/xcshareddata/xcschemes/PassCulture-Staging.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Load env file"
-               scriptText = "python ${SRCROOT}/../scripts/build_ios_env_files.py --dir=${SRCROOT}/.. --env=staging&#10;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb ${SRCROOT}/.. ${SRCROOT}/react-native-config.xcconfig&#10;">
+               scriptText = "python3 ${SRCROOT}/../scripts/build_ios_env_files.py --dir=${SRCROOT}/.. --env=staging&#10;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb ${SRCROOT}/.. ${SRCROOT}/react-native-config.xcconfig&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/PassCulture.xcodeproj/xcshareddata/xcschemes/PassCulture-Testing.xcscheme
+++ b/ios/PassCulture.xcodeproj/xcshareddata/xcschemes/PassCulture-Testing.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Load env file"
-               scriptText = "python ${SRCROOT}/../scripts/build_ios_env_files.py --dir=${SRCROOT}/.. --env=testing&#10;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb ${SRCROOT}/.. ${SRCROOT}/react-native-config.xcconfig&#10;">
+               scriptText = "python3 ${SRCROOT}/../scripts/build_ios_env_files.py --dir=${SRCROOT}/.. --env=testing&#10;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb ${SRCROOT}/.. ${SRCROOT}/react-native-config.xcconfig&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42925

On peut trouver une disparité dans le succès de l’installation de l’app en local par les différents développeurs, en fonction de leur configuration.

Le shell de XCode a un environnement appauvri dont le $PATH se limite à /usr/bin:/bin:/usr/sbin:/sbin

Ce qui pose un problème dans l’utilisation de **node** et **python**

### Node

Pour un développeur utilisant nvm, node est introuvable dans le PATH appauvri.

```rb
# ios/.xcode.env

PATH_PREVIOUS="$PATH"

PATH="$HOME/.nix-profile/bin:$PATH"
PATH="/run/current-system/sw/bin:$PATH"
PATH="/nix/var/nix/profiles/default/bin:$PATH"

if type nix &>/dev/null; then
    NODE_BINARY="$(realpath "$(nix develop --command which node)")"
else
    NODE_BINARY=$(command -v node)
fi

export NODE_BINARY

PATH="$(dirname "$NODE_BINARY"):$PATH_PREVIOUS"
export PATH
```

S’il n’utilise pas nix , la commande node sera directement exécutée, mais elle n’est pas dans le $PATH

Le path de node est par contre présent dans ios/.xcode.env.local généré à l’installation des pods

### Python

python peut ne pas se trouver dans le $PATH, il n’y est pas par défaut sur macOS, par contre python3 y est par défaut.

