### PR TITLE
(PC-43050) fix(ui): display correctly GenericInfoPage with or without scroll in all platforms

### DIFF
--- a/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<AccountCreated /> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<AccountCreated /> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<AccountCreated /> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
@@ -219,9 +219,7 @@ exports[`QuitSignupModal should render correctly 1`] = `
               flexValue={1}
               style={
                 {
-                  "flexBasis": 0,
                   "flexGrow": 1,
-                  "flexShrink": 1,
                   "justifyContent": "space-between",
                 }
               }
@@ -231,9 +229,7 @@ exports[`QuitSignupModal should render correctly 1`] = `
                 marginVertical={0}
                 style={
                   {
-                    "flexBasis": 0,
                     "flexGrow": 1,
-                    "flexShrink": 1,
                     "justifyContent": "center",
                     "marginTop": 8,
                     "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
@@ -216,16 +216,24 @@ exports[`QuitSignupModal should render correctly 1`] = `
               }
             />
             <View
+              flexValue={1}
               style={
                 {
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                   "justifyContent": "space-between",
                 }
               }
             >
               <View
+                flexValue={1}
                 marginVertical={0}
                 style={
                   {
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                     "justifyContent": "center",
                     "marginTop": 8,
                     "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`CulturalSurveyIntro page should render the page with correct layout and
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`CulturalSurveyIntro page should render the page with correct layout and
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`CulturalSurveyIntro page should render the page with correct layout and
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
@@ -220,9 +220,7 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
               flexValue={1}
               style={
                 {
-                  "flexBasis": 0,
                   "flexGrow": 1,
-                  "flexShrink": 1,
                   "justifyContent": "space-between",
                 }
               }
@@ -232,9 +230,7 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
                 marginVertical={0}
                 style={
                   {
-                    "flexBasis": 0,
                     "flexGrow": 1,
-                    "flexShrink": 1,
                     "justifyContent": "center",
                     "marginTop": 8,
                     "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
@@ -217,16 +217,24 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
               }
             />
             <View
+              flexValue={1}
               style={
                 {
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                   "justifyContent": "space-between",
                 }
               }
             >
               <View
+                flexValue={1}
                 marginVertical={0}
                 style={
                   {
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                     "justifyContent": "center",
                     "marginTop": 8,
                     "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<DisableActivation/> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -507,16 +515,24 @@ exports[`<DisableActivation/> with RemoteActivationBanner informations should re
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<DisableActivation/> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<DisableActivation/> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -518,9 +514,7 @@ exports[`<DisableActivation/> with RemoteActivationBanner informations should re
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -530,9 +524,7 @@ exports[`<DisableActivation/> with RemoteActivationBanner informations should re
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`BeneficiaryAccountCreated should render correctly for 18 year-old benef
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`BeneficiaryAccountCreated should render correctly for 18 year-old benef
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -552,9 +548,7 @@ exports[`BeneficiaryAccountCreated should render correctly for underage benefici
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -564,9 +558,7 @@ exports[`BeneficiaryAccountCreated should render correctly for underage benefici
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`BeneficiaryAccountCreated should render correctly for 18 year-old benef
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -541,16 +549,24 @@ exports[`BeneficiaryAccountCreated should render correctly for underage benefici
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/confirmation/FreeBeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/FreeBeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`FreeBeneficiaryAccountCreated should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/confirmation/FreeBeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/FreeBeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`FreeBeneficiaryAccountCreated should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`FreeBeneficiaryAccountCreated should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
@@ -192,16 +192,24 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -835,16 +843,24 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
@@ -195,9 +195,7 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -207,9 +205,7 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -846,9 +842,7 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -858,9 +852,7 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`NotEligibleEduConnect should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`NotEligibleEduConnect should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`NotEligibleEduConnect should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
@@ -195,9 +195,7 @@ exports[`ComeBackLater should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -207,9 +205,7 @@ exports[`ComeBackLater should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
@@ -192,16 +192,24 @@ exports[`ComeBackLater should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
@@ -195,9 +195,7 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -207,9 +205,7 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
@@ -192,16 +192,24 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<SetProfileBookingError/> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<SetProfileBookingError/> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<SetProfileBookingError/> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
@@ -122,9 +122,7 @@ exports[`<PageNotFound/> should render correctly 1`] = `
           flexValue={1}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "space-between",
             }
           }
@@ -134,9 +132,7 @@ exports[`<PageNotFound/> should render correctly 1`] = `
             marginVertical={0}
             style={
               {
-                "flexBasis": 0,
                 "flexGrow": 1,
-                "flexShrink": 1,
                 "justifyContent": "center",
                 "marginTop": 8,
                 "marginVertical": 0,

--- a/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
@@ -119,16 +119,24 @@ exports[`<PageNotFound/> should render correctly 1`] = `
           }
         />
         <View
+          flexValue={1}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "space-between",
             }
           }
         >
           <View
+            flexValue={1}
             marginVertical={0}
             style={
               {
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
                 "justifyContent": "center",
                 "marginTop": 8,
                 "marginVertical": 0,

--- a/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
@@ -195,9 +195,7 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -207,9 +205,7 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
@@ -192,16 +192,24 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
@@ -195,9 +195,7 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -207,9 +205,7 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
@@ -192,16 +192,24 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -535,16 +543,24 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -546,9 +542,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -558,9 +552,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
@@ -195,9 +195,7 @@ exports[`ConfirmDeleteProfile should render confirm delete profile 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -207,9 +205,7 @@ exports[`ConfirmDeleteProfile should render confirm delete profile 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
@@ -192,16 +192,24 @@ exports[`ConfirmDeleteProfile should render confirm delete profile 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`DeactivateProfileSuccess should render deactivate profile success 1`] =
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`DeactivateProfileSuccess should render deactivate profile success 1`] =
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`DeactivateProfileSuccess should render deactivate profile success 1`] =
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
@@ -195,9 +195,7 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -207,9 +205,7 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
@@ -192,16 +192,24 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
@@ -192,16 +192,24 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
@@ -195,9 +195,7 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -207,9 +205,7 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
@@ -195,9 +195,7 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -207,9 +205,7 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
@@ -192,16 +192,24 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
@@ -195,9 +195,7 @@ exports[`DeleteProfileContactSupport should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -207,9 +205,7 @@ exports[`DeleteProfileContactSupport should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
@@ -192,16 +192,24 @@ exports[`DeleteProfileContactSupport should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
@@ -192,16 +192,24 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
@@ -195,9 +195,7 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -207,9 +205,7 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`DeleteProfileSuccess should render delete profile success 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`DeleteProfileSuccess should render delete profile success 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`DeleteProfileSuccess should render delete profile success 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
@@ -185,16 +185,24 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
@@ -188,9 +188,7 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -200,9 +198,7 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<MandatoryUpdatePersonalData /> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<MandatoryUpdatePersonalData /> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<MandatoryUpdatePersonalData /> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<UpdatePersonalDataConfirmation /> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<UpdatePersonalDataConfirmation /> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<UpdatePersonalDataConfirmation /> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -785,9 +781,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -797,9 +791,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -1359,9 +1351,7 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -1371,9 +1361,7 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -774,16 +782,24 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,
@@ -1340,16 +1356,24 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -195,9 +195,7 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -207,9 +205,7 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -192,16 +192,24 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
@@ -109,9 +109,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -121,9 +119,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
@@ -106,16 +106,24 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
@@ -271,16 +271,24 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
         }
       />
       <View
+        flexValue={1}
         style={
           {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
       >
         <View
+          flexValue={1}
           marginVertical={0}
           style={
             {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
@@ -274,9 +274,7 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
         flexValue={1}
         style={
           {
-            "flexBasis": 0,
             "flexGrow": 1,
-            "flexShrink": 1,
             "justifyContent": "space-between",
           }
         }
@@ -286,9 +284,7 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
           marginVertical={0}
           style={
             {
-              "flexBasis": 0,
               "flexGrow": 1,
-              "flexShrink": 1,
               "justifyContent": "center",
               "marginTop": 8,
               "marginVertical": 0,

--- a/jest/jest.setup.ts
+++ b/jest/jest.setup.ts
@@ -44,6 +44,7 @@ jest.mock('shared/accessibility/helpers/zoomHelpers', () => ({
     title: titleDefaultValue,
     subtitle: subtitleDefaultValue,
   }),
+  useWebZoomToDisplay: ({ default: at100PercentZoom }) => at100PercentZoom,
   useZoomInPercent: () => 100,
 }))
 

--- a/src/shared/accessibility/helpers/zoomHelpers.ts
+++ b/src/shared/accessibility/helpers/zoomHelpers.ts
@@ -14,6 +14,11 @@ const isWeb = Platform.OS === 'web'
 // that can impact the UI but is still acceptable for most of the users.
 const MOBILE_ZOOM_THRESHOLD = 1.5
 
+// We use 150% as threshold because 200% zoom is quite extreme and
+// would break too much the UI. 150% is already a quite zoomed font size
+// that can impact the UI but is still acceptable for most of the users
+const WEB_ZOOM_THRESHOLD = 150
+
 /* Get device font scale (in order to adapt the display).
  * The value is rounded to 3 decimals to limit rendering variations.
  */
@@ -62,6 +67,21 @@ export const useMobileFontScaleToDisplay = <T>({
 export const useZoomInPercent = () => {
   const metrics = useDeviceMetrics()
   return metrics?.screenZoomLevel ? Math.round(metrics.screenZoomLevel * 100) / 2 : undefined
+}
+
+/**
+ * Value hook to get the adapted value according to the web zoom.
+ * if the `zoomPercent` is above the threshold (`150`), we consider the display
+ * to be heavily zoomed and return the value for 200% zoom,
+ *  which is a key value in digital accessibility.
+ */
+export const useWebZoomToDisplay = <T>({
+  default: at100PercentZoom,
+  at200PercentZoom,
+}: ZoomedValue<T>): T => {
+  const zoomPercent = useZoomInPercent()
+  const isZoomedWeb = zoomPercent && zoomPercent > WEB_ZOOM_THRESHOLD
+  return isZoomedWeb ? at200PercentZoom : at100PercentZoom
 }
 
 export const useNumberOfLine = (defaultValue: number): number | undefined => {

--- a/src/ui/pages/GenericInfoPage.tsx
+++ b/src/ui/pages/GenericInfoPage.tsx
@@ -230,13 +230,13 @@ const FeatureFlaggedIllustration = ({
 
 const ContainerFlex = styled.View<{ flexValue?: number }>(({ theme, flexValue }) => ({
   justifyContent: theme.isDesktopViewport ? 'center' : 'space-between',
-  ...(flexValue !== undefined && { flex: flexValue }),
+  ...(flexValue !== undefined && { flexGrow: flexValue }),
 }))
 
 const ContainerWithCenteredContent = styled.View<{ marginVertical: number; flexValue?: number }>(
   ({ marginVertical, theme, flexValue }) => ({
     justifyContent: 'center',
-    ...(flexValue !== undefined && { flex: flexValue }),
+    ...(flexValue !== undefined && { flexGrow: flexValue }),
     marginVertical,
     marginTop: theme.designSystem.size.spacing.s,
   })

--- a/src/ui/pages/GenericInfoPage.tsx
+++ b/src/ui/pages/GenericInfoPage.tsx
@@ -5,7 +5,10 @@ import styled, { useTheme } from 'styled-components/native'
 
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
+import {
+  useMobileFontScaleToDisplay,
+  useWebZoomToDisplay,
+} from 'shared/accessibility/helpers/zoomHelpers'
 import { useGetHeaderHeight } from 'shared/header/useGetHeaderHeight'
 import { useIsLandscape } from 'shared/useIsLandscape/useIsLandscape'
 import type { ColorsType } from 'theme/types'
@@ -129,6 +132,7 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
     at200PercentZoom: 0,
   })
 
+  const flexWeb = useWebZoomToDisplay({ default: 1, at200PercentZoom: undefined })
   const illustrationContent = renderIllustrationContent({
     IllustrationComponent,
     remoteIllustration,
@@ -144,8 +148,8 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
       <StyledScrollView showsVerticalScrollIndicator={false}>
         {isLandscape ? null : <Placeholder height={placeholderHeight} />}
 
-        <ContainerFlex>
-          <ContainerWithCenteredContent marginVertical={marginVertical}>
+        <ContainerFlex flexValue={flexWeb}>
+          <ContainerWithCenteredContent marginVertical={marginVertical} flexValue={flexWeb}>
             <IllustrationContainer animation={!!animation}>
               {illustrationContent}
               {animation ? (
@@ -224,13 +228,15 @@ const FeatureFlaggedIllustration = ({
   )
 }
 
-const ContainerFlex = styled.View(({ theme }) => ({
+const ContainerFlex = styled.View<{ flexValue?: number }>(({ theme, flexValue }) => ({
   justifyContent: theme.isDesktopViewport ? 'center' : 'space-between',
+  ...(flexValue !== undefined && { flex: flexValue }),
 }))
 
-const ContainerWithCenteredContent = styled.View<{ marginVertical: number }>(
-  ({ marginVertical, theme }) => ({
+const ContainerWithCenteredContent = styled.View<{ marginVertical: number; flexValue?: number }>(
+  ({ marginVertical, theme, flexValue }) => ({
     justifyContent: 'center',
+    ...(flexValue !== undefined && { flex: flexValue }),
     marginVertical,
     marginTop: theme.designSystem.size.spacing.s,
   })

--- a/src/ui/pages/GenericInfoPageIllustration.tsx
+++ b/src/ui/pages/GenericInfoPageIllustration.tsx
@@ -34,6 +34,7 @@ const Container = styled.View<{
   backgroundColor: theme.designSystem.color.illustration[illustrationBackgroundColor],
   borderTopLeftRadius: getSpacing(14),
   borderBottomRightRadius: getSpacing(14),
+  marginTop: theme.designSystem.size.spacing.l,
 }))
 
 const RemoteIllustration = styled(FastImage)({

--- a/src/ui/pages/GenericInfoPageIllustration.tsx
+++ b/src/ui/pages/GenericInfoPageIllustration.tsx
@@ -34,7 +34,6 @@ const Container = styled.View<{
   backgroundColor: theme.designSystem.color.illustration[illustrationBackgroundColor],
   borderTopLeftRadius: getSpacing(14),
   borderBottomRightRadius: getSpacing(14),
-  marginTop: theme.designSystem.size.spacing.l,
 }))
 
 const RemoteIllustration = styled(FastImage)({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43050

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 24 49" src="https://github.com/user-attachments/assets/3b3ee093-a085-41a0-91bd-8daf32346351" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 24 58" src="https://github.com/user-attachments/assets/3b54843e-11b3-409f-b9c5-8fe0859f01c0" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 25 09" src="https://github.com/user-attachments/assets/8961a284-0052-494f-9e9e-d3e8b4a29463" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 25 27" src="https://github.com/user-attachments/assets/9c1f06b4-b45b-4cc7-a4cd-581941975745" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 25 39" src="https://github.com/user-attachments/assets/88d828fe-f92a-4fd4-8493-06da9906e0cd" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 25 54" src="https://github.com/user-attachments/assets/c0dda69c-3b1a-4047-9048-0177b894db4f" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 26 11" src="https://github.com/user-attachments/assets/2059fe53-42dc-4a62-8545-4c37b5bd35ab" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 26 25" src="https://github.com/user-attachments/assets/60dd21c8-d5ea-4e45-aea3-c7f503a956ba" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 26 37" src="https://github.com/user-attachments/assets/0c0cc291-76ce-49ec-8856-6c64583060f2" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 26 51" src="https://github.com/user-attachments/assets/b918fba1-70cd-49f6-8a0a-a4731f7040c9" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 04 02" src="https://github.com/user-attachments/assets/08eba4ce-a971-42f3-87dd-b9f5efd57095" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 04 18" src="https://github.com/user-attachments/assets/06e93329-4426-4d66-b219-143a329c7d1b" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 04 28" src="https://github.com/user-attachments/assets/87b7c756-64a3-4dcb-a88f-583721c84df1" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 05 39" src="https://github.com/user-attachments/assets/b06a8909-aab6-4dba-859c-f2ddf9ba6806" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 05 48" src="https://github.com/user-attachments/assets/e5f9d5d7-d534-4e22-a5f6-3f7448ebe499" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 06 03" src="https://github.com/user-attachments/assets/27c4ea53-108a-458a-89ad-061332b63973" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 06 17" src="https://github.com/user-attachments/assets/c65f6dda-6b4f-4926-8083-88c45312b401" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 06 32" src="https://github.com/user-attachments/assets/c0745608-c6ce-4967-9230-5f114bb773f2" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 06 44" src="https://github.com/user-attachments/assets/0dff2533-7187-4d8b-a46f-1156920351c2" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 12 06 54" src="https://github.com/user-attachments/assets/c55a7854-d0ef-40cc-a008-5d1e60ed79eb" />|
| Android          |               |       |
| Phone - Chrome   |<img width="384" height="681" alt="Capture d’écran 2026-07-29 à 13 54 18" src="https://github.com/user-attachments/assets/a83972d9-3c29-4586-a6a2-ec621a1106b6" /> <img width="383" height="673" alt="Capture d’écran 2026-07-29 à 13 54 34" src="https://github.com/user-attachments/assets/d6f81966-08ad-48d6-9963-ac38d1366022" /> <img width="380" height="674" alt="Capture d’écran 2026-07-29 à 13 54 45" src="https://github.com/user-attachments/assets/4f55026d-ce6a-4e2c-b385-6b9893e97bda" /> <img width="390" height="682" alt="Capture d’écran 2026-07-29 à 13 55 00" src="https://github.com/user-attachments/assets/b816990a-5c28-4f16-b0ef-a61974f2fbef" /> <img width="390" height="680" alt="Capture d’écran 2026-07-29 à 13 55 12" src="https://github.com/user-attachments/assets/c68b99c8-cbad-4171-948f-5e7cbf165bd0" /> <img width="389" height="685" alt="Capture d’écran 2026-07-29 à 13 55 27" src="https://github.com/user-attachments/assets/2f8807cf-9a03-4299-819b-bd55e705a897" /> <img width="388" height="678" alt="Capture d’écran 2026-07-29 à 13 55 45" src="https://github.com/user-attachments/assets/94d2ea93-1d21-4103-bc41-262ca3333d64" /> <img width="385" height="681" alt="Capture d’écran 2026-07-29 à 13 55 59" src="https://github.com/user-attachments/assets/3aede005-56e6-4ee5-94a6-c4247c9374fd" /> <img width="389" height="680" alt="Capture d’écran 2026-07-29 à 13 56 13" src="https://github.com/user-attachments/assets/a3916db3-0de2-4483-aa88-d6d16858a49a" /> <img width="387" height="683" alt="Capture d’écran 2026-07-29 à 13 56 27" src="https://github.com/user-attachments/assets/30454432-a2ac-41f5-93d7-2ef00dadaaa2" />|<img width="385" height="679" alt="Capture d’écran 2026-07-29 à 11 56 35" src="https://github.com/user-attachments/assets/942b4bc1-02fb-4d6b-8653-2f3377c82e88" /> <img width="388" height="676" alt="Capture d’écran 2026-07-29 à 11 56 56" src="https://github.com/user-attachments/assets/c6a16a0a-f26f-4860-9817-8560ed821a5f" /> <img width="389" height="678" alt="Capture d’écran 2026-07-29 à 11 57 08" src="https://github.com/user-attachments/assets/d16bd48c-b452-4227-8212-0991fe931bab" /> <img width="410" height="685" alt="Capture d’écran 2026-07-29 à 11 57 26" src="https://github.com/user-attachments/assets/9dd899dd-bc1a-4a11-8c0c-215ecf513597" /> <img width="397" height="689" alt="Capture d’écran 2026-07-29 à 11 57 43" src="https://github.com/user-attachments/assets/2b26d2da-f7c7-4059-9e3e-4ed66afcdae8" /> <img width="398" height="689" alt="Capture d’écran 2026-07-29 à 11 57 59" src="https://github.com/user-attachments/assets/21881e0c-c6bb-4cf3-8e5d-a65e2801319f" /> <img width="396" height="683" alt="Capture d’écran 2026-07-29 à 11 58 16" src="https://github.com/user-attachments/assets/8c7f7ff1-f08f-42ab-8ddd-d6beed94852d" /> <img width="391" height="686" alt="Capture d’écran 2026-07-29 à 11 58 32" src="https://github.com/user-attachments/assets/6d85379d-8e3a-471b-83f8-a1b44ca308b3" /> <img width="398" height="684" alt="Capture d’écran 2026-07-29 à 11 58 50" src="https://github.com/user-attachments/assets/6a644736-fc31-453f-b3e4-07d5bcb71329" /> <img width="399" height="694" alt="Capture d’écran 2026-07-29 à 11 59 03" src="https://github.com/user-attachments/assets/fc6ae1e9-4e0d-49fa-bb40-9dcdea7afd9c" />|
| Desktop - Chrome |<img width="1508" height="767" alt="Capture d’écran 2026-07-29 à 13 43 33" src="https://github.com/user-attachments/assets/d11ea2bc-8490-469f-b065-3374ccb07d6a" /> <img width="1514" height="764" alt="Capture d’écran 2026-07-29 à 13 43 47" src="https://github.com/user-attachments/assets/bd24b659-e411-476d-8559-a171fa7267e5" /> <img width="1506" height="764" alt="Capture d’écran 2026-07-29 à 13 44 01" src="https://github.com/user-attachments/assets/806982b8-2ea7-43ca-8248-7724aa8caa8c" /> <img width="1509" height="765" alt="Capture d’écran 2026-07-29 à 13 44 18" src="https://github.com/user-attachments/assets/c96d7f50-af31-4ce2-86b6-656f5710b392" /> <img width="1504" height="766" alt="Capture d’écran 2026-07-29 à 13 44 31" src="https://github.com/user-attachments/assets/82c98dab-e6c5-4a4e-a070-2d12d3496182" /> <img width="1512" height="763" alt="Capture d’écran 2026-07-29 à 13 44 46" src="https://github.com/user-attachments/assets/ae98447a-7157-46dd-b9c8-b75817f4ade5" /> <img width="1511" height="763" alt="Capture d’écran 2026-07-29 à 13 44 59" src="https://github.com/user-attachments/assets/489d8014-0a7b-4ca4-820d-7459b85576a0" /> <img width="1509" height="764" alt="Capture d’écran 2026-07-29 à 13 45 10" src="https://github.com/user-attachments/assets/9c45235f-0e30-4a56-9e8d-bffb881e67ac" /> <img width="1498" height="764" alt="Capture d’écran 2026-07-29 à 13 45 32" src="https://github.com/user-attachments/assets/47b95fe2-babe-4eab-8ed6-be9b3e7117d6" /> <img width="1508" height="764" alt="Capture d’écran 2026-07-29 à 13 45 44" src="https://github.com/user-attachments/assets/a2ce6cac-5429-46de-9d8d-910d512471f4" />|<img width="1512" height="762" alt="Capture d’écran 2026-07-29 à 12 00 24" src="https://github.com/user-attachments/assets/c4f8c0bd-662d-41eb-8d62-dbd9f6f8be6a" /> <img width="1508" height="766" alt="Capture d’écran 2026-07-29 à 12 00 37" src="https://github.com/user-attachments/assets/5934caf1-e5da-459d-94a3-69eba2897ab1" /> <img width="1509" height="764" alt="Capture d’écran 2026-07-29 à 12 00 51" src="https://github.com/user-attachments/assets/1735ffa0-c0eb-4246-afd7-b30ee7ef6782" /> <img width="1508" height="763" alt="Capture d’écran 2026-07-29 à 12 01 07" src="https://github.com/user-attachments/assets/ee70c06f-d3fc-4f3e-b76f-cf6d3f3a4d1a" /> <img width="1510" height="763" alt="Capture d’écran 2026-07-29 à 12 01 24" src="https://github.com/user-attachments/assets/93de1c57-c104-4941-aa9f-75c0726fa56d" /> <img width="1507" height="765" alt="Capture d’écran 2026-07-29 à 12 01 42" src="https://github.com/user-attachments/assets/f5347910-b30d-4318-8147-082df6295d51" /> <img width="1509" height="765" alt="Capture d’écran 2026-07-29 à 12 01 56" src="https://github.com/user-attachments/assets/256fe8ee-570f-4601-8e40-5c9b2a66adaf" /> <img width="1503" height="764" alt="Capture d’écran 2026-07-29 à 12 02 12" src="https://github.com/user-attachments/assets/66315fb9-bb02-45a4-9d70-55113d4688d7" /> <img width="1507" height="765" alt="Capture d’écran 2026-07-29 à 12 02 24" src="https://github.com/user-attachments/assets/20df6661-12af-47fb-8766-e6d180ec7077" /> <img width="1505" height="765" alt="Capture d’écran 2026-07-29 à 12 02 39" src="https://github.com/user-attachments/assets/b333b1eb-4f39-4265-b9d1-e3cc952f1c63" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
