### PR TITLE
(PC-42681) refactor(ui): lot 1 illustration

### DIFF
--- a/src/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx
+++ b/src/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { navigateFromRef } from 'features/navigation/navigationRef'
 import { RootStackParamList } from 'features/navigation/navigators/RootNavigator/types'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { NotYetUnderageEligibility } from './NotYetUnderageEligibility'
@@ -27,6 +28,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('<NotYetUnderageEligibility />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render properly', () => {
     render(<NotYetUnderageEligibility {...navigationProps} />)
 

--- a/src/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.tsx
+++ b/src/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.tsx
@@ -4,6 +4,7 @@ import React, { FunctionComponent } from 'react'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { RootStackParamList } from 'features/navigation/navigators/RootNavigator/types'
 import { formatToReadableFrenchDate } from 'libs/dates'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { CalendarIllustration } from 'ui/svg/icons/CalendarIllustration'
 
@@ -15,6 +16,10 @@ export const NotYetUnderageEligibility: FunctionComponent<Props> = (props) => {
   return (
     <GenericInfoPage
       illustration={CalendarIllustration}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.hourglass,
+        backgroundColor: 'information04',
+      }}
       title="C’est pour bientôt&nbsp;!"
       subtitle={NotYetUnderageEligibilityText}
       buttonPrimary={{

--- a/src/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.web.test.tsx
+++ b/src/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.web.test.tsx
@@ -2,6 +2,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import React from 'react'
 
 import { RootStackParamList } from 'features/navigation/navigators/RootNavigator/types'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, checkAccessibilityFor } from 'tests/utils/web'
 
 import { NotYetUnderageEligibility } from './NotYetUnderageEligibility'
@@ -13,6 +14,10 @@ const navigationProps = {
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<NotYetUnderageEligibility/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(<NotYetUnderageEligibility {...navigationProps} />)

--- a/src/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx
+++ b/src/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { SignupStep } from 'features/auth/enums'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { QuitSignupModal } from './QuitSignupModal'
@@ -25,6 +26,7 @@ describe('QuitSignupModal', () => {
   beforeEach(() => {
     // @ts-expect-error: logCancelSignup is the mock function but is seen as the real function
     analytics.logCancelSignup.mockClear()
+    setFeatureFlags()
   })
 
   it('should render correctly', () => {

--- a/src/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.tsx
+++ b/src/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent, useCallback } from 'react'
 import { SignupStep } from 'features/auth/enums'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { analytics } from 'libs/analytics/provider'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { AppFullPageModal } from 'ui/components/modals/AppFullPageModal'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { Clear } from 'ui/svg/icons/Clear'
@@ -36,6 +37,10 @@ export const QuitSignupModal: FunctionComponent<Props> = ({
     <AppFullPageModal visible={visible} testIdSuffix={testIdSuffix} onRequestClose={continueSignup}>
       <GenericInfoPage
         illustration={ErrorIllustration}
+        remoteIllustration={{
+          url: genericInfoPageIllustrationUrls.brokenDinosaurSkeletonLarge,
+          backgroundColor: 'negative01',
+        }}
         title="Veux-tu abandonner l’inscription&nbsp;?"
         subtitle="Les informations que tu as renseignées ne seront pas enregistrées."
         buttonPrimary={{

--- a/src/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.web.test.tsx
+++ b/src/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.web.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { SignupStep } from 'features/auth/enums'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, checkAccessibilityFor } from 'tests/utils/web'
 
 import { QuitSignupModal } from './QuitSignupModal'
@@ -8,6 +9,10 @@ import { QuitSignupModal } from './QuitSignupModal'
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<QuitSignupModal/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(

--- a/src/features/auth/pages/suspendedAccount/AccountStatusScreenHandler/AccountStatusScreenHandler.native.test.tsx
+++ b/src/features/auth/pages/suspendedAccount/AccountStatusScreenHandler/AccountStatusScreenHandler.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { AccountState } from 'api/gen'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { useCurrentRoute } from 'features/navigation/helpers/useCurrentRoute'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen } from 'tests/utils'
 
 import { AccountStatusScreenHandler } from './AccountStatusScreenHandler'
@@ -32,6 +33,10 @@ function mockUseCurrentRoute(name: string) {
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<AccountStatusScreenHandler />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should display SuspendedAccountUponUserRequest component if account is suspended upon user request', () => {
     mockSuspensionStatus.status = AccountState.SUSPENDED_UPON_USER_REQUEST
     render(<AccountStatusScreenHandler />)

--- a/src/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx
+++ b/src/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { FraudulentSuspendedAccount } from './FraudulentSuspendedAccount'
@@ -19,6 +20,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('<FraudulentSuspendedAccount />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should match snapshot', () => {
     render(<FraudulentSuspendedAccount />)
 

--- a/src/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.web.test.tsx
+++ b/src/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
 import { FraudulentSuspendedAccount } from './FraudulentSuspendedAccount'
@@ -9,6 +10,10 @@ jest.mock('features/auth/helpers/useLogoutRoutine')
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<FraudulentSuspendedAccount/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(<FraudulentSuspendedAccount />)

--- a/src/features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount.native.test.tsx
+++ b/src/features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount.native.test.tsx
@@ -6,6 +6,7 @@ import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { buildZendeskUrlForFraud } from 'features/profile/helpers/buildZendeskUrl'
 import { beneficiaryUser } from 'fixtures/user'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { userEvent, render, screen } from 'tests/utils'
 
@@ -41,6 +42,7 @@ jest.useFakeTimers()
 describe('<GenericSuspendedAccount />', () => {
   beforeEach(() => {
     mockAuthContextWithUser(beneficiaryUser)
+    setFeatureFlags()
   })
 
   it('should open Zendesk url when clicking on "Contacter le service fraude" button', async () => {

--- a/src/features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount.tsx
+++ b/src/features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount.tsx
@@ -1,10 +1,12 @@
 import React, { PropsWithChildren } from 'react'
+import { useTheme } from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { buildZendeskUrlForFraud } from 'features/profile/helpers/buildZendeskUrl'
 import { useDeviceMetrics } from 'features/trustedDevice/helpers/useDeviceMetrics'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { useVersion } from 'ui/hooks/useVersion'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
@@ -18,6 +20,7 @@ export const GenericSuspendedAccount: React.FC<Props> = ({
   children,
   onBeforeNavigateContactFraudTeam,
 }) => {
+  const { isDesktopViewport } = useTheme()
   const signOut = useLogoutRoutine()
   const { user } = useAuthContext()
   const version = useVersion()
@@ -26,6 +29,11 @@ export const GenericSuspendedAccount: React.FC<Props> = ({
   return (
     <GenericInfoPage
       illustration={UserBlocked}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.blockedPaintingLarge,
+        backgroundColor: 'information03',
+        size: isDesktopViewport ? 'default' : 'small',
+      }}
       title="Ton compte a été suspendu"
       buttonPrimary={{
         wording: 'Contacter le service fraude',

--- a/src/features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount.tsx
+++ b/src/features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount.tsx
@@ -1,5 +1,4 @@
 import React, { PropsWithChildren } from 'react'
-import { useTheme } from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
@@ -20,7 +19,6 @@ export const GenericSuspendedAccount: React.FC<Props> = ({
   children,
   onBeforeNavigateContactFraudTeam,
 }) => {
-  const { isDesktopViewport } = useTheme()
   const signOut = useLogoutRoutine()
   const { user } = useAuthContext()
   const version = useVersion()
@@ -32,7 +30,6 @@ export const GenericSuspendedAccount: React.FC<Props> = ({
       remoteIllustration={{
         url: genericInfoPageIllustrationUrls.blockedPaintingLarge,
         backgroundColor: 'information03',
-        size: isDesktopViewport ? 'default' : 'small',
       }}
       title="Ton compte a été suspendu"
       buttonPrimary={{

--- a/src/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx
+++ b/src/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx
@@ -4,6 +4,7 @@ import { navigate, replace } from '__mocks__/@react-navigation/native'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { analytics } from 'libs/analytics/provider'
 import { EmptyResponse } from 'libs/fetch'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent } from 'tests/utils'
@@ -33,6 +34,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('<SuspendedAccountUponUserRequest />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should match snapshot', () => {
     render(reactQueryProviderHOC(<SuspendedAccountUponUserRequest />))
 

--- a/src/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.tsx
+++ b/src/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.tsx
@@ -10,6 +10,7 @@ import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/
 import { analytics } from 'libs/analytics/provider'
 import { formatToCompleteFrenchDateTime } from 'libs/parsers/formatDates'
 import { useAccountUnsuspensionLimit } from 'queries/settings/useSettings'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
@@ -56,6 +57,10 @@ export const SuspendedAccountUponUserRequest = () => {
   return (
     <GenericInfoPage
       illustration={ProfileDeletion}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.trashMosaic,
+        backgroundColor: 'negative01',
+      }}
       title="Ton compte est désactivé"
       subtitle={`Tu as jusqu’au ${formattedDate} pour réactiver ton compte.`}
       buttonPrimary={{

--- a/src/features/bookOffer/pages/BookingConfirmation.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.tsx
@@ -17,7 +17,6 @@ import { useOfferQuery } from 'queries/offer/useOfferQuery'
 import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
 import { formatCurrencyFromCents } from 'shared/currency/formatCurrencyFromCents'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
-import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { getIsUserEligibleFree } from 'shared/user/checkEligibilityType'
 import { getAvailableCredit } from 'shared/user/getAvailableCredit'
 import { useModal } from 'ui/components/modals/useModal'
@@ -101,10 +100,6 @@ export const BookingConfirmation: FC = () => {
     <React.Fragment>
       <GenericInfoPage
         illustration={TicketBooked}
-        remoteIllustration={{
-          url: genericInfoPageIllustrationUrls.hourglass,
-          backgroundColor: 'information04',
-        }}
         title="Réservation confirmée&nbsp;!"
         subtitle={`${amountLeftText}Tu peux retrouver toutes les informations concernant ta réservation sur l’application.`}
         buttonPrimary={{

--- a/src/features/bookOffer/pages/BookingConfirmation.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.tsx
@@ -17,6 +17,7 @@ import { useOfferQuery } from 'queries/offer/useOfferQuery'
 import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
 import { formatCurrencyFromCents } from 'shared/currency/formatCurrencyFromCents'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { getIsUserEligibleFree } from 'shared/user/checkEligibilityType'
 import { getAvailableCredit } from 'shared/user/getAvailableCredit'
 import { useModal } from 'ui/components/modals/useModal'
@@ -100,6 +101,10 @@ export const BookingConfirmation: FC = () => {
     <React.Fragment>
       <GenericInfoPage
         illustration={TicketBooked}
+        remoteIllustration={{
+          url: genericInfoPageIllustrationUrls.hourglass,
+          backgroundColor: 'information04',
+        }}
         title="Réservation confirmée&nbsp;!"
         subtitle={`${amountLeftText}Tu peux retrouver toutes les informations concernant ta réservation sur l’application.`}
         buttonPrimary={{

--- a/src/features/bookings/pages/BookingNotFound/BookingNotFound.tsx
+++ b/src/features/bookings/pages/BookingNotFound/BookingNotFound.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react'
+import { useTheme } from 'styled-components/native'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { ScreenErrorProps } from 'libs/monitoring/errors'
@@ -8,6 +9,7 @@ import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { NoBookings } from 'ui/svg/icons/NoBookings'
 
 export const BookingNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
+  const { isDesktopViewport } = useTheme()
   const timer = useRef<number>(null)
 
   useEffect(
@@ -38,7 +40,7 @@ export const BookingNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
         remoteIllustration={{
           url: genericInfoPageIllustrationUrls.emptyWalletLarge,
           backgroundColor: 'information03',
-          size: 'small',
+          size: isDesktopViewport ? 'default' : 'small',
         }}
         title="Réservation introuvable&nbsp;!"
         subtitle="Désolé, nous ne retrouvons pas ta réservation. Peut-être a-t-elle été annulée. N’hésite pas à retrouver la liste de tes réservations terminées et annulées pour t’en assurer."

--- a/src/features/bookings/pages/BookingNotFound/BookingNotFound.tsx
+++ b/src/features/bookings/pages/BookingNotFound/BookingNotFound.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef } from 'react'
-import { useTheme } from 'styled-components/native'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { ScreenErrorProps } from 'libs/monitoring/errors'
@@ -9,7 +8,6 @@ import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { NoBookings } from 'ui/svg/icons/NoBookings'
 
 export const BookingNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
-  const { isDesktopViewport } = useTheme()
   const timer = useRef<number>(null)
 
   useEffect(
@@ -40,7 +38,6 @@ export const BookingNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
         remoteIllustration={{
           url: genericInfoPageIllustrationUrls.emptyWalletLarge,
           backgroundColor: 'information03',
-          size: isDesktopViewport ? 'default' : 'small',
         }}
         title="Réservation introuvable&nbsp;!"
         subtitle="Désolé, nous ne retrouvons pas ta réservation. Peut-être a-t-elle été annulée. N’hésite pas à retrouver la liste de tes réservations terminées et annulées pour t’en assurer."

--- a/src/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx
+++ b/src/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { QuitIdentityCheckModal } from 'features/identityCheck/components/modals/QuitIdentityCheckModal'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
@@ -25,6 +26,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('<QuitIdentityCheckModal/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', () => {
     renderQuitIdentityCheckModal(true)
 

--- a/src/features/identityCheck/components/modals/QuitIdentityCheckModal.tsx
+++ b/src/features/identityCheck/components/modals/QuitIdentityCheckModal.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent } from 'react'
 import { useSubscriptionContext } from 'features/identityCheck/context/SubscriptionContextProvider'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { analytics } from 'libs/analytics/provider'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { AppFullPageModal } from 'ui/components/modals/AppFullPageModal'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { Clear } from 'ui/svg/icons/Clear'
@@ -39,6 +40,10 @@ export const QuitIdentityCheckModal: FunctionComponent<Props> = ({
       onRequestClose={continueIdentityCheck}>
       <GenericInfoPage
         illustration={ErrorIllustration}
+        remoteIllustration={{
+          url: genericInfoPageIllustrationUrls.brokenDinosaurSkeletonLarge,
+          backgroundColor: 'negative01',
+        }}
         title="Veux-tu abandonner la vérification d’identité&nbsp;?"
         subtitle="Les informations que tu as renseignées ne seront pas enregistrées."
         buttonPrimary={{

--- a/src/features/identityCheck/components/modals/QuitIdentityCheckModal.web.test.tsx
+++ b/src/features/identityCheck/components/modals/QuitIdentityCheckModal.web.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { QuitIdentityCheckModal } from 'features/identityCheck/components/modals/QuitIdentityCheckModal'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { fireEvent, render, checkAccessibilityFor, screen, waitFor } from 'tests/utils/web'
 
 jest.mock('libs/firebase/analytics/analytics')
@@ -16,6 +17,10 @@ jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({
 }))
 
 describe('<QuitIdentityCheckModal/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should not display the modal when visible is false', () => {
     renderQuitIdentityCheckModal(false)
 

--- a/src/features/navigation/pages/PageNotFound.tsx
+++ b/src/features/navigation/pages/PageNotFound.tsx
@@ -19,7 +19,6 @@ export const PageNotFound: React.FC = () => {
         remoteIllustration={{
           url: genericInfoPageIllustrationUrls.emptyDigitalWindowLarge,
           backgroundColor: 'pending01',
-          size: 'default',
         }}
         title="Page introuvable&nbsp;!"
         subtitle="Il est possible que cette page soit désactivée ou n’existe pas."

--- a/src/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx
+++ b/src/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { OfferNotFound } from 'features/offer/pages/OfferNotFound/OfferNotFound'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render } from 'tests/utils'
 
 const resetErrorBoundary = () => null
@@ -15,6 +16,10 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 })
 
 describe('<OfferNotFound />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', () => {
     expect(
       render(<OfferNotFound error={error} resetErrorBoundary={resetErrorBoundary} />)

--- a/src/features/offer/pages/OfferNotFound/OfferNotFound.tsx
+++ b/src/features/offer/pages/OfferNotFound/OfferNotFound.tsx
@@ -1,12 +1,15 @@
 import React, { useEffect, useRef } from 'react'
+import { useTheme } from 'styled-components/native'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { ScreenErrorProps } from 'libs/monitoring/errors'
 import { Helmet } from 'libs/react-helmet/Helmet'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { NoOffer } from 'ui/svg/icons/NoOffer'
 
 export const OfferNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
+  const { isDesktopViewport } = useTheme()
   const timer = useRef<number>(null)
 
   useEffect(
@@ -31,6 +34,11 @@ export const OfferNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
       </Helmet>
       <GenericInfoPage
         illustration={NoOffer}
+        remoteIllustration={{
+          url: genericInfoPageIllustrationUrls.emptyDigitalWindowLarge,
+          backgroundColor: 'pending01',
+          size: isDesktopViewport ? 'default' : 'small',
+        }}
         title="Offre introuvable&nbsp;!"
         subtitle="Il est possible que cette offre soit désactivée ou n’existe pas."
         buttonPrimary={{

--- a/src/features/offer/pages/OfferNotFound/OfferNotFound.tsx
+++ b/src/features/offer/pages/OfferNotFound/OfferNotFound.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef } from 'react'
-import { useTheme } from 'styled-components/native'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { ScreenErrorProps } from 'libs/monitoring/errors'
@@ -9,7 +8,6 @@ import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { NoOffer } from 'ui/svg/icons/NoOffer'
 
 export const OfferNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
-  const { isDesktopViewport } = useTheme()
   const timer = useRef<number>(null)
 
   useEffect(
@@ -37,7 +35,6 @@ export const OfferNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
         remoteIllustration={{
           url: genericInfoPageIllustrationUrls.emptyDigitalWindowLarge,
           backgroundColor: 'pending01',
-          size: isDesktopViewport ? 'default' : 'small',
         }}
         title="Offre introuvable&nbsp;!"
         subtitle="Il est possible que cette offre soit désactivée ou n’existe pas."

--- a/src/features/offer/pages/OfferNotFound/OfferNotFound.web.test.tsx
+++ b/src/features/offer/pages/OfferNotFound/OfferNotFound.web.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { OfferNotFound } from 'features/offer/pages/OfferNotFound/OfferNotFound'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
 const resetErrorBoundary = () => null
@@ -9,6 +10,10 @@ const error = new Error('error')
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<OfferNotFound/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(

--- a/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx
@@ -6,6 +6,7 @@ import { resetFromRef } from 'features/navigation/navigationRef'
 import { Adjust } from 'libs/adjust/adjust'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent, waitFor } from 'tests/utils'
@@ -41,6 +42,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('ConfirmDeleteProfile', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render confirm delete profile', () => {
     renderConfirmDeleteProfile()
 

--- a/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.tsx
+++ b/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.tsx
@@ -9,6 +9,7 @@ import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { Adjust } from 'libs/adjust/adjust'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { BulletListItem } from 'ui/components/BulletListItem'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { VerticalUl } from 'ui/components/Ul'
@@ -40,6 +41,10 @@ export function ConfirmDeleteProfile() {
     <GenericInfoPage
       withGoBack
       illustration={ErrorIllustration}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.trashMosaic,
+        backgroundColor: 'negative01',
+      }}
       title="Veux-tu vraiment supprimer ton compte&nbsp;?"
       buttonPrimary={{
         wording: 'Supprimer mon compte',

--- a/src/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx
@@ -6,6 +6,7 @@ import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome
 import { navigateFromRef } from 'features/navigation/navigationRef'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { DeactivateProfileSuccess } from './DeactivateProfileSuccess'
@@ -28,6 +29,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('DeactivateProfileSuccess', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render deactivate profile success', () => {
     render(<DeactivateProfileSuccess />)
 

--- a/src/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.tsx
@@ -5,6 +5,7 @@ import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
 import { useAccountUnsuspensionLimit } from 'queries/settings/useSettings'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { Emoji } from 'ui/components/Emoji'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
@@ -18,6 +19,10 @@ export const DeactivateProfileSuccess = () => {
   return (
     <GenericInfoPage
       illustration={ProfileDeletion}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.trashMosaic,
+        backgroundColor: 'negative01',
+      }}
       title="Ton compte a été désactivé"
       buttonPrimary={{
         wording: 'Retourner à l’accueil',

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { DeleteProfileAccountHacked } from './DeleteProfileAccountHacked'
@@ -17,6 +18,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('DeleteProfileAccountHacked', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', () => {
     render(<DeleteProfileAccountHacked />)
 

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.tsx
@@ -1,9 +1,11 @@
 import { useNavigation } from '@react-navigation/native'
 import React, { FC } from 'react'
+import { useTheme } from 'styled-components/native'
 
 import { getProfileHookConfig } from 'features/navigation/navigators/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
 import { getTabHookConfig } from 'features/navigation/TabBar/getTabHookConfig'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Banner } from 'ui/designSystem/Banner/Banner'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
@@ -12,6 +14,7 @@ import { UserBlocked } from 'ui/svg/icons/UserBlocked'
 import { Typo } from 'ui/theme'
 
 export const DeleteProfileAccountHacked: FC = () => {
+  const { isDesktopViewport } = useTheme()
   const { navigate } = useNavigation<UseNavigationType>()
 
   const navigateToProfile = () => navigate(...getTabHookConfig('Profile'))
@@ -24,6 +27,11 @@ export const DeleteProfileAccountHacked: FC = () => {
     <GenericInfoPage
       withGoBack
       illustration={UserBlocked}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.blockedPaintingLarge,
+        backgroundColor: 'information03',
+        size: isDesktopViewport ? 'default' : 'small',
+      }}
       title="Sécurise ton compte"
       buttonPrimary={{ wording: 'Suspendre mon compte', onPress: navigateToSuspendAccount }}
       buttonTertiary={{

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.tsx
@@ -1,6 +1,5 @@
 import { useNavigation } from '@react-navigation/native'
 import React, { FC } from 'react'
-import { useTheme } from 'styled-components/native'
 
 import { getProfileHookConfig } from 'features/navigation/navigators/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
@@ -14,7 +13,6 @@ import { UserBlocked } from 'ui/svg/icons/UserBlocked'
 import { Typo } from 'ui/theme'
 
 export const DeleteProfileAccountHacked: FC = () => {
-  const { isDesktopViewport } = useTheme()
   const { navigate } = useNavigation<UseNavigationType>()
 
   const navigateToProfile = () => navigate(...getTabHookConfig('Profile'))
@@ -30,7 +28,6 @@ export const DeleteProfileAccountHacked: FC = () => {
       remoteIllustration={{
         url: genericInfoPageIllustrationUrls.blockedPaintingLarge,
         backgroundColor: 'information03',
-        size: isDesktopViewport ? 'default' : 'small',
       }}
       title="Sécurise ton compte"
       buttonPrimary={{ wording: 'Suspendre mon compte', onPress: navigateToSuspendAccount }}

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.web.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
 import { DeleteProfileAccountHacked } from './DeleteProfileAccountHacked'
@@ -7,6 +8,10 @@ import { DeleteProfileAccountHacked } from './DeleteProfileAccountHacked'
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('DeleteProfileAccountHacked', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(<DeleteProfileAccountHacked />)

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import * as OpenUrlAPI from 'features/navigation/helpers/openUrl'
 import { env } from 'libs/environment/fixtures'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { DeleteProfileAccountNotDeletable } from './DeleteProfileAccountNotDeletable'
@@ -20,6 +21,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('DeleteProfileAccountNotDeletable', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', () => {
     render(<DeleteProfileAccountNotDeletable />)
 

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
@@ -6,6 +6,7 @@ import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/
 import { getTabHookConfig } from 'features/navigation/TabBar/getTabHookConfig'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { env } from 'libs/environment/env'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Link } from 'ui/designSystem/Link/Link'
@@ -25,6 +26,10 @@ export const DeleteProfileAccountNotDeletable: FC = () => {
     <GenericInfoPage
       withGoBack
       illustration={ErrorIllustration}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.brokenDinosaurSkeletonLarge,
+        backgroundColor: 'negative01',
+      }}
       title="Nous ne pouvons pas encore supprimer ton compte"
       buttonPrimary={{ wording: 'Retourner sur mon profil', onPress: navigateToProfile }}
       buttonTertiary={{

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.web.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
 import { DeleteProfileAccountNotDeletable } from './DeleteProfileAccountNotDeletable'
@@ -13,6 +14,10 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 })
 
 describe('DeleteProfileAccountNotDeletable', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(<DeleteProfileAccountNotDeletable />)

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx
@@ -8,6 +8,7 @@ import { resetFromRef } from 'features/navigation/navigationRef'
 import { nonBeneficiaryUser } from 'fixtures/user'
 import { Adjust } from 'libs/adjust/adjust'
 import { env } from 'libs/environment/fixtures'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent } from 'tests/utils'
 
@@ -46,6 +47,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('DeleteProfileConfirmation', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should match snapshot', () => {
     renderDeleteProfileConfirmation()
 

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.tsx
@@ -8,6 +8,7 @@ import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/
 import { useAnonymizeAccountMutation } from 'features/profile/queries/useAnonymizeAccountMutation'
 import { Adjust } from 'libs/adjust/adjust'
 import { env } from 'libs/environment/env'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Banner } from 'ui/designSystem/Banner/Banner'
 import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
@@ -40,6 +41,10 @@ export const DeleteProfileConfirmation = () => {
     <GenericInfoPage
       withGoBack
       illustration={ProfileDeletion}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.trashMosaic,
+        backgroundColor: 'negative01',
+      }}
       title="Ta demande de suppression de compte"
       buttonPrimary={{
         wording: 'Supprimer mon compte',

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { DeleteProfileEmailHacked } from './DeleteProfileEmailHacked'
@@ -17,6 +18,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('DeleteProfileEmailHacked', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', () => {
     render(<DeleteProfileEmailHacked />)
 

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.tsx
@@ -1,9 +1,11 @@
 import { useNavigation } from '@react-navigation/native'
 import React, { FC } from 'react'
+import { useTheme } from 'styled-components/native'
 
 import { getProfileHookConfig } from 'features/navigation/navigators/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
 import { getTabHookConfig } from 'features/navigation/TabBar/getTabHookConfig'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { Clear } from 'ui/svg/icons/Clear'
@@ -11,6 +13,7 @@ import { UserBlocked } from 'ui/svg/icons/UserBlocked'
 import { Typo } from 'ui/theme'
 
 export const DeleteProfileEmailHacked: FC = () => {
+  const { isDesktopViewport } = useTheme()
   const { navigate } = useNavigation<UseNavigationType>()
 
   const navigateToProfile = () => navigate(...getTabHookConfig('Profile'))
@@ -25,6 +28,11 @@ export const DeleteProfileEmailHacked: FC = () => {
     <GenericInfoPage
       withGoBack
       illustration={UserBlocked}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.blockedPaintingLarge,
+        backgroundColor: 'information03',
+        size: isDesktopViewport ? 'default' : 'small',
+      }}
       title="Sécurise ton compte"
       buttonPrimary={{
         wording: 'Modifier mon adresse e-mail',

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.tsx
@@ -1,6 +1,5 @@
 import { useNavigation } from '@react-navigation/native'
 import React, { FC } from 'react'
-import { useTheme } from 'styled-components/native'
 
 import { getProfileHookConfig } from 'features/navigation/navigators/ProfileStackNavigator/getProfileHookConfig'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
@@ -13,7 +12,6 @@ import { UserBlocked } from 'ui/svg/icons/UserBlocked'
 import { Typo } from 'ui/theme'
 
 export const DeleteProfileEmailHacked: FC = () => {
-  const { isDesktopViewport } = useTheme()
   const { navigate } = useNavigation<UseNavigationType>()
 
   const navigateToProfile = () => navigate(...getTabHookConfig('Profile'))
@@ -31,7 +29,6 @@ export const DeleteProfileEmailHacked: FC = () => {
       remoteIllustration={{
         url: genericInfoPageIllustrationUrls.blockedPaintingLarge,
         backgroundColor: 'information03',
-        size: isDesktopViewport ? 'default' : 'small',
       }}
       title="Sécurise ton compte"
       buttonPrimary={{

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.web.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
 import { DeleteProfileEmailHacked } from './DeleteProfileEmailHacked'
@@ -7,6 +8,10 @@ import { DeleteProfileEmailHacked } from './DeleteProfileEmailHacked'
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('DeleteProfileEmailHacked', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(<DeleteProfileEmailHacked />)

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import * as LogoutRoutine from 'features/auth/helpers/useLogoutRoutine'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { navigateFromRef } from 'features/navigation/navigationRef'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { userEvent, render, screen } from 'tests/utils'
 
 import { DeleteProfileSuccess } from './DeleteProfileSuccess'
@@ -24,6 +25,10 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 jest.useFakeTimers()
 
 describe('DeleteProfileSuccess', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render delete profile success', () => {
     render(<DeleteProfileSuccess />)
 

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { Emoji } from 'ui/components/Emoji'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
@@ -11,6 +12,10 @@ import { Typo } from 'ui/theme'
 export const DeleteProfileSuccess = () => (
   <GenericInfoPage
     illustration={ProfileDeletion}
+    remoteIllustration={{
+      url: genericInfoPageIllustrationUrls.trashMosaic,
+      backgroundColor: 'negative01',
+    }}
     title="Ton compte a été supprimé"
     buttonPrimary={{
       wording: 'Retourner à l’accueil',

--- a/src/features/trustedDevice/pages/AccountSecurity.native.test.tsx
+++ b/src/features/trustedDevice/pages/AccountSecurity.native.test.tsx
@@ -5,6 +5,7 @@ import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { ROUTE_PARAMS } from 'features/trustedDevice/fixtures/fixtures'
 import { beneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { mockAuthContextWithoutUser, mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { render, screen, userEvent } from 'tests/utils'
 
@@ -28,6 +29,7 @@ describe('<AccountSecurity/>', () => {
   describe('with route params', () => {
     beforeEach(() => {
       useRoute.mockReturnValueOnce({ params: ROUTE_PARAMS })
+      setFeatureFlags()
     })
 
     describe('when user is connected and has a password', () => {

--- a/src/features/trustedDevice/pages/AccountSecurity.tsx
+++ b/src/features/trustedDevice/pages/AccountSecurity.tsx
@@ -8,6 +8,7 @@ import { DeviceInformationsBanner } from 'features/trustedDevice/components/Devi
 import { formatTokenInfo } from 'features/trustedDevice/helpers/formatTokenInfo'
 import { getTokenInfo } from 'features/trustedDevice/helpers/getTokenInfo'
 import { analytics } from 'libs/analytics/provider'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
@@ -29,6 +30,11 @@ export const AccountSecurity = () => {
   return (
     <GenericInfoPage
       illustration={UserBlocked}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.blockedPaintingLarge,
+        backgroundColor: 'information03',
+        size: 'small',
+      }}
       title="Sécurise ton compte"
       buttonPrimary={
         isLoggedOutOrHasPassword

--- a/src/features/trustedDevice/pages/AccountSecurity.tsx
+++ b/src/features/trustedDevice/pages/AccountSecurity.tsx
@@ -33,7 +33,6 @@ export const AccountSecurity = () => {
       remoteIllustration={{
         url: genericInfoPageIllustrationUrls.blockedPaintingLarge,
         backgroundColor: 'information03',
-        size: 'small',
       }}
       title="Sécurise ton compte"
       buttonPrimary={

--- a/src/features/trustedDevice/pages/AccountSecurity.web.test.tsx
+++ b/src/features/trustedDevice/pages/AccountSecurity.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
 import { AccountSecurity } from './AccountSecurity'
@@ -7,6 +8,10 @@ import { AccountSecurity } from './AccountSecurity'
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<AccountSecurity />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(<AccountSecurity />)

--- a/src/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx
+++ b/src/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { SuspiciousLoginSuspendedAccount } from './SuspiciousLoginSuspendedAccount'
@@ -29,6 +30,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('<SuspiciousLoginSuspendedAccount/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should match snapshot', () => {
     render(<SuspiciousLoginSuspendedAccount />)
 

--- a/src/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.web.test.tsx
+++ b/src/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
 import { SuspiciousLoginSuspendedAccount } from './SuspiciousLoginSuspendedAccount'
@@ -9,6 +10,10 @@ jest.mock('features/auth/helpers/useLogoutRoutine')
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<SuspiciousLoginSuspendedAccount/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(<SuspiciousLoginSuspendedAccount />)

--- a/src/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx
+++ b/src/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { VenueNotFound } from 'features/venue/pages/VenueNotFound/VenueNotFound'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render } from 'tests/utils'
 
 const resetErrorBoundary = () => null
@@ -15,6 +16,10 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 })
 
 describe('<VenueNotFound />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', () => {
     expect(
       render(<VenueNotFound error={error} resetErrorBoundary={resetErrorBoundary} />)

--- a/src/features/venue/pages/VenueNotFound/VenueNotFound.tsx
+++ b/src/features/venue/pages/VenueNotFound/VenueNotFound.tsx
@@ -1,12 +1,15 @@
 import React, { useEffect, useRef } from 'react'
+import { useTheme } from 'styled-components/native'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { ScreenErrorProps } from 'libs/monitoring/errors'
 import { Helmet } from 'libs/react-helmet/Helmet'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { NoOffer } from 'ui/svg/icons/NoOffer'
 
 export const VenueNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
+  const { isDesktopViewport } = useTheme()
   const timer = useRef<number>(null)
 
   useEffect(
@@ -34,6 +37,11 @@ export const VenueNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
       </Helmet>
       <GenericInfoPage
         illustration={NoOffer}
+        remoteIllustration={{
+          url: genericInfoPageIllustrationUrls.emptyDigitalWindowLarge,
+          backgroundColor: 'pending01',
+          size: isDesktopViewport ? 'default' : 'small',
+        }}
         title="Lieu introuvable&nbsp;!"
         subtitle="Il est possible que ce lieu soit désactivé ou n’existe pas."
         buttonPrimary={{

--- a/src/features/venue/pages/VenueNotFound/VenueNotFound.tsx
+++ b/src/features/venue/pages/VenueNotFound/VenueNotFound.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef } from 'react'
-import { useTheme } from 'styled-components/native'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { ScreenErrorProps } from 'libs/monitoring/errors'
@@ -9,7 +8,6 @@ import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { NoOffer } from 'ui/svg/icons/NoOffer'
 
 export const VenueNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
-  const { isDesktopViewport } = useTheme()
   const timer = useRef<number>(null)
 
   useEffect(
@@ -40,7 +38,6 @@ export const VenueNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
         remoteIllustration={{
           url: genericInfoPageIllustrationUrls.emptyDigitalWindowLarge,
           backgroundColor: 'pending01',
-          size: isDesktopViewport ? 'default' : 'small',
         }}
         title="Lieu introuvable&nbsp;!"
         subtitle="Il est possible que ce lieu soit désactivé ou n’existe pas."

--- a/src/features/venue/pages/VenueNotFound/VenueNotFound.web.test.tsx
+++ b/src/features/venue/pages/VenueNotFound/VenueNotFound.web.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { VenueNotFound } from 'features/venue/pages/VenueNotFound/VenueNotFound'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
 const resetErrorBoundary = () => null
@@ -9,6 +10,10 @@ const error = new Error('error')
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<VenueNotFound />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(

--- a/src/shared/illustrations/genericInfoPageIllustrations.ts
+++ b/src/shared/illustrations/genericInfoPageIllustrations.ts
@@ -1,10 +1,21 @@
 import { buildCategoryIllustrationUrl } from 'shared/illustrations/buildCategoryIllustrationUrl'
 
-const genericInfoPageIllustrationNames = ['emptyDigitalWindowLarge', 'emptyWalletLarge'] as const
+const genericInfoPageIllustrationNames = [
+  'blockedPaintingLarge',
+  'brokenDinosaurSkeletonLarge',
+  'emptyDigitalWindowLarge',
+  'emptyWalletLarge',
+  'hourglass',
+  'trashMosaic',
+] as const
 
 type GenericInfoPageIllustrationName = (typeof genericInfoPageIllustrationNames)[number]
 
 export const genericInfoPageIllustrationUrls = {
+  blockedPaintingLarge: buildCategoryIllustrationUrl('blockedPaintingLarge.png'),
+  brokenDinosaurSkeletonLarge: buildCategoryIllustrationUrl('brokenDinosaurSkeletonLarge.png'),
   emptyDigitalWindowLarge: buildCategoryIllustrationUrl('emptyDigitalWindowLarge.png'),
   emptyWalletLarge: buildCategoryIllustrationUrl('emptyWalletLarge.png'),
+  hourglass: buildCategoryIllustrationUrl('emptyWalletLarge.png'),
+  trashMosaic: buildCategoryIllustrationUrl('trashMosaic.png'),
 } as const satisfies Record<GenericInfoPageIllustrationName, string>

--- a/src/shared/illustrations/genericInfoPageIllustrations.ts
+++ b/src/shared/illustrations/genericInfoPageIllustrations.ts
@@ -16,6 +16,6 @@ export const genericInfoPageIllustrationUrls = {
   brokenDinosaurSkeletonLarge: buildCategoryIllustrationUrl('brokenDinosaurSkeletonLarge.png'),
   emptyDigitalWindowLarge: buildCategoryIllustrationUrl('emptyDigitalWindowLarge.png'),
   emptyWalletLarge: buildCategoryIllustrationUrl('emptyWalletLarge.png'),
-  hourglass: buildCategoryIllustrationUrl('emptyWalletLarge.png'),
+  hourglass: buildCategoryIllustrationUrl('hourglass.png'),
   trashMosaic: buildCategoryIllustrationUrl('trashMosaic.png'),
 } as const satisfies Record<GenericInfoPageIllustrationName, string>

--- a/src/ui/pages/GenericInfoPage.native.test.tsx
+++ b/src/ui/pages/GenericInfoPage.native.test.tsx
@@ -57,7 +57,6 @@ describe('<GenericInfoPage />', () => {
         remoteIllustration={{
           url: 'https://example.com/illustration.png',
           backgroundColor: 'positive01',
-          size: 'default',
         }}
         title="Title"
         buttonPrimary={{
@@ -79,7 +78,6 @@ describe('<GenericInfoPage />', () => {
         remoteIllustration={{
           url: 'https://example.com/illustration.png',
           backgroundColor: 'positive01',
-          size: 'small',
         }}
         title="Title"
         buttonPrimary={{

--- a/src/ui/pages/GenericInfoPageIllustration.tsx
+++ b/src/ui/pages/GenericInfoPageIllustration.tsx
@@ -18,7 +18,7 @@ const ILLUSTRATION_SIZES = {
   small: 200,
 } as const satisfies Record<RemoteIllustrationSize, number>
 
-const ILLUSTRATION_BORDER_RADII = {
+const ILLUSTRATION_BORDER_RADIUS = {
   default: 96,
   small: 56,
 } as const satisfies Record<RemoteIllustrationSize, number>
@@ -29,7 +29,7 @@ export const GenericInfoPageIllustration = ({
   size,
 }: RemoteIllustration): React.JSX.Element => (
   <Container
-    cropRadius={ILLUSTRATION_BORDER_RADII[size]}
+    cropRadius={ILLUSTRATION_BORDER_RADIUS[size]}
     illustrationBackgroundColor={backgroundColor}
     illustrationSize={ILLUSTRATION_SIZES[size]}
     testID="generic-info-page-remote-illustration">

--- a/src/ui/pages/GenericInfoPageIllustration.tsx
+++ b/src/ui/pages/GenericInfoPageIllustration.tsx
@@ -4,53 +4,36 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { IllustrationColorKey } from 'theme/types'
-
-type RemoteIllustrationSize = 'default' | 'small'
+import { getSpacing } from 'ui/theme'
 
 export type RemoteIllustration = {
   url: string
   backgroundColor: IllustrationColorKey
-  size: RemoteIllustrationSize
 }
-
-const ILLUSTRATION_SIZES = {
-  default: 320,
-  small: 200,
-} as const satisfies Record<RemoteIllustrationSize, number>
-
-const ILLUSTRATION_BORDER_RADIUS = {
-  default: 96,
-  small: 56,
-} as const satisfies Record<RemoteIllustrationSize, number>
 
 export const GenericInfoPageIllustration = ({
   url,
   backgroundColor,
-  size,
 }: RemoteIllustration): React.JSX.Element => (
   <Container
-    cropRadius={ILLUSTRATION_BORDER_RADIUS[size]}
     illustrationBackgroundColor={backgroundColor}
-    illustrationSize={ILLUSTRATION_SIZES[size]}
     testID="generic-info-page-remote-illustration">
     <RemoteIllustration source={{ uri: url }} resizeMode="contain" />
   </Container>
 )
 
 const Container = styled.View<{
-  cropRadius: number
   illustrationBackgroundColor: IllustrationColorKey
-  illustrationSize: number
-}>(({ cropRadius, illustrationBackgroundColor, illustrationSize, theme }) => ({
+}>(({ illustrationBackgroundColor, theme }) => ({
   alignItems: 'center',
   justifyContent: 'center',
-  width: illustrationSize,
+  width: theme.designSystem.size.illustration.xl,
   maxWidth: '100%',
   aspectRatio: 1,
   overflow: 'hidden',
   backgroundColor: theme.designSystem.color.illustration[illustrationBackgroundColor],
-  borderTopLeftRadius: cropRadius,
-  borderBottomRightRadius: cropRadius,
+  borderTopLeftRadius: getSpacing(14),
+  borderBottomRightRadius: getSpacing(14),
 }))
 
 const RemoteIllustration = styled(FastImage)({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42681
## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |<img width="399" height="686" alt="Capture d’écran 2026-07-27 à 11 14 29" src="https://github.com/user-attachments/assets/28a951d6-4b79-4389-b9b4-d8709e027033" /> <img width="390" height="683" alt="Capture d’écran 2026-07-27 à 11 13 53" src="https://github.com/user-attachments/assets/822ea254-4911-4809-a43b-e90b05438007" /> <img width="388" height="677" alt="Capture d’écran 2026-07-27 à 11 35 04" src="https://github.com/user-attachments/assets/5d6a9898-dcf6-4422-8dce-5affb3d9ad65" /> <img width="401" height="693" alt="Capture d’écran 2026-07-27 à 11 38 43" src="https://github.com/user-attachments/assets/fc7e1b1e-5230-4a96-8cc7-2998ec0bd269" /> <img width="391" height="681" alt="Capture d’écran 2026-07-27 à 11 42 18" src="https://github.com/user-attachments/assets/36de14db-f090-4e47-af01-e0a3d6299759" /> <img width="398" height="682" alt="Capture d’écran 2026-07-27 à 11 50 40" src="https://github.com/user-attachments/assets/f21c5283-8f0a-4cea-bf03-08a8f1c3c0d6" /> <img width="389" height="679" alt="Capture d’écran 2026-07-27 à 12 00 08" src="https://github.com/user-attachments/assets/7dbc65b5-c0f2-400f-b46d-3effc2e3abb2" /> <img width="393" height="686" alt="Capture d’écran 2026-07-27 à 12 05 59" src="https://github.com/user-attachments/assets/c71849cd-572d-471e-b349-57c2fc1f6072" /> <img width="390" height="677" alt="Capture d’écran 2026-07-27 à 12 18 29" src="https://github.com/user-attachments/assets/711ea7ec-88ad-4ff0-91cc-d7e981043bb0" /> <img width="391" height="679" alt="Capture d’écran 2026-07-27 à 12 22 27" src="https://github.com/user-attachments/assets/bf6b96b8-eeea-46b2-af84-d3e836339692" /> <img width="403" height="681" alt="Capture d’écran 2026-07-27 à 12 27 57" src="https://github.com/user-attachments/assets/e581a644-18c2-4852-b4f4-2e9e3642062d" /> <img width="392" height="686" alt="Capture d’écran 2026-07-27 à 12 38 15" src="https://github.com/user-attachments/assets/b0797eb9-a3cd-4df7-8f3e-8ae0a1557bfe" /> <img width="392" height="686" alt="Capture d’écran 2026-07-27 à 12 46 18" src="https://github.com/user-attachments/assets/9534ef79-47e2-4ab6-b345-d87c952cfde7" /> <img width="389" height="682" alt="Capture d’écran 2026-07-27 à 12 52 01" src="https://github.com/user-attachments/assets/ca3cca83-68db-4232-b758-666b797891ab" /> <img width="389" height="679" alt="Capture d’écran 2026-07-27 à 15 47 36" src="https://github.com/user-attachments/assets/c6bc410c-3c3a-4b74-b0a0-c134f903b92c" />|<img width="393" height="681" alt="Capture d’écran 2026-07-27 à 11 12 35" src="https://github.com/user-attachments/assets/8f557651-bb41-4448-9bd6-175b10b6b806" /> <img width="390" height="684" alt="Capture d’écran 2026-07-27 à 11 13 24" src="https://github.com/user-attachments/assets/5803c7de-91a2-46ed-adf6-9382805643f4" /> <img width="404" height="691" alt="Capture d’écran 2026-07-27 à 11 34 48" src="https://github.com/user-attachments/assets/06c1d686-3274-4049-92c6-d014ea90523d" /> <img width="390" height="685" alt="Capture d’écran 2026-07-27 à 11 39 05" src="https://github.com/user-attachments/assets/a37b7bdc-cfe1-43dc-b605-4e70201dc264" /> <img width="398" height="690" alt="Capture d’écran 2026-07-27 à 11 41 58" src="https://github.com/user-attachments/assets/a61b1cb6-4b83-43b1-823a-a71e990363f1" /> <img width="394" height="687" alt="Capture d’écran 2026-07-27 à 11 51 52" src="https://github.com/user-attachments/assets/30460a02-cfb0-46de-aa4a-3efe92846682" /> <img width="399" height="686" alt="Capture d’écran 2026-07-27 à 11 59 49" src="https://github.com/user-attachments/assets/cd069b9a-b38c-45b0-b0ce-25ece0180550" /> <img width="394" height="683" alt="Capture d’écran 2026-07-27 à 12 04 22" src="https://github.com/user-attachments/assets/83d5f77a-ddb2-497a-b1a8-7c5fe0e8f6e3" /> <img width="389" height="682" alt="Capture d’écran 2026-07-27 à 12 16 43" src="https://github.com/user-attachments/assets/1fae889d-4177-49aa-bc89-9c0196472712" /> <img width="397" height="680" alt="Capture d’écran 2026-07-27 à 12 22 02" src="https://github.com/user-attachments/assets/043a5f7f-92b8-46a8-b537-7a3f5a19eec6" /> <img width="395" height="679" alt="Capture d’écran 2026-07-27 à 12 27 32" src="https://github.com/user-attachments/assets/7f828a0b-518a-4b7d-bbf6-042c63c5059b" /> <img width="402" height="688" alt="Capture d’écran 2026-07-27 à 12 38 03" src="https://github.com/user-attachments/assets/05ecdd77-7036-49ad-876e-0cc3655310a1" /> <img width="390" height="679" alt="Capture d’écran 2026-07-27 à 12 45 58" src="https://github.com/user-attachments/assets/83eb1af2-14e0-4132-b01a-147622cffd1c" /> <img width="387" height="678" alt="Capture d’écran 2026-07-27 à 12 52 41" src="https://github.com/user-attachments/assets/054c6161-cb62-42a0-9680-7ca309e8293c" /> <img width="396" height="683" alt="Capture d’écran 2026-07-27 à 15 46 57" src="https://github.com/user-attachments/assets/bc0e85c4-fda7-40d8-91f5-6910c4a7ace4" />|
| Desktop - Chrome |<img width="1917" height="932" alt="Capture d’écran 2026-07-27 à 11 14 19" src="https://github.com/user-attachments/assets/5f60c501-ccc6-410b-8c84-9ecf17e68507" /> <img width="1917" height="931" alt="Capture d’écran 2026-07-27 à 11 14 03" src="https://github.com/user-attachments/assets/e19bca36-5d9b-47c5-ad19-db6919f39459" /> <img width="1507" height="763" alt="Capture d’écran 2026-07-27 à 11 35 37" src="https://github.com/user-attachments/assets/56f1187c-8c44-4c0a-a142-fcee599d6187" /> <img width="1512" height="764" alt="Capture d’écran 2026-07-27 à 11 38 32" src="https://github.com/user-attachments/assets/10cb4dd3-0753-455d-87f8-614ed1860e6f" /> <img width="1511" height="764" alt="Capture d’écran 2026-07-27 à 11 42 28" src="https://github.com/user-attachments/assets/ea031678-0576-4a59-8c57-45f5ed517435" /> <img width="1513" height="763" alt="Capture d’écran 2026-07-27 à 11 50 20" src="https://github.com/user-attachments/assets/bb5dc3a2-e14e-4593-9f3d-229d7792a867" /> <img width="1509" height="763" alt="Capture d’écran 2026-07-27 à 12 00 17" src="https://github.com/user-attachments/assets/684cb5a9-f6e7-4926-a872-bd1f1629a351" /> <img width="1507" height="763" alt="Capture d’écran 2026-07-27 à 12 05 48" src="https://github.com/user-attachments/assets/6bc08a73-179b-408b-b455-ee56a1867395" /> <img width="1507" height="762" alt="Capture d’écran 2026-07-27 à 12 18 44" src="https://github.com/user-attachments/assets/98411b81-9d99-4907-adc5-edc529d2faf2" /> <img width="1509" height="763" alt="Capture d’écran 2026-07-27 à 12 22 36" src="https://github.com/user-attachments/assets/f52eb3d2-75b8-4f53-b2c8-6a285adf06af" /> <img width="1511" height="766" alt="Capture d’écran 2026-07-27 à 12 28 07" src="https://github.com/user-attachments/assets/d685fc26-bac1-4dc6-ad83-2f20e0f72472" /> <img width="1510" height="763" alt="Capture d’écran 2026-07-27 à 12 38 25" src="https://github.com/user-attachments/assets/76693ba0-5a9e-42c2-944d-5700e695d8c4" /> <img width="1508" height="767" alt="Capture d’écran 2026-07-27 à 12 46 30" src="https://github.com/user-attachments/assets/bf7874a4-01e9-4ba6-b6c1-a4bcf94acd1a" /> <img width="1510" height="762" alt="Capture d’écran 2026-07-27 à 12 51 52" src="https://github.com/user-attachments/assets/3691eef1-b2f9-4c22-adcd-740a4cd19e46" /> <img width="1510" height="759" alt="Capture d’écran 2026-07-27 à 15 47 41" src="https://github.com/user-attachments/assets/137fe9d8-adbb-476a-88b2-f9d730939d1c" />|<img width="1920" height="929" alt="Capture d’écran 2026-07-27 à 11 12 21" src="https://github.com/user-attachments/assets/4ce84827-2fe6-4504-b2d3-7a1af87bcf0e" /> <img width="1917" height="927" alt="Capture d’écran 2026-07-27 à 11 13 06" src="https://github.com/user-attachments/assets/9714250b-3624-46bb-a0e8-048f516f1f82" /> <img width="1512" height="762" alt="Capture d’écran 2026-07-27 à 11 34 38" src="https://github.com/user-attachments/assets/641e33b2-12e5-4ddc-a924-e46b17a7911b" /> <img width="1509" height="763" alt="Capture d’écran 2026-07-27 à 11 39 28" src="https://github.com/user-attachments/assets/38ec5c97-d912-4549-9c6a-42f454d9c309" /> <img width="1510" height="766" alt="Capture d’écran 2026-07-27 à 11 41 42" src="https://github.com/user-attachments/assets/51afbac5-bc0a-41b4-8533-11a04bd68fd2" /> <img width="1515" height="764" alt="Capture d’écran 2026-07-27 à 11 51 38" src="https://github.com/user-attachments/assets/4e592c37-107b-4479-a185-f005ad77ecfe" /> <img width="1510" height="762" alt="Capture d’écran 2026-07-27 à 11 59 40" src="https://github.com/user-attachments/assets/f9ddd546-353f-41b7-878d-4ee5a34a3ca7" /> <img width="1507" height="765" alt="Capture d’écran 2026-07-27 à 12 04 12" src="https://github.com/user-attachments/assets/9f10783e-a964-4d5b-a28b-bc8e69fb92f2" /> <img width="1509" height="764" alt="Capture d’écran 2026-07-27 à 12 16 20" src="https://github.com/user-attachments/assets/57968645-18fd-456a-8272-f9dfd21c9b5a" /> <img width="1510" height="766" alt="Capture d’écran 2026-07-27 à 12 21 52" src="https://github.com/user-attachments/assets/2509e470-e8e1-4efc-b39e-c698d8dc039a" /> <img width="1512" height="761" alt="Capture d’écran 2026-07-27 à 12 27 21" src="https://github.com/user-attachments/assets/500e5c12-0c90-4806-8ef9-e4af5bc55d30" /> <img width="1510" height="765" alt="Capture d’écran 2026-07-27 à 12 37 53" src="https://github.com/user-attachments/assets/da9fb2a2-37a8-4730-865c-04a21b5219f8" /> <img width="1510" height="762" alt="Capture d’écran 2026-07-27 à 12 44 20" src="https://github.com/user-attachments/assets/3b5510af-0ce1-4d0a-ba84-df6a33ded3fa" /> <img width="1509" height="764" alt="Capture d’écran 2026-07-27 à 12 52 59" src="https://github.com/user-attachments/assets/e6fd28d1-356b-44cd-bfa0-91a5bccc31f5" /> <img width="1509" height="766" alt="Capture d’écran 2026-07-27 à 15 46 47" src="https://github.com/user-attachments/assets/57e2ced7-cee7-4385-8990-888d82cea816" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
