### PR TITLE
(PC-42648) feat(clubs): add scene clubs

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -1476,6 +1476,17 @@ export interface ChronicleAuthor {
 }
 /**
  * @export
+ * @enum {string}
+ */
+export enum ChronicleClubType {
+  'CINE' = 'CINE',
+  'BOOK' = 'BOOK',
+  'ALBUM' = 'ALBUM',
+  'CONCERT' = 'CONCERT',
+  'SCENE' = 'SCENE',
+}
+/**
+ * @export
  * @interface ChroniclePreview
  */
 export interface ChroniclePreview {
@@ -1484,6 +1495,11 @@ export interface ChroniclePreview {
    * @memberof ChroniclePreview
    */
   author?: ChronicleAuthor | null
+  /**
+   * @type {ChronicleClubType}
+   * @memberof ChroniclePreview
+   */
+  clubType: ChronicleClubType
   /**
    * @type {string}
    * @memberof ChroniclePreview
@@ -2851,6 +2867,11 @@ export interface OfferChronicle {
    * @memberof OfferChronicle
    */
   author?: ChronicleAuthor | null
+  /**
+   * @type {ChronicleClubType}
+   * @memberof OfferChronicle
+   */
+  clubType: ChronicleClubType
   /**
    * @type {string}
    * @memberof OfferChronicle

--- a/src/features/artist/components/ArtistPlaylist/ArtistCategoryPlaylist.tsx
+++ b/src/features/artist/components/ArtistPlaylist/ArtistCategoryPlaylist.tsx
@@ -10,6 +10,8 @@ import { PlaylistType } from 'features/offer/enums'
 import { AlgoliaOfferWithArtistAndEan } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics/provider'
 import { getPlaylistItemDimensionsFromLayout } from 'libs/contentful/getPlaylistItemDimensionsFromLayout'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
 import { useCategoryIdMapping } from 'libs/subcategories'
 import { useSubcategoryOfferLabelMapping } from 'libs/subcategories/mappings'
@@ -56,6 +58,7 @@ export const ArtistCategoryPlaylist: FunctionComponent<ArtistCategoryPlaylistPro
   const { data: euroToPacificFrancRate } = usePacificFrancToEuroRate()
   const categoryMapping = useCategoryIdMapping()
   const labelMapping = useSubcategoryOfferLabelMapping()
+  const enableSceneClubTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_SCENE_CLUB)
   const { itemWidth, itemHeight } = getPlaylistItemDimensionsFromLayout('three-items')
   const isFocused = useIsFocused()
 
@@ -107,6 +110,7 @@ export const ArtistCategoryPlaylist: FunctionComponent<ArtistCategoryPlaylistPro
               getDisplayedPrice(item.offer.prices, currency, euroToPacificFrancRate),
             proAdvicesSegment,
             enableProAdvicesTag,
+            enableSceneClubTag,
           })}
           itemWidth={itemWidth}
           itemHeight={itemHeight}

--- a/src/features/artist/components/ArtistTopOffers/ArtistTopOffers.tsx
+++ b/src/features/artist/components/ArtistTopOffers/ArtistTopOffers.tsx
@@ -7,6 +7,8 @@ import { PlaylistType } from 'features/offer/enums'
 import { AlgoliaOfferWithArtistAndEan } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics/provider'
 import { getPlaylistItemDimensionsFromLayout } from 'libs/contentful/getPlaylistItemDimensionsFromLayout'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
 import { useCategoryIdMapping } from 'libs/subcategories'
 import { useSubcategoryOfferLabelMapping } from 'libs/subcategories/mappings'
@@ -39,6 +41,7 @@ export const ArtistTopOffers: FunctionComponent<Props> = ({
   const { data: euroToPacificFrancRate } = usePacificFrancToEuroRate()
   const categoryMapping = useCategoryIdMapping()
   const labelMapping = useSubcategoryOfferLabelMapping()
+  const enableSceneClubTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_SCENE_CLUB)
   const { itemWidth, itemHeight } = getPlaylistItemDimensionsFromLayout('three-items')
   const topOffers = items.slice(0, MAX_TOP_OFFERS)
 
@@ -82,6 +85,7 @@ export const ArtistTopOffers: FunctionComponent<Props> = ({
           getDisplayedPrice(item.offer.prices, currency, euroToPacificFrancRate),
         proAdvicesSegment,
         enableProAdvicesTag,
+        enableSceneClubTag,
       })}
       itemWidth={itemWidth}
       itemHeight={itemHeight}

--- a/src/features/clubAdvices/constants.tsx
+++ b/src/features/clubAdvices/constants.tsx
@@ -6,6 +6,7 @@ import { Tag } from 'ui/designSystem/Tag/Tag'
 import { TagVariant } from 'ui/designSystem/Tag/types'
 import { BookClubCertification } from 'ui/svg/BookClubCertification'
 import { CineClubCertification } from 'ui/svg/CineClubCertification'
+import { SceneClubCertification } from 'ui/svg/SceneClubCertification'
 
 const BookClubIcon = styled(BookClubCertification).attrs(({ theme }) => ({
   color: theme.designSystem.color.icon.bookclub,
@@ -25,6 +26,15 @@ const SmallCineClubIcon = styled(CineClubCertification).attrs(({ theme }) => ({
   size: theme.designSystem.size.icon.m,
 }))``
 
+const SceneClubIcon = styled(SceneClubCertification).attrs(({ theme }) => ({
+  color: theme.designSystem.color.icon.sceneClub,
+}))``
+
+const SmallSceneClubIcon = styled(SceneClubCertification).attrs(({ theme }) => ({
+  color: theme.designSystem.color.icon.sceneClub,
+  size: theme.designSystem.size.icon.m,
+}))``
+
 export const BOOK_CLUB_SUBCATEGORIES = [
   SubcategoryIdEnum.LIVRE_AUDIO_PHYSIQUE,
   SubcategoryIdEnum.LIVRE_NUMERIQUE,
@@ -37,6 +47,19 @@ export const CINE_CLUB_SUBCATEGORIES = [
   SubcategoryIdEnum.AUTRE_SUPPORT_NUMERIQUE,
   SubcategoryIdEnum.VOD,
   SubcategoryIdEnum.CINE_PLEIN_AIR,
+] as const
+
+export const SCENE_CLUB_SUBCATEGORIES = [
+  SubcategoryIdEnum.SPECTACLE_REPRESENTATION,
+  SubcategoryIdEnum.SPECTACLE_ENREGISTRE,
+  SubcategoryIdEnum.SPECTACLE_VENTE_DISTANCE,
+  SubcategoryIdEnum.CONFERENCE,
+  SubcategoryIdEnum.VISITE_GUIDEE,
+  SubcategoryIdEnum.RENCONTRE,
+  SubcategoryIdEnum.SALON,
+  SubcategoryIdEnum.FESTIVAL_SPECTACLE,
+  SubcategoryIdEnum.LIVESTREAM_PRATIQUE_ARTISTIQUE,
+  SubcategoryIdEnum.ABO_SPECTACLE,
 ] as const
 
 export const PRO_ADVICE_VARIANT_CONFIG = {
@@ -82,8 +105,24 @@ const CINE_CLUB_VARIANT_CONFIG = {
   buttonWording: 'Voir tous les avis des clubs',
 } as const
 
+const SCENE_CLUB_VARIANT_CONFIG = {
+  subcategories: SCENE_CLUB_SUBCATEGORIES,
+  labelReaction: 'scène club',
+  titleSection: 'Les avis de la scène club',
+  subtitleSection: 'La communauté de jeunes passionnés te partage leur avis\u00a0!',
+  subtitleItem: 'Membre de la scène club',
+  Icon: <SceneClubIcon testID="sceneClubIcon" />,
+  SmallIcon: <SmallSceneClubIcon />,
+  modalTitle: 'Qui écrit les avis de la scène club\u00a0?',
+  modalWording:
+    'La scène club, c’est une équipe de jeunes passionnés de spectacle vivant réunis par le pass Culture. \n\nChaque mois, ils vont voir des spectacles et donnent leur avis pour t’aider à trouver ta prochaine sortie\u00a0!',
+  tag: <Tag variant={TagVariant.SCENECLUB} label="membre de la scène club" />,
+  buttonWording: 'Voir tous les avis des clubs',
+} as const
+
 export const CLUB_ADVICE_VARIANT_CONFIG = [
   BOOK_CLUB_VARIANT_CONFIG,
   CINE_CLUB_VARIANT_CONFIG,
+  SCENE_CLUB_VARIANT_CONFIG,
   PRO_ADVICE_VARIANT_CONFIG,
 ] as const

--- a/src/features/clubAdvices/fixtures/clubAdvices.fixture.ts
+++ b/src/features/clubAdvices/fixtures/clubAdvices.fixture.ts
@@ -1,10 +1,11 @@
 import type { ReadonlyDeep } from 'type-fest'
 
-import { OfferChronicle, OfferChronicles } from 'api/gen'
+import { ChronicleClubType, OfferChronicle, OfferChronicles } from 'api/gen'
 
 export const clubAdvicesFixture = [
   {
     id: 31,
+    clubType: ChronicleClubType.BOOK,
     dateCreated: '2025-01-20T23:32:14.456451Z',
     author: {
       firstName: null,
@@ -15,6 +16,7 @@ export const clubAdvicesFixture = [
   },
   {
     id: 1,
+    clubType: ChronicleClubType.BOOK,
     dateCreated: '2025-01-20T23:32:13.978038Z',
     author: {
       firstName: 'Jeanne',
@@ -22,6 +24,20 @@ export const clubAdvicesFixture = [
       city: 'Paris',
     },
     content: 'Chronique sur le produit Product 30 \u00e9crite par l’utilisateur Jeanne Doux (2).',
+  },
+] as const satisfies readonly OfferChronicle[]
+
+export const sceneClubAdvicesFixture = [
+  {
+    id: 42,
+    clubType: ChronicleClubType.SCENE,
+    dateCreated: '2025-04-12T09:14:52.123456Z',
+    author: {
+      firstName: 'Camille',
+      age: 17,
+      city: 'Lyon',
+    },
+    content: 'Une mise en scène bluffante, on ne voit pas le temps passer.',
   },
 ] as const satisfies readonly OfferChronicle[]
 

--- a/src/features/clubAdvices/helpers/clubAdviceVariant.native.test.ts
+++ b/src/features/clubAdvices/helpers/clubAdviceVariant.native.test.ts
@@ -1,4 +1,8 @@
-import { BOOK_CLUB_SUBCATEGORIES, CINE_CLUB_SUBCATEGORIES } from 'features/clubAdvices/constants'
+import {
+  BOOK_CLUB_SUBCATEGORIES,
+  CINE_CLUB_SUBCATEGORIES,
+  SCENE_CLUB_SUBCATEGORIES,
+} from 'features/clubAdvices/constants'
 import { clubAdviceVariant } from 'features/clubAdvices/helpers/clubAdviceVariant'
 
 describe('clubAdviceVariant', () => {
@@ -6,7 +10,7 @@ describe('clubAdviceVariant', () => {
     BOOK_CLUB_SUBCATEGORIES.forEach((subcategoryId) => {
       const variant = clubAdviceVariant[subcategoryId]
 
-      expect(variant.titleSection).toEqual('Les avis du book club')
+      expect(variant?.titleSection).toEqual('Les avis du book club')
     })
   })
 
@@ -14,7 +18,15 @@ describe('clubAdviceVariant', () => {
     CINE_CLUB_SUBCATEGORIES.forEach((subcategoryId) => {
       const variant = clubAdviceVariant[subcategoryId]
 
-      expect(variant.titleSection).toEqual('Les avis du ciné club')
+      expect(variant?.titleSection).toEqual('Les avis du ciné club')
+    })
+  })
+
+  it('should define all scène club subcategories', () => {
+    SCENE_CLUB_SUBCATEGORIES.forEach((subcategoryId) => {
+      const variant = clubAdviceVariant[subcategoryId]
+
+      expect(variant?.titleSection).toEqual('Les avis de la scène club')
     })
   })
 })

--- a/src/features/clubAdvices/helpers/clubAdviceVariant.ts
+++ b/src/features/clubAdvices/helpers/clubAdviceVariant.ts
@@ -2,8 +2,9 @@ import { SubcategoryIdEnum } from 'api/gen'
 import { AdviceVariantInfo } from 'features/advices/types'
 import { CLUB_ADVICE_VARIANT_CONFIG } from 'features/clubAdvices/constants'
 
-export const clubAdviceVariant: Record<SubcategoryIdEnum, AdviceVariantInfo> = Object.fromEntries(
-  CLUB_ADVICE_VARIANT_CONFIG.flatMap(({ subcategories, ...variant }) =>
-    subcategories.map((id) => [id, variant] as const)
+export const clubAdviceVariant: Partial<Record<SubcategoryIdEnum, AdviceVariantInfo>> =
+  Object.fromEntries(
+    CLUB_ADVICE_VARIANT_CONFIG.flatMap(({ subcategories, ...variant }) =>
+      subcategories.map((id) => [id, variant] as const)
+    )
   )
-)

--- a/src/features/clubAdvices/helpers/isBookClubSubcategory.ts
+++ b/src/features/clubAdvices/helpers/isBookClubSubcategory.ts
@@ -1,6 +1,6 @@
 import { SubcategoryIdEnum } from 'api/gen'
 import { BOOK_CLUB_SUBCATEGORIES } from 'features/clubAdvices/constants'
-import { BookClubSubcategoryId } from 'features/offer/components/OfferContent/ClubAdviceSection/types'
+import { BookClubSubcategoryId } from 'features/clubAdvices/types'
 
 export const isBookClubSubcategory = (
   subcategoryId: SubcategoryIdEnum

--- a/src/features/clubAdvices/helpers/isCineClubSubcategory.native.test.ts
+++ b/src/features/clubAdvices/helpers/isCineClubSubcategory.native.test.ts
@@ -1,0 +1,17 @@
+import { SubcategoryIdEnum } from 'api/gen'
+import { CINE_CLUB_SUBCATEGORIES } from 'features/clubAdvices/constants'
+import { isCineClubSubcategory } from 'features/clubAdvices/helpers/isCineClubSubcategory'
+
+describe('isCineClubSubcategory', () => {
+  it.each([...CINE_CLUB_SUBCATEGORIES])(
+    'should return true when subcategory is %s',
+    (subcategoryId) => {
+      expect(isCineClubSubcategory(subcategoryId)).toEqual(true)
+    }
+  )
+
+  it('should return false when subcategory not includes in CINE_CLUB_SUBCATEGORIES', () => {
+    expect(isCineClubSubcategory(SubcategoryIdEnum.LIVRE_PAPIER)).toEqual(false)
+    expect(isCineClubSubcategory(SubcategoryIdEnum.SPECTACLE_REPRESENTATION)).toEqual(false)
+  })
+})

--- a/src/features/clubAdvices/helpers/isCineClubSubcategory.ts
+++ b/src/features/clubAdvices/helpers/isCineClubSubcategory.ts
@@ -1,0 +1,8 @@
+import { SubcategoryIdEnum } from 'api/gen'
+import { CINE_CLUB_SUBCATEGORIES } from 'features/clubAdvices/constants'
+import { CineClubSubcategoryId } from 'features/clubAdvices/types'
+
+export const isCineClubSubcategory = (
+  subcategoryId: SubcategoryIdEnum
+): subcategoryId is CineClubSubcategoryId =>
+  CINE_CLUB_SUBCATEGORIES.includes(subcategoryId as CineClubSubcategoryId)

--- a/src/features/clubAdvices/helpers/isSceneClubSubcategory.native.test.ts
+++ b/src/features/clubAdvices/helpers/isSceneClubSubcategory.native.test.ts
@@ -1,0 +1,17 @@
+import { SubcategoryIdEnum } from 'api/gen'
+import { SCENE_CLUB_SUBCATEGORIES } from 'features/clubAdvices/constants'
+import { isSceneClubSubcategory } from 'features/clubAdvices/helpers/isSceneClubSubcategory'
+
+describe('isSceneClubSubcategory', () => {
+  it.each([...SCENE_CLUB_SUBCATEGORIES])(
+    'should return true when subcategory is %s',
+    (subcategoryId) => {
+      expect(isSceneClubSubcategory(subcategoryId)).toEqual(true)
+    }
+  )
+
+  it('should return false when subcategory not includes in SCENE_CLUB_SUBCATEGORIES', () => {
+    expect(isSceneClubSubcategory(SubcategoryIdEnum.LIVRE_PAPIER)).toEqual(false)
+    expect(isSceneClubSubcategory(SubcategoryIdEnum.SEANCE_CINE)).toEqual(false)
+  })
+})

--- a/src/features/clubAdvices/helpers/isSceneClubSubcategory.ts
+++ b/src/features/clubAdvices/helpers/isSceneClubSubcategory.ts
@@ -1,0 +1,8 @@
+import { SubcategoryIdEnum } from 'api/gen'
+import { SCENE_CLUB_SUBCATEGORIES } from 'features/clubAdvices/constants'
+import { SceneClubSubcategoryId } from 'features/clubAdvices/types'
+
+export const isSceneClubSubcategory = (
+  subcategoryId: SubcategoryIdEnum
+): subcategoryId is SceneClubSubcategoryId =>
+  SCENE_CLUB_SUBCATEGORIES.includes(subcategoryId as SceneClubSubcategoryId)

--- a/src/features/clubAdvices/helpers/useClubAdviceVariant.native.test.ts
+++ b/src/features/clubAdvices/helpers/useClubAdviceVariant.native.test.ts
@@ -1,0 +1,54 @@
+import { SubcategoryIdEnum } from 'api/gen'
+import { useClubAdviceVariant } from 'features/clubAdvices/helpers/useClubAdviceVariant'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { renderHook } from 'tests/utils'
+
+describe('useClubAdviceVariant', () => {
+  it('should return undefined when subcategory is not defined', () => {
+    setFeatureFlags()
+
+    const { result } = renderHook(() => useClubAdviceVariant())
+
+    expect(result.current).toBeUndefined()
+  })
+
+  it('should return undefined when subcategory has no club', () => {
+    setFeatureFlags()
+
+    const { result } = renderHook(() => useClubAdviceVariant(SubcategoryIdEnum.CARTE_MUSEE))
+
+    expect(result.current).toBeUndefined()
+  })
+
+  it.each([SubcategoryIdEnum.LIVRE_PAPIER, SubcategoryIdEnum.SEANCE_CINE])(
+    'should return the variant for %s whatever the scene club feature flag',
+    (subcategoryId) => {
+      setFeatureFlags()
+
+      const { result } = renderHook(() => useClubAdviceVariant(subcategoryId))
+
+      expect(result.current).toBeDefined()
+    }
+  )
+
+  it('should return the scène club variant when feature flag is enabled', () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_SCENE_CLUB])
+
+    const { result } = renderHook(() =>
+      useClubAdviceVariant(SubcategoryIdEnum.SPECTACLE_REPRESENTATION)
+    )
+
+    expect(result.current?.titleSection).toEqual('Les avis de la scène club')
+  })
+
+  it('should not return the scène club variant when feature flag is disabled', () => {
+    setFeatureFlags()
+
+    const { result } = renderHook(() =>
+      useClubAdviceVariant(SubcategoryIdEnum.SPECTACLE_REPRESENTATION)
+    )
+
+    expect(result.current).toBeUndefined()
+  })
+})

--- a/src/features/clubAdvices/helpers/useClubAdviceVariant.ts
+++ b/src/features/clubAdvices/helpers/useClubAdviceVariant.ts
@@ -1,0 +1,17 @@
+import { SubcategoryIdEnum } from 'api/gen'
+import { AdviceVariantInfo } from 'features/advices/types'
+import { clubAdviceVariant } from 'features/clubAdvices/helpers/clubAdviceVariant'
+import { isSceneClubSubcategory } from 'features/clubAdvices/helpers/isSceneClubSubcategory'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+
+export const useClubAdviceVariant = (
+  subcategoryId?: SubcategoryIdEnum
+): AdviceVariantInfo | undefined => {
+  const enableSceneClub = useFeatureFlag(RemoteStoreFeatureFlags.WIP_SCENE_CLUB)
+
+  if (!subcategoryId) return undefined
+  if (!enableSceneClub && isSceneClubSubcategory(subcategoryId)) return undefined
+
+  return clubAdviceVariant[subcategoryId]
+}

--- a/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.native.test.tsx
+++ b/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.native.test.tsx
@@ -3,12 +3,17 @@ import React from 'react'
 import { FlatList } from 'react-native'
 
 import { useRoute } from '__mocks__/@react-navigation/native'
-import { SubcategoriesResponseModelv2, SubcategoryIdEnum } from 'api/gen'
-import { offerClubAdvicesFixture } from 'features/clubAdvices/fixtures/clubAdvices.fixture'
+import { OfferChronicle, SubcategoriesResponseModelv2, SubcategoryIdEnum } from 'api/gen'
+import {
+  offerClubAdvicesFixture,
+  sceneClubAdvicesFixture,
+} from 'features/clubAdvices/fixtures/clubAdvices.fixture'
 import { ClubAdvices } from 'features/clubAdvices/pages/ClubAdvices/ClubAdvices'
 import * as useGoBack from 'features/navigation/useGoBack'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -29,9 +34,9 @@ jest.mock('libs/firebase/analytics/analytics')
 const mockScrollToIndex = jest.fn()
 jest.spyOn(FlatList.prototype, 'scrollToIndex').mockImplementation(mockScrollToIndex)
 
-const mockAdvices = offerClubAdvicesFixture.chronicles
+let mockClubAdvices: { chronicles: readonly OfferChronicle[] } = offerClubAdvicesFixture
 jest.mock('features/clubAdvices/queries/useClubAdvicesQuery', () => ({
-  useClubAdvicesQuery: () => ({ data: mockAdvices, isLoading: false }),
+  useClubAdvicesQuery: () => ({ data: mockClubAdvices, isLoading: false }),
 }))
 
 const mockNavigate = jest.fn()
@@ -60,6 +65,8 @@ jest.useFakeTimers()
 
 describe('ClubAdvices', () => {
   beforeEach(() => {
+    setFeatureFlags()
+    mockClubAdvices = offerClubAdvicesFixture
     mockServer.getApi(`/v3/offer/${offerResponseSnap.id}`, offerResponseSnap)
     mockServer.getApi(`/v1/offer/${offerResponseSnap.id}/chronicles`, offerClubAdvicesFixture)
   })
@@ -98,6 +105,21 @@ describe('ClubAdvices', () => {
       await screen.findByText('Tous les avis du ciné club')
 
       expect(screen.getAllByTestId('cineClubIcon')[0]).toBeOnTheScreen()
+    })
+
+    it('should display scene club icon when offer subcategory linked to a live show', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_SCENE_CLUB])
+      mockClubAdvices = { chronicles: sceneClubAdvicesFixture }
+      mockServer.getApi(`/v3/offer/${offerResponseSnap.id}`, {
+        ...offerResponseSnap,
+        subcategoryId: SubcategoryIdEnum.SPECTACLE_REPRESENTATION,
+      })
+
+      render(reactQueryProviderHOC(<ClubAdvices />))
+
+      await screen.findByText('Qui écrit les avis de la scène club ?')
+
+      expect(screen.getAllByTestId('sceneClubIcon')[0]).toBeOnTheScreen()
     })
 
     it('should scroll to selected advice on layout', async () => {

--- a/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.tsx
+++ b/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.tsx
@@ -1,10 +1,8 @@
 import { useNavigation, useRoute } from '@react-navigation/native'
 import React, { FunctionComponent } from 'react'
 
-import { SubcategoryIdEnum } from 'api/gen'
-import { AdviceCardData } from 'features/advices/types'
 import { clubAdvicesToAdviceCardData } from 'features/clubAdvices/adapters/clubAdvicesToAdviceCardData/clubAdvicesToAdviceCardData'
-import { clubAdviceVariant } from 'features/clubAdvices/helpers/clubAdviceVariant'
+import { useClubAdviceVariant } from 'features/clubAdvices/helpers/useClubAdviceVariant'
 import { ClubAdvicesBase } from 'features/clubAdvices/pages/ClubAdvices/ClubAdvicesBase'
 import { useClubAdvicesQuery } from 'features/clubAdvices/queries/useClubAdvicesQuery'
 import { UseNavigationType, UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
@@ -20,12 +18,10 @@ export const ClubAdvices: FunctionComponent = () => {
   const offerId = route.params?.offerId
   const { data: offer } = useOfferQuery({ offerId })
   const subcategoriesMapping = useSubcategoriesMapping()
-  const adviceVariantInfo =
-    clubAdviceVariant[offer?.subcategoryId ?? SubcategoryIdEnum.LIVRE_PAPIER]
-  const { data: adviceCardsData } = useClubAdvicesQuery<AdviceCardData[]>({
+  const adviceVariantInfo = useClubAdviceVariant(offer?.subcategoryId)
+  const { data: clubAdvices } = useClubAdvicesQuery({
     offerId,
-    select: ({ chronicles: advices }) =>
-      clubAdvicesToAdviceCardData(advices, adviceVariantInfo.subtitleItem),
+    enabled: !!adviceVariantInfo,
   })
 
   const handleOnShowRecoButtonPress = () => {
@@ -41,7 +37,12 @@ export const ClubAdvices: FunctionComponent = () => {
     })
   }
 
-  if (!offer || !adviceCardsData) return null
+  if (!offer || !clubAdvices || !adviceVariantInfo) return null
+
+  const adviceCardsData = clubAdvicesToAdviceCardData(
+    clubAdvices.chronicles,
+    adviceVariantInfo.subtitleItem
+  )
 
   return (
     <ClubAdvicesBase

--- a/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.web.test.tsx
+++ b/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.web.test.tsx
@@ -5,6 +5,7 @@ import { SubcategoryIdEnum } from 'api/gen'
 import { offerClubAdvicesFixture } from 'features/clubAdvices/fixtures/clubAdvices.fixture'
 import { ClubAdvices } from 'features/clubAdvices/pages/ClubAdvices/ClubAdvices'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -22,6 +23,7 @@ jest.mock('features/navigation/helpers/openUrl')
 
 describe('ClubAdvices', () => {
   beforeEach(() => {
+    setFeatureFlags()
     mockServer.getApi(`/v1/offer/${offerResponseSnap.id}/chronicles`, offerClubAdvicesFixture)
     mockServer.getApi('/v1/subcategories/v2', subcategoriesDataTest)
   })

--- a/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.web.tsx
+++ b/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.web.tsx
@@ -2,11 +2,10 @@ import { useNavigation, useRoute } from '@react-navigation/native'
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { SubcategoryIdEnum, SubcategoryIdEnumv2 } from 'api/gen'
+import { SubcategoryIdEnumv2 } from 'api/gen'
 import { AdvicesOfferColumn } from 'features/advices/components/AdvicesOfferColumn/AdvicesOfferColumn.web'
-import { AdviceCardData } from 'features/advices/types'
 import { clubAdvicesToAdviceCardData } from 'features/clubAdvices/adapters/clubAdvicesToAdviceCardData/clubAdvicesToAdviceCardData'
-import { clubAdviceVariant } from 'features/clubAdvices/helpers/clubAdviceVariant'
+import { useClubAdviceVariant } from 'features/clubAdvices/helpers/useClubAdviceVariant'
 import { ClubAdvicesBase } from 'features/clubAdvices/pages/ClubAdvices/ClubAdvicesBase'
 import { useClubAdvicesQuery } from 'features/clubAdvices/queries/useClubAdvicesQuery'
 import { UseNavigationType, UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
@@ -20,12 +19,10 @@ export const ClubAdvices: FunctionComponent = () => {
   const { navigate } = useNavigation<UseNavigationType>()
   const { data: offer } = useOfferQuery({ offerId })
   const subcategoriesMapping = useSubcategoriesMapping()
-  const adviceVariantInfo =
-    clubAdviceVariant[offer?.subcategoryId ?? SubcategoryIdEnum.LIVRE_PAPIER]
-  const { data: adviceCardsData } = useClubAdvicesQuery<AdviceCardData[]>({
+  const adviceVariantInfo = useClubAdviceVariant(offer?.subcategoryId)
+  const { data: clubAdvices } = useClubAdvicesQuery({
     offerId,
-    select: ({ chronicles: advices }) =>
-      clubAdvicesToAdviceCardData(advices, adviceVariantInfo.subtitleItem),
+    enabled: !!adviceVariantInfo,
   })
 
   const subcategory = offer
@@ -47,7 +44,12 @@ export const ClubAdvices: FunctionComponent = () => {
     navigate('ThematicHome', { homeId: '4mlVpAZySUZO6eHazWKZeV', from: 'chronicles' })
   }
 
-  if (!offer || !adviceCardsData) return null
+  if (!offer || !clubAdvices || !adviceVariantInfo) return null
+
+  const adviceCardsData = clubAdvicesToAdviceCardData(
+    clubAdvices.chronicles,
+    adviceVariantInfo.subtitleItem
+  )
 
   return (
     <Container>

--- a/src/features/clubAdvices/queries/useClubAdvicesQuery.ts
+++ b/src/features/clubAdvices/queries/useClubAdvicesQuery.ts
@@ -9,13 +9,15 @@ export const useClubAdvicesQuery = <
 >({
   offerId,
   select,
+  enabled = true,
 }: {
   offerId: number
   select?: (data: OfferChronicles) => TData
+  enabled?: boolean
 }) =>
   useQuery({
     queryKey: [QueryKeys.CLUB_ADVICES, offerId],
     queryFn: () => api.getNativeV1OfferofferIdChronicles(offerId),
-    enabled: !!offerId,
+    enabled: !!offerId && enabled,
     select,
   })

--- a/src/features/clubAdvices/types.ts
+++ b/src/features/clubAdvices/types.ts
@@ -1,0 +1,11 @@
+import {
+  BOOK_CLUB_SUBCATEGORIES,
+  CINE_CLUB_SUBCATEGORIES,
+  SCENE_CLUB_SUBCATEGORIES,
+} from 'features/clubAdvices/constants'
+
+export type BookClubSubcategoryId = (typeof BOOK_CLUB_SUBCATEGORIES)[number]
+
+export type CineClubSubcategoryId = (typeof CINE_CLUB_SUBCATEGORIES)[number]
+
+export type SceneClubSubcategoryId = (typeof SCENE_CLUB_SUBCATEGORIES)[number]

--- a/src/features/offer/adapters/advicePreviewToAdviceCardData.native.test.ts
+++ b/src/features/offer/adapters/advicePreviewToAdviceCardData.native.test.ts
@@ -1,8 +1,9 @@
-import { ChroniclePreview } from 'api/gen'
+import { ChronicleClubType, ChroniclePreview } from 'api/gen'
 import { advicePreviewToAdviceCardData } from 'features/offer/adapters/advicePreviewToAdviceCardData'
 
 const ADVICE_PREVIEW: ChroniclePreview = {
   id: 1,
+  clubType: ChronicleClubType.BOOK,
   contentPreview: 'lorem ipsum dolor',
   dateCreated: '2025-01-20T23:32:13.978038Z',
   author: {

--- a/src/features/offer/components/InteractionTag/InteractionTag.native.test.tsx
+++ b/src/features/offer/components/InteractionTag/InteractionTag.native.test.tsx
@@ -116,4 +116,71 @@ describe('getTagProps', () => {
       variant: TagVariant.CINECLUB,
     })
   })
+
+  it('should return "X avis scène club" tag when advicesCount > 0 and subcategory is a scene club', () => {
+    expect(
+      getTagProps({
+        theme: computedTheme,
+        clubAdvicesCount: 3,
+        subcategoryId: SubcategoryIdEnum.SPECTACLE_REPRESENTATION,
+        enableSceneClubTag: true,
+      })
+    ).toEqual({
+      label: '3 avis scène club',
+      variant: TagVariant.SCENECLUB,
+    })
+  })
+
+  it('should return short label "X avis" when advicesCount > 0, hasSmallLayout is true, and subcategory is a scene club', () => {
+    expect(
+      getTagProps({
+        theme: computedTheme,
+        clubAdvicesCount: 3,
+        hasSmallLayout: true,
+        subcategoryId: SubcategoryIdEnum.SPECTACLE_REPRESENTATION,
+        enableSceneClubTag: true,
+      })
+    ).toEqual({
+      label: '3 avis',
+      variant: TagVariant.SCENECLUB,
+    })
+  })
+
+  it('should not return a club tag when subcategory is a scene club and scene club tag is disabled', () => {
+    expect(
+      getTagProps({
+        theme: computedTheme,
+        clubAdvicesCount: 3,
+        subcategoryId: SubcategoryIdEnum.SPECTACLE_REPRESENTATION,
+      })
+    ).toBeNull()
+  })
+
+  it('should fall back to the likes tag when subcategory is a scene club and scene club tag is disabled', () => {
+    expect(
+      getTagProps({
+        theme: computedTheme,
+        clubAdvicesCount: 3,
+        likesCount: 10,
+        subcategoryId: SubcategoryIdEnum.SPECTACLE_REPRESENTATION,
+      })
+    ).toEqual({
+      label: '10 j’aime',
+      variant: TagVariant.LIKE,
+    })
+  })
+
+  it.each([SubcategoryIdEnum.CONCERT, SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_CD])(
+    'should not return a club tag when advicesCount > 0 and subcategory %s belongs to no club',
+    (subcategoryId) => {
+      expect(
+        getTagProps({
+          theme: computedTheme,
+          clubAdvicesCount: 3,
+          subcategoryId,
+          enableSceneClubTag: true,
+        })
+      ).toBeNull()
+    }
+  )
 })

--- a/src/features/offer/components/InteractionTag/InteractionTag.tsx
+++ b/src/features/offer/components/InteractionTag/InteractionTag.tsx
@@ -3,6 +3,8 @@ import { DefaultTheme } from 'styled-components/native'
 
 import { SubcategoryIdEnum } from 'api/gen'
 import { isBookClubSubcategory } from 'features/clubAdvices/helpers/isBookClubSubcategory'
+import { isCineClubSubcategory } from 'features/clubAdvices/helpers/isCineClubSubcategory'
+import { isSceneClubSubcategory } from 'features/clubAdvices/helpers/isSceneClubSubcategory'
 import { formatLikesCounter } from 'features/offer/helpers/formatLikesCounter/formatLikesCounter'
 import { Tag } from 'ui/designSystem/Tag/Tag'
 import { TagProps, TagVariant } from 'ui/designSystem/Tag/types'
@@ -16,7 +18,26 @@ type InteractionTagParams = {
   proAdvicesCount?: number
   hasSmallLayout?: boolean
   isComingSoonOffer?: boolean
+  enableSceneClubTag?: boolean
 }
+
+type ClubTagConfig = {
+  isClubSubcategory: (subcategoryId: SubcategoryIdEnum) => boolean
+  wording: string
+  variant: TagVariant
+  isBehindSceneClubFlag?: boolean
+}
+
+const CLUB_TAGS: ClubTagConfig[] = [
+  { isClubSubcategory: isBookClubSubcategory, wording: 'book club', variant: TagVariant.BOOKCLUB },
+  { isClubSubcategory: isCineClubSubcategory, wording: 'ciné club', variant: TagVariant.CINECLUB },
+  {
+    isClubSubcategory: isSceneClubSubcategory,
+    wording: 'scène club',
+    variant: TagVariant.SCENECLUB,
+    isBehindSceneClubFlag: true,
+  },
+]
 
 export const renderInteractionTag = (params: InteractionTagParams): ReactNode | undefined => {
   const tagProps = getTagProps(params)
@@ -25,14 +46,29 @@ export const renderInteractionTag = (params: InteractionTagParams): ReactNode | 
   return <Tag testID="interaction-tag" {...tagProps} />
 }
 
-export const getTagProps = ({
-  likesCount = 0,
+const getClubTagProps = ({
   clubAdvicesCount = 0,
-  proAdvicesCount = 0,
-  hasSmallLayout,
-  isComingSoonOffer,
   subcategoryId,
+  hasSmallLayout,
+  enableSceneClubTag,
 }: InteractionTagParams): TagProps | null => {
+  if (clubAdvicesCount === 0) return null
+
+  const club = CLUB_TAGS.find(
+    ({ isClubSubcategory, isBehindSceneClubFlag }) =>
+      isClubSubcategory(subcategoryId) && (!isBehindSceneClubFlag || enableSceneClubTag)
+  )
+  if (!club) return null
+
+  return {
+    label: hasSmallLayout ? `${clubAdvicesCount} avis` : `${clubAdvicesCount} avis ${club.wording}`,
+    variant: club.variant,
+  }
+}
+
+export const getTagProps = (params: InteractionTagParams): TagProps | null => {
+  const { likesCount = 0, proAdvicesCount = 0, hasSmallLayout, isComingSoonOffer } = params
+
   if (isComingSoonOffer) {
     return {
       label: hasSmallLayout ? 'Bientôt' : 'Bientôt dispo',
@@ -41,18 +77,8 @@ export const getTagProps = ({
     }
   }
 
-  if (clubAdvicesCount > 0) {
-    if (isBookClubSubcategory(subcategoryId)) {
-      return {
-        label: hasSmallLayout ? `${clubAdvicesCount} avis` : `${clubAdvicesCount} avis book club`,
-        variant: TagVariant.BOOKCLUB,
-      }
-    }
-    return {
-      label: hasSmallLayout ? `${clubAdvicesCount} avis` : `${clubAdvicesCount} avis ciné club`,
-      variant: TagVariant.CINECLUB,
-    }
-  }
+  const clubTagProps = getClubTagProps(params)
+  if (clubTagProps) return clubTagProps
 
   if (proAdvicesCount > 0) {
     return {

--- a/src/features/offer/components/OfferContent/ClubAdviceSection/types.ts
+++ b/src/features/offer/components/OfferContent/ClubAdviceSection/types.ts
@@ -2,7 +2,6 @@ import { ReactNode } from 'react'
 import { StyleProp, ViewStyle } from 'react-native'
 
 import { AdviceCardData, AdviceVariantInfo } from 'features/advices/types'
-import { BOOK_CLUB_SUBCATEGORIES } from 'features/clubAdvices/constants'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 
 export type ClubAdviceSectionProps = {
@@ -18,5 +17,3 @@ export type ClubAdviceSectionProps = {
   feedback?: ReactNode
   style?: StyleProp<ViewStyle>
 }
-
-export type BookClubSubcategoryId = (typeof BOOK_CLUB_SUBCATEGORIES)[number]

--- a/src/features/offer/components/OfferPlaylistItem/OfferPlaylistItem.tsx
+++ b/src/features/offer/components/OfferPlaylistItem/OfferPlaylistItem.tsx
@@ -33,6 +33,7 @@ type OfferPlaylistItemProps = {
   hasSmallLayout?: boolean
   proAdvicesSegment?: string
   enableProAdvicesTag?: boolean
+  enableSceneClubTag?: boolean
 }
 
 type RenderOfferPlaylistItemProps = {
@@ -56,6 +57,7 @@ export const OfferPlaylistItem = ({
   hasSmallLayout,
   proAdvicesSegment,
   enableProAdvicesTag,
+  enableSceneClubTag,
 }: OfferPlaylistItemProps) => {
   return function RenderItem({ item, width, height, playlistType }: RenderOfferPlaylistItemProps) {
     const timestampsInMillis = item.offer.dates && getTimeStampInMillis(item.offer.dates)
@@ -70,6 +72,7 @@ export const OfferPlaylistItem = ({
       subcategoryId: item.offer.subcategoryId,
       proAdvicesCount:
         enableProAdvicesTag && proAdvicesSegment === 'A' ? item.offer.proAdvicesCount : undefined,
+      enableSceneClubTag,
     })
     return (
       <OfferTile

--- a/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
+++ b/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
@@ -80,6 +80,7 @@ export function OfferPlaylistList({
   const currency = useGetCurrencyToDisplay()
   const { data: euroToPacificFrancRate } = usePacificFrancToEuroRate()
   const enableProAdvicesTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_PRO_REVIEWS_PLAYLIST)
+  const enableSceneClubTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_SCENE_CLUB)
   const {
     logSameCategoryPlaylistVerticalScroll,
     logBooksSameCategoryPlaylistVerticalScroll,
@@ -191,6 +192,7 @@ export function OfferPlaylistList({
                   theme,
                   proAdvicesSegment,
                   enableProAdvicesTag,
+                  enableSceneClubTag,
                 })}
                 title={playlist.title}
                 playlistType={playlist.type}

--- a/src/features/offer/components/OfferTile/OfferTileWrapper.tsx
+++ b/src/features/offer/components/OfferTile/OfferTileWrapper.tsx
@@ -40,6 +40,7 @@ export const OfferTileWrapper = React.memo(function OfferTileWrapper(props: Prop
     item.offer
   const proAdvicesSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
   const enableProAdvicesTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_PRO_REVIEWS_PLAYLIST)
+  const enableSceneClubTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_SCENE_CLUB)
 
   const formattedDate = getOfferDates({
     subcategoryId,
@@ -65,6 +66,7 @@ export const OfferTileWrapper = React.memo(function OfferTileWrapper(props: Prop
     subcategoryId: item.offer.subcategoryId,
     proAdvicesCount:
       enableProAdvicesTag && proAdvicesSegment === 'A' ? item.offer.proAdvicesCount : undefined,
+    enableSceneClubTag,
   })
 
   return (

--- a/src/features/offer/fixtures/offerResponse.ts
+++ b/src/features/offer/fixtures/offerResponse.ts
@@ -1,6 +1,6 @@
 import type { ReadonlyDeep } from 'type-fest'
 
-import { ExpenseDomain, OfferResponse, SubcategoryIdEnum } from 'api/gen'
+import { ChronicleClubType, ExpenseDomain, OfferResponse, SubcategoryIdEnum } from 'api/gen'
 import { toMutable } from 'shared/types/toMutable'
 
 // humanizedId AHD3A
@@ -43,6 +43,7 @@ export const offerResponseSnap = toMutable({
   chronicles: [
     {
       id: 1,
+      clubType: ChronicleClubType.BOOK,
       contentPreview: 'Le Voyage Extraordinaire',
       dateCreated: '2025-01-20T23:32:13.978038Z',
       author: {
@@ -52,6 +53,7 @@ export const offerResponseSnap = toMutable({
     },
     {
       id: 2,
+      clubType: ChronicleClubType.BOOK,
       contentPreview: 'L’Art de la Cuisine',
       dateCreated: '2025-02-20T23:32:13.978038Z',
       author: {
@@ -61,6 +63,7 @@ export const offerResponseSnap = toMutable({
     },
     {
       id: 3,
+      clubType: ChronicleClubType.BOOK,
       contentPreview: 'Le Futur de la Technologie',
       dateCreated: '2025-03-20T23:32:13.978038Z',
       author: null,

--- a/src/features/offer/pages/Offer/Offer.native.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.native.test.tsx
@@ -3,10 +3,12 @@ import { ReactTestInstance } from 'react-test-renderer'
 
 import {
   BookingsResponseV2,
+  ChronicleClubType,
   GetRemindersResponse,
   OfferProAdvices,
   PaginatedFavoritesResponse,
   SubcategoriesResponseModelv2,
+  SubcategoryIdEnum,
 } from 'api/gen'
 import { offerProAdvicesFixture } from 'features/advices/fixtures/offerProAdvices.fixture'
 import { bookingsSnapV2 } from 'features/bookings/fixtures'
@@ -267,6 +269,48 @@ describe('<Offer />', () => {
       categoryName: 'CINEMA',
       from: 'offer',
       offerId: '116656',
+    })
+  })
+
+  describe('scène club advices', () => {
+    const sceneClubOffer = {
+      ...offerResponseSnap,
+      subcategoryId: SubcategoryIdEnum.SPECTACLE_REPRESENTATION,
+      chronicles: [
+        {
+          id: 1,
+          clubType: ChronicleClubType.SCENE,
+          contentPreview: 'Une mise en scène bluffante',
+          dateCreated: '2025-04-12T09:14:52.123456Z',
+          author: { firstName: 'Camille', age: 17 },
+        },
+      ],
+      chroniclesCount: 1,
+    }
+
+    it('should display scène club advices section when offer has scène club advices', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_SCENE_CLUB])
+      renderOfferPage({ mockOffer: sceneClubOffer })
+
+      expect(await screen.findByText('Les avis de la scène club')).toBeOnTheScreen()
+    })
+
+    it('should not display scène club advices section when offer has no advice', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_SCENE_CLUB])
+      renderOfferPage({ mockOffer: { ...sceneClubOffer, chronicles: [], chroniclesCount: 0 } })
+
+      await screen.findByTestId('offerv2-container')
+
+      expect(screen.queryByText('Les avis de la scène club')).not.toBeOnTheScreen()
+    })
+
+    it('should not display scène club advices section when feature flag is disabled', async () => {
+      setFeatureFlags()
+      renderOfferPage({ mockOffer: sceneClubOffer })
+
+      await screen.findByTestId('offerv2-container')
+
+      expect(screen.queryByText('Les avis de la scène club')).not.toBeOnTheScreen()
     })
   })
 

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -6,7 +6,7 @@ import { ReactionTypeEnum } from 'api/gen'
 import { AdvicesWritersModal } from 'features/advices/pages/AdvicesWritersModal/AdvicesWritersModal'
 import { useOfferProAdvicesQuery } from 'features/advices/queries/useOfferProAdvicesQuery'
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { clubAdviceVariant } from 'features/clubAdvices/helpers/clubAdviceVariant'
+import { useClubAdviceVariant } from 'features/clubAdvices/helpers/useClubAdviceVariant'
 import { ConsentState, CookieNameEnum } from 'features/cookies/enums'
 import { useCookies } from 'features/cookies/helpers/useCookies'
 import { UseNavigationType, UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
@@ -138,10 +138,10 @@ export function Offer() {
   })
   const proAdvices = shouldDisplayProAdvices ? proAdvicesData : undefined
 
+  const adviceVariantInfo = useClubAdviceVariant(offer?.subcategoryId)
+
   if (!offer || !subcategories || !subcategoriesMapping?.[offer?.subcategoryId]) return null
 
-  const subcategory = subcategoriesMapping[offer?.subcategoryId]
-  const adviceVariantInfo = clubAdviceVariant[subcategory.id]
   const hasClubAdviceVariant = !!adviceVariantInfo
 
   const clubAdvices = hasClubAdviceVariant

--- a/src/features/venue/components/VenueOffers/VenueOffersList.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffersList.tsx
@@ -72,6 +72,7 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
   const theme = useTheme()
   const { user } = useAuthContext()
   const enableProAdvicesTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_PRO_REVIEWS_PLAYLIST)
+  const enableSceneClubTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_SCENE_CLUB)
   const { params: routeParams } = useRoute<UseRouteType<'Offer'>>()
   const searchNavigationConfig = useNavigateToSearchWithVenueOffers(venue)
   const isFocused = useIsFocused()
@@ -93,6 +94,7 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
       subcategoryId: item.offer.subcategoryId,
       proAdvicesCount:
         enableProAdvicesTag && shouldDisplayAdvicesSection ? item.offer.proAdvicesCount : undefined,
+      enableSceneClubTag,
     })
 
     return (

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueMapOfferPlaylist.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueMapOfferPlaylist.tsx
@@ -54,6 +54,7 @@ export const VenueMapOfferPlaylist = ({
   const isFocused = useIsFocused()
   const proAdvicesSegment = useABSegment(AB_TESTS.PRO_REVIEWS_ON_OFFER)
   const enableProAdvicesTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_PRO_REVIEWS_PLAYLIST)
+  const enableSceneClubTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_SCENE_CLUB)
 
   const renderItem: CustomListRenderItem<Offer> = useCallback(
     ({ item }) => {
@@ -66,6 +67,7 @@ export const VenueMapOfferPlaylist = ({
         subcategoryId: item.offer.subcategoryId,
         proAdvicesCount:
           enableProAdvicesTag && proAdvicesSegment === 'A' ? item.offer.proAdvicesCount : undefined,
+        enableSceneClubTag,
       })
       return (
         <OfferTile
@@ -88,6 +90,7 @@ export const VenueMapOfferPlaylist = ({
     [
       currency,
       enableProAdvicesTag,
+      enableSceneClubTag,
       euroToPacificFrancRate,
       labelMapping,
       mapping,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42648

## Context

Ajout de la **scène club** (spectacle vivant), troisième club d'avis après le book club et le ciné club, derrière le feature flag `wipSceneClub`.

### Modèle de données

- `ChronicleClubType` (`CINE` / `BOOK` / `ALBUM` / `CONCERT` / `SCENE`) ajouté dans `src/api/gen/api.ts`, exposé sur `ChroniclePreview` et `OfferChronicle`.

### Variante scène club

- `SCENE_CLUB_SUBCATEGORIES` : 10 sous-catégories de spectacle vivant (`SPECTACLE_REPRESENTATION`, `FESTIVAL_SPECTACLE`, `CONFERENCE`, `VISITE_GUIDEE`, `SALON`, etc.).
- `SCENE_CLUB_VARIANT_CONFIG` : wordings, icône `SceneClubCertification`, tag `TagVariant.SCENECLUB`, modale « Qui écrit les avis de la scène club ? ».

### Nouveau hook `useClubAdviceVariant`

`clubAdviceVariant` devient un `Partial<Record<...>>` : une sous-catégorie sans club renvoie désormais `undefined` au lieu de retomber silencieusement sur la variante book club. Le hook encapsule cette lecture et masque la variante scène club quand le feature flag est désactivé.

Conséquence sur `ClubAdvices` (native + web) : le `select` de `useClubAdvicesQuery` est remplacé par une transformation après le garde-fou `if (!offer || !clubAdvices || !adviceVariantInfo) return null`, et la query est désactivée (`enabled`) tant qu'aucune variante n'est résolue.

### Tag sur les tuiles d'offre

`getTagProps` ne suppose plus « pas book club ⇒ ciné club » : chaque club est testé explicitement via `isBookClubSubcategory` / `isCineClubSubcategory` / `isSceneClubSubcategory`. Une sous-catégorie sans club ne renvoie plus de tag club et retombe sur le tag « j'aime ». Le flag `enableSceneClubTag` est propagé depuis les playlists (offre, artiste, lieu, carte des lieux).

### Réorganisation

- `BookClubSubcategoryId` déplacé de `features/offer/components/OfferContent/ClubAdviceSection/types.ts` vers `features/clubAdvices/types.ts`, aux côtés de `CineClubSubcategoryId` et `SceneClubSubcategoryId`.

### Tests

Nouveaux tests : `isCineClubSubcategory`, `isSceneClubSubcategory`, `useClubAdviceVariant`, tag scène club dans `InteractionTag`, section scène club dans `Offer` et `ClubAdvices` (flag activé et désactivé).

### Screenshots

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-07-23 at 11 24 13" src="https://github.com/user-attachments/assets/f545856d-5ff2-47f3-9c24-e791267491d4" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-07-23 at 11 13 14" src="https://github.com/user-attachments/assets/d99c3937-28f8-47fb-b0e9-ca7de7ce1236" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-07-23 at 11 12 57" src="https://github.com/user-attachments/assets/4d4344a2-bd9d-4a53-afe7-fd87728091d1" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-07-23 at 11 12 52" src="https://github.com/user-attachments/assets/f96cab34-8ab7-41b7-b999-94b2727e4b58" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-07-23 at 11 12 47" src="https://github.com/user-attachments/assets/ce488c4a-a097-4812-ab12-5526ce19721c" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-07-23 at 11 12 32" src="https://github.com/user-attachments/assets/50a72d07-19d3-45f8-8159-72bd7c61272a" />

<img width="1728" height="996" alt="SCR-20260723-kjje" src="https://github.com/user-attachments/assets/2346c23c-080b-43df-bb5c-721161ebdb92" />
<img width="1728" height="996" alt="SCR-20260723-kjhj" src="https://github.com/user-attachments/assets/7cc96c81-9016-4787-a7b8-6f4d10d61aba" />
<img width="1728" height="997" alt="SCR-20260723-kjgb" src="https://github.com/user-attachments/assets/ae30f99e-43f9-4ed6-b220-edbb164baa6f" />
<img width="3456" height="1994" alt="SCR-20260723-kjer" src="https://github.com/user-attachments/assets/d32d6174-aec6-4d25-939b-4c8b53bdb67e" />

