### PR TITLE
(BSR) feat(CI): make production deployment script message red + bold

### DIFF
--- a/scripts/deploy_new_production_version.sh
+++ b/scripts/deploy_new_production_version.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 error() {
-  echo "$1"
+  echo -e "\e[1;31m$1\e[0m"  # display message in red + bold and resets to normal
   exit 1
 }
 


### PR DESCRIPTION
Les erreurs du script sont transparente et ne notifient pas assez le lanceur d'un arrêt brutal.

La mise en grs et rouge permet de bien le montrer.