### PR TITLE
(PC-42328) feat(artist): display artist playlist module on artist page when artist has it on Contentful

### DIFF
--- a/src/features/artist/api/fetchArtistPlaylistConfig.native.test.ts
+++ b/src/features/artist/api/fetchArtistPlaylistConfig.native.test.ts
@@ -1,0 +1,31 @@
+import { fetchArtistPlaylistConfig } from 'features/artist/api/fetchArtistPlaylistConfig'
+import { contentfulArtistPlaylistSnap } from 'features/artist/fixtures/contentfulArtistPlaylistSnap'
+import { CONTENTFUL_BASE_URL } from 'libs/contentful/constants'
+import { mockServer } from 'tests/mswServer'
+
+describe('fetchArtistPlaylistConfig', () => {
+  beforeEach(() => {
+    mockServer.universalGet(`${CONTENTFUL_BASE_URL}/entries`, contentfulArtistPlaylistSnap)
+  })
+
+  it('should return correct data', async () => {
+    const result = await fetchArtistPlaylistConfig()
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: '3ekwFnm4jZy5ohgDNTjLRK',
+        artistId: '819d02dd-6097-4d11-aa8d-8dd9dcba4c97',
+        displayParameters: expect.objectContaining({
+          title: 'Reco d’artiste',
+          layout: 'three-items',
+          minOffers: 1,
+        }),
+        offersModuleParameters: [
+          expect.objectContaining({
+            hitsPerPage: 10,
+          }),
+        ],
+      }),
+    ])
+  })
+})

--- a/src/features/artist/api/fetchArtistPlaylistConfig.ts
+++ b/src/features/artist/api/fetchArtistPlaylistConfig.ts
@@ -1,0 +1,25 @@
+import resolveResponse from 'contentful-resolve-response'
+
+import { ArtistPlaylistModule } from 'features/home/types'
+import { adaptArtistPlaylistModule } from 'libs/contentful/adapters/modules/adaptArtistPlaylistModule'
+import { CONTENTFUL_BASE_URL } from 'libs/contentful/constants'
+import { ArtistPlaylistContentModel } from 'libs/contentful/types'
+import { env } from 'libs/environment/env'
+import { getExternal } from 'libs/fetch'
+
+const DEPTH_LEVEL = 2 // We need this to be able to fetch contentTypes referenced in our contentModel
+
+const PARAMS = `?include=${DEPTH_LEVEL}&content_type=artistPlaylist&access_token=${env.CONTENTFUL_PUBLIC_ACCESS_TOKEN}`
+const URL = `${CONTENTFUL_BASE_URL}/entries${PARAMS}`
+
+export async function fetchArtistPlaylistConfig() {
+  const json = await getExternal(URL)
+  const jsonResponse = resolveResponse(json) as ArtistPlaylistContentModel[]
+
+  // Build parameters list from Contentful algolia parameters for algolia
+  const artistPlaylistRequests = jsonResponse
+    .map(adaptArtistPlaylistModule)
+    .filter((item): item is ArtistPlaylistModule => item !== null)
+
+  return artistPlaylistRequests
+}

--- a/src/features/artist/components/ArtistBody/ArtistBody.native.test.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.native.test.tsx
@@ -7,12 +7,19 @@ import { SubcategoryIdEnum } from 'api/gen'
 import { ArtistBody } from 'features/artist/components/ArtistBody/ArtistBody'
 import { mockArtist } from 'features/artist/fixtures/mockArtist'
 import { mockOffer } from 'features/bookOffer/fixtures/offer'
+import { useGetOffersDataQuery } from 'features/home/queries/useGetOffersDataQuery'
+import { HomepageModuleType } from 'features/home/types'
 import * as useGoBack from 'features/navigation/useGoBack'
-import { mockedAlgoliaOffersWithSameArtistResponse } from 'libs/algolia/fixtures/algoliaFixtures'
+import {
+  mockedAlgoliaOffersWithSameArtistResponse,
+  mockedAlgoliaResponse,
+} from 'libs/algolia/fixtures/algoliaFixtures'
 import { AlgoliaOfferWithArtistAndEan } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
+import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent, waitFor } from 'tests/utils'
 
@@ -42,6 +49,11 @@ useRoute.mockReturnValue({ params: { fromOfferId: 1 } })
 
 const mockShare = jest.spyOn(Share, 'share').mockImplementation(jest.fn())
 
