### PR TITLE
(PC-41151) refactor(offer): load movie offer's screenings from movie calendar endpoint for connected user

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -479,8 +479,13 @@ export enum Bookability {
   'STOCK_IS_SOLD_OUT' = 'STOCK_IS_SOLD_OUT',
   'USER_CANNOT_BOOK' = 'USER_CANNOT_BOOK',
   'USER_HAS_ALREADY_BOOKED_OFFER' = 'USER_HAS_ALREADY_BOOKED_OFFER',
+  'USER_HAS_ALREADY_BOOKED_RELATED_OFFER' = 'USER_HAS_ALREADY_BOOKED_RELATED_OFFER',
   'USER_HAS_INSUFFICIENT_CREDIT' = 'USER_HAS_INSUFFICIENT_CREDIT',
   'AUTHENTICATION_REQUIRED' = 'AUTHENTICATION_REQUIRED',
+  'FINISH_SUBSCRIPTION_REQUIRED' = 'FINISH_SUBSCRIPTION_REQUIRED',
+  'USER_APPLICATION_STILL_PROCESSING' = 'USER_APPLICATION_STILL_PROCESSING',
+  'USER_HAS_APPLICATION_ERROR' = 'USER_HAS_APPLICATION_ERROR',
+
 }
 /**
  * @export
@@ -6120,7 +6125,7 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
         options: localVarRequestOptions,
       }
     },
-        /**
+    /**
      * @summary get_movie_screenings <GET>
      * @param {number} latitude
      * @param {number} longitude
@@ -6183,6 +6188,79 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
       }).join('&')
       pathname += encodedQueryParams
       let secureOptions = Object.assign(options, { credentials: 'omit' })
+      const localVarRequestOptions = Object.assign({ method: 'GET' }, secureOptions)
+      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
+      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
+      return {
+        url: pathname,
+        options: localVarRequestOptions,
+      }
+    },
+        /**
+     * @summary get_movie_screenings_for_user <GET>
+     * @param {number} latitude 
+     * @param {number} longitude 
+     * @param {Allocineid} [allocineId] 
+     * @param {Visa} [visa] 
+     * @param {number} [aroundRadius] 
+     * @param {string} [from] 
+     * @param {string} [to] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getNativeV1MovieCalendarMe(latitude: number, longitude: number, allocineId?: string, visa?: string, aroundRadius?: number, from?: string, to?: string, options: any = {}): Promise<FetchArgs> {
+      // verify required parameter 'latitude' is not null or undefined
+      if (latitude === null || latitude === undefined) {
+        throw new RequiredError(
+          'latitude',
+          'Required parameter latitude was null or undefined when calling getNativeV1MovieCalendarMe.'
+        )
+      }
+      // verify required parameter 'longitude' is not null or undefined
+      if (longitude === null || longitude === undefined) {
+        throw new RequiredError(
+          'longitude',
+          'Required parameter longitude was null or undefined when calling getNativeV1MovieCalendarMe.'
+        )
+      }
+      let pathname = `/native/v1/movie/calendar/me`
+      const queryParameters: any = {};
+
+        if (allocineId != null) {
+            queryParameters['allocineId'] = allocineId;
+        }
+
+        if (visa != null) {
+            queryParameters['visa'] = visa;
+        }
+
+        if (latitude != null) {
+            queryParameters['latitude'] = latitude;
+        }
+
+        if (longitude != null) {
+            queryParameters['longitude'] = longitude;
+        }
+
+        if (aroundRadius != null) {
+            queryParameters['aroundRadius'] = aroundRadius;
+        }
+
+        if (from != null) {
+            queryParameters['from'] = from;
+        }
+
+        if (to != null) {
+            queryParameters['to'] = to;
+        }
+
+      const encodedQueryParams = '?' + Object.keys(queryParameters).map((key) => {
+        return `${encodeURIComponent(key as string)}=${encodeURIComponent(queryParameters[key])}`
+      }).join('&')
+      pathname += encodedQueryParams
+      let secureOptions = Object.assign(options, { credentials: 'omit' })
+      // authentication JWTAuth required
+      secureOptions = Object.assign(secureOptions, { credentials: 'include' })
       const localVarRequestOptions = Object.assign({ method: 'GET' }, secureOptions)
       const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
       localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
@@ -8284,6 +8362,24 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
       return handleGeneratedApiResponse(response, options)
     },
+     /**
+     * 
+     * @summary get_movie_screenings_for_user <GET>
+     * @param {number} latitude 
+     * @param {number} longitude 
+     * @param {Allocineid1} [allocineId] 
+     * @param {Visa1} [visa] 
+     * @param {number} [aroundRadius] 
+     * @param {string} [from] 
+     * @param {string} [to] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getNativeV1MovieCalendarMe(latitude: number, longitude: number, allocineId?: string, visa?: string, aroundRadius?: number, from?: string, to?: string, options?: any): Promise<MovieCalendarResponse> {
+      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1MovieCalendarMe(latitude, longitude, allocineId, visa, aroundRadius, from, to, options)
+      const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
+      return handleGeneratedApiResponse(response, options)
+    },
     /**
      *
      * @summary google_oauth_state <GET>
@@ -9324,6 +9420,24 @@ export class DefaultApi extends BaseAPI {
   public async getNativeV1MovieCalendar(latitude: number, longitude: number, allocineId?: string, visa?: string, aroundRadius?: number, from?: string, to?: string, options?: any) {
     const configuration = this.getConfiguration()
     return DefaultApiFp(this, configuration).getNativeV1MovieCalendar(latitude, longitude, allocineId, visa, aroundRadius, from, to, options)
+  }
+  /**
+    * 
+    * @summary get_movie_screenings_for_user <GET>
+    * @param {number} latitude 
+    * @param {number} longitude 
+    * @param {Allocineid1} [allocineId] 
+    * @param {Visa1} [visa] 
+    * @param {number} [aroundRadius] 
+    * @param {string} [from] 
+    * @param {string} [to] 
+    * @param {*} [options] Override http request option.
+    * @throws {RequiredError}
+    * @memberof DefaultApi
+    */
+  public async getNativeV1MovieCalendarMe(latitude: number, longitude: number, allocineId?: string, visa?: string, aroundRadius?: number, from?: string, to?: string, options?: any) {
+    const configuration = this.getConfiguration()
+    return DefaultApiFp(this, configuration).getNativeV1MovieCalendarMe(latitude, longitude, allocineId, visa, aroundRadius, from, to, options)
   }
   /**
     *

--- a/src/features/bookOffer/components/AlreadyBooked.native.test.tsx
+++ b/src/features/bookOffer/components/AlreadyBooked.native.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { OfferResponse } from 'api/gen'
 import { initialBookingState, Step } from 'features/bookOffer/context/reducer'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
@@ -55,5 +54,5 @@ describe('<AlreadyBooked />', () => {
 })
 
 const renderAlreadyBookedModal = () => {
-  render(<AlreadyBooked offer={{ name: 'hello' } as OfferResponse} />)
+  render(<AlreadyBooked offerName="hello" />)
 }

--- a/src/features/bookOffer/components/AlreadyBooked.tsx
+++ b/src/features/bookOffer/components/AlreadyBooked.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
-import { OfferResponse } from 'api/gen'
 import { Step } from 'features/bookOffer/context/reducer'
 import { useBookingContext } from 'features/bookOffer/context/useBookingContext'
 import { env } from 'libs/environment/env'
@@ -11,7 +10,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Typo } from 'ui/theme'
 
-export function AlreadyBooked({ offer }: { offer: OfferResponse }) {
+export function AlreadyBooked({ offerName }: { offerName: string }) {
   const { bookingState, dismissModal, dispatch } = useBookingContext()
   const { designSystem } = useTheme()
   // Change step to confirmation
@@ -25,7 +24,7 @@ export function AlreadyBooked({ offer }: { offer: OfferResponse }) {
     <Container>
       <StyledBody>Tu as déjà réservé&nbsp;:</StyledBody>
       <StyledViewGap gap={designSystem.size.spacing.xs}>
-        <Bold>{offer.name}</Bold>
+        <Bold>{offerName}</Bold>
         <StyledBody>
           Tu ne peux donc pas réserver cette offre à nouveau. Pour en savoir plus, n’hésite pas à
           consulter notre article.

--- a/src/features/bookOffer/components/BookingOfferModalFooter.tsx
+++ b/src/features/bookOffer/components/BookingOfferModalFooter.tsx
@@ -35,7 +35,7 @@ export const BookingOfferModalFooter = ({ hasPricesStep, isDuo }: BookingOptions
     handleBookingSteps(step, dispatch, { isDuo, hasPricesStep })
   }, [dispatch, hasPricesStep, isDuo, step])
 
-  return step == Step.CONFIRMATION ? null : (
+  return step === Step.CONFIRMATION ? null : (
     <FooterContainer testID="bookingOfferModalFooter">
       <Button
         wording={getButtonWording(bookingState.step)}

--- a/src/features/bookOffer/helpers/useModalContent.tsx
+++ b/src/features/bookOffer/helpers/useModalContent.tsx
@@ -34,7 +34,7 @@ const getDefaultModalContent = (): ModalContent => {
 
 const getEndedUseBookingModalContent = (offer: OfferResponse): ModalContent => {
   return {
-    children: <AlreadyBooked offer={offer} />,
+    children: <AlreadyBooked offerName={offer.name} />,
     title: 'Réservation impossible',
     leftIconAccessibilityLabel: undefined,
     leftIcon: undefined,

--- a/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
@@ -465,6 +465,14 @@ describe('<BookingOfferModalComponent />', () => {
       }
 
       it('should update bookingState when bookingDataMovieScreening props is received', async () => {
+        mockUseBookingContext.mockReturnValueOnce({
+          bookingState: {
+            offerId: mockOffer.id,
+            step: Step.DATE,
+          } as BookingState,
+          dismissModal: mockDismissModal,
+          dispatch: mockDispatch,
+        })
         renderBookingOfferModal({ bookingDataMovieScreening })
 
         expect(mockDispatch).toHaveBeenNthCalledWith(2, {

--- a/src/features/bookOffer/pages/BookingOfferModal.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.tsx
@@ -152,6 +152,13 @@ export const BookingOfferModalComponent: React.FC<BookingOfferModalComponentProp
   } as ModalLeftIconProps
 
   useEffect(() => {
+    // In case the context's state is CONFIRMATION we don't need to switch back to DUO state.
+    // Probably when the component is used through useBookOfferModal hook bookingDataMovieScreening's
+    // value is not set at first render. But when used through BookOfferModal
+    // its value is already set at first component's render
+    if (step === Step.CONFIRMATION) {
+      return
+    }
     dispatch({ type: 'SET_OFFER_ID', payload: offerId })
     if (!bookingDataMovieScreening) {
       return
@@ -162,7 +169,7 @@ export const BookingOfferModalComponent: React.FC<BookingOfferModalComponentProp
     })
     dispatch({ type: 'CHANGE_STEP', payload: Step.DUO })
     dispatch({ type: 'SELECT_STOCK', payload: bookingDataMovieScreening.stockId })
-  }, [offerId, dispatch, bookingDataMovieScreening])
+  }, [offerId, dispatch, bookingDataMovieScreening, step])
 
   const {
     visible: qualtricsSurveyModalVisible,

--- a/src/features/offer/components/OfferEventCardList/OfferEventCardListV2.test.tsx
+++ b/src/features/offer/components/OfferEventCardList/OfferEventCardListV2.test.tsx
@@ -1,0 +1,143 @@
+import { Bookability, Screening } from 'api/gen'
+import { EventCardSubtitleEnum } from 'features/offer/components/MovieScreeningCalendar/enums'
+import {
+  getEventCardIsEnabled,
+  getEventCardLeftSubtitle,
+  getEventCardRightSubtitle,
+} from 'features/offer/components/OfferEventCardList/OfferEventCardListV2'
+import { Currency } from 'shared/currency/useGetCurrencyToDisplay'
+import { DEFAULT_PACIFIC_FRANC_TO_EURO_RATE } from 'shared/exchangeRates/defaultRateValues'
+
+jest.mock('features/offer/components/MovieScreeningCalendar/useMovieScreeningCalendar')
+jest.mock('features/offer/components/MovieScreeningCalendar/useSelectedDateScreenings')
+jest.mock('features/offer/components/OfferCTAButton/useOfferCTAButton')
+jest.mock('libs/subcategories')
+jest.mock('libs/firebase/analytics/analytics')
+
+describe('OfferEventCardListV2', () => {
+  it.each`
+    bookability                                          | expectedIsEnabled | status
+    ${Bookability.BOOKABLE}                              | ${true}           | ${'enabled'}
+    ${Bookability.AUTHENTICATION_REQUIRED}               | ${true}           | ${'enabled'}
+    ${Bookability.FINISH_SUBSCRIPTION_REQUIRED}          | ${true}           | ${'enabled'}
+    ${Bookability.USER_APPLICATION_STILL_PROCESSING}     | ${true}           | ${'enabled'}
+    ${Bookability.USER_HAS_APPLICATION_ERROR}            | ${true}           | ${'enabled'}
+    ${Bookability.STOCK_BOOKING_IS_DISABLED}             | ${false}          | ${'disabled'}
+    ${Bookability.STOCK_IS_SOLD_OUT}                     | ${false}          | ${'disabled'}
+    ${Bookability.USER_CANNOT_BOOK}                      | ${false}          | ${'disabled'}
+    ${Bookability.USER_HAS_ALREADY_BOOKED_OFFER}         | ${false}          | ${'disabled'}
+    ${Bookability.USER_HAS_ALREADY_BOOKED_RELATED_OFFER} | ${false}          | ${'disabled'}
+    ${Bookability.USER_HAS_INSUFFICIENT_CREDIT}          | ${false}          | ${'disabled'}
+  `(
+    'should display a $status event card for "$bookability" bookability',
+    ({ bookability, expectedIsEnabled }) => {
+      const beginningDatetime = new Date().toISOString()
+      const screening = {
+        beginningDatetime: beginningDatetime,
+        bookability: bookability,
+        features: [],
+        price: 5,
+        stockId: 1,
+      } as Screening
+      const eventCardIsEnabled = getEventCardIsEnabled(screening)
+
+      expect(eventCardIsEnabled).toEqual(expectedIsEnabled)
+    }
+  )
+
+  it.each`
+    bookability                                  | expectedText
+    ${Bookability.STOCK_BOOKING_IS_DISABLED}     | ${EventCardSubtitleEnum.UNAVAILABLE}
+    ${Bookability.STOCK_IS_SOLD_OUT}             | ${EventCardSubtitleEnum.FULLY_BOOKED}
+    ${Bookability.USER_HAS_ALREADY_BOOKED_OFFER} | ${EventCardSubtitleEnum.ALREADY_BOOKED}
+    ${Bookability.USER_HAS_INSUFFICIENT_CREDIT}  | ${EventCardSubtitleEnum.NOT_ENOUGH_CREDIT}
+    ${Bookability.USER_CANNOT_BOOK}              | ${EventCardSubtitleEnum.UNAVAILABLE}
+  `(
+    'should display "$expectedText" as event card left subtitle for "$bookability" bookability',
+    ({ bookability, expectedText }) => {
+      const screening = {
+        beginningDatetime: new Date().toISOString(),
+        bookability: bookability,
+        features: [],
+        price: 5,
+        stockId: 1,
+      }
+      const eventCardLeftSubtitle = getEventCardLeftSubtitle(screening)
+
+      expect(eventCardLeftSubtitle).toEqual(expectedText)
+    }
+  )
+
+  it.each`
+    bookability
+    ${Bookability.USER_HAS_ALREADY_BOOKED_RELATED_OFFER}
+    ${Bookability.FINISH_SUBSCRIPTION_REQUIRED}
+    ${Bookability.USER_APPLICATION_STILL_PROCESSING}
+    ${Bookability.USER_HAS_APPLICATION_ERROR}
+    ${Bookability.AUTHENTICATION_REQUIRED}
+    ${Bookability.BOOKABLE}
+  `(
+    'should display features as event card left subtitle for "$bookability" bookability',
+    ({ bookability }) => {
+      const screening = {
+        beginningDatetime: new Date().toISOString(),
+        bookability: bookability,
+        features: ['FR', 'ICE'],
+        price: 5,
+        stockId: 1,
+      }
+      const eventCardLeftSubtitle = getEventCardLeftSubtitle(screening)
+
+      expect(eventCardLeftSubtitle).toEqual('FR, ICE')
+    }
+  )
+
+  it.each`
+    bookability
+    ${Bookability.AUTHENTICATION_REQUIRED}
+    ${Bookability.BOOKABLE}
+    ${Bookability.USER_HAS_ALREADY_BOOKED_RELATED_OFFER}
+  `('should display price as event card right subtitle for $bookability', ({ bookability }) => {
+    const screening = {
+      beginningDatetime: new Date().toISOString(),
+      bookability: bookability,
+      features: ['FR', 'ICE'],
+      price: 5,
+      stockId: 1,
+    }
+    const eventCardRightSubtitle = getEventCardRightSubtitle(
+      screening,
+      Currency.EURO,
+      DEFAULT_PACIFIC_FRANC_TO_EURO_RATE
+    )
+
+    expect(eventCardRightSubtitle).toEqual('5\u00a0€')
+  })
+
+  it.each`
+    bookability
+    ${Bookability.FINISH_SUBSCRIPTION_REQUIRED}
+    ${Bookability.STOCK_BOOKING_IS_DISABLED}
+    ${Bookability.STOCK_IS_SOLD_OUT}
+    ${Bookability.USER_APPLICATION_STILL_PROCESSING}
+    ${Bookability.USER_CANNOT_BOOK}
+    ${Bookability.USER_HAS_ALREADY_BOOKED_OFFER}
+    ${Bookability.USER_HAS_APPLICATION_ERROR}
+    ${Bookability.USER_HAS_INSUFFICIENT_CREDIT}
+  `('should display empty event card right subtitle for $bookability', ({ bookability }) => {
+    const screening = {
+      beginningDatetime: new Date().toISOString(),
+      bookability: bookability,
+      features: ['FR', 'ICE'],
+      price: 5,
+      stockId: 1,
+    }
+    const eventCardRightSubtitle = getEventCardRightSubtitle(
+      screening,
+      Currency.EURO,
+      DEFAULT_PACIFIC_FRANC_TO_EURO_RATE
+    )
+
+    expect(eventCardRightSubtitle).toEqual('')
+  })
+})

--- a/src/features/offer/components/OfferEventCardList/OfferEventCardListV2.tsx
+++ b/src/features/offer/components/OfferEventCardList/OfferEventCardListV2.tsx
@@ -3,6 +3,7 @@ import { View } from 'react-native'
 
 import { Bookability, Screening, VenueScreenings } from 'api/gen'
 import { formatHour } from 'features/bookOffer/helpers/utils'
+import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { EventCardSubtitleEnum } from 'features/offer/components/MovieScreeningCalendar/enums'
 import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
 import { formatCurrencyFromCents } from 'shared/currency/formatCurrencyFromCents'
@@ -17,7 +18,7 @@ type Props = {
   offerId: number
 }
 
-const getEventCardLeftSubtitle = (screening: Screening) => {
+export const getEventCardLeftSubtitle = (screening: Screening) => {
   switch (screening.bookability) {
     case Bookability.STOCK_BOOKING_IS_DISABLED:
       return EventCardSubtitleEnum.UNAVAILABLE
@@ -29,9 +30,41 @@ const getEventCardLeftSubtitle = (screening: Screening) => {
       return EventCardSubtitleEnum.NOT_ENOUGH_CREDIT
     case Bookability.USER_CANNOT_BOOK:
       return EventCardSubtitleEnum.UNAVAILABLE
+    case Bookability.USER_HAS_ALREADY_BOOKED_RELATED_OFFER:
+    case Bookability.FINISH_SUBSCRIPTION_REQUIRED:
+    case Bookability.USER_APPLICATION_STILL_PROCESSING:
+    case Bookability.USER_HAS_APPLICATION_ERROR:
     case Bookability.AUTHENTICATION_REQUIRED:
     case Bookability.BOOKABLE:
       return screening.features.join(', ')
+  }
+}
+
+export const getEventCardRightSubtitle = (
+  screening: Screening,
+  currency,
+  euroToPacificFrancRate
+) => {
+  switch (screening.bookability) {
+    case Bookability.AUTHENTICATION_REQUIRED:
+    case Bookability.BOOKABLE:
+    case Bookability.USER_HAS_ALREADY_BOOKED_RELATED_OFFER:
+      return formatCurrencyFromCents(screening.price * 100, currency, euroToPacificFrancRate)
+    default:
+      return ''
+  }
+}
+
+export const getEventCardIsEnabled = (screening: Screening) => {
+  switch (screening.bookability) {
+    case Bookability.BOOKABLE:
+    case Bookability.AUTHENTICATION_REQUIRED:
+    case Bookability.FINISH_SUBSCRIPTION_REQUIRED:
+    case Bookability.USER_APPLICATION_STILL_PROCESSING:
+    case Bookability.USER_HAS_APPLICATION_ERROR:
+      return true
+    default:
+      return false
   }
 }
 
@@ -48,16 +81,10 @@ export const OfferEventCardListV2: FC<Props> = ({ venueScreenings, offerId }) =>
           setSelectedScreening(screening)
           modalSettings.showModal()
         },
-        isDisabled: ![Bookability.AUTHENTICATION_REQUIRED, Bookability.BOOKABLE].includes(
-          screening.bookability
-        ),
+        isDisabled: !getEventCardIsEnabled(screening),
         title: formatHour(screening.beginningDatetime).replace(':', 'h'),
         subtitleLeft: getEventCardLeftSubtitle(screening),
-        subtitleRight: [Bookability.AUTHENTICATION_REQUIRED, Bookability.BOOKABLE].includes(
-          screening.bookability
-        )
-          ? formatCurrencyFromCents(screening.price * 100, currency, euroToPacificFrancRate)
-          : '',
+        subtitleRight: getEventCardRightSubtitle(screening, currency, euroToPacificFrancRate),
       }) as EventCardProps,
     [currency, euroToPacificFrancRate, modalSettings]
   )
@@ -71,7 +98,8 @@ export const OfferEventCardListV2: FC<Props> = ({ venueScreenings, offerId }) =>
         <BookOfferModal
           screening={selectedScreening}
           offerId={offerId}
-          modalSettings={modalSettings}></BookOfferModal>
+          modalSettings={modalSettings}
+          from={StepperOrigin.OFFER}></BookOfferModal>
       ) : null}
     </View>
   )

--- a/src/features/offer/components/OfferPlace/OfferPlace.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.tsx
@@ -4,7 +4,6 @@ import React, { FC, ReactNode } from 'react'
 import { useTheme } from 'styled-components/native'
 
 import { Activity, OfferResponse, SubcategoryIdEnum, VenueResponse } from 'api/gen'
-import { useAuthContext } from 'features/auth/context/AuthContext'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
 import { OfferCineBlock } from 'features/offer/components/OfferCine/OfferCineBlock'
 import { OfferCineBlockV2 } from 'features/offer/components/OfferCine/OfferCineBlockV2'
@@ -56,7 +55,6 @@ export const OfferPlace: FC<OfferPlaceProps> = ({
   proAdvicesOnVenueSegment,
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
-  const { user } = useAuthContext()
   const queryClient = useQueryClient()
   const wipUseMovieScreeningEndpoint = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_USE_MOVIE_SCREENINGS_ENDPOINT
@@ -82,7 +80,7 @@ export const OfferPlace: FC<OfferPlaceProps> = ({
   const { coordinates } = offerVenue
   const { latitude: offerVenueLatitude, longitude: offerVenueLongitude } = coordinates
   const offerCineBlock =
-    wipUseMovieScreeningEndpoint && (!!allocineId || !!visa) && !user ? (
+    wipUseMovieScreeningEndpoint && (!!allocineId || !!visa) ? (
       <OfferCineBlockV2
         title={venueSectionTitle}
         offerId={offerId}

--- a/src/features/offer/queries/useMovieCalendarQuery.ts
+++ b/src/features/offer/queries/useMovieCalendarQuery.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import { api } from 'api/api'
 import { MovieCalendarResponse } from 'api/gen'
+import { useAuthContext } from 'features/auth/context/AuthContext'
 import { OfferNotFound } from 'features/offer/pages/OfferNotFound/OfferNotFound'
 import { useLogTypeFromRemoteConfig } from 'libs/hooks/useLogTypeFromRemoteConfig'
 import { locationStore } from 'libs/locationV2/location.store'
@@ -26,6 +27,7 @@ export const useOfferMovieCalendarQuery = <TData = MovieCalendarResponse>(
   }
 ) => {
   const userLocation = locationStore.hooks.useUserLocation()
+  const { user, isLoggedIn } = useAuthContext()
   const longitude = userLocation?.longitude ?? offerVenueLongitude ?? 0
   const latitude = userLocation?.latitude ?? offerVenueLatitude ?? 0
   const radius = DEFAULT_RADIUS_KM * 1000
@@ -39,15 +41,21 @@ export const useOfferMovieCalendarQuery = <TData = MovieCalendarResponse>(
           logType,
         })
       }
-      return api.getNativeV1MovieCalendar(
-        latitude,
-        longitude,
-        allocineId ?? undefined,
-        allocineId ? undefined : (visa ?? undefined),
-        radius
-      )
+      const allocineIdParam = allocineId ?? undefined
+      const visaParam = allocineId ? undefined : (visa ?? undefined)
+      return isLoggedIn
+        ? api.getNativeV1MovieCalendarMe(latitude, longitude, allocineIdParam, visaParam, radius)
+        : api.getNativeV1MovieCalendar(latitude, longitude, allocineIdParam, visaParam, radius)
     },
-    queryKey: [QueryKeys.OFFER_MOVIE_CALENDAR, latitude, longitude, allocineId, visa, radius],
+    queryKey: [
+      QueryKeys.OFFER_MOVIE_CALENDAR,
+      user?.id,
+      latitude,
+      longitude,
+      allocineId,
+      visa,
+      radius,
+    ],
     select: options?.select,
     enabled: options?.enabled,
   })

--- a/src/shared/offer/components/BookOfferModal/BookOfferModal.tsx
+++ b/src/shared/offer/components/BookOfferModal/BookOfferModal.tsx
@@ -1,27 +1,81 @@
 import React from 'react'
 
 import { Bookability, Screening } from 'api/gen'
+import { BookingOfferModal } from 'features/bookOffer/pages/BookingOfferModal'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
+import { MovieScreeningBookingData } from 'features/offer/components/MovieScreeningCalendar/types'
+import { ApplicationProcessingModal } from 'shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal'
 import { AuthenticationModal } from 'shared/offer/components/AuthenticationModal/AuthenticationModal'
+import { ErrorApplicationModal } from 'shared/offer/components/ErrorApplicationModal/ErrorApplicationModal'
+import { FinishSubscriptionModal } from 'shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal'
 import { ModalSettings } from 'ui/components/modals/useModal'
 
 type BookOfferModalProps = {
   screening?: Screening
   offerId: number
   modalSettings: ModalSettings
+  from: StepperOrigin
 }
 
-export const BookOfferModal = ({ screening, offerId, modalSettings }: BookOfferModalProps) => {
-  if (screening?.bookability === Bookability.AUTHENTICATION_REQUIRED) {
-    return (
-      <AuthenticationModal
-        visible={modalSettings.visible}
-        hideModal={modalSettings.hideModal}
-        offerId={offerId}
-        from={StepperOrigin.BOOKING}
-      />
-    )
-  } else {
-    return null
+const screeningToBookingData = (screening: Screening): MovieScreeningBookingData => {
+  const screeningDate = new Date(screening.beginningDatetime)
+  return {
+    stockId: screening.stockId,
+    date: screeningDate,
+    hour: screeningDate.getHours(),
+  } as MovieScreeningBookingData
+}
+
+export const BookOfferModal = ({
+  screening,
+  offerId,
+  modalSettings,
+  from,
+}: BookOfferModalProps) => {
+  switch (screening?.bookability) {
+    case Bookability.AUTHENTICATION_REQUIRED:
+      return (
+        <AuthenticationModal
+          visible={modalSettings.visible}
+          hideModal={modalSettings.hideModal}
+          offerId={offerId}
+          from={from}
+        />
+      )
+    case Bookability.BOOKABLE:
+      return (
+        <BookingOfferModal
+          visible={modalSettings.visible}
+          dismissModal={modalSettings.hideModal}
+          offerId={offerId}
+          bookingDataMovieScreening={screeningToBookingData(screening)}
+        />
+      )
+    case Bookability.USER_APPLICATION_STILL_PROCESSING:
+      return (
+        <ApplicationProcessingModal
+          visible={modalSettings.visible}
+          hideModal={modalSettings.hideModal}
+          offerId={offerId}
+        />
+      )
+    case Bookability.FINISH_SUBSCRIPTION_REQUIRED:
+      return (
+        <FinishSubscriptionModal
+          visible={modalSettings.visible}
+          hideModal={modalSettings.hideModal}
+          from={StepperOrigin.OFFER}
+        />
+      )
+    case Bookability.USER_HAS_APPLICATION_ERROR:
+      return (
+        <ErrorApplicationModal
+          visible={modalSettings.visible}
+          hideModal={modalSettings.hideModal}
+          offerId={offerId}
+        />
+      )
+    default:
+      return null
   }
 }


### PR DESCRIPTION

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41148

depends on https://github.com/pass-culture/pass-culture-main/pull/23692

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
