### PR TITLE
(PC-43041) fix(ui): display correctly GenericInfoPage on web mobile

### DIFF
--- a/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<AccountCreated /> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
@@ -216,24 +216,16 @@ exports[`QuitSignupModal should render correctly 1`] = `
               }
             />
             <View
-              flexValue={1}
               style={
                 {
-                  "flexBasis": 0,
-                  "flexGrow": 1,
-                  "flexShrink": 1,
                   "justifyContent": "space-between",
                 }
               }
             >
               <View
-                flexValue={1}
                 marginVertical={0}
                 style={
                   {
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "flexShrink": 1,
                     "justifyContent": "center",
                     "marginTop": 8,
                     "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`CulturalSurveyIntro page should render the page with correct layout and
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
@@ -217,24 +217,16 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
               }
             />
             <View
-              flexValue={1}
               style={
                 {
-                  "flexBasis": 0,
-                  "flexGrow": 1,
-                  "flexShrink": 1,
                   "justifyContent": "space-between",
                 }
               }
             >
               <View
-                flexValue={1}
                 marginVertical={0}
                 style={
                   {
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "flexShrink": 1,
                     "justifyContent": "center",
                     "marginTop": 8,
                     "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<DisableActivation/> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -515,24 +507,16 @@ exports[`<DisableActivation/> with RemoteActivationBanner informations should re
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`BeneficiaryAccountCreated should render correctly for 18 year-old benef
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -549,24 +541,16 @@ exports[`BeneficiaryAccountCreated should render correctly for underage benefici
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/confirmation/FreeBeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/FreeBeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`FreeBeneficiaryAccountCreated should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
@@ -192,24 +192,16 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -843,24 +835,16 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`NotEligibleEduConnect should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
@@ -192,24 +192,16 @@ exports[`ComeBackLater should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
@@ -192,24 +192,16 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<SetProfileBookingError/> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
@@ -119,24 +119,16 @@ exports[`<PageNotFound/> should render correctly 1`] = `
           }
         />
         <View
-          flexValue={1}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "space-between",
             }
           }
         >
           <View
