### PR TITLE
(PC-43016) ci(webProxy): fix typescript error

### DIFF
--- a/.github/workflows/dev_on_workflow_tester.yml
+++ b/.github/workflows/dev_on_workflow_tester.yml
@@ -233,7 +233,9 @@ jobs:
           restore-keys: |
             v1-yarn-proxy-dependency-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install packages for proxy
-        run: cd server && yarn install && cd ..
+        run: (cd server && yarn)
+      - name: Test proxy types
+        run: (cd server && yarn test:types)
       - name: Run proxy unit tests
         # the test https://github.com/pass-culture/pass-culture-app-native/blob/64e47e0bd8887e80fa20b6d7df00e110d77fd22e/server/src/middlewares/tests/webAppProxyMiddleware.test.ts#L275 fails sometimes, we suppose the backend doesn't respond sometimes
         run: cd server && (yarn test:unit:ci || yarn test:unit:ci || yarn test:unit:ci) && cd ..

--- a/server/src/env.d.ts
+++ b/server/src/env.d.ts
@@ -1,0 +1,16 @@
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      NODE_ENV: 'development' | 'production' | 'test'
+      ENV: 'production' | 'testing' | 'staging'
+      APP_PUBLIC_URL: string
+      APP_BUCKET_URL: string
+      API_BASE_URL: string
+      DEEPLINK_PROTOCOL: string
+      PROXY_CACHE_CONTROL: string
+      ORGANIZATION_PREFIX: string
+    }
+  }
+}
+
+export {}

--- a/server/src/index.test.ts
+++ b/server/src/index.test.ts
@@ -16,7 +16,7 @@ const serverMock = setupServer(
 
 describe('express server', () => {
   let server: Server
-  let initialEnv: string | undefined
+  let initialEnv: NodeJS.ProcessEnv['ENV']
 
   beforeAll(async () => {
     serverMock.listen()

--- a/server/src/libs/environment/serverEnv.ts
+++ b/server/src/libs/environment/serverEnv.ts
@@ -2,7 +2,6 @@ import { existsSync } from 'fs'
 import { resolve, join } from 'path'
 
 import { config as dotEnvConfig } from 'dotenv'
-
 import { Environment } from './types'
 
 const envVariable = process.env.ENV ?? 'this should never happen'
@@ -19,6 +18,6 @@ if (!existsSync(path)) {
 dotEnvConfig({ path })
 
 export const env: Environment = {
-  ...(process.env as Environment),
+  ...process.env,
   __DEV__,
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43016

Le proxy est build avec tsc. Un mauvais typage empêche donc le build du proxy.
La CI ne nous a pas permis de nous rendre compte de cette erreur introduite par https://github.com/pass-culture/pass-culture-app-native/pull/9899

Stratégie:
- création d'un fichier `.env.d.ts` qui écrasera les types de `Process.env` par les types correspondants aux fichiers d'environnements.
- Ajout d'un test de type en CI 