### PR TITLE
(PC-42932) fix(apiHelpers): make credentials not mandatory to test options

### DIFF
--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -164,7 +164,7 @@ export async function handleGeneratedApiResponse(
         extra: { responseBody },
       })
       // We navigate to Login in case of a 401 -> user not connected / session revoked server side
-      if (options.credentials !== 'omit') {
+      if (options?.credentials !== 'omit') {
         navigateToLoginMethods()
         return {}
       }

--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -7837,7 +7837,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async deleteNativeV1MeFavoritesfavoriteId(favorite_id: number, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).deleteNativeV1MeFavoritesfavoriteId(favorite_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -7849,7 +7849,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async deleteNativeV1MeRemindersreminderId(reminder_id: number, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).deleteNativeV1MeRemindersreminderId(reminder_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -7861,7 +7861,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1AccountSuspendTokenValidationtoken(token: string, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1AccountSuspendTokenValidationtoken(token, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -7872,7 +7872,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1AccountSuspensionDate(options?: any): Promise<UserSuspensionDateResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1AccountSuspensionDate(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -7883,7 +7883,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1AccountSuspensionStatus(options?: any): Promise<UserSuspensionStatusResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1AccountSuspensionStatus(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -7895,7 +7895,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1ArtistsartistId(artist_id: string, options?: any): Promise<ArtistResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1ArtistsartistId(artist_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      *
@@ -7907,7 +7907,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1ArtistsartistIdSimilar(artist_id: string, options?: any): Promise<SimilarArtistsResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1ArtistsartistIdSimilar(artist_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      *
@@ -7919,7 +7919,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1Banner(isGeolocated?: boolean, options?: any): Promise<BannerResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1Banner(isGeolocated, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -7930,7 +7930,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1Categories(options?: any): Promise<CategoriesResponseModel> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1Categories(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -7941,7 +7941,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1Countries(options?: any): Promise<InseeCountries> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1Countries(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -7952,7 +7952,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1CulturalSurveyQuestions(options?: any): Promise<CulturalSurveyQuestionsResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1CulturalSurveyQuestions(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -7964,7 +7964,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1EmailValidationRemainingResendsemail(email: string, options?: any): Promise<EmailValidationRemainingResendsResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1EmailValidationRemainingResendsemail(email, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -7975,7 +7975,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1Me(options?: any): Promise<UserProfileResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1Me(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -7986,7 +7986,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1MeFavorites(options?: any): Promise<PaginatedFavoritesResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1MeFavorites(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -7997,7 +7997,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1MeReminders(options?: any): Promise<GetRemindersResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1MeReminders(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8008,7 +8008,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1OauthState(options?: any): Promise<OauthStateResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1OauthState(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8020,7 +8020,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1OffereroffererIdHeadlineOffer(offerer_id: number, options?: any): Promise<OffererHeadLineOfferResponseModel> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1OffereroffererIdHeadlineOffer(offerer_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8033,7 +8033,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1OfferofferId(offer_id: number, options?: any): Promise<OfferResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1OfferofferId(offer_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8045,7 +8045,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1OfferofferIdChronicles(offer_id: number, options?: any): Promise<OfferChronicles> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1OfferofferIdChronicles(offer_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8062,7 +8062,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1OfferofferIdAdvices(offer_id: number, maxContentLength?: number, page?: number, resultsPerPage?: number, latitude?: number, longitude?: number, options?: any): Promise<OfferProAdvices> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1OfferofferIdAdvices(offer_id, maxContentLength, page, resultsPerPage, latitude, longitude, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8073,7 +8073,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1ProfileTokenExpiration(options?: any): Promise<UpdateEmailTokenExpiration> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1ProfileTokenExpiration(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8085,7 +8085,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1ReactionAvailable(options?: any): Promise<GetAvailableReactionsResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1ReactionAvailable(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8103,7 +8103,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1RecommendationSimilarOffersofferId(offer_id: number, longitude?: number, latitude?: number, categories?: Array<string>, subcategories?: Array<string>, search_group_names?: Array<string>, retrievalModel?: SimilarOffersRequestQuery.RetrievalModelEnum, options?: any): Promise<SimilarOffersResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1RecommendationSimilarOffersofferId(offer_id, longitude, latitude, categories, subcategories, search_group_names, retrievalModel, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8114,7 +8114,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1Settings(options?: any): Promise<SettingsResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1Settings(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8125,7 +8125,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1SubcategoriesV2(options?: any): Promise<SubcategoriesResponseModelv2> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1SubcategoriesV2(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8136,7 +8136,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1SubscriptionActivityTypes(options?: any): Promise<ActivityTypesResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1SubscriptionActivityTypes(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8147,7 +8147,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1SubscriptionProfile(options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1SubscriptionProfile(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8160,7 +8160,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1VenuevenueId(venue_id: number, options?: any): Promise<VenueResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1VenuevenueId(venue_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8175,7 +8175,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV1VenuevenueIdAdvices(venue_id: number, maxContentLength?: number, page?: number, resultsPerPage?: number, options?: any): Promise<VenueProAdvices> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1VenuevenueIdAdvices(venue_id, maxContentLength, page, resultsPerPage, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8195,7 +8195,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV2Bookings(options?: any): Promise<BookingsResponseV2> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV2Bookings(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8207,7 +8207,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV2BookingsbookingId(booking_id: number, options?: any): Promise<BookingResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV2BookingsbookingId(booking_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8219,7 +8219,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV2Bookingsstatus(status: string, options?: any): Promise<BookingsListResponseV2> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV2Bookingsstatus(status, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8230,7 +8230,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV2ProfileEmailUpdateStatus(options?: any): Promise<EmailUpdateStatusResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV2ProfileEmailUpdateStatus(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8241,7 +8241,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV2ReactionAvailable(options?: any): Promise<GetAvailableReactionsResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV2ReactionAvailable(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8252,7 +8252,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV2SubscriptionStepper(options?: any): Promise<SubscriptionStepperResponseV2> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV2SubscriptionStepper(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8264,7 +8264,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV2VenuevenueId(venue_id: number, options?: any): Promise<VenueResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV2VenuevenueId(venue_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8276,7 +8276,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV3OfferofferId(offer_id: number, options?: any): Promise<OfferResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV3OfferofferId(offer_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8287,7 +8287,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async getNativeV3SubscriptionStepper(options?: any): Promise<SubscriptionStepperResponseV3> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV3SubscriptionStepper(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8299,7 +8299,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async patchNativeV1Profile(body: UserProfilePatchRequest, options?: any): Promise<UserProfileResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).patchNativeV1Profile(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8311,7 +8311,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1Account(body: AccountRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1Account(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8322,7 +8322,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1AccountAnonymize(options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1AccountAnonymize(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8333,7 +8333,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1AccountSuspend(options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1AccountSuspend(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8344,7 +8344,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1AccountSuspendForHackSuspicion(options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1AccountSuspendForHackSuspicion(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8356,7 +8356,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1AccountSuspendForSuspiciousLogin(body: SuspendAccountForSuspiciousLoginRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1AccountSuspendForSuspiciousLogin(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8367,7 +8367,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1AccountUnsuspend(options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1AccountUnsuspend(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8379,7 +8379,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1AchievementsMarkAsSeen(body: MarkAchievementsAsSeenRequest, options?: any): Promise<AchievementsResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1AchievementsMarkAsSeen(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8391,7 +8391,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1Bookings(body: BookOfferRequest, options?: any): Promise<BookOfferResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1Bookings(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8403,7 +8403,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1BookingsbookingIdCancel(booking_id: number, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1BookingsbookingIdCancel(booking_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8416,7 +8416,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1BookingsbookingIdToggleDisplay(body: BookingDisplayStatusRequest, booking_id: number, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1BookingsbookingIdToggleDisplay(body, booking_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8428,7 +8428,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1ChangePassword(body: ChangePasswordRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1ChangePassword(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8440,7 +8440,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1CookiesConsent(body: CookieConsentRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1CookiesConsent(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8452,7 +8452,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1CulturalSurveyAnswers(body: CulturalSurveyAnswersRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1CulturalSurveyAnswers(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8464,7 +8464,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1Feedback(body: PostFeedbackBody, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1Feedback(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8476,7 +8476,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1MeFavorites(body: FavoriteRequest, options?: any): Promise<FavoriteResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1MeFavorites(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8488,7 +8488,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1MeReminders(body: PostReminderRequest, options?: any): Promise<ReminderResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1MeReminders(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      *
@@ -8501,7 +8501,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1OauthssoProviderAccount(body: SSOAccountRequest, sso_provider: string, options?: any): Promise<SigninResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1OauthssoProviderAccount(body, sso_provider, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      *
@@ -8514,7 +8514,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1OauthssoProviderAuthorize(body: OAuthSigninRequest, sso_provider: string, options?: any): Promise<SigninResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1OauthssoProviderAuthorize(body, sso_provider, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8526,7 +8526,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1Profile(body: UserProfilePatchRequest, options?: any): Promise<UserProfileResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1Profile(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8538,7 +8538,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1ProfileEmailUpdateCancel(body: ChangeBeneficiaryEmailBody, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1ProfileEmailUpdateCancel(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8551,7 +8551,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1Reaction(body: PostReactionRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1Reaction(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8566,7 +8566,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1RecommendationPlaylist(body: PlaylistRequestBody, modelEndpoint?: string, longitude?: number, latitude?: number, options?: any): Promise<PlaylistResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1RecommendationPlaylist(body, modelEndpoint, longitude, latitude, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8577,7 +8577,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1RefreshAccessToken(options?: any): Promise<RefreshResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1RefreshAccessToken(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8589,7 +8589,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1RequestPasswordReset(body: RequestPasswordResetRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1RequestPasswordReset(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8601,7 +8601,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1ResendEmailValidation(body: ResendEmailValidationRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1ResendEmailValidation(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8613,7 +8613,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1ResetPassword(body: ResetPasswordRequest, options?: any): Promise<ResetPasswordResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1ResetPassword(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8624,7 +8624,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1ResetRecreditAmountToShow(options?: any): Promise<UserProfileResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1ResetRecreditAmountToShow(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8636,7 +8636,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1SendOfferLinkByPushofferId(offer_id: number, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1SendOfferLinkByPushofferId(offer_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8648,7 +8648,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1SendOfferWebappLinkByEmailofferId(offer_id: number, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1SendOfferWebappLinkByEmailofferId(offer_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8660,7 +8660,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1Signin(body: SigninRequest, options?: any): Promise<SigninResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1Signin(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8672,7 +8672,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1SubscriptionBonusDisability(body: DisabilityBonusCreditRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1SubscriptionBonusDisability(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8684,7 +8684,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1SubscriptionBonusQuotientFamilial(body: QuotientFamilialBonusCreditRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1SubscriptionBonusQuotientFamilial(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8695,7 +8695,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1SubscriptionHonorStatement(options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1SubscriptionHonorStatement(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8707,7 +8707,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1SubscriptionProfile(body: ProfileUpdateRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1SubscriptionProfile(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8719,7 +8719,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1UbbleIdentification(body: IdentificationSessionRequest, options?: any): Promise<IdentificationSessionResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1UbbleIdentification(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8731,7 +8731,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV1ValidateEmail(body: ValidateEmailRequest, options?: any): Promise<ValidateEmailResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1ValidateEmail(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8743,7 +8743,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV2OffersStocks(body: OffersStocksRequest, options?: any): Promise<OffersStocksResponseV2> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV2OffersStocks(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8755,7 +8755,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV2ProfileEmailUpdateConfirm(body: ChangeBeneficiaryEmailBody, options?: any): Promise<EmailChangeConfirmationResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV2ProfileEmailUpdateConfirm(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8767,7 +8767,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV2ProfileEmailUpdateNewEmail(body: NewEmailSelectionRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV2ProfileEmailUpdateNewEmail(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8779,7 +8779,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV2ProfileEmailUpdateNewPassword(body: ResetPasswordRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV2ProfileEmailUpdateNewPassword(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8790,7 +8790,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV2ProfileUpdateEmail(options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV2ProfileUpdateEmail(options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8802,7 +8802,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV2Reaction(body: PostReactionRequest, options?: any): Promise<EmptyResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV2Reaction(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8814,7 +8814,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV2RefreshAccessToken(body: RefreshRequestV2, options?: any): Promise<RefreshResponseV2> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV2RefreshAccessToken(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8826,7 +8826,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async postNativeV2Signin(body: SigninRequestV2, options?: any): Promise<SigninResponseV2> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV2Signin(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
     /**
      * 
@@ -8838,7 +8838,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     async putNativeV1ProfileEmailUpdateValidate(body: ChangeBeneficiaryEmailBody, options?: any): Promise<ChangeBeneficiaryEmailResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).putNativeV1ProfileEmailUpdateValidate(body, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response, options)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
   }
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42932

## Context
Prevent access to credentials key for options undefined in handleApiGeneratedResponse.