+const mockUseGetOffersDataQuery = useGetOffersDataQuery as jest.Mock
+jest.mock('features/home/queries/useGetOffersDataQuery', () => ({
+  useGetOffersDataQuery: jest.fn(),
+}))
+
 const user = userEvent.setup()
 
 jest.useFakeTimers()
@@ -50,6 +62,7 @@ describe('<ArtistBody />', () => {
   beforeEach(async () => {
     setFeatureFlags()
     await AsyncStorage.clear()
+    mockServer.getApi('/v1/subcategories/v2', subcategoriesDataTest)
   })
 
   it('should display only the main artist when there are several artists on header title', async () => {
@@ -524,6 +537,63 @@ describe('<ArtistBody />', () => {
     expect(screen.getByLabelText('© Contenu généré par IA')).toBeTruthy()
     expect(screen.queryByLabelText('© Contenu généré par IA ✨')).toBeNull()
     expect(screen.queryByText('© Contenu généré par IA ✨')).toBeNull()
+  })
+
+  it('should display artist playlist module when defined', async () => {
+    mockServer.getApi(`/v1/artists/${mockArtist.id}`, mockArtist)
+    mockUseGetOffersDataQuery.mockReturnValueOnce([
+      {
+        playlistItems: [mockedAlgoliaResponse.hits[0], mockedAlgoliaResponse.hits[1]],
+      },
+    ])
+    render(
+      reactQueryProviderHOC(
+        <ArtistBody
+          artist={mockArtist}
+          artistPlaylist={[]}
+          artistTopOffers={[]}
+          artistPlaylistModule={{
+            type: HomepageModuleType.ArtistPlaylistModule,
+            id: '2DYuR6KoSLElDuiMMjxx8g',
+            title: 'Mes recommandations',
+            artistId: mockArtist.id,
+            displayParameters: {
+              title: 'Mes recommandations',
+              layout: 'two-items',
+              minOffers: 1,
+            },
+            offersModuleParameters: [
+              {
+                title: 'Mes recommandations',
+                hitsPerPage: 10,
+              },
+            ],
+          }}
+          onViewableItemsChanged={jest.fn()}
+          onExpandBioPress={jest.fn()}
+        />
+      )
+    )
+
+    expect(await screen.findByText('te partage ses pépites')).toBeOnTheScreen()
+  })
+
+  it('should not display artist playlist module when not defined', async () => {
+    render(
+      reactQueryProviderHOC(
+        <ArtistBody
+          artist={mockArtist}
+          artistPlaylist={[]}
+          artistTopOffers={[]}
+          onViewableItemsChanged={jest.fn()}
+          onExpandBioPress={jest.fn()}
+        />
+      )
+    )
+
+    await screen.findAllByText('Avril Lavigne')
+
+    expect(screen.queryByText('te partage ses pépites')).not.toBeOnTheScreen()
   })
 })
 

--- a/src/features/artist/components/ArtistBody/ArtistBody.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.tsx
@@ -1,4 +1,4 @@
-import { useNavigation } from '@react-navigation/native'
+import { useIsFocused, useNavigation } from '@react-navigation/native'
 import React, { FunctionComponent } from 'react'
 import { Platform, ViewToken } from 'react-native'
 import { IOScrollView as IntersectionObserverScrollView } from 'react-native-intersection-observer'
@@ -17,7 +17,10 @@ import {
   FOLLOW_ARTIST_SURVEY_KEY,
 } from 'features/artist/helpers/buildFollowArtistSurveyUrl'
 import { getDisplayableArtistPlaylists } from 'features/artist/helpers/getDisplayableArtistPlaylists'
+import { ArtistPlaylistModule } from 'features/home/components/modules/ArtistPlaylistModule'
 import { separateTitleAndEmojis } from 'features/home/helpers/separateTitleAndEmojis'
+import { useGetOffersDataQuery } from 'features/home/queries/useGetOffersDataQuery'
+import { ArtistPlaylistModule as ArtistPlaylistModuleType } from 'features/home/types'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
 import { getSearchHookConfig } from 'features/navigation/navigators/SearchStackNavigator/getSearchHookConfig'
 import { useGoBack } from 'features/navigation/useGoBack'
@@ -61,6 +64,7 @@ type Props = {
     playlistIndex?: number
   ) => void
   onExpandBioPress: () => void
+  artistPlaylistModule?: ArtistPlaylistModuleType
 }
 
 const ShareButton = ({ onPress }: { onPress: () => void }) => {
@@ -80,6 +84,7 @@ export const ArtistBody: FunctionComponent<Props> = ({
   artist,
   artistPlaylist,
   artistTopOffers,
+  artistPlaylistModule,
   onViewableItemsChanged,
   onExpandBioPress,
 }) => {
@@ -95,6 +100,10 @@ export const ArtistBody: FunctionComponent<Props> = ({
 
   const { top, bottom } = useSafeAreaInsets()
   const headerHeight = appBarHeight + top
+
+  const offersArtistPlaylistModulesData = useGetOffersDataQuery(
+    artistPlaylistModule ? [artistPlaylistModule] : []
+  )
 
   const { name, description, image } = artist
   const descriptionWithDot = ensureEndingDot(description ?? '')
@@ -112,6 +121,7 @@ export const ArtistBody: FunctionComponent<Props> = ({
   })
 
   const { navigate } = useNavigation<UseNavigationType>()
+  const isFocused = useIsFocused()
 
   const handlePressFollow = async () => {
     const [firstArtistPlaylist] = enablePlaylistByCategory
@@ -153,6 +163,13 @@ export const ArtistBody: FunctionComponent<Props> = ({
     })
     void shareArtist()
     showShareArtistModal()
+  }
+
+  const handleArtistPlaylistModuleOffersViewableItemsChanged = (
+    items: Pick<ViewToken, 'key' | 'index'>[]
+  ) => {
+    if (!isFocused || !artistPlaylistModule) return
+    onViewableItemsChanged(items, `artistPage${artistPlaylistModule.id}`, 'offer', artist.id)
   }
 
   return (
@@ -239,6 +256,19 @@ export const ArtistBody: FunctionComponent<Props> = ({
               onViewableItemsChanged={onViewableItemsChanged}
               proAdvicesSegment={proAdvicesSegment}
               enableProAdvicesTag={enableProAdvicesTag}
+            />
+          ) : null}
+          {artistPlaylistModule ? (
+            <ArtistPlaylistModule
+              displayParameters={artistPlaylistModule.displayParameters}
+              offersModuleParameters={artistPlaylistModule.offersModuleParameters}
+              artistId={artist.id}
+              index={0}
+              moduleId={artistPlaylistModule.id}
+              data={offersArtistPlaylistModulesData[0]}
+              onViewableItemsChanged={handleArtistPlaylistModuleOffersViewableItemsChanged}
+              homeEntryId={undefined}
+              disableArtistNavigation
             />
           ) : null}
           <ArtistSimilarArtists artistId={artist.id} />

--- a/src/features/artist/fixtures/contentfulArtistPlaylistSnap.ts
+++ b/src/features/artist/fixtures/contentfulArtistPlaylistSnap.ts
@@ -1,0 +1,149 @@
+export const contentfulArtistPlaylistSnap = {
+  sys: {
+    type: 'Array',
+  },
+  total: 1,
+  skip: 0,
+  limit: 100,
+  items: [
+    {
+      metadata: {
+        tags: [],
+        concepts: [],
+      },
+      sys: {
+        space: {
+          sys: {
+            type: 'Link',
+            linkType: 'Space',
+            id: '2bg01iqy0isv',
+          },
+        },
+        id: '3ekwFnm4jZy5ohgDNTjLRK',
+        type: 'Entry',
+        createdAt: '2026-06-16T14:46:35.284Z',
+        updatedAt: '2026-07-22T10:03:56.198Z',
+        environment: {
+          sys: {
+            id: 'testing',
+            type: 'Link',
+            linkType: 'Environment',
+          },
+        },
+        publishedVersion: 76,
+        revision: 34,
+        contentType: {
+          sys: {
+            type: 'Link',
+            linkType: 'ContentType',
+            id: 'artistPlaylist',
+          },
+        },
+        locale: 'en-US',
+      },
+      fields: {
+        title: 'Reco d’artiste',
+        artistId: '819d02dd-6097-4d11-aa8d-8dd9dcba4c97',
+        algoliaParameters: {
+          sys: {
+            type: 'Link',
+            linkType: 'Entry',
+            id: 'QzD7Rp54PTJzL5ZMjUcbO',
+          },
+        },
+        displayParameters: {
+          sys: {
+            type: 'Link',
+            linkType: 'Entry',
+            id: '5bx0MUKm5ciZTPxATx88dr',
+          },
+        },
+      },
+    },
+  ],
+  includes: {
+    Entry: [
+      {
+        metadata: {
+          tags: [],
+          concepts: [],
+        },
+        sys: {
+          space: {
+            sys: {
+              type: 'Link',
+              linkType: 'Space',
+              id: '2bg01iqy0isv',
+            },
+          },
+          id: '5bx0MUKm5ciZTPxATx88dr',
+          type: 'Entry',
+          createdAt: '2026-06-16T14:46:29.236Z',
+          updatedAt: '2026-06-25T06:52:41.808Z',
+          environment: {
+            sys: {
+              id: 'testing',
+              type: 'Link',
+              linkType: 'Environment',
+            },
+          },
+          publishedVersion: 13,
+          revision: 5,
+          contentType: {
+            sys: {
+              type: 'Link',
+              linkType: 'ContentType',
+              id: 'displayParameters',
+            },
+          },
+          locale: 'en-US',
+        },
+        fields: {
+          title: 'Reco d’artiste',
+          layout: 'three-items',
+          minOffers: 1,
+        },
+      },
+      {
+        metadata: {
+          tags: [],
+          concepts: [],
+        },
+        sys: {
+          space: {
+            sys: {
+              type: 'Link',
+              linkType: 'Space',
+              id: '2bg01iqy0isv',
+            },
+          },
+          id: 'QzD7Rp54PTJzL5ZMjUcbO',
+          type: 'Entry',
+          createdAt: '2026-06-16T14:43:17.123Z',
+          updatedAt: '2026-07-01T13:19:30.836Z',
+          environment: {
+            sys: {
+              id: 'testing',
+              type: 'Link',
+              linkType: 'Environment',
+            },
+          },
+          publishedVersion: 17,
+          revision: 7,
+          contentType: {
+            sys: {
+              type: 'Link',
+              linkType: 'ContentType',
+              id: 'algoliaParameters',
+            },
+          },
+          locale: 'en-US',
+        },
+        fields: {
+          title: 'Reco d’artiste',
+          hitsPerPage: 10,
+        },
+      },
+    ],
+  },
+} as const

--- a/src/features/artist/pages/Artist.native.test.tsx
+++ b/src/features/artist/pages/Artist.native.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 
 import { useRoute } from '__mocks__/@react-navigation/native'
+import { contentfulArtistPlaylistSnap } from 'features/artist/fixtures/contentfulArtistPlaylistSnap'
 import { mockArtist } from 'features/artist/fixtures/mockArtist'
 import { Artist } from 'features/artist/pages/Artist'
 import * as useGoBack from 'features/navigation/useGoBack'
 import { analytics } from 'libs/analytics/provider'
+import { CONTENTFUL_BASE_URL } from 'libs/contentful/constants'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
 import { mockServer } from 'tests/mswServer'
@@ -27,6 +29,7 @@ describe('<Artist />', () => {
   beforeEach(() => {
     mockServer.getApi('/v1/subcategories/v2', subcategoriesDataTest)
     mockServer.getApi(`/v1/artists/${mockArtist.id}/similar`, { artists: [] })
+    mockServer.universalGet(`${CONTENTFUL_BASE_URL}/entries`, contentfulArtistPlaylistSnap)
     setFeatureFlags()
   })
 

--- a/src/features/artist/pages/Artist.tsx
+++ b/src/features/artist/pages/Artist.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from 'react-error-boundary'
 import { ViewToken } from 'react-native'
 
 import { ArtistBody } from 'features/artist/components/ArtistBody/ArtistBody'
+import { useGetArtistPlaylistConfigQuery } from 'features/artist/queries/useGetArtistPlaylistConfigQuery'
 import { UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
 import { PageNotFound } from 'features/navigation/pages/PageNotFound'
 import { analytics } from 'libs/analytics/provider'
@@ -25,6 +26,10 @@ const ArtistContent: FunctionComponent = () => {
   const { artistPlaylist, artistTopOffers } = useArtistResultsQuery({
     artistId: params.id,
   })
+  const { data: artistPlaylistModule } = useGetArtistPlaylistConfigQuery((modules) =>
+    modules.find((module) => module.artistId === params.id)
+  )
+
   const { data: artist, isError, error } = useArtistSuspenseQuery(params.id)
 
   useEffect(() => {
@@ -67,6 +72,7 @@ const ArtistContent: FunctionComponent = () => {
       artist={artist}
       artistPlaylist={artistPlaylist}
       artistTopOffers={artistTopOffers}
+      artistPlaylistModule={artistPlaylistModule}
       onViewableItemsChanged={handleViewableItemsChanged}
       onExpandBioPress={handleOnExpandBioPress}
     />

--- a/src/features/artist/queries/useGetArtistPlaylistConfigQuery.native.test.ts
+++ b/src/features/artist/queries/useGetArtistPlaylistConfigQuery.native.test.ts
@@ -1,0 +1,51 @@
+import { contentfulArtistPlaylistSnap } from 'features/artist/fixtures/contentfulArtistPlaylistSnap'
+import { useGetArtistPlaylistConfigQuery } from 'features/artist/queries/useGetArtistPlaylistConfigQuery'
+import { ArtistPlaylistModule } from 'features/home/types'
+import { CONTENTFUL_BASE_URL } from 'libs/contentful/constants'
+import { mockServer } from 'tests/mswServer'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { renderHook, waitFor } from 'tests/utils'
+
+jest.mock('libs/jwt/jwt')
+jest.mock('features/auth/context/AuthContext', () => ({
+  useAuthContext: jest.fn(() => ({ isLoggedIn: true })),
+}))
+
+describe('useGetArtistPlaylistConfigQuery', () => {
+  beforeEach(() => {
+    mockServer.universalGet(`${CONTENTFUL_BASE_URL}/entries`, contentfulArtistPlaylistSnap)
+  })
+
+  it('should allow selecting a subset of data', async () => {
+    const defaultArtistId = '819d02dd-6097-4d11-aa8d-8dd9dcba4c97'
+    const { result } = renderUseGetArtistPlaylistConfigQuery((data) =>
+      data.find((r) => r.artistId === defaultArtistId)
+    )
+
+    await waitFor(async () => expect(result.current.isFetched).toEqual(true))
+
+    expect(result.current.data).toEqual(
+      expect.objectContaining({
+        id: '3ekwFnm4jZy5ohgDNTjLRK',
+        artistId: '819d02dd-6097-4d11-aa8d-8dd9dcba4c97',
+        displayParameters: expect.objectContaining({
+          title: 'Reco d’artiste',
+          layout: 'three-items',
+          minOffers: 1,
+        }),
+        offersModuleParameters: [
+          expect.objectContaining({
+            hitsPerPage: 10,
+          }),
+        ],
+      })
+    )
+  })
+})
+
+const renderUseGetArtistPlaylistConfigQuery = <TData = ArtistPlaylistModule[]>(
+  select?: (data: ArtistPlaylistModule[]) => TData
+) =>
+  renderHook(() => useGetArtistPlaylistConfigQuery(select), {
+    wrapper: ({ children }) => reactQueryProviderHOC(children),
+  })

--- a/src/features/artist/queries/useGetArtistPlaylistConfigQuery.ts
+++ b/src/features/artist/queries/useGetArtistPlaylistConfigQuery.ts
@@ -4,7 +4,7 @@ import { fetchArtistPlaylistConfig } from 'features/artist/api/fetchArtistPlayli
 import { ArtistPlaylistModule } from 'features/home/types'
 import { QueryKeys } from 'libs/queryKeys'
 
-const STALE_TIME_ARTIST_PLAYLIST_CONFIG = 24 * 60 * 1000
+const STALE_TIME_ARTIST_PLAYLIST_CONFIG = 60 * 60 * 1000 // 1h
 
 export const useGetArtistPlaylistConfigQuery = <TData = ArtistPlaylistModule[]>(
   select?: (data: ArtistPlaylistModule[]) => TData

--- a/src/features/artist/queries/useGetArtistPlaylistConfigQuery.ts
+++ b/src/features/artist/queries/useGetArtistPlaylistConfigQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { fetchArtistPlaylistConfig } from 'features/artist/api/fetchArtistPlaylistConfig'
+import { ArtistPlaylistModule } from 'features/home/types'
+import { QueryKeys } from 'libs/queryKeys'
+
+const STALE_TIME_ARTIST_PLAYLIST_CONFIG = 24 * 60 * 1000
+
+export const useGetArtistPlaylistConfigQuery = <TData = ArtistPlaylistModule[]>(
+  select?: (data: ArtistPlaylistModule[]) => TData
+) =>
+  useQuery<ArtistPlaylistModule[], Error, TData>({
+    queryKey: [QueryKeys.ARTIST_PLAYLIST_CONFIG],
+    queryFn: fetchArtistPlaylistConfig,
+    select,
+    staleTime: STALE_TIME_ARTIST_PLAYLIST_CONFIG,
+  })

--- a/src/features/home/components/modules/ArtistPlaylistModule.native.test.tsx
+++ b/src/features/home/components/modules/ArtistPlaylistModule.native.test.tsx
@@ -130,6 +130,17 @@ describe('ArtistPlaylistModule', () => {
     expect(navigate).toHaveBeenCalledWith('Artist', { id: mockArtist.id })
   })
 
+  it('should display right filled icon on artist button', async () => {
+    renderArtistPlaylistModule({
+      data: { playlistItems: mockHitsItems, nbPlaylistResults: 10, moduleId: 'fakeModuleId' },
+      artistId: mockArtist.id,
+    })
+
+    await screen.findByLabelText('Accéder à la page artiste de Avril Lavigne')
+
+    expect(screen.getByTestId('RightFilled')).toBeOnTheScreen()
+  })
+
   describe('Analytics', () => {
     it('should trigger logEvent "AllTilesSeen" only once', async () => {
       renderArtistPlaylistModule()
@@ -208,6 +219,34 @@ describe('ArtistPlaylistModule', () => {
         from: 'home',
         originDetails: 'artistRecommendation',
       })
+    })
+  })
+
+  describe('When disableArtistNavigation prop is true', () => {
+    it('should not navigate on artist page', async () => {
+      renderArtistPlaylistModule({
+        data: { playlistItems: mockHitsItems, nbPlaylistResults: 10, moduleId: 'fakeModuleId' },
+        artistId: mockArtist.id,
+        disableArtistNavigation: true,
+      })
+
+      await screen.findByText('te partage ses pépites')
+
+      expect(
+        screen.queryByLabelText('Accéder à la page artiste de Avril Lavigne')
+      ).not.toBeOnTheScreen()
+    })
+
+    it('should not display right filled icon on artist header', async () => {
+      renderArtistPlaylistModule({
+        data: { playlistItems: mockHitsItems, nbPlaylistResults: 10, moduleId: 'fakeModuleId' },
+        artistId: mockArtist.id,
+        disableArtistNavigation: true,
+      })
+
+      await screen.findByText('te partage ses pépites')
+
+      expect(screen.queryByTestId('RightFilled')).not.toBeOnTheScreen()
     })
   })
 })

--- a/src/features/home/components/modules/ArtistPlaylistModule.tsx
+++ b/src/features/home/components/modules/ArtistPlaylistModule.tsx
@@ -40,6 +40,7 @@ export type ArtistPlaylistModuleProps = {
   homeEntryId: string | undefined
   data: ModuleData | undefined
   onViewableItemsChanged?: (items: Pick<ViewToken, 'key' | 'index'>[]) => void
+  disableArtistNavigation?: boolean
 }
 
 const keyExtractor = (item: Offer) => item.objectID
@@ -54,6 +55,7 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
     homeEntryId,
     data,
     onViewableItemsChanged,
+    disableArtistNavigation,
   } = props
   const { designSystem } = useTheme()
   const adaptedPlaylistParameters = useAdaptOffersPlaylistParameters()
@@ -159,6 +161,46 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
     })
   }
 
+  const artistHeader = (
+    <StyledInfoHeader
+      title={artist?.name}
+      subtitle="te partage ses pépites"
+      defaultThumbnailSize={AVATAR_SMALL}
+      thumbnailComponent={
+        <Avatar
+          size={AVATAR_SMALL}
+          rounded={false}
+          borderRadius={designSystem.size.borderRadius.pill}>
+          {artist?.image ? (
+            <ArtistImage url={artist.image} testID="ArtistImage" />
+          ) : (
+            <DefaultAvatar testID="defaultArtistAvatar" />
+          )}
+        </Avatar>
+      }
+      rightComponent={
+        disableArtistNavigation ? undefined : (
+          <RightFilled size={designSystem.size.icon.s} testID="RightFilled" />
+        )
+      }
+    />
+  )
+
+  const renderPlaylistHeader = () => {
+    if (!artist) return undefined
+    if (disableArtistNavigation) return artistHeader
+
+    return (
+      <InternalTouchableLink
+        navigateTo={{ screen: 'Artist', params: { id: artist.id } }}
+        accessibilityLabel={`Accéder à la page artiste de ${artist.name}`}
+        accessibilityRole={accessibilityRoleInternalNavigation()}
+        onBeforeNavigate={() => onArtistPress(artist.id, artist.name)}>
+        {artistHeader}
+      </InternalTouchableLink>
+    )
+  }
+
   return (
     <ObservedPlaylist onViewableItemsChanged={onViewableItemsChanged}>
       {({ listRef, handleViewableItemsChanged }) => (
@@ -179,36 +221,7 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
             navigateToSearchPlaylist: searchTabConfig,
             hideSearchSeeAll: isWeb,
           }}
-          playlistHeader={
-            artist ? (
-              <InternalTouchableLink
-                navigateTo={{ screen: 'Artist', params: { id: artist.id } }}
-                accessibilityLabel={`Accéder à la page artiste de ${artist.name}`}
-                accessibilityRole={accessibilityRoleInternalNavigation()}
-                onBeforeNavigate={() => onArtistPress(artist.id, artist.name)}>
-                <StyledInfoHeader
-                  title={artist.name}
-                  subtitle="te partage ses pépites"
-                  defaultThumbnailSize={AVATAR_SMALL}
-                  thumbnailComponent={
-                    <Avatar
-                      size={AVATAR_SMALL}
-                      rounded={false}
-                      borderRadius={designSystem.size.borderRadius.pill}>
-                      {artist.image ? (
-                        <ArtistImage url={artist.image} testID="ArtistImage" />
-                      ) : (
-                        <DefaultAvatar testID="defaultArtistAvatar" />
-                      )}
-                    </Avatar>
-                  }
-                  rightComponent={
-                    <RightFilled size={designSystem.size.icon.s} testID="RightFilled" />
-                  }
-                />
-              </InternalTouchableLink>
-            ) : undefined
-          }
+          playlistHeader={renderPlaylistHeader()}
         />
       )}
     </ObservedPlaylist>

--- a/src/libs/queryKeys.ts
+++ b/src/libs/queryKeys.ts
@@ -7,6 +7,7 @@ export enum QueryKeys {
   ALGOLIA_SIMILAR_OFFERS = 'algoliaSimilarOffers',
   ARTIST = 'artist',
   ARTIST_PLAYLIST = 'artistPlaylist',
+  ARTIST_PLAYLIST_CONFIG = 'artistPlaylistConfig',
   AVAILABLE_REACTION = 'availableReaction',
   BOOKINGSV2 = 'bookingsV2',
   BOOKINGSLIST = 'bookingsList',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42328

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="105" height="546" alt="Capture d’écran 2026-07-22 à 17 44 20" src="https://github.com/user-attachments/assets/236963e1-8440-400c-8b6f-c1d5467336ad" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-22 at 17 41 19" src="https://github.com/user-attachments/assets/ff325b2c-2857-4d16-90e1-e36ae33bf799" />|
| Android          |               |<img width="1080" height="2400" alt="Screenshot_1784734984" src="https://github.com/user-attachments/assets/4ccf6755-b554-4770-b498-f014d564ddc7" />|
| Phone - Chrome   |               |<img width="405" height="695" alt="Capture d’écran 2026-07-22 à 17 41 07" src="https://github.com/user-attachments/assets/4cb49de5-b550-47d4-8a3f-bf9cc547abf4" />|
| Desktop - Chrome |               |<img width="1508" height="762" alt="Capture d’écran 2026-07-22 à 17 40 59" src="https://github.com/user-attachments/assets/aaf4f3b2-599a-4206-9af3-5b7a9fbc0c1b" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
