### PR TITLE
(PC-42965) build(DesignSystem): add borderRadius 5xl and 10xl

### DIFF
--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -512,6 +512,8 @@ exports[`<SetBirthday /> should render correctly 1`] = `
               },
               "size": {
                 "borderRadius": {
+                  "10xl": 96,
+                  "5xl": 56,
                   "l": 16,
                   "m": 8,
                   "pill": 999,
@@ -1483,6 +1485,8 @@ exports[`<SetBirthday /> should render correctly when account creation token and
               },
               "size": {
                 "borderRadius": {
+                  "10xl": 96,
+                  "5xl": 56,
                   "l": 16,
                   "m": 8,
                   "pill": 999,

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -2320,6 +2320,8 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
                     },
                     "size": {
                       "borderRadius": {
+                        "10xl": 96,
+                        "5xl": 56,
                         "l": 16,
                         "m": 8,
                         "pill": 999,

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@hot-updater/react-native": "^0.35.3",
     "@invertase/react-native-apple-authentication": "^2.5.1",
     "@openspacelabs/react-native-zoomable-view": "^2.1.5",
-    "@pass-culture/design-system": "0.11.0",
+    "@pass-culture/design-system": "0.12.0",
     "@ptomasroos/react-native-multi-slider": "^2.2.2",
     "@react-native-async-storage/async-storage": "^1.17.11",
     "@react-native-clipboard/clipboard": "^1.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7301,10 +7301,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pass-culture/design-system@npm:0.11.0":
-  version: 0.11.0
-  resolution: "@pass-culture/design-system@npm:0.11.0"
-  checksum: 10/9ed9fbef3f3fb1582d64c168dc1044a59bc2c241f5fbc47810b9b001b3bd5d4018387a06e562f1b73e559cdd62cec947c591e59573f45efed473f07c89b33c4a
+"@pass-culture/design-system@npm:0.12.0":
+  version: 0.12.0
+  resolution: "@pass-culture/design-system@npm:0.12.0"
+  checksum: 10/288ec71c16d917e7085131a90fe56dbdbba39a12deaec3a370e6beb30b992547d3f3136faf5befc803053cf0a1724b0769ecd3ce4272eb0e099323249f065103
   languageName: node
   linkType: hard
 
@@ -10751,7 +10751,7 @@ __metadata:
     "@hot-updater/sentry-plugin": "npm:^0.35.3"
     "@invertase/react-native-apple-authentication": "npm:^2.5.1"
     "@openspacelabs/react-native-zoomable-view": "npm:^2.1.5"
-    "@pass-culture/design-system": "npm:0.11.0"
+    "@pass-culture/design-system": "npm:0.12.0"
     "@ptomasroos/react-native-multi-slider": "npm:^2.2.2"
     "@react-native-async-storage/async-storage": "npm:^1.17.11"
     "@react-native-clipboard/clipboard": "npm:^1.16.2"


### PR DESCRIPTION
## Context

`@pass-culture/design-system` : bump `v0.11.0` -> `v0.12.0`

### 🔧 Changements

Étend la palette sémantique de `borderRadius` avec deux tailles intermédiaires (`5xl`, `10xl`) pour couvrir les cas de coins très arrondis entre `xxl` (32px) et `pill`, sans hardcoder de valeurs côté consommateurs.

- Ajout de `size.borderRadius.5xl` → `{size.1000}` (56px)
- Ajout de `size.borderRadius.10xl` → `{size.1500}` (96px)