### PR TITLE
(PC-42883) refactor(ui): lot 2 illustration

### DIFF
--- a/src/features/bookOffer/pages/BookingConfirmation.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.tsx
@@ -17,6 +17,7 @@ import { useOfferQuery } from 'queries/offer/useOfferQuery'
 import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
 import { formatCurrencyFromCents } from 'shared/currency/formatCurrencyFromCents'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { getIsUserEligibleFree } from 'shared/user/checkEligibilityType'
 import { getAvailableCredit } from 'shared/user/getAvailableCredit'
 import { useModal } from 'ui/components/modals/useModal'
@@ -100,6 +101,10 @@ export const BookingConfirmation: FC = () => {
     <React.Fragment>
       <GenericInfoPage
         illustration={TicketBooked}
+        remoteIllustration={{
+          url: genericInfoPageIllustrationUrls.validStampMosaïcLarge,
+          backgroundColor: 'positive01',
+        }}
         title="Réservation confirmée&nbsp;!"
         subtitle={`${amountLeftText}Tu peux retrouver toutes les informations concernant ta réservation sur l’application.`}
         buttonPrimary={{

--- a/src/features/bookOffer/pages/BookingConfirmation.web.test.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, checkAccessibilityFor, render } from 'tests/utils/web'
 
@@ -12,6 +13,10 @@ jest.mock('shared/user/getAvailableCredit', () => ({
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<BookingConfirmation />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(reactQueryProviderHOC(<BookingConfirmation />))

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { RequestSent } from 'ui/svg/icons/RequestSent'
 import { LINE_BREAK } from 'ui/theme/constants'
@@ -11,6 +12,10 @@ export function BeneficiaryRequestSent() {
   return (
     <GenericInfoPage
       illustration={RequestSent}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.sculptureMagnifyingGlassPaperLarge,
+        backgroundColor: 'information02',
+      }}
       title="Demande envoyée&nbsp;!"
       subtitle={subtitle}
       buttonPrimary={{

--- a/src/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx
@@ -4,6 +4,7 @@ import { ComeBackLater } from 'features/identityCheck/pages/identification/ubble
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { navigateFromRef } from 'features/navigation/navigationRef'
 import * as useGoBack from 'features/navigation/useGoBack'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { BatchEvent, BatchProfile } from 'libs/react-native-batch'
 import { render, screen, userEvent, waitFor } from 'tests/utils'
 
@@ -27,6 +28,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('ComeBackLater', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', () => {
     render(<ComeBackLater />)
 

--- a/src/features/identityCheck/pages/identification/ubble/ComeBackLater.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/ComeBackLater.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { analytics } from 'libs/analytics/provider'
 import { BatchEvent, BatchProfile } from 'libs/react-native-batch'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { IdCardInvalid } from 'ui/svg/icons/IdCardInvalid'
 import { Typo } from 'ui/theme'
@@ -24,6 +25,10 @@ export const ComeBackLater: FunctionComponent = () => {
     <GenericInfoPage
       withGoBack
       illustration={IdCardInvalid}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.stressedKnightLarge,
+        backgroundColor: 'negative01',
+      }}
       title="Reviens plus tard"
       buttonPrimary={{
         wording: 'M’identifier plus tard',

--- a/src/features/identityCheck/pages/identification/ubble/ComeBackLater.web.test.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/ComeBackLater.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, checkAccessibilityFor } from 'tests/utils/web'
 
 import { ComeBackLater } from './ComeBackLater'
@@ -7,6 +8,10 @@ import { ComeBackLater } from './ComeBackLater'
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<ComeBackLater/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(<ComeBackLater />)

--- a/src/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx
@@ -4,6 +4,7 @@ import { ExpiredOrLostID } from 'features/identityCheck/pages/identification/ubb
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import * as useGoBack from 'features/navigation/useGoBack'
 import { env } from 'libs/environment/env'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { BatchEvent, BatchProfile } from 'libs/react-native-batch'
 import { render, screen, userEvent, waitFor } from 'tests/utils'
 
@@ -26,6 +27,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('ExpiredOrLostID', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', () => {
     render(<ExpiredOrLostID />)
 

--- a/src/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
 import { BatchEvent, BatchProfile } from 'libs/react-native-batch'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { IdCardError } from 'ui/svg/icons/IdCardError'
@@ -25,6 +26,10 @@ export const ExpiredOrLostID = (): React.JSX.Element => {
     <GenericInfoPage
       withGoBack
       illustration={IdCardError}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.questioningKnightLarge,
+        backgroundColor: 'information03',
+      }}
       title="Ta pièce d’identité expirée ou perdue"
       buttonPrimary={{
         wording: 'Aller sur demarche.numerique.gouv.fr',

--- a/src/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.web.test.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
 import { ExpiredOrLostID } from './ExpiredOrLostID'
@@ -7,6 +8,10 @@ import { ExpiredOrLostID } from './ExpiredOrLostID'
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<ExpiredOrLostID/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(<ExpiredOrLostID />)

--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { IdentityCheckPending } from 'features/identityCheck/pages/identification/ubble/IdentityCheckPending'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { navigateFromRef } from 'features/navigation/navigationRef'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
@@ -19,6 +20,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('<IdentityCheckPending/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', () => {
     render(<IdentityCheckPending />)
 

--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckPending.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckPending.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { IdCardError } from 'ui/svg/icons/IdCardError'
@@ -11,6 +12,10 @@ export function IdentityCheckPending() {
   return (
     <GenericInfoPage
       illustration={IdCardError}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.sculptureMagnifyingGlassPaperLarge,
+        backgroundColor: 'information02',
+      }}
       title="Oups&nbsp;!"
       buttonPrimary={{
         wording: 'Retourner à l’accueil',

--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckPending.web.test.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckPending.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, checkAccessibilityFor } from 'tests/utils/web'
 
 import { IdentityCheckPending } from './IdentityCheckPending'
@@ -7,6 +8,10 @@ import { IdentityCheckPending } from './IdentityCheckPending'
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<IdentityCheckPending/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(<IdentityCheckPending />)

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { DeleteProfileContactSupport } from './DeleteProfileContactSupport'
@@ -14,6 +15,10 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 })
 
 describe('DeleteProfileContactSupport', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', () => {
     render(<DeleteProfileContactSupport />)
 

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.tsx
@@ -6,6 +6,7 @@ import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/
 import { getTabHookConfig } from 'features/navigation/TabBar/getTabHookConfig'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { EmailSent as InitialEmailSent } from 'ui/svg/icons/EmailSent'
@@ -20,6 +21,10 @@ export const DeleteProfileContactSupport: FC = () => {
     <GenericInfoPage
       withGoBack
       illustration={EmailSent}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.mailBoxSendingLarge,
+        backgroundColor: 'positive01',
+      }}
       title="Contacte le support"
       buttonPrimary={{
         wording: 'Contacter le support',

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.web.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
 import { DeleteProfileContactSupport } from './DeleteProfileContactSupport'
@@ -7,6 +8,10 @@ import { DeleteProfileContactSupport } from './DeleteProfileContactSupport'
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('DeleteProfileContactSupport', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(<DeleteProfileContactSupport />)

--- a/src/shared/illustrations/genericInfoPageIllustrations.ts
+++ b/src/shared/illustrations/genericInfoPageIllustrations.ts
@@ -6,7 +6,12 @@ const genericInfoPageIllustrationNames = [
   'emptyDigitalWindowLarge',
   'emptyWalletLarge',
   'hourglass',
+  'mailBoxSendingLarge',
+  'questioningKnightLarge',
+  'sculptureMagnifyingGlassPaperLarge',
+  'stressedKnightLarge',
   'trashMosaic',
+  'validStampMosaïcLarge',
 ] as const
 
 type GenericInfoPageIllustrationName = (typeof genericInfoPageIllustrationNames)[number]
@@ -17,5 +22,12 @@ export const genericInfoPageIllustrationUrls = {
   emptyDigitalWindowLarge: buildCategoryIllustrationUrl('emptyDigitalWindowLarge.png'),
   emptyWalletLarge: buildCategoryIllustrationUrl('emptyWalletLarge.png'),
   hourglass: buildCategoryIllustrationUrl('hourglass.png'),
+  mailBoxSendingLarge: buildCategoryIllustrationUrl('mailBoxSendingLarge.png'),
+  questioningKnightLarge: buildCategoryIllustrationUrl('questioningKnightLarge.png'),
+  sculptureMagnifyingGlassPaperLarge: buildCategoryIllustrationUrl(
+    'sculptureMagnifyingGlassPaperLarge.png'
+  ),
+  stressedKnightLarge: buildCategoryIllustrationUrl('stressedKnightLarge.png'),
   trashMosaic: buildCategoryIllustrationUrl('trashMosaic.png'),
+  validStampMosaïcLarge: buildCategoryIllustrationUrl('validStampMosaïcLarge.png'),
 } as const satisfies Record<GenericInfoPageIllustrationName, string>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42883

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |<img width="386" height="676" alt="Capture d’écran 2026-07-27 à 15 13 04" src="https://github.com/user-attachments/assets/a60bc80d-1551-4478-ad28-62485701c3c1" /> <img width="386" height="679" alt="Capture d’écran 2026-07-27 à 15 15 02" src="https://github.com/user-attachments/assets/b153b017-4469-4ce5-819e-4ed62ea9c5f1" /> <img width="419" height="690" alt="Capture d’écran 2026-07-27 à 15 56 02" src="https://github.com/user-attachments/assets/08a752a4-acef-4c77-9fd2-4f0c3fd6f64c" /> <img width="397" height="683" alt="Capture d’écran 2026-07-27 à 17 10 52" src="https://github.com/user-attachments/assets/ab76fa25-f854-47d3-aacf-0a2a5a2ff696" /> <img width="400" height="679" alt="Capture d’écran 2026-07-27 à 16 11 59" src="https://github.com/user-attachments/assets/fc7908dc-6d3b-497e-8fd4-b4188a4ca904" /> <img width="395" height="687" alt="Capture d’écran 2026-07-27 à 16 18 37" src="https://github.com/user-attachments/assets/51ac3e6c-9681-4b3f-9347-d03e9048fef5" />|<img width="389" height="681" alt="Capture d’écran 2026-07-27 à 15 12 35" src="https://github.com/user-attachments/assets/2885f53a-6f54-4604-94d5-cd6d0e2ae4a8" /> <img width="392" height="684" alt="Capture d’écran 2026-07-27 à 15 18 41" src="https://github.com/user-attachments/assets/ef7d5370-bee6-492a-873c-10f677ad312d" /> <img width="403" height="686" alt="Capture d’écran 2026-07-27 à 15 32 31" src="https://github.com/user-attachments/assets/068347dc-1c0c-4c25-b44f-c81647ec4ed8" /> <img width="400" height="683" alt="Capture d’écran 2026-07-27 à 16 01 22" src="https://github.com/user-attachments/assets/0230924d-2494-4eee-8a64-a53a024ff455" /> <img width="393" height="685" alt="Capture d’écran 2026-07-27 à 16 12 42" src="https://github.com/user-attachments/assets/9f5eed2a-c397-44f6-af2b-ffae6d4e87e4" /> <img width="385" height="674" alt="Capture d’écran 2026-07-27 à 16 18 59" src="https://github.com/user-attachments/assets/ef2868d6-aa11-404f-83bb-689cae0ddee3" />|
| Desktop - Chrome |<img width="1507" height="764" alt="Capture d’écran 2026-07-27 à 15 13 16" src="https://github.com/user-attachments/assets/c6146e51-5808-4132-bec0-2635499dc31b" /> <img width="1508" height="762" alt="Capture d’écran 2026-07-27 à 15 14 50" src="https://github.com/user-attachments/assets/49d448a6-a318-4e51-9267-a9315bfacb25" /> <img width="1513" height="765" alt="Capture d’écran 2026-07-27 à 15 55 55" src="https://github.com/user-attachments/assets/0014b21a-f373-4d56-af6e-37c54591b359" /> <img width="1510" height="762" alt="Capture d’écran 2026-07-27 à 17 10 42" src="https://github.com/user-attachments/assets/811644d9-8cb5-4bc6-a445-dccc06505832" /> <img width="1508" height="763" alt="Capture d’écran 2026-07-27 à 16 11 48" src="https://github.com/user-attachments/assets/1290bc0d-8d1e-4957-89f6-b6d6435fb004" /> <img width="1506" height="760" alt="Capture d’écran 2026-07-27 à 16 18 28" src="https://github.com/user-attachments/assets/3b8037bb-0987-470c-8076-c66b51196a7d" />|<img width="1507" height="766" alt="Capture d’écran 2026-07-27 à 15 12 23" src="https://github.com/user-attachments/assets/1ee3c406-9663-4c7c-8da5-36fd540c609e" /> <img width="1505" height="763" alt="Capture d’écran 2026-07-27 à 15 18 54" src="https://github.com/user-attachments/assets/8eb3d005-90ef-4d2f-8c0e-197b9d509d13" /> <img width="1509" height="765" alt="Capture d’écran 2026-07-27 à 15 32 21" src="https://github.com/user-attachments/assets/98f0d38b-767b-49ac-8cda-698f82ca13cb" /> <img width="1506" height="766" alt="Capture d’écran 2026-07-27 à 16 01 13" src="https://github.com/user-attachments/assets/3efabd64-e176-453c-98ea-2d768d19b99e" /> <img width="1510" height="761" alt="Capture d’écran 2026-07-27 à 16 12 53" src="https://github.com/user-attachments/assets/3457b39b-9ee1-437d-bca2-557775f00afb" /> <img width="1508" height="763" alt="Capture d’écran 2026-07-27 à 16 19 10" src="https://github.com/user-attachments/assets/a90b6d5e-e960-4ad5-bf19-0f4bc053d7b5" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