-            flexValue={1}
             marginVertical={0}
             style={
               {
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "justifyContent": "center",
                 "marginTop": 8,
                 "marginVertical": 0,

--- a/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
@@ -192,24 +192,16 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
@@ -192,24 +192,16 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -543,24 +535,16 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
@@ -192,24 +192,16 @@ exports[`ConfirmDeleteProfile should render confirm delete profile 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`DeactivateProfileSuccess should render deactivate profile success 1`] =
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
@@ -192,24 +192,16 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
@@ -192,24 +192,16 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
@@ -192,24 +192,16 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
@@ -192,24 +192,16 @@ exports[`DeleteProfileContactSupport should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
@@ -192,24 +192,16 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`DeleteProfileSuccess should render delete profile success 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
@@ -185,24 +185,16 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<MandatoryUpdatePersonalData /> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<UpdatePersonalDataConfirmation /> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -782,24 +774,16 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -1356,24 +1340,16 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -192,24 +192,16 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
@@ -106,24 +106,16 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
@@ -271,24 +271,16 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
         }
       />
       <View
-        flexValue={1}
         style={
           {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
-          flexValue={1}
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/jest/jest.setup.ts
+++ b/jest/jest.setup.ts
@@ -44,7 +44,6 @@ jest.mock('shared/accessibility/helpers/zoomHelpers', () => ({
     title: titleDefaultValue,
     subtitle: subtitleDefaultValue,
   }),
-  useWebZoomToDisplay: ({ default: at100PercentZoom }) => at100PercentZoom,
   useZoomInPercent: () => 100,
 }))
 

--- a/src/shared/accessibility/helpers/zoomHelpers.ts
+++ b/src/shared/accessibility/helpers/zoomHelpers.ts
@@ -14,11 +14,6 @@ const isWeb = Platform.OS === 'web'
 // that can impact the UI but is still acceptable for most of the users.
 const MOBILE_ZOOM_THRESHOLD = 1.5
 
-// We use 150% as threshold because 200% zoom is quite extreme and
-// would break too much the UI. 150% is already a quite zoomed font size
-// that can impact the UI but is still acceptable for most of the users
-const WEB_ZOOM_THRESHOLD = 150
-
 /* Get device font scale (in order to adapt the display).
  * The value is rounded to 3 decimals to limit rendering variations.
  */
@@ -67,21 +62,6 @@ export const useMobileFontScaleToDisplay = <T>({
 export const useZoomInPercent = () => {
   const metrics = useDeviceMetrics()
   return metrics?.screenZoomLevel ? Math.round(metrics.screenZoomLevel * 100) / 2 : undefined
-}
-
-/**
- * Value hook to get the adapted value according to the web zoom.
- * if the `zoomPercent` is above the threshold (`150`), we consider the display
- * to be heavily zoomed and return the value for 200% zoom,
- *  which is a key value in digital accessibility.
- */
-export const useWebZoomToDisplay = <T>({
-  default: at100PercentZoom,
-  at200PercentZoom,
-}: ZoomedValue<T>): T => {
-  const zoomPercent = useZoomInPercent()
-  const isZoomedWeb = zoomPercent && zoomPercent > WEB_ZOOM_THRESHOLD
-  return isZoomedWeb ? at200PercentZoom : at100PercentZoom
 }
 
 export const useNumberOfLine = (defaultValue: number): number | undefined => {

--- a/src/ui/pages/GenericInfoPage.tsx
+++ b/src/ui/pages/GenericInfoPage.tsx
@@ -132,7 +132,7 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
     at200PercentZoom: 0,
   })
 
-  const flexWeb = useWebZoomToDisplay({ default: 1, at200PercentZoom: undefined })
+  const flexWeb = useWebZoomToDisplay({ default: undefined, at200PercentZoom: undefined })
   const illustrationContent = renderIllustrationContent({
     IllustrationComponent,
     remoteIllustration,

--- a/src/ui/pages/GenericInfoPage.tsx
+++ b/src/ui/pages/GenericInfoPage.tsx
@@ -5,10 +5,7 @@ import styled, { useTheme } from 'styled-components/native'
 
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import {
-  useMobileFontScaleToDisplay,
-  useWebZoomToDisplay,
-} from 'shared/accessibility/helpers/zoomHelpers'
+import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
 import { useGetHeaderHeight } from 'shared/header/useGetHeaderHeight'
 import { useIsLandscape } from 'shared/useIsLandscape/useIsLandscape'
 import type { ColorsType } from 'theme/types'
@@ -132,7 +129,6 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
     at200PercentZoom: 0,
   })
 
-  const flexWeb = useWebZoomToDisplay({ default: undefined, at200PercentZoom: undefined })
   const illustrationContent = renderIllustrationContent({
     IllustrationComponent,
     remoteIllustration,
@@ -148,8 +144,8 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
       <StyledScrollView showsVerticalScrollIndicator={false}>
         {isLandscape ? null : <Placeholder height={placeholderHeight} />}
 
-        <ContainerFlex flexValue={flexWeb}>
-          <ContainerWithCenteredContent marginVertical={marginVertical} flexValue={flexWeb}>
+        <ContainerFlex>
+          <ContainerWithCenteredContent marginVertical={marginVertical}>
             <IllustrationContainer animation={!!animation}>
               {illustrationContent}
               {animation ? (
@@ -228,15 +224,13 @@ const FeatureFlaggedIllustration = ({
   )
 }
 
-const ContainerFlex = styled.View<{ flexValue?: number }>(({ theme, flexValue }) => ({
+const ContainerFlex = styled.View(({ theme }) => ({
   justifyContent: theme.isDesktopViewport ? 'center' : 'space-between',
-  ...(flexValue !== undefined && { flex: flexValue }),
 }))
 
-const ContainerWithCenteredContent = styled.View<{ marginVertical: number; flexValue?: number }>(
-  ({ marginVertical, theme, flexValue }) => ({
+const ContainerWithCenteredContent = styled.View<{ marginVertical: number }>(
+  ({ marginVertical, theme }) => ({
     justifyContent: 'center',
-    ...(flexValue !== undefined && { flex: flexValue }),
     marginVertical,
     marginTop: theme.designSystem.size.spacing.s,
   })

--- a/src/ui/pages/GenericInfoPageIllustration.tsx
+++ b/src/ui/pages/GenericInfoPageIllustration.tsx
@@ -34,6 +34,7 @@ const Container = styled.View<{
   backgroundColor: theme.designSystem.color.illustration[illustrationBackgroundColor],
   borderTopLeftRadius: getSpacing(14),
   borderBottomRightRadius: getSpacing(14),
+  marginTop: theme.designSystem.size.spacing.l,
 }))
 
 const RemoteIllustration = styled(FastImage)({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43041

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 12 19 24" src="https://github.com/user-attachments/assets/6be82520-faa8-46ed-b239-39acace60a39" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 12 24 57" src="https://github.com/user-attachments/assets/834d52c1-0c14-4c07-a91d-c1f22baa49ca" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 12 30 01" src="https://github.com/user-attachments/assets/0c24fe2e-0c82-437e-87de-ccc6ace1c070" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 14 17 26" src="https://github.com/user-attachments/assets/a85975f9-07d8-4c99-be88-3c216ece58f8" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 14 22 55" src="https://github.com/user-attachments/assets/743fc4e8-3a22-4641-a122-e5fe20bdf5d8" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 14 23 36" src="https://github.com/user-attachments/assets/3c2b3ee3-b2b3-42a4-8e07-e08ef6e22966" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 14 27 46" src="https://github.com/user-attachments/assets/30bf30d8-e8d0-4a1a-9dc0-4e2b7286d683" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 12 26 21" src="https://github.com/user-attachments/assets/b48a82e5-e041-4eea-ae8a-7f278208264e" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 12 26 44" src="https://github.com/user-attachments/assets/aebd8ae2-f68c-4f3b-bad5-d5a41836c56b" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 12 28 37" src="https://github.com/user-attachments/assets/cd737cdf-5bd3-4927-9a1a-eaea44ea1373" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 14 19 19" src="https://github.com/user-attachments/assets/5258ca51-8b6c-4aae-b6f5-30030c895038" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 14 20 38" src="https://github.com/user-attachments/assets/78b7f5bb-5a94-43b2-a31e-7896b2a6ab29" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 14 25 21" src="https://github.com/user-attachments/assets/5394a11a-99b7-4329-8228-9ee7e24c6d2a" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 14 26 14" src="https://github.com/user-attachments/assets/469bc031-51a9-4397-9b20-b925adf315d7" />|
| Android          |               |       |
| Phone - Chrome   |<img width="396" height="679" alt="Capture d’écran 2026-07-28 à 12 19 08" src="https://github.com/user-attachments/assets/63417f98-939b-48a3-ab4d-8471f5f30adf" /> <img width="399" height="681" alt="Capture d’écran 2026-07-28 à 15 29 38" src="https://github.com/user-attachments/assets/2405f6e9-f394-4c8a-9a04-9b87667219e2" /> <img width="397" height="685" alt="Capture d’écran 2026-07-28 à 15 41 35" src="https://github.com/user-attachments/assets/43ae8c47-09a4-47b5-b2ac-d9a053422d8b" /> <img width="395" height="686" alt="Capture d’écran 2026-07-28 à 14 16 53" src="https://github.com/user-attachments/assets/c0356c45-b64a-4fe7-9947-5062a92fdbd6" /> <img width="391" height="683" alt="Capture d’écran 2026-07-28 à 14 22 07" src="https://github.com/user-attachments/assets/2b04d314-25cd-4196-b281-356547f450d6" /> <img width="385" height="682" alt="Capture d’écran 2026-07-28 à 14 24 02" src="https://github.com/user-attachments/assets/3e20b53d-b1c4-43ff-a109-77f5a70de1ea" /> <img width="395" height="685" alt="Capture d’écran 2026-07-28 à 14 27 11" src="https://github.com/user-attachments/assets/2222fdfc-8d5b-493f-8138-02d1ca43c078" />|<img width="395" height="694" alt="Capture d’écran 2026-07-28 à 12 27 14" src="https://github.com/user-attachments/assets/c0d3d5e9-6122-4ce7-af1e-f68d37498cda" /> <img width="383" height="680" alt="Capture d’écran 2026-07-28 à 15 28 19" src="https://github.com/user-attachments/assets/7ea90683-a1c3-4455-9df2-e9d4479b0f16" /> <img width="401" height="688" alt="Capture d’écran 2026-07-28 à 12 28 03" src="https://github.com/user-attachments/assets/3ecdcd38-fc23-48d8-b00f-321e9ece3fc3" /> <img width="410" height="687" alt="Capture d’écran 2026-07-28 à 14 18 13" src="https://github.com/user-attachments/assets/cab228c9-2d9b-4ded-8f68-38a3d4890fd8" /> <img width="393" height="688" alt="Capture d’écran 2026-07-28 à 14 21 35" src="https://github.com/user-attachments/assets/6e2109ff-617f-4727-8992-620721b79d5b" /> <img width="398" height="687" alt="Capture d’écran 2026-07-28 à 14 24 38" src="https://github.com/user-attachments/assets/4126e74f-0e87-4687-a581-c03a8dee68b0" /> <img width="406" height="688" alt="Capture d’écran 2026-07-28 à 14 26 44" src="https://github.com/user-attachments/assets/b0503115-0c24-417a-a067-52bd5549e606" />|
| Desktop - Chrome |<img width="1515" height="767" alt="Capture d’écran 2026-07-28 à 12 18 58" src="https://github.com/user-attachments/assets/03775abb-3d3f-4719-84aa-5da322be3775" /> <img width="1507" height="763" alt="Capture d’écran 2026-07-28 à 15 29 48" src="https://github.com/user-attachments/assets/93f13c23-f8a2-498a-ba61-101c88a14d5e" /> <img width="1511" height="767" alt="Capture d’écran 2026-07-28 à 12 29 22" src="https://github.com/user-attachments/assets/bd75f872-b032-4f05-8b10-038eba106461" /> <img width="1510" height="765" alt="Capture d’écran 2026-07-28 à 14 17 03" src="https://github.com/user-attachments/assets/1aaeed39-327a-47c5-b8f3-76ddc1b0fe71" /> <img width="1508" height="766" alt="Capture d’écran 2026-07-28 à 14 22 19" src="https://github.com/user-attachments/assets/a4a29c4f-e3b8-4f4c-8de8-875125d792ad" /> <img width="1509" height="763" alt="Capture d’écran 2026-07-28 à 14 23 53" src="https://github.com/user-attachments/assets/b91bf491-89cb-4d0f-b391-9ec28c806736" /> <img width="1505" height="764" alt="Capture d’écran 2026-07-28 à 14 27 20" src="https://github.com/user-attachments/assets/5fccf8a6-6cb1-49f1-9992-53eb70f90c75" />|<img width="1509" height="763" alt="Capture d’écran 2026-07-28 à 12 27 04" src="https://github.com/user-attachments/assets/c84030f6-3e44-4779-8bd4-8460c02231b3" /> <img width="1504" height="765" alt="Capture d’écran 2026-07-28 à 15 28 04" src="https://github.com/user-attachments/assets/a664ef7c-437c-4dc8-9055-b811d00b9f44" /> <img width="1513" height="764" alt="Capture d’écran 2026-07-28 à 12 28 23" src="https://github.com/user-attachments/assets/fc262ab5-86e7-440e-b0ee-19e8a1df581d" /> <img width="1512" height="762" alt="Capture d’écran 2026-07-28 à 14 17 58" src="https://github.com/user-attachments/assets/780ce93c-01d5-461f-9c85-e093e4afe7e8" /> <img width="1508" height="766" alt="Capture d’écran 2026-07-28 à 14 21 01" src="https://github.com/user-attachments/assets/ae96d268-e6d8-4c53-b288-b1cbac337457" /> <img width="1507" height="762" alt="Capture d’écran 2026-07-28 à 14 24 50" src="https://github.com/user-attachments/assets/bd95ac80-7792-48b7-9383-ffe22845739a" /> <img width="1504" height="764" alt="Capture d’écran 2026-07-28 à 14 26 32" src="https://github.com/user-attachments/assets/8b7b65b4-c908-49d0-842f-7fd54166544c" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
