### PR TITLE
(PC-43000) feat(a11y): use correct title and tag + (PC-42999)

### DIFF
--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
@@ -1,12 +1,45 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SetBirthday /> no touch device should render correctly 1`] = `
+.c1 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.1875rem;
+  line-height: 1.9rem;
+}
+
+.c2 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 0.875rem;
+  line-height: 1.4rem;
+}
+
+.c11 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 1rem;
+  line-height: 1.375rem;
+}
+
 .c0 {
   width: 100%;
   max-width: 500px;
 }
 
-.c1 {
+.c3 {
   font-family: Montserrat-Medium;
   font-size: 1rem;
   line-height: 1.6rem;
@@ -14,12 +47,12 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
   cursor: pointer;
 }
 
-.c2 {
+.c4 {
   width: 100%;
   position: relative;
 }
 
-.c5 {
+.c7 {
   padding-right: 16px;
   display: flex;
   align-items: center;
@@ -31,7 +64,7 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
   pointer-events: none;
 }
 
-.c3 {
+.c5 {
   font-family: Montserrat-Medium;
   font-size: 1rem;
   line-height: 1.6rem;
@@ -50,12 +83,12 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
   appearance: none;
 }
 
-.c3:focus-visible,
-.c3:active {
+.c5:focus-visible,
+.c5:active {
   border-color: #6123df;
 }
 
-.c6 {
+.c8 {
   font-family: Montserrat-Medium;
   font-size: 1rem;
   line-height: 1.6rem;
@@ -74,12 +107,12 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
   appearance: none;
 }
 
-.c6:focus-visible,
-.c6:active {
+.c8:focus-visible,
+.c8:active {
   border-color: #6123df;
 }
 
-.c7 {
+.c9 {
   font-family: Montserrat-Medium;
   font-size: 1rem;
   line-height: 1.6rem;
@@ -98,16 +131,16 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
   appearance: none;
 }
 
-.c7:focus-visible,
-.c7:active {
+.c9:focus-visible,
+.c9:active {
   border-color: #6123df;
 }
 
-.c4 {
+.c6 {
   font-family: 'Arial',sans-serif;
 }
 
-.c8 {
+.c10 {
   flex-direction: row;
   align-items: center;
   justify-content: center;
@@ -131,7 +164,7 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
   box-sizing: border-box;
 }
 
-.c8:disabled {
+.c10:disabled {
   cursor: initial;
 }
 
@@ -143,10 +176,7 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
       class="c0"
     >
       <h2
-        aria-level="2"
-        class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-19e3y8m r-lineHeight-1w51ilw"
-        dir="ltr"
-        role="heading"
+        class="c1"
       >
         Renseigne ta date de naissance
       </h2>
@@ -174,12 +204,11 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
               class="css-view-175oi2r r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-9aw3ui"
               role="presentation"
             >
-              <div
-                class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1o4mh9l r-lineHeight-kmu5yi"
-                dir="ltr"
+              <p
+                class="c2"
               >
                 Assure-toi que ta date de naissance est exacte. Elle ne pourra plus être modifiée par la suite et nous vérifions tes informations.
-              </div>
+              </p>
             </div>
           </div>
         </div>
@@ -194,236 +223,236 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
               class="css-view-175oi2r r-alignItems-1habvwh r-display-6koalj r-flexDirection-eqz5dr r-gap-1cmwbt1 r-maxWidth-1ik5qf4 r-width-13qz1uu"
             >
               <label
-                class="c1"
+                class="c3"
                 for="testUuidV4"
               >
                 Jour
               </label>
               <div
-                class="c2"
+                class="c4"
               >
                 <select
                   aria-label="Entrée pour le jour de la date de naissance"
-                  class="c3"
+                  class="c5"
                   data-testid="select-Jour"
                   id="testUuidV4"
                 >
                   <option
-                    class="c4"
+                    class="c6"
                     value=""
                   />
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1"
                   >
                     1
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="2"
                   >
                     2
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="3"
                   >
                     3
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="4"
                   >
                     4
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="5"
                   >
                     5
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="6"
                   >
                     6
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="7"
                   >
                     7
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="8"
                   >
                     8
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="9"
                   >
                     9
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="10"
                   >
                     10
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="11"
                   >
                     11
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="12"
                   >
                     12
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="13"
                   >
                     13
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="14"
                   >
                     14
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="15"
                   >
                     15
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="16"
                   >
                     16
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="17"
                   >
                     17
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="18"
                   >
                     18
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="19"
                   >
                     19
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="20"
                   >
                     20
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="21"
                   >
                     21
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="22"
                   >
                     22
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="23"
                   >
                     23
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="24"
                   >
                     24
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="25"
                   >
                     25
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="26"
                   >
                     26
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="27"
                   >
                     27
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="28"
                   >
                     28
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="29"
                   >
                     29
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="30"
                   >
                     30
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="31"
                   >
@@ -431,7 +460,7 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
                   </option>
                 </select>
                 <div
-                  class="c5"
+                  class="c7"
                 >
                   <div
                     class="css-view-175oi2r"
@@ -454,103 +483,103 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
               class="css-view-175oi2r r-alignItems-1habvwh r-display-6koalj r-flexDirection-eqz5dr r-gap-1cmwbt1 r-maxWidth-1ik5qf4 r-width-13qz1uu"
             >
               <label
-                class="c1"
+                class="c3"
                 for="testUuidV4"
               >
                 Mois
               </label>
               <div
-                class="c2"
+                class="c4"
               >
                 <select
                   aria-label="Entrée pour le mois de la date de naissance"
-                  class="c6"
+                  class="c8"
                   data-testid="select-Mois"
                   id="testUuidV4"
                 >
                   <option
-                    class="c4"
+                    class="c6"
                     value=""
                   />
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="Janvier"
                   >
                     Janvier
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="Février"
                   >
                     Février
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="Mars"
                   >
                     Mars
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="Avril"
                   >
                     Avril
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="Mai"
                   >
                     Mai
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="Juin"
                   >
                     Juin
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="Juillet"
                   >
                     Juillet
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="Août"
                   >
                     Août
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="Septembre"
                   >
                     Septembre
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="Octobre"
                   >
                     Octobre
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="Novembre"
                   >
                     Novembre
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="Décembre"
                   >
@@ -558,7 +587,7 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
                   </option>
                 </select>
                 <div
-                  class="c5"
+                  class="c7"
                 >
                   <div
                     class="css-view-175oi2r"
@@ -581,768 +610,768 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
               class="css-view-175oi2r r-alignItems-1habvwh r-display-6koalj r-flexDirection-eqz5dr r-gap-1cmwbt1 r-maxWidth-1ik5qf4 r-width-13qz1uu"
             >
               <label
-                class="c1"
+                class="c3"
                 for="testUuidV4"
               >
                 Année
               </label>
               <div
-                class="c2"
+                class="c4"
               >
                 <select
                   aria-label="Entrée pour l’année de la date de naissance"
-                  class="c7"
+                  class="c9"
                   data-testid="select-Année"
                   id="testUuidV4"
                 >
                   <option
-                    class="c4"
+                    class="c6"
                     value=""
                   />
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="2006"
                   >
                     2006
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="2005"
                   >
                     2005
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="2004"
                   >
                     2004
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="2003"
                   >
                     2003
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="2002"
                   >
                     2002
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="2001"
                   >
                     2001
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="2000"
                   >
                     2000
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1999"
                   >
                     1999
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1998"
                   >
                     1998
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1997"
                   >
                     1997
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1996"
                   >
                     1996
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1995"
                   >
                     1995
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1994"
                   >
                     1994
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1993"
                   >
                     1993
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1992"
                   >
                     1992
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1991"
                   >
                     1991
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1990"
                   >
                     1990
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1989"
                   >
                     1989
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1988"
                   >
                     1988
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1987"
                   >
                     1987
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1986"
                   >
                     1986
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1985"
                   >
                     1985
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1984"
                   >
                     1984
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1983"
                   >
                     1983
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1982"
                   >
                     1982
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1981"
                   >
                     1981
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1980"
                   >
                     1980
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1979"
                   >
                     1979
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1978"
                   >
                     1978
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1977"
                   >
                     1977
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1976"
                   >
                     1976
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1975"
                   >
                     1975
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1974"
                   >
                     1974
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1973"
                   >
                     1973
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1972"
                   >
                     1972
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1971"
                   >
                     1971
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1970"
                   >
                     1970
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1969"
                   >
                     1969
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1968"
                   >
                     1968
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1967"
                   >
                     1967
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1966"
                   >
                     1966
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1965"
                   >
                     1965
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1964"
                   >
                     1964
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1963"
                   >
                     1963
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1962"
                   >
                     1962
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1961"
                   >
                     1961
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1960"
                   >
                     1960
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1959"
                   >
                     1959
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1958"
                   >
                     1958
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1957"
                   >
                     1957
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1956"
                   >
                     1956
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1955"
                   >
                     1955
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1954"
                   >
                     1954
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1953"
                   >
                     1953
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1952"
                   >
                     1952
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1951"
                   >
                     1951
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1950"
                   >
                     1950
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1949"
                   >
                     1949
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1948"
                   >
                     1948
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1947"
                   >
                     1947
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1946"
                   >
                     1946
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1945"
                   >
                     1945
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1944"
                   >
                     1944
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1943"
                   >
                     1943
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1942"
                   >
                     1942
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1941"
                   >
                     1941
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1940"
                   >
                     1940
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1939"
                   >
                     1939
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1938"
                   >
                     1938
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1937"
                   >
                     1937
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1936"
                   >
                     1936
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1935"
                   >
                     1935
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1934"
                   >
                     1934
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1933"
                   >
                     1933
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1932"
                   >
                     1932
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1931"
                   >
                     1931
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1930"
                   >
                     1930
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1929"
                   >
                     1929
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1928"
                   >
                     1928
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1927"
                   >
                     1927
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1926"
                   >
                     1926
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1925"
                   >
                     1925
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1924"
                   >
                     1924
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1923"
                   >
                     1923
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1922"
                   >
                     1922
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1921"
                   >
                     1921
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1920"
                   >
                     1920
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1919"
                   >
                     1919
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1918"
                   >
                     1918
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1917"
                   >
                     1917
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1916"
                   >
                     1916
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1915"
                   >
                     1915
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1914"
                   >
                     1914
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1913"
                   >
                     1913
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1912"
                   >
                     1912
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1911"
                   >
                     1911
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1910"
                   >
                     1910
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1909"
                   >
                     1909
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1908"
                   >
                     1908
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1907"
                   >
                     1907
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1906"
                   >
                     1906
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1905"
                   >
                     1905
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1904"
                   >
                     1904
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1903"
                   >
                     1903
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1902"
                   >
                     1902
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1901"
                   >
                     1901
                   </option>
                   <option
-                    class="c4"
+                    class="c6"
                     data-testid="select-option"
                     value="1900"
                   >
@@ -1350,7 +1379,7 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
                   </option>
                 </select>
                 <div
-                  class="c5"
+                  class="c7"
                 >
                   <div
                     class="css-view-175oi2r"
@@ -1379,7 +1408,7 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
         >
           <button
             aria-label="Continuer"
-            class="c8"
+            class="c10"
             data-testid="Continuer"
             disabled=""
             type="button"
@@ -1387,13 +1416,12 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz r-justifyContent-1777fci r-width-13qz1uu"
             >
-              <div
-                class="css-text-146c3p1 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-7sbvxv"
-                dir="ltr"
-                style="color: rgb(105, 106, 111); max-width: 100%; min-width: 0px; flex-shrink: 1; flex-grow: 1; flex-basis: 0px; text-align: center;"
+              <p
+                class="c11"
+                style="color: rgb(105, 106, 111); max-width: 100%; min-width: 0; flex-shrink: 1; flex-grow: 1; flex-basis: 0px; text-align: center;"
               >
                 Continuer
-              </div>
+              </p>
             </div>
           </button>
         </div>
@@ -1404,12 +1432,56 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
 `;
 
 exports[`<SetBirthday /> touch device should render correctly 1`] = `
+.c1 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.1875rem;
+  line-height: 1.9rem;
+}
+
+.c4 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
+}
+
+.c2 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 0.875rem;
+  line-height: 1.4rem;
+}
+
+.c6 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 1rem;
+  line-height: 1.375rem;
+}
+
 .c0 {
   width: 100%;
   max-width: 500px;
 }
 
-.c1 {
+.c3 {
   font-family: Montserrat-Medium;
   font-size: 1rem;
   line-height: 1.6rem;
@@ -1417,7 +1489,7 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
   cursor: pointer;
 }
 
-.c2 {
+.c5 {
   flex-direction: row;
   align-items: center;
   justify-content: center;
@@ -1441,7 +1513,7 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
   box-sizing: border-box;
 }
 
-.c2:disabled {
+.c5:disabled {
   cursor: initial;
 }
 
@@ -1453,10 +1525,7 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
       class="c0"
     >
       <h2
-        aria-level="2"
-        class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-19e3y8m r-lineHeight-1w51ilw"
-        dir="ltr"
-        role="heading"
+        class="c1"
       >
         Renseigne ta date de naissance
       </h2>
@@ -1484,12 +1553,11 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
               class="css-view-175oi2r r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-9aw3ui"
               role="presentation"
             >
-              <div
-                class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1o4mh9l r-lineHeight-kmu5yi"
-                dir="ltr"
+              <p
+                class="c2"
               >
                 Assure-toi que ta date de naissance est exacte. Elle ne pourra plus être modifiée par la suite et nous vérifions tes informations.
-              </div>
+              </p>
             </div>
           </div>
         </div>
@@ -1501,7 +1569,7 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
             class="css-view-175oi2r r-alignItems-obd0qt r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-width-13qz1uu"
           >
             <label
-              class="c1"
+              class="c3"
               for="testUuidV4"
             >
               Date de naissance
@@ -1511,13 +1579,11 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
             class="css-view-175oi2r r-alignItems-1awozwy r-backgroundColor-14lw9ot r-borderBottomLeftRadius-kj4tcz r-borderBottomRightRadius-wab3e5 r-borderColor-w7parf r-borderStyle-1phboty r-borderTopLeftRadius-wowrgg r-borderTopRightRadius-oho8x9 r-borderWidth-d045u9 r-flexDirection-18u37iz r-height-eu3ka r-paddingBottom-1mdbw0j r-paddingLeft-1937ghh r-paddingRight-145ew9a r-paddingTop-wk8lta r-width-13qz1uu"
             data-testid="styled-input-container"
           >
-            <div
-              class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
-              dir="ltr"
-              id="testUuidV4"
+            <p
+              class="c4"
             >
               1er décembre 2006
-            </div>
+            </p>
           </div>
         </div>
         <div
@@ -2473,7 +2539,7 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
         >
           <button
             aria-label="Continuer"
-            class="c2"
+            class="c5"
             data-testid="Continuer"
             disabled=""
             type="button"
@@ -2481,13 +2547,12 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz r-justifyContent-1777fci r-width-13qz1uu"
             >
-              <div
-                class="css-text-146c3p1 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-7sbvxv"
-                dir="ltr"
-                style="color: rgb(105, 106, 111); max-width: 100%; min-width: 0px; flex-shrink: 1; flex-grow: 1; flex-basis: 0px; text-align: center;"
+              <p
+                class="c6"
+                style="color: rgb(105, 106, 111); max-width: 100%; min-width: 0; flex-shrink: 1; flex-grow: 1; flex-basis: 0px; text-align: center;"
               >
                 Continuer
-              </div>
+              </p>
             </div>
           </button>
         </div>

--- a/__snapshots__/features/errors/pages/AsyncErrorBoundary.web.test.tsx.web-snap
+++ b/__snapshots__/features/errors/pages/AsyncErrorBoundary.web.test.tsx.web-snap
@@ -2,6 +2,39 @@
 
 exports[`AsyncErrorBoundary component should render correctly 1`] = `
 .c2 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.3125rem;
+  line-height: 2.1rem;
+}
+
+.c3 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
+}
+
+.c5 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 1rem;
+  line-height: 1.375rem;
+}
+
+.c4 {
   flex-direction: row;
   align-items: center;
   justify-content: center;
@@ -25,7 +58,7 @@ exports[`AsyncErrorBoundary component should render correctly 1`] = `
   box-sizing: border-box;
 }
 
-.c2:disabled {
+.c4:disabled {
   cursor: initial;
 }
 
@@ -117,18 +150,14 @@ exports[`AsyncErrorBoundary component should render correctly 1`] = `
           class="css-view-175oi2r r-alignItems-1awozwy r-gap-f4gmv6 r-marginBottom-zd98yo"
         >
           <h1
-            aria-level="1"
-            class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-1a2aj48 r-lineHeight-758dxi r-textAlign-q4m81j"
-            dir="ltr"
-            role="heading"
+            class="c2"
+            style="text-align: center;"
           >
             Oups !
           </h1>
           <h2
-            aria-level="2"
-            class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm r-textAlign-q4m81j"
-            dir="ltr"
-            role="heading"
+            class="c3"
+            style="text-align: center;"
           >
             Une erreur s’est produite pendant le chargement.
           </h2>
@@ -138,7 +167,7 @@ exports[`AsyncErrorBoundary component should render correctly 1`] = `
         >
           <button
             aria-label="Réessayer"
-            class="c2"
+            class="c4"
             data-testid="Réessayer"
             tabindex="0"
             type="button"
@@ -146,13 +175,12 @@ exports[`AsyncErrorBoundary component should render correctly 1`] = `
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz r-justifyContent-1777fci r-width-13qz1uu"
             >
-              <div
-                class="css-text-146c3p1 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-7sbvxv"
-                dir="ltr"
-                style="color: rgb(255, 255, 255); max-width: 100%; min-width: 0px; flex-shrink: 1; flex-grow: 1; flex-basis: 0px; text-align: center;"
+              <p
+                class="c5"
+                style="color: rgb(255, 255, 255); max-width: 100%; min-width: 0; flex-shrink: 1; flex-grow: 1; flex-basis: 0px; text-align: center;"
               >
                 Réessayer
-              </div>
+              </p>
             </div>
           </button>
         </div>

--- a/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
@@ -304,10 +304,7 @@ exports[`Stepper navigation should render correctly 1`] = `
                     <View
                       style={
                         {
-                          "flexBasis": 0,
                           "flexDirection": "column",
-                          "flexGrow": 1,
-                          "flexShrink": 1,
                           "paddingRight": 16,
                         }
                       }
@@ -804,10 +801,7 @@ exports[`Stepper navigation should render correctly 1`] = `
                     <View
                       style={
                         {
-                          "flexBasis": 0,
                           "flexDirection": "column",
-                          "flexGrow": 1,
-                          "flexShrink": 1,
                           "paddingRight": 16,
                         }
                       }
@@ -1044,10 +1038,7 @@ exports[`Stepper navigation should render correctly 1`] = `
                     <View
                       style={
                         {
-                          "flexBasis": 0,
                           "flexDirection": "column",
-                          "flexGrow": 1,
-                          "flexShrink": 1,
                           "paddingRight": 16,
                         }
                       }

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -278,7 +278,6 @@ exports[`BeneficiaryAccountCreated should render correctly for 18 year-old benef
                 </View>
               </View>
               <Text
-                accessibilityRole="header"
                 style={
                   {
                     "color": "#6123df",
@@ -717,7 +716,6 @@ exports[`BeneficiaryAccountCreated should render correctly for underage benefici
                 </View>
               </View>
               <Text
-                accessibilityRole="header"
                 style={
                   {
                     "color": "#6123df",

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
@@ -1,6 +1,64 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
+.c1 {
+  display: -webkit-box;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.0625rem;
+  line-height: 1.7rem;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.c3 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
+}
+
+.c2 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 1rem;
+  line-height: 1.6rem;
+}
+
+.c4 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 0.875rem;
+  line-height: 1.4rem;
+}
+
+.c6 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 1rem;
+  line-height: 1.375rem;
+}
+
 .c0 {
   flex-direction: row;
   align-items: center;
@@ -26,7 +84,7 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
   cursor: initial;
 }
 
-.c1 {
+.c5 {
   flex-direction: row;
   align-items: center;
   justify-content: center;
@@ -49,7 +107,7 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
   box-sizing: border-box;
 }
 
-.c1:disabled {
+.c5:disabled {
   cursor: initial;
 }
 
@@ -102,10 +160,8 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
           class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
         >
           <h1
-            aria-level="1"
-            class="css-text-146c3p1 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-1wf0xld r-lineHeight-1ln193j r-textAlign-q4m81j"
-            dir="ltr"
-            role="heading"
+            class="c1"
+            style="text-align: center;"
           >
             Mon identité
           </h1>
@@ -149,18 +205,18 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  class="css-text-146c3p1 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm r-textAlign-q4m81j"
-                  dir="ltr"
+                <p
+                  class="c2"
+                  style="text-align: center; color: rgb(105, 106, 111);"
                 >
                   Identification
-                </div>
-                <div
-                  class="css-text-146c3p1 r-color-v2ubm6 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm r-marginBlock-12kyg2d r-textAlign-q4m81j"
-                  dir="ltr"
+                </p>
+                <p
+                  class="c3"
+                  style="text-align: center; color: rgb(105, 106, 111);"
                 >
                   Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect ! Si tu ne les as pas, contacte ton établissement pour les récupérer.
-                </div>
+                </p>
                 <div
                   class="css-view-175oi2r r-alignItems-1habvwh r-backgroundColor-1k962jn r-borderBottomLeftRadius-5qlx7g r-borderBottomRightRadius-nefvgx r-borderTopLeftRadius-1vznrp2 r-borderTopRightRadius-3f7b68 r-flexDirection-18u37iz r-gap-1ssbvtb r-paddingBottom-1l7z4oj r-paddingLeft-1qhn6m8 r-paddingRight-i023vh r-paddingTop-95jzfe"
                 >
@@ -179,12 +235,11 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
                     class="css-view-175oi2r r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-9aw3ui"
                     role="presentation"
                   >
-                    <div
-                      class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1o4mh9l r-lineHeight-kmu5yi"
-                      dir="ltr"
+                    <p
+                      class="c4"
                     >
                       Un souci pour accéder à la page ? Essaie en navigation privée ou pense bien à accepter les pop-ups de ton navigateur.
-                    </div>
+                    </p>
                   </div>
                 </div>
               </div>
@@ -201,7 +256,7 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
           >
             <button
               aria-label="Ouvrir un onglet ÉduConnect"
-              class="c1"
+              class="c5"
               data-testid="Ouvrir un onglet ÉduConnect"
               tabindex="0"
               type="button"
@@ -224,13 +279,12 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  class="css-text-146c3p1 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-7sbvxv"
-                  dir="ltr"
-                  style="color: rgb(255, 255, 255); max-width: 100%; min-width: 0px; flex-shrink: 1;"
+                <p
+                  class="c6"
+                  style="color: rgb(255, 255, 255); max-width: 100%; min-width: 0; flex-shrink: 1;"
                 >
                   Ouvrir un onglet ÉduConnect
-                </div>
+                </p>
               </div>
             </button>
             <div

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
@@ -1,6 +1,64 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<EduConnectValidation /> should render EduConnectValidation component correctly 1`] = `
+.c2 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.1875rem;
+  line-height: 1.9rem;
+}
+
+.c1 {
+  display: -webkit-box;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.0625rem;
+  line-height: 1.7rem;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.c3 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Medium;
+  font-size: 0.75rem;
+  line-height: 1.2rem;
+}
+
+.c4 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 1rem;
+  line-height: 1.6rem;
+}
+
+.c6 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 1rem;
+  line-height: 1.375rem;
+}
+
 .c0 {
   flex-direction: row;
   align-items: center;
@@ -26,7 +84,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
   cursor: initial;
 }
 
-.c1 {
+.c5 {
   flex-direction: row;
   align-items: center;
   justify-content: center;
@@ -49,7 +107,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
   box-sizing: border-box;
 }
 
-.c1:disabled {
+.c5:disabled {
   cursor: initial;
 }
 
@@ -102,10 +160,8 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
           class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
         >
           <h1
-            aria-level="1"
-            class="css-text-146c3p1 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-1wf0xld r-lineHeight-1ln193j r-textAlign-q4m81j"
-            dir="ltr"
-            role="heading"
+            class="c1"
+            style="text-align: center;"
           >
             Informations personnelles
           </h1>
@@ -135,65 +191,55 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
               <div
                 class="css-view-175oi2r r-gap-16pcm1t"
               >
-                <div
-                  class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-19e3y8m r-lineHeight-1w51ilw"
-                  dir="ltr"
+                <p
+                  class="c2"
                 >
                   Voici les informations que nous avons récupérées. Vérifie qu’elles sont correctes.
-                </div>
+                </p>
                 <div
                   class="css-view-175oi2r r-backgroundColor-14a9t8x r-borderBottomLeftRadius-5qlx7g r-borderBottomRightRadius-nefvgx r-borderTopLeftRadius-1vznrp2 r-borderTopRightRadius-3f7b68 r-gap-1fdih9r r-paddingBlock-nj0m1c r-paddingInline-cxgwc0"
                 >
                   <div
                     class="css-view-175oi2r r-gap-9aw3ui"
                   >
-                    <div
-                      class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-1r11ck1 r-lineHeight-66i6z8"
-                      dir="ltr"
+                    <p
+                      class="c3"
                     >
                       Ton prénom
-                    </div>
-                    <div
-                      class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                      data-testid="validation-first-name"
-                      dir="ltr"
+                    </p>
+                    <p
+                      class="c4"
                     >
                       John
-                    </div>
+                    </p>
                   </div>
                   <div
                     class="css-view-175oi2r r-gap-9aw3ui"
                   >
-                    <div
-                      class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-1r11ck1 r-lineHeight-66i6z8"
-                      dir="ltr"
+                    <p
+                      class="c3"
                     >
                       Ton nom de famille
-                    </div>
-                    <div
-                      class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                      data-testid="validation-name"
-                      dir="ltr"
+                    </p>
+                    <p
+                      class="c4"
                     >
                       Doe
-                    </div>
+                    </p>
                   </div>
                   <div
                     class="css-view-175oi2r r-gap-9aw3ui"
                   >
-                    <div
-                      class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-1r11ck1 r-lineHeight-66i6z8"
-                      dir="ltr"
+                    <p
+                      class="c3"
                     >
                       Ville de résidence
-                    </div>
-                    <div
-                      class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                      data-testid="validation-birth-date"
-                      dir="ltr"
+                    </p>
+                    <p
+                      class="c4"
                     >
                       28/01/1993
-                    </div>
+                    </p>
                   </div>
                 </div>
               </div>
@@ -210,7 +256,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
           >
             <button
               aria-label="Continuer"
-              class="c1"
+              class="c5"
               data-testid="Continuer"
               tabindex="0"
               type="submit"
@@ -218,13 +264,12 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
               <div
                 class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz"
               >
-                <div
-                  class="css-text-146c3p1 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-7sbvxv"
-                  dir="ltr"
-                  style="color: rgb(255, 255, 255); max-width: 100%; min-width: 0px; flex-shrink: 1;"
+                <p
+                  class="c6"
+                  style="color: rgb(255, 255, 255); max-width: 100%; min-width: 0; flex-shrink: 1;"
                 >
                   Continuer
-                </div>
+                </p>
               </div>
             </button>
             <div

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.test.tsx.web-snap
@@ -1,6 +1,42 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SelectPhoneStatus should render correctly 1`] = `
+.c1 {
+  display: -webkit-box;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.0625rem;
+  line-height: 1.7rem;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.c2 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.0625rem;
+  line-height: 1.7rem;
+}
+
+.c3 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
+}
+
 .c0 {
   flex-direction: row;
   align-items: center;
@@ -75,10 +111,8 @@ exports[`SelectPhoneStatus should render correctly 1`] = `
           class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
         >
           <h1
-            aria-level="1"
-            class="css-text-146c3p1 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-1wf0xld r-lineHeight-1ln193j r-textAlign-q4m81j"
-            dir="ltr"
-            role="heading"
+            class="c1"
+            style="text-align: center;"
           >
             Identification
           </h1>
@@ -122,19 +156,17 @@ exports[`SelectPhoneStatus should render correctly 1`] = `
                   class="css-view-175oi2r r-gap-f4gmv6 r-marginBottom-zd98yo r-marginTop-1wzrnnt"
                 >
                   <h2
-                    aria-level="2"
-                    class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-1wf0xld r-lineHeight-1ln193j r-textAlign-q4m81j"
-                    dir="ltr"
-                    role="heading"
+                    class="c2"
+                    style="text-align: center;"
                   >
                     Vérifie ton identité avec un smartphone
                   </h2>
-                  <div
-                    class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm r-textAlign-q4m81j"
-                    dir="ltr"
+                  <p
+                    class="c3"
+                    style="text-align: center;"
                   >
                     Gagne du temps en vérifiant ton identité sur un smartphone ! Tu peux aussi passer par le site demarche.numerique.gouv.fr mais le traitement sera plus long.
-                  </div>
+                  </p>
                 </div>
                 <ul
                   class="css-view-175oi2r r-flexDirection-eqz5dr r-gap-1jnkns4 r-overflow-1dqxon3 r-paddingBottom-iphfwy r-paddingLeft-m2pi6t r-paddingRight-1hvjb8t r-paddingTop-1h8ys4a r-width-13qz1uu"
@@ -175,12 +207,11 @@ exports[`SelectPhoneStatus should render correctly 1`] = `
                           <div
                             class="css-view-175oi2r r-justifyContent-1777fci r-minHeight-mipnz4"
                           >
-                            <div
-                              class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                              dir="ltr"
+                            <p
+                              class="c3"
                             >
                               J’ai un smartphone à proximité
-                            </div>
+                            </p>
                           </div>
                         </div>
                         <div
@@ -237,12 +268,11 @@ exports[`SelectPhoneStatus should render correctly 1`] = `
                           <div
                             class="css-view-175oi2r r-justifyContent-1777fci r-minHeight-mipnz4"
                           >
-                            <div
-                              class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                              dir="ltr"
+                            <p
+                              class="c3"
                             >
                               Je n’ai pas de smartphone à proximité
-                            </div>
+                            </p>
                           </div>
                         </div>
                         <div

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
@@ -442,7 +442,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                                 "flexShrink": 1,
                                 "fontFamily": "Montserrat-SemiBold",
                                 "fontSize": 12,
-                                "lineHeight": 16,
+                                "lineHeight": 19.2,
                               }
                             }
                           >
@@ -472,7 +472,6 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                           </Text>
                         </View>
                         <Text
-                          accessibilityRole="header"
                           style={
                             {
                               "color": "#320096",
@@ -660,7 +659,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                                 "flexShrink": 1,
                                 "fontFamily": "Montserrat-SemiBold",
                                 "fontSize": 12,
-                                "lineHeight": 16,
+                                "lineHeight": 19.2,
                               }
                             }
                           >
@@ -707,7 +706,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                               "color": "#696a6f",
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 10,
-                              "lineHeight": 12,
+                              "lineHeight": 19.2,
                               "marginTop": 4,
                             }
                           }
@@ -1426,7 +1425,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                                 "flexShrink": 1,
                                 "fontFamily": "Montserrat-SemiBold",
                                 "fontSize": 12,
-                                "lineHeight": 16,
+                                "lineHeight": 19.2,
                               }
                             }
                           >
@@ -1641,7 +1640,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                                 "flexShrink": 1,
                                 "fontFamily": "Montserrat-SemiBold",
                                 "fontSize": 12,
-                                "lineHeight": 16,
+                                "lineHeight": 19.2,
                               }
                             }
                           >
@@ -1671,7 +1670,6 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                           </Text>
                         </View>
                         <Text
-                          accessibilityRole="header"
                           style={
                             {
                               "color": "#320096",
@@ -1689,7 +1687,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                               "color": "#696a6f",
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 10,
-                              "lineHeight": 12,
+                              "lineHeight": 19.2,
                               "marginTop": 4,
                             }
                           }

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.native.test.tsx.native-snap
@@ -282,7 +282,6 @@ exports[`OnboardingAgeSelectionFork should render correctly 1`] = `
                     >
                       J’ai 
                       <Text
-                        accessibilityRole="header"
                         style={
                           {
                             "color": "#320096",
@@ -403,7 +402,6 @@ exports[`OnboardingAgeSelectionFork should render correctly 1`] = `
                     >
                       J’ai 
                       <Text
-                        accessibilityRole="header"
                         style={
                           {
                             "color": "#320096",
@@ -523,7 +521,6 @@ exports[`OnboardingAgeSelectionFork should render correctly 1`] = `
                     >
                       J’ai 
                       <Text
-                        accessibilityRole="header"
                         style={
                           {
                             "color": "#320096",
@@ -643,7 +640,6 @@ exports[`OnboardingAgeSelectionFork should render correctly 1`] = `
                     >
                       J’ai 
                       <Text
-                        accessibilityRole="header"
                         style={
                           {
                             "color": "#320096",

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
@@ -1,7 +1,65 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ChangeCity should render correctly 1`] = `
+.c2 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.1875rem;
+  line-height: 1.9rem;
+}
+
 .c1 {
+  display: -webkit-box;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.0625rem;
+  line-height: 1.7rem;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.c6 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
+}
+
+.c7 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 0.75rem;
+  line-height: 1.2rem;
+}
+
+.c9 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 1rem;
+  line-height: 1.375rem;
+}
+
+.c3 {
   width: 100%;
   max-width: 500px;
 }
@@ -31,7 +89,7 @@ exports[`ChangeCity should render correctly 1`] = `
   cursor: initial;
 }
 
-.c4 {
+.c8 {
   flex-direction: row;
   align-items: center;
   justify-content: center;
@@ -54,11 +112,11 @@ exports[`ChangeCity should render correctly 1`] = `
   box-sizing: border-box;
 }
 
-.c4:disabled {
+.c8:disabled {
   cursor: initial;
 }
 
-.c2 {
+.c4 {
   font-family: Montserrat-Medium;
   font-size: 1rem;
   line-height: 1.6rem;
@@ -66,7 +124,7 @@ exports[`ChangeCity should render correctly 1`] = `
   cursor: pointer;
 }
 
-.c3 {
+.c5 {
   width: 100%;
 }
 
@@ -119,10 +177,8 @@ exports[`ChangeCity should render correctly 1`] = `
           class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
         >
           <h1
-            aria-level="1"
-            class="css-text-146c3p1 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-1wf0xld r-lineHeight-1ln193j r-textAlign-q4m81j"
-            dir="ltr"
-            role="heading"
+            class="c1"
+            style="text-align: center;"
           >
             Modifier ma ville de résidence
           </h1>
@@ -153,16 +209,13 @@ exports[`ChangeCity should render correctly 1`] = `
                 class="css-view-175oi2r r-marginBottom-1peese0"
               >
                 <h2
-                  aria-level="2"
-                  class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-19e3y8m r-lineHeight-1w51ilw"
-                  dir="ltr"
-                  role="heading"
+                  class="c2"
                 >
                   Renseigne ta ville de résidence
                 </h2>
               </div>
               <form
-                class="c1"
+                class="c3"
               >
                 <div
                   class="css-view-175oi2r r-marginBottom-5oul0u"
@@ -171,7 +224,7 @@ exports[`ChangeCity should render correctly 1`] = `
                     class="css-view-175oi2r r-alignItems-1habvwh r-width-13qz1uu"
                   >
                     <label
-                      class="c2 c3"
+                      class="c4 c5"
                       for="Entrée pour la ville"
                     >
                       <div
@@ -180,18 +233,17 @@ exports[`ChangeCity should render correctly 1`] = `
                         <div
                           class="css-view-175oi2r"
                         >
-                          <div
-                            class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                            dir="ltr"
+                          <p
+                            class="c6"
                           >
                             Indique ton code postal et choisis ta ville
-                          </div>
-                          <div
-                            class="css-text-146c3p1 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8 r-marginTop-1bymd8e"
-                            dir="ltr"
+                          </p>
+                          <p
+                            class="c7"
+                            style="color: rgb(105, 106, 111); margin-top: 2px;"
                           >
                             Exemple : 75017
-                          </div>
+                          </p>
                         </div>
                       </div>
                     </label>
@@ -261,7 +313,7 @@ exports[`ChangeCity should render correctly 1`] = `
           >
             <button
               aria-label="Valider ma ville de résidence"
-              class="c4"
+              class="c8"
               data-testid="Valider ma ville de résidence"
               disabled=""
               type="submit"
@@ -269,13 +321,12 @@ exports[`ChangeCity should render correctly 1`] = `
               <div
                 class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz"
               >
-                <div
-                  class="css-text-146c3p1 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-7sbvxv"
-                  dir="ltr"
-                  style="color: rgb(105, 106, 111); max-width: 100%; min-width: 0px; flex-shrink: 1;"
+                <p
+                  class="c9"
+                  style="color: rgb(105, 106, 111); max-width: 100%; min-width: 0; flex-shrink: 1;"
                 >
                   Valider ma ville de résidence
-                </div>
+                </p>
               </div>
             </button>
             <div

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -273,7 +273,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c6"
-                          for="186"
+                          for="182"
                         >
                           <p
                             class="c7"
@@ -292,9 +292,155 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Autoriser l’envoi d’e-mails - Interrupteur à bascule - non coché"
-                            aria-labelledby="185"
+                            aria-labelledby="181"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Autoriser l’envoi d’e-mails - Interrupteur à bascule - non coché"
+                            role="switch"
+                            style="transition-duration: 0s;"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="css-view-175oi2r r-backgroundColor-1ru0s5g r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-1r8g8re r-justifyContent-1777fci r-width-7a29px"
+                            >
+                              <div
+                                class="css-view-175oi2r r-alignItems-1awozwy r-aspectRatio-1ujkv8a r-backgroundColor-14lw9ot r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-mabqd8 r-justifyContent-1777fci r-width-1yvhtrz"
+                                style="transform: translateX(2px);"
+                              >
+                                <div
+                                  class="css-view-175oi2r"
+                                >
+                                  <div
+                                    class="css-text-146c3p1"
+                                    dir="ltr"
+                                  >
+                                    undefined-SVG-Mock
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <input
+                            hidden=""
+                            id="182"
+                            readonly=""
+                            type="checkbox"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="css-view-175oi2r r-backgroundColor-14a9t8x r-height-109y4c4 r-marginBottom-zd98yo r-marginTop-1wzrnnt r-width-13qz1uu"
+                  />
+                  <h2
+                    class="c3"
+                  >
+                    Tes thèmes suivis
+                  </h2>
+                  <div
+                    class="css-view-175oi2r r-marginBottom-5oul0u r-marginTop-11c0sde"
+                  >
+                    <div
+                      class="css-view-175oi2r r-paddingBlock-w7s2jr"
+                    >
+                      <div
+                        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6 r-justifyContent-1h0z5md"
+                      >
+                        <div
+                          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
+                        >
+                          <label
+                            class="c6"
+                            for="184"
+                          >
+                            <p
+                              class="c7"
+                            >
+                              Suivre tous les thèmes
+                            </p>
+                          </label>
+                        </div>
+                        <div
+                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
+                        >
+                          <div
+                            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+                          >
+                            <div
+                              aria-checked="false"
+                              aria-disabled="true"
+                              aria-label="Suivre tous les thèmes - Interrupteur à bascule - non coché"
+                              aria-labelledby="183"
+                              class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
+                              data-testid="Suivre tous les thèmes - Interrupteur à bascule - non coché"
+                              role="switch"
+                              style="transition-duration: 0s;"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="css-view-175oi2r r-backgroundColor-1ru0s5g r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-1r8g8re r-justifyContent-1777fci r-width-7a29px"
+                              >
+                                <div
+                                  class="css-view-175oi2r r-alignItems-1awozwy r-aspectRatio-1ujkv8a r-backgroundColor-14lw9ot r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-mabqd8 r-justifyContent-1777fci r-width-1yvhtrz"
+                                  style="transform: translateX(2px);"
+                                >
+                                  <div
+                                    class="css-view-175oi2r"
+                                  >
+                                    <div
+                                      class="css-text-146c3p1"
+                                      dir="ltr"
+                                    >
+                                      undefined-SVG-Mock
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <input
+                              hidden=""
+                              id="184"
+                              readonly=""
+                              type="checkbox"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="css-view-175oi2r r-paddingBlock-w7s2jr"
+                  >
+                    <div
+                      class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6 r-justifyContent-1h0z5md"
+                    >
+                      <div
+                        class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
+                      >
+                        <label
+                          class="c6"
+                          for="186"
+                        >
+                          <p
+                            class="c7"
+                          >
+                            Cinéma
+                          </p>
+                        </label>
+                      </div>
+                      <div
+                        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
+                      >
+                        <div
+                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+                        >
+                          <div
+                            aria-checked="false"
+                            aria-disabled="true"
+                            aria-label="Cinéma - Interrupteur à bascule - non coché"
+                            aria-labelledby="185"
+                            class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
+                            data-testid="Cinéma - Interrupteur à bascule - non coché"
                             role="switch"
                             style="transition-duration: 0s;"
                             tabindex="-1"
@@ -330,80 +476,68 @@ exports[`NotificationsSettings should render correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="css-view-175oi2r r-backgroundColor-14a9t8x r-height-109y4c4 r-marginBottom-zd98yo r-marginTop-1wzrnnt r-width-13qz1uu"
-                  />
-                  <h2
-                    class="c3"
-                  >
-                    Tes thèmes suivis
-                  </h2>
-                  <div
-                    class="css-view-175oi2r r-marginBottom-5oul0u r-marginTop-11c0sde"
+                    class="css-view-175oi2r r-paddingBlock-w7s2jr"
                   >
                     <div
-                      class="css-view-175oi2r r-paddingBlock-w7s2jr"
+                      class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6 r-justifyContent-1h0z5md"
                     >
                       <div
-                        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6 r-justifyContent-1h0z5md"
+                        class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
+                      >
+                        <label
+                          class="c6"
+                          for="188"
+                        >
+                          <p
+                            class="c7"
+                          >
+                            Lecture
+                          </p>
+                        </label>
+                      </div>
+                      <div
+                        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
                       >
                         <div
-                          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
-                        >
-                          <label
-                            class="c6"
-                            for="188"
-                          >
-                            <p
-                              class="c7"
-                            >
-                              Suivre tous les thèmes
-                            </p>
-                          </label>
-                        </div>
-                        <div
-                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
+                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
                         >
                           <div
-                            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+                            aria-checked="false"
+                            aria-disabled="true"
+                            aria-label="Lecture - Interrupteur à bascule - non coché"
+                            aria-labelledby="187"
+                            class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
+                            data-testid="Lecture - Interrupteur à bascule - non coché"
+                            role="switch"
+                            style="transition-duration: 0s;"
+                            tabindex="-1"
                           >
                             <div
-                              aria-checked="false"
-                              aria-disabled="true"
-                              aria-label="Suivre tous les thèmes - Interrupteur à bascule - non coché"
-                              aria-labelledby="187"
-                              class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
-                              data-testid="Suivre tous les thèmes - Interrupteur à bascule - non coché"
-                              role="switch"
-                              style="transition-duration: 0s;"
-                              tabindex="-1"
+                              class="css-view-175oi2r r-backgroundColor-1ru0s5g r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-1r8g8re r-justifyContent-1777fci r-width-7a29px"
                             >
                               <div
-                                class="css-view-175oi2r r-backgroundColor-1ru0s5g r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-1r8g8re r-justifyContent-1777fci r-width-7a29px"
+                                class="css-view-175oi2r r-alignItems-1awozwy r-aspectRatio-1ujkv8a r-backgroundColor-14lw9ot r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-mabqd8 r-justifyContent-1777fci r-width-1yvhtrz"
+                                style="transform: translateX(2px);"
                               >
                                 <div
-                                  class="css-view-175oi2r r-alignItems-1awozwy r-aspectRatio-1ujkv8a r-backgroundColor-14lw9ot r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-mabqd8 r-justifyContent-1777fci r-width-1yvhtrz"
-                                  style="transform: translateX(2px);"
+                                  class="css-view-175oi2r"
                                 >
                                   <div
-                                    class="css-view-175oi2r"
+                                    class="css-text-146c3p1"
+                                    dir="ltr"
                                   >
-                                    <div
-                                      class="css-text-146c3p1"
-                                      dir="ltr"
-                                    >
-                                      undefined-SVG-Mock
-                                    </div>
+                                    undefined-SVG-Mock
                                   </div>
                                 </div>
                               </div>
                             </div>
-                            <input
-                              hidden=""
-                              id="188"
-                              readonly=""
-                              type="checkbox"
-                            />
                           </div>
+                          <input
+                            hidden=""
+                            id="188"
+                            readonly=""
+                            type="checkbox"
+                          />
                         </div>
                       </div>
                     </div>
@@ -424,7 +558,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <p
                             class="c7"
                           >
-                            Cinéma
+                            Musique
                           </p>
                         </label>
                       </div>
@@ -437,10 +571,10 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <div
                             aria-checked="false"
                             aria-disabled="true"
-                            aria-label="Cinéma - Interrupteur à bascule - non coché"
+                            aria-label="Musique - Interrupteur à bascule - non coché"
                             aria-labelledby="189"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
-                            data-testid="Cinéma - Interrupteur à bascule - non coché"
+                            data-testid="Musique - Interrupteur à bascule - non coché"
                             role="switch"
                             style="transition-duration: 0s;"
                             tabindex="-1"
@@ -491,7 +625,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <p
                             class="c7"
                           >
-                            Lecture
+                            Spectacles
                           </p>
                         </label>
                       </div>
@@ -504,10 +638,10 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <div
                             aria-checked="false"
                             aria-disabled="true"
-                            aria-label="Lecture - Interrupteur à bascule - non coché"
+                            aria-label="Spectacles - Interrupteur à bascule - non coché"
                             aria-labelledby="191"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
-                            data-testid="Lecture - Interrupteur à bascule - non coché"
+                            data-testid="Spectacles - Interrupteur à bascule - non coché"
                             role="switch"
                             style="transition-duration: 0s;"
                             tabindex="-1"
@@ -558,7 +692,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <p
                             class="c7"
                           >
-                            Musique
+                            Activités créatives
                           </p>
                         </label>
                       </div>
@@ -571,10 +705,10 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <div
                             aria-checked="false"
                             aria-disabled="true"
-                            aria-label="Musique - Interrupteur à bascule - non coché"
+                            aria-label="Activités créatives - Interrupteur à bascule - non coché"
                             aria-labelledby="193"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
-                            data-testid="Musique - Interrupteur à bascule - non coché"
+                            data-testid="Activités créatives - Interrupteur à bascule - non coché"
                             role="switch"
                             style="transition-duration: 0s;"
                             tabindex="-1"
@@ -625,140 +759,6 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <p
                             class="c7"
                           >
-                            Spectacles
-                          </p>
-                        </label>
-                      </div>
-                      <div
-                        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
-                      >
-                        <div
-                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-                        >
-                          <div
-                            aria-checked="false"
-                            aria-disabled="true"
-                            aria-label="Spectacles - Interrupteur à bascule - non coché"
-                            aria-labelledby="195"
-                            class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
-                            data-testid="Spectacles - Interrupteur à bascule - non coché"
-                            role="switch"
-                            style="transition-duration: 0s;"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="css-view-175oi2r r-backgroundColor-1ru0s5g r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-1r8g8re r-justifyContent-1777fci r-width-7a29px"
-                            >
-                              <div
-                                class="css-view-175oi2r r-alignItems-1awozwy r-aspectRatio-1ujkv8a r-backgroundColor-14lw9ot r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-mabqd8 r-justifyContent-1777fci r-width-1yvhtrz"
-                                style="transform: translateX(2px);"
-                              >
-                                <div
-                                  class="css-view-175oi2r"
-                                >
-                                  <div
-                                    class="css-text-146c3p1"
-                                    dir="ltr"
-                                  >
-                                    undefined-SVG-Mock
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <input
-                            hidden=""
-                            id="196"
-                            readonly=""
-                            type="checkbox"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="css-view-175oi2r r-paddingBlock-w7s2jr"
-                  >
-                    <div
-                      class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6 r-justifyContent-1h0z5md"
-                    >
-                      <div
-                        class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
-                      >
-                        <label
-                          class="c6"
-                          for="198"
-                        >
-                          <p
-                            class="c7"
-                          >
-                            Activités créatives
-                          </p>
-                        </label>
-                      </div>
-                      <div
-                        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
-                      >
-                        <div
-                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-                        >
-                          <div
-                            aria-checked="false"
-                            aria-disabled="true"
-                            aria-label="Activités créatives - Interrupteur à bascule - non coché"
-                            aria-labelledby="197"
-                            class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
-                            data-testid="Activités créatives - Interrupteur à bascule - non coché"
-                            role="switch"
-                            style="transition-duration: 0s;"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="css-view-175oi2r r-backgroundColor-1ru0s5g r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-1r8g8re r-justifyContent-1777fci r-width-7a29px"
-                            >
-                              <div
-                                class="css-view-175oi2r r-alignItems-1awozwy r-aspectRatio-1ujkv8a r-backgroundColor-14lw9ot r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-mabqd8 r-justifyContent-1777fci r-width-1yvhtrz"
-                                style="transform: translateX(2px);"
-                              >
-                                <div
-                                  class="css-view-175oi2r"
-                                >
-                                  <div
-                                    class="css-text-146c3p1"
-                                    dir="ltr"
-                                  >
-                                    undefined-SVG-Mock
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <input
-                            hidden=""
-                            id="198"
-                            readonly=""
-                            type="checkbox"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="css-view-175oi2r r-paddingBlock-w7s2jr"
-                  >
-                    <div
-                      class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6 r-justifyContent-1h0z5md"
-                    >
-                      <div
-                        class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
-                      >
-                        <label
-                          class="c6"
-                          for="200"
-                        >
-                          <p
-                            class="c7"
-                          >
                             Visites et sorties
                           </p>
                         </label>
@@ -773,7 +773,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                             aria-checked="false"
                             aria-disabled="true"
                             aria-label="Visites et sorties - Interrupteur à bascule - non coché"
-                            aria-labelledby="199"
+                            aria-labelledby="195"
                             class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
                             data-testid="Visites et sorties - Interrupteur à bascule - non coché"
                             role="switch"
@@ -802,7 +802,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           </div>
                           <input
                             hidden=""
-                            id="200"
+                            id="196"
                             readonly=""
                             type="checkbox"
                           />

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -1,6 +1,75 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NotificationsSettings should render correctly 1`] = `
+.c1 {
+  display: -webkit-box;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.0625rem;
+  line-height: 1.7rem;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.c3 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.0625rem;
+  line-height: 1.7rem;
+}
+
+.c4 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
+}
+
+.c7 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 1rem;
+  line-height: 1.6rem;
+}
+
+.c2 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 0.875rem;
+  line-height: 1.4rem;
+}
+
+.c9 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 1rem;
+  line-height: 1.375rem;
+}
+
 .c0 {
   flex-direction: row;
   align-items: center;
@@ -26,7 +95,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
   cursor: initial;
 }
 
-.c3 {
+.c8 {
   flex-direction: row;
   align-items: center;
   justify-content: center;
@@ -49,11 +118,11 @@ exports[`NotificationsSettings should render correctly 1`] = `
   box-sizing: border-box;
 }
 
-.c3:disabled {
+.c8:disabled {
   cursor: initial;
 }
 
-.c2 {
+.c6 {
   font-family: Montserrat-Medium;
   font-size: 1rem;
   line-height: 1.6rem;
@@ -61,7 +130,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
   cursor: pointer;
 }
 
-.c1 {
+.c5 {
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -116,10 +185,8 @@ exports[`NotificationsSettings should render correctly 1`] = `
           class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
         >
           <h1
-            aria-level="1"
-            class="css-text-146c3p1 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-1wf0xld r-lineHeight-1ln193j r-textAlign-q4m81j"
-            dir="ltr"
-            role="heading"
+            class="c1"
+            style="text-align: center;"
           >
             Suivi et notifications
           </h1>
@@ -170,35 +237,30 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       class="css-view-175oi2r r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-9aw3ui"
                       role="presentation"
                     >
-                      <div
-                        class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1o4mh9l r-lineHeight-kmu5yi"
-                        dir="ltr"
+                      <p
+                        class="c2"
                       >
                         Tu dois être connecté pour activer les notifications et rester informé des bons plans sur le pass Culture.
-                      </div>
+                      </p>
                     </div>
                   </div>
                 </div>
                 <h2
-                  aria-level="2"
-                  class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-1wf0xld r-lineHeight-1ln193j"
-                  dir="ltr"
-                  role="heading"
+                  class="c3"
                 >
                   Type d’alerte
                 </h2>
                 <div
                   class="css-view-175oi2r r-marginBottom-5oul0u r-marginTop-1wzrnnt"
                 >
-                  <div
-                    class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                    dir="ltr"
+                  <p
+                    class="c4"
                   >
                     Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
-                  </div>
+                  </p>
                 </div>
                 <form
-                  class="c1"
+                  class="c5"
                 >
                   <div
                     class="css-view-175oi2r r-paddingBlock-w7s2jr"
@@ -210,15 +272,14 @@ exports[`NotificationsSettings should render correctly 1`] = `
                         class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
                       >
                         <label
-                          class="c2"
+                          class="c6"
                           for="186"
                         >
-                          <div
-                            class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                            dir="ltr"
+                          <p
+                            class="c7"
                           >
                             Autoriser l’envoi d’e-mails
-                          </div>
+                          </p>
                         </label>
                       </div>
                       <div
@@ -272,10 +333,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                     class="css-view-175oi2r r-backgroundColor-14a9t8x r-height-109y4c4 r-marginBottom-zd98yo r-marginTop-1wzrnnt r-width-13qz1uu"
                   />
                   <h2
-                    aria-level="2"
-                    class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-1wf0xld r-lineHeight-1ln193j"
-                    dir="ltr"
-                    role="heading"
+                    class="c3"
                   >
                     Tes thèmes suivis
                   </h2>
@@ -292,15 +350,14 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
                         >
                           <label
-                            class="c2"
+                            class="c6"
                             for="188"
                           >
-                            <div
-                              class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                              dir="ltr"
+                            <p
+                              class="c7"
                             >
                               Suivre tous les thèmes
-                            </div>
+                            </p>
                           </label>
                         </div>
                         <div
@@ -361,15 +418,14 @@ exports[`NotificationsSettings should render correctly 1`] = `
                         class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
                       >
                         <label
-                          class="c2"
+                          class="c6"
                           for="190"
                         >
-                          <div
-                            class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                            dir="ltr"
+                          <p
+                            class="c7"
                           >
                             Cinéma
-                          </div>
+                          </p>
                         </label>
                       </div>
                       <div
@@ -429,15 +485,14 @@ exports[`NotificationsSettings should render correctly 1`] = `
                         class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
                       >
                         <label
-                          class="c2"
+                          class="c6"
                           for="192"
                         >
-                          <div
-                            class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                            dir="ltr"
+                          <p
+                            class="c7"
                           >
                             Lecture
-                          </div>
+                          </p>
                         </label>
                       </div>
                       <div
@@ -497,15 +552,14 @@ exports[`NotificationsSettings should render correctly 1`] = `
                         class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
                       >
                         <label
-                          class="c2"
+                          class="c6"
                           for="194"
                         >
-                          <div
-                            class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                            dir="ltr"
+                          <p
+                            class="c7"
                           >
                             Musique
-                          </div>
+                          </p>
                         </label>
                       </div>
                       <div
@@ -565,15 +619,14 @@ exports[`NotificationsSettings should render correctly 1`] = `
                         class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
                       >
                         <label
-                          class="c2"
+                          class="c6"
                           for="196"
                         >
-                          <div
-                            class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                            dir="ltr"
+                          <p
+                            class="c7"
                           >
                             Spectacles
-                          </div>
+                          </p>
                         </label>
                       </div>
                       <div
@@ -633,15 +686,14 @@ exports[`NotificationsSettings should render correctly 1`] = `
                         class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
                       >
                         <label
-                          class="c2"
+                          class="c6"
                           for="198"
                         >
-                          <div
-                            class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                            dir="ltr"
+                          <p
+                            class="c7"
                           >
                             Activités créatives
-                          </div>
+                          </p>
                         </label>
                       </div>
                       <div
@@ -701,15 +753,14 @@ exports[`NotificationsSettings should render correctly 1`] = `
                         class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
                       >
                         <label
-                          class="c2"
+                          class="c6"
                           for="200"
                         >
-                          <div
-                            class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                            dir="ltr"
+                          <p
+                            class="c7"
                           >
                             Visites et sorties
-                          </div>
+                          </p>
                         </label>
                       </div>
                       <div
@@ -764,7 +815,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                   >
                     <button
                       aria-label="Enregistrer les modifications"
-                      class="c3"
+                      class="c8"
                       data-testid="Enregistrer les modifications"
                       disabled=""
                       type="button"
@@ -772,13 +823,12 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       <div
                         class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz"
                       >
-                        <div
-                          class="css-text-146c3p1 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-7sbvxv"
-                          dir="ltr"
-                          style="color: rgb(105, 106, 111); max-width: 100%; min-width: 0px; flex-shrink: 1;"
+                        <p
+                          class="c9"
+                          style="color: rgb(105, 106, 111); max-width: 100%; min-width: 0; flex-shrink: 1;"
                         >
                           Enregistrer
-                        </div>
+                        </p>
                       </div>
                     </button>
                   </div>

--- a/__snapshots__/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx.native-snap
@@ -487,10 +487,7 @@ exports[`TrackEmailChange account with password should render correctly when cho
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -975,10 +972,7 @@ exports[`TrackEmailChange account with password should render correctly when cho
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -1775,10 +1769,7 @@ exports[`TrackEmailChange account with password should render correctly when con
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -2007,10 +1998,7 @@ exports[`TrackEmailChange account with password should render correctly when con
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -2540,10 +2528,7 @@ exports[`TrackEmailChange account with password should render correctly when val
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -2765,10 +2750,7 @@ exports[`TrackEmailChange account with password should render correctly when val
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -3550,10 +3532,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -3775,10 +3754,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -4263,10 +4239,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -5063,10 +5036,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -5299,10 +5269,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -5531,10 +5498,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -6064,10 +6028,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -6556,10 +6517,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -6788,10 +6746,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -7321,10 +7276,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -7546,10 +7498,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }
@@ -7771,10 +7720,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
                           <View
                             style={
                               {
-                                "flexBasis": 0,
                                 "flexDirection": "column",
-                                "flexGrow": 1,
-                                "flexShrink": 1,
                                 "paddingRight": 16,
                               }
                             }

--- a/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
@@ -215,7 +215,6 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification disabled shou
                   >
                     Tu reçois 
                     <Text
-                      accessibilityRole="header"
                       style={
                         {
                           "color": "#320096",
@@ -486,7 +485,6 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification disabled shou
                   >
                     Tu reçois 
                     <Text
-                      accessibilityRole="header"
                       style={
                         {
                           "color": "#320096",
@@ -1418,7 +1416,6 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
                   >
                     Tu reçois 
                     <Text
-                      accessibilityRole="header"
                       style={
                         {
                           "color": "#320096",
@@ -1689,7 +1686,6 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
                   >
                     Tu reçois 
                     <Text
-                      accessibilityRole="header"
                       style={
                         {
                           "color": "#320096",
@@ -2137,7 +2133,6 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
                     Tu peux recevoir
                      
                     <Text
-                      accessibilityRole="header"
                       style={
                         {
                           "color": "#320096",
@@ -2245,7 +2240,6 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
                       }
                     >
                       <Text
-                        accessibilityRole="header"
                         style={
                           {
                             "color": "#320096",

--- a/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
@@ -526,12 +526,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                       "borderTopLeftRadius": 8,
                       "borderTopRightRadius": 8,
                       "borderWidth": 1.6,
-                      "display": "flex",
-                      "flexDirection": "column",
                       "height": 144,
                       "justifyContent": "flex-end",
                       "minHeight": 80,
                       "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
                     },
                     {
                       "flexBasis": 0,
@@ -548,33 +550,20 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
               }
               testID="Catégorie Concerts et festivals"
             >
-              <View
+              <Text
+                numberOfLines={4}
                 style={
                   {
-                    "alignItems": "flex-start",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "100%",
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 14,
+                    "lineHeight": 22.4,
+                    "textAlign": "left",
                   }
                 }
               >
-                <Text
-                  numberOfLines={4}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 22.4,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  CONCERTS ET FESTIVALS
-                </Text>
-              </View>
+                CONCERTS ET FESTIVALS
+              </Text>
             </View>
             <View
               accessibilityLabel="Catégorie Cinéma"
@@ -620,12 +609,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                       "borderTopLeftRadius": 8,
                       "borderTopRightRadius": 8,
                       "borderWidth": 1.6,
-                      "display": "flex",
-                      "flexDirection": "column",
                       "height": 144,
                       "justifyContent": "flex-end",
                       "minHeight": 80,
                       "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
                     },
                     {
                       "flexBasis": 0,
@@ -642,33 +633,20 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
               }
               testID="Catégorie Cinéma"
             >
-              <View
+              <Text
+                numberOfLines={4}
                 style={
                   {
-                    "alignItems": "flex-start",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "100%",
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 14,
+                    "lineHeight": 22.4,
+                    "textAlign": "left",
                   }
                 }
               >
-                <Text
-                  numberOfLines={4}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 22.4,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  CINÉMA
-                </Text>
-              </View>
+                CINÉMA
+              </Text>
             </View>
             <View
               accessibilityLabel="Catégorie Films, séries et documentaires"
@@ -714,12 +692,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                       "borderTopLeftRadius": 8,
                       "borderTopRightRadius": 8,
                       "borderWidth": 1.6,
-                      "display": "flex",
-                      "flexDirection": "column",
                       "height": 144,
                       "justifyContent": "flex-end",
                       "minHeight": 80,
                       "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
                     },
                     {
                       "flexBasis": 0,
@@ -736,33 +716,20 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
               }
               testID="Catégorie Films, séries et documentaires"
             >
-              <View
+              <Text
+                numberOfLines={4}
                 style={
                   {
-                    "alignItems": "flex-start",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "100%",
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 14,
+                    "lineHeight": 22.4,
+                    "textAlign": "left",
                   }
                 }
               >
-                <Text
-                  numberOfLines={4}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 22.4,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  FILMS, SÉRIES ET DOCUMENTAIRES
-                </Text>
-              </View>
+                FILMS, SÉRIES ET DOCUMENTAIRES
+              </Text>
             </View>
             <View
               accessibilityLabel="Catégorie Livres"
@@ -808,12 +775,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                       "borderTopLeftRadius": 8,
                       "borderTopRightRadius": 8,
                       "borderWidth": 1.6,
-                      "display": "flex",
-                      "flexDirection": "column",
                       "height": 144,
                       "justifyContent": "flex-end",
                       "minHeight": 80,
                       "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
                     },
                     {
                       "flexBasis": 0,
@@ -830,33 +799,20 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
               }
               testID="Catégorie Livres"
             >
-              <View
+              <Text
+                numberOfLines={4}
                 style={
                   {
-                    "alignItems": "flex-start",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "100%",
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 14,
+                    "lineHeight": 22.4,
+                    "textAlign": "left",
                   }
                 }
               >
-                <Text
-                  numberOfLines={4}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 22.4,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  LIVRES
-                </Text>
-              </View>
+                LIVRES
+              </Text>
             </View>
             <View
               accessibilityLabel="Catégorie Musique"
@@ -902,12 +858,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                       "borderTopLeftRadius": 8,
                       "borderTopRightRadius": 8,
                       "borderWidth": 1.6,
-                      "display": "flex",
-                      "flexDirection": "column",
                       "height": 144,
                       "justifyContent": "flex-end",
                       "minHeight": 80,
                       "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
                     },
                     {
                       "flexBasis": 0,
@@ -924,33 +882,20 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
               }
               testID="Catégorie Musique"
             >
-              <View
+              <Text
+                numberOfLines={4}
                 style={
                   {
-                    "alignItems": "flex-start",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "100%",
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 14,
+                    "lineHeight": 22.4,
+                    "textAlign": "left",
                   }
                 }
               >
-                <Text
-                  numberOfLines={4}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 22.4,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  MUSIQUE
-                </Text>
-              </View>
+                MUSIQUE
+              </Text>
             </View>
             <View
               accessibilityLabel="Catégorie Arts et loisirs créatifs"
@@ -996,12 +941,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                       "borderTopLeftRadius": 8,
                       "borderTopRightRadius": 8,
                       "borderWidth": 1.6,
-                      "display": "flex",
-                      "flexDirection": "column",
                       "height": 144,
                       "justifyContent": "flex-end",
                       "minHeight": 80,
                       "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
                     },
                     {
                       "flexBasis": 0,
@@ -1018,33 +965,20 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
               }
               testID="Catégorie Arts et loisirs créatifs"
             >
-              <View
+              <Text
+                numberOfLines={4}
                 style={
                   {
-                    "alignItems": "flex-start",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "100%",
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 14,
+                    "lineHeight": 22.4,
+                    "textAlign": "left",
                   }
                 }
               >
-                <Text
-                  numberOfLines={4}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 22.4,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  ARTS ET LOISIRS CRÉATIFS
-                </Text>
-              </View>
+                ARTS ET LOISIRS CRÉATIFS
+              </Text>
             </View>
             <View
               accessibilityLabel="Catégorie Spectacles"
@@ -1090,12 +1024,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                       "borderTopLeftRadius": 8,
                       "borderTopRightRadius": 8,
                       "borderWidth": 1.6,
-                      "display": "flex",
-                      "flexDirection": "column",
                       "height": 144,
                       "justifyContent": "flex-end",
                       "minHeight": 80,
                       "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
                     },
                     {
                       "flexBasis": 0,
@@ -1112,33 +1048,20 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
               }
               testID="Catégorie Spectacles"
             >
-              <View
+              <Text
+                numberOfLines={4}
                 style={
                   {
-                    "alignItems": "flex-start",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "100%",
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 14,
+                    "lineHeight": 22.4,
+                    "textAlign": "left",
                   }
                 }
               >
-                <Text
-                  numberOfLines={4}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 22.4,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  SPECTACLES
-                </Text>
-              </View>
+                SPECTACLES
+              </Text>
             </View>
             <View
               accessibilityLabel="Catégorie Musées et visites"
@@ -1184,12 +1107,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                       "borderTopLeftRadius": 8,
                       "borderTopRightRadius": 8,
                       "borderWidth": 1.6,
-                      "display": "flex",
-                      "flexDirection": "column",
                       "height": 144,
                       "justifyContent": "flex-end",
                       "minHeight": 80,
                       "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
                     },
                     {
                       "flexBasis": 0,
@@ -1206,33 +1131,20 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
               }
               testID="Catégorie Musées et visites"
             >
-              <View
+              <Text
+                numberOfLines={4}
                 style={
                   {
-                    "alignItems": "flex-start",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "100%",
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 14,
+                    "lineHeight": 22.4,
+                    "textAlign": "left",
                   }
                 }
               >
-                <Text
-                  numberOfLines={4}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 22.4,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  MUSÉES ET VISITES
-                </Text>
-              </View>
+                MUSÉES ET VISITES
+              </Text>
             </View>
             <View
               accessibilityLabel="Catégorie Jeux et jeux vidéos"
@@ -1278,12 +1190,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                       "borderTopLeftRadius": 8,
                       "borderTopRightRadius": 8,
                       "borderWidth": 1.6,
-                      "display": "flex",
-                      "flexDirection": "column",
                       "height": 144,
                       "justifyContent": "flex-end",
                       "minHeight": 80,
                       "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
                     },
                     {
                       "flexBasis": 0,
@@ -1300,33 +1214,20 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
               }
               testID="Catégorie Jeux et jeux vidéos"
             >
-              <View
+              <Text
+                numberOfLines={4}
                 style={
                   {
-                    "alignItems": "flex-start",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "100%",
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 14,
+                    "lineHeight": 22.4,
+                    "textAlign": "left",
                   }
                 }
               >
-                <Text
-                  numberOfLines={4}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 22.4,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  JEUX ET JEUX VIDÉOS
-                </Text>
-              </View>
+                JEUX ET JEUX VIDÉOS
+              </Text>
             </View>
             <View
               accessibilityLabel="Catégorie Médias et presse"
@@ -1372,12 +1273,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                       "borderTopLeftRadius": 8,
                       "borderTopRightRadius": 8,
                       "borderWidth": 1.6,
-                      "display": "flex",
-                      "flexDirection": "column",
                       "height": 144,
                       "justifyContent": "flex-end",
                       "minHeight": 80,
                       "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
                     },
                     {
                       "flexBasis": 0,
@@ -1394,33 +1297,20 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
               }
               testID="Catégorie Médias et presse"
             >
-              <View
+              <Text
+                numberOfLines={4}
                 style={
                   {
-                    "alignItems": "flex-start",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "100%",
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 14,
+                    "lineHeight": 22.4,
+                    "textAlign": "left",
                   }
                 }
               >
-                <Text
-                  numberOfLines={4}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 22.4,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  MÉDIAS ET PRESSE
-                </Text>
-              </View>
+                MÉDIAS ET PRESSE
+              </Text>
             </View>
             <View
               accessibilityLabel="Catégorie Cartes jeunes"
@@ -1466,12 +1356,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                       "borderTopLeftRadius": 8,
                       "borderTopRightRadius": 8,
                       "borderWidth": 1.6,
-                      "display": "flex",
-                      "flexDirection": "column",
                       "height": 144,
                       "justifyContent": "flex-end",
                       "minHeight": 80,
                       "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
                     },
                     {
                       "flexBasis": 0,
@@ -1488,33 +1380,20 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
               }
               testID="Catégorie Cartes jeunes"
             >
-              <View
+              <Text
+                numberOfLines={4}
                 style={
                   {
-                    "alignItems": "flex-start",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "100%",
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 14,
+                    "lineHeight": 22.4,
+                    "textAlign": "left",
                   }
                 }
               >
-                <Text
-                  numberOfLines={4}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 22.4,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  CARTES JEUNES
-                </Text>
-              </View>
+                CARTES JEUNES
+              </Text>
             </View>
             <View
               accessibilityLabel="Catégorie Conférences et rencontres"
@@ -1560,12 +1439,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                       "borderTopLeftRadius": 8,
                       "borderTopRightRadius": 8,
                       "borderWidth": 1.6,
-                      "display": "flex",
-                      "flexDirection": "column",
                       "height": 144,
                       "justifyContent": "flex-end",
                       "minHeight": 80,
                       "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
                     },
                     {
                       "flexBasis": 0,
@@ -1582,33 +1463,20 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
               }
               testID="Catégorie Conférences et rencontres"
             >
-              <View
+              <Text
+                numberOfLines={4}
                 style={
                   {
-                    "alignItems": "flex-start",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "100%",
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 14,
+                    "lineHeight": 22.4,
+                    "textAlign": "left",
                   }
                 }
               >
-                <Text
-                  numberOfLines={4}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 22.4,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  CONFÉRENCES ET RENCONTRES
-                </Text>
-              </View>
+                CONFÉRENCES ET RENCONTRES
+              </Text>
             </View>
             <View
               accessibilityLabel="Catégorie Évènements en ligne"
@@ -1654,12 +1522,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                       "borderTopLeftRadius": 8,
                       "borderTopRightRadius": 8,
                       "borderWidth": 1.6,
-                      "display": "flex",
-                      "flexDirection": "column",
                       "height": 144,
                       "justifyContent": "flex-end",
                       "minHeight": 80,
                       "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
                     },
                     {
                       "flexBasis": 0,
@@ -1676,33 +1546,20 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
               }
               testID="Catégorie Évènements en ligne"
             >
-              <View
+              <Text
+                numberOfLines={4}
                 style={
                   {
-                    "alignItems": "flex-start",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "100%",
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 14,
+                    "lineHeight": 22.4,
+                    "textAlign": "left",
                   }
                 }
               >
-                <Text
-                  numberOfLines={4}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 14,
-                      "lineHeight": 22.4,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  ÉVÈNEMENTS EN LIGNE
-                </Text>
-              </View>
+                ÉVÈNEMENTS EN LIGNE
+              </Text>
             </View>
           </View>
           <View

--- a/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
@@ -103,23 +103,14 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                 >
                   <Text
                     accessibilityRole="header"
-                    htmlFor="testUuidV4"
                     small={false}
                     style={
-                      [
-                        {
-                          "color": "#161617",
-                          "fontFamily": "Montserrat-Medium",
-                          "fontSize": 16,
-                          "lineHeight": 25.6,
-                        },
-                        {
-                          "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 28,
-                          "lineHeight": 44.8,
-                        },
-                      ]
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 28,
+                        "lineHeight": 44.8,
+                      }
                     }
                   >
                     Rechercher

--- a/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
@@ -201,23 +201,14 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                 >
                   <Text
                     accessibilityRole="header"
-                    htmlFor="testUuidV4"
                     small={false}
                     style={
-                      [
-                        {
-                          "color": "#161617",
-                          "fontFamily": "Montserrat-Medium",
-                          "fontSize": 16,
-                          "lineHeight": 25.6,
-                        },
-                        {
-                          "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 28,
-                          "lineHeight": 44.8,
-                        },
-                      ]
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 28,
+                        "lineHeight": 44.8,
+                      }
                     }
                   >
                     Rechercher

--- a/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
@@ -533,13 +533,12 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                 }
               >
                 <Text
-                  BADGE_SIZE={16}
                   style={
                     {
                       "color": "#ffffff",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                       "textAlign": "center",
                     }
                   }
@@ -1943,7 +1942,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                               "flexShrink": 1,
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                             }
                           }
                         >
@@ -2292,7 +2291,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                               "flexShrink": 1,
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                             }
                           }
                         >
@@ -2637,7 +2636,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                               "flexShrink": 1,
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                             }
                           }
                         >
@@ -2981,7 +2980,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                               "flexShrink": 1,
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                             }
                           }
                         >

--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -192,23 +192,14 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
               >
                 <Text
                   accessibilityRole="header"
-                  htmlFor="testUuidV4"
                   small={true}
                   style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      },
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 19,
-                        "lineHeight": 30.4,
-                      },
-                    ]
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 19,
+                      "lineHeight": 30.4,
+                    }
                   }
                 >
                   Livres

--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -720,6 +720,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "borderWidth": 1.6,
                           "flexDirection": "row",
                           "minHeight": 56,
+                          "paddingHorizontal": 8,
                           "paddingVertical": 8,
                           "textAlign": "left",
                           "width": 156,
@@ -741,7 +742,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
-                        "marginHorizontal": 8,
                       }
                     }
                   >
@@ -797,6 +797,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "borderWidth": 1.6,
                           "flexDirection": "row",
                           "minHeight": 56,
+                          "paddingHorizontal": 8,
                           "paddingVertical": 8,
                           "textAlign": "left",
                           "width": 156,
@@ -818,7 +819,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
-                        "marginHorizontal": 8,
                       }
                     }
                   >
@@ -874,6 +874,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "borderWidth": 1.6,
                           "flexDirection": "row",
                           "minHeight": 56,
+                          "paddingHorizontal": 8,
                           "paddingVertical": 8,
                           "textAlign": "left",
                           "width": 156,
@@ -895,7 +896,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
-                        "marginHorizontal": 8,
                       }
                     }
                   >
@@ -951,6 +951,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "borderWidth": 1.6,
                           "flexDirection": "row",
                           "minHeight": 56,
+                          "paddingHorizontal": 8,
                           "paddingVertical": 8,
                           "textAlign": "left",
                           "width": 156,
@@ -972,7 +973,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
-                        "marginHorizontal": 8,
                       }
                     }
                   >
@@ -1028,6 +1028,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "borderWidth": 1.6,
                           "flexDirection": "row",
                           "minHeight": 56,
+                          "paddingHorizontal": 8,
                           "paddingVertical": 8,
                           "textAlign": "left",
                           "width": 156,
@@ -1049,7 +1050,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
-                        "marginHorizontal": 8,
                       }
                     }
                   >
@@ -1105,6 +1105,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "borderWidth": 1.6,
                           "flexDirection": "row",
                           "minHeight": 56,
+                          "paddingHorizontal": 8,
                           "paddingVertical": 8,
                           "textAlign": "left",
                           "width": 156,
@@ -1126,7 +1127,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
-                        "marginHorizontal": 8,
                       }
                     }
                   >
@@ -1182,6 +1182,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "borderWidth": 1.6,
                           "flexDirection": "row",
                           "minHeight": 56,
+                          "paddingHorizontal": 8,
                           "paddingVertical": 8,
                           "textAlign": "left",
                           "width": 156,
@@ -1203,7 +1204,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
-                        "marginHorizontal": 8,
                       }
                     }
                   >
@@ -1268,6 +1268,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "borderWidth": 1.6,
                           "flexDirection": "row",
                           "minHeight": 56,
+                          "paddingHorizontal": 8,
                           "paddingVertical": 8,
                           "textAlign": "left",
                           "width": 156,
@@ -1289,7 +1290,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
-                        "marginHorizontal": 8,
                       }
                     }
                   >
@@ -1345,6 +1345,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "borderWidth": 1.6,
                           "flexDirection": "row",
                           "minHeight": 56,
+                          "paddingHorizontal": 8,
                           "paddingVertical": 8,
                           "textAlign": "left",
                           "width": 156,
@@ -1366,7 +1367,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
-                        "marginHorizontal": 8,
                       }
                     }
                   >
@@ -1422,6 +1422,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "borderWidth": 1.6,
                           "flexDirection": "row",
                           "minHeight": 56,
+                          "paddingHorizontal": 8,
                           "paddingVertical": 8,
                           "textAlign": "left",
                           "width": 156,
@@ -1443,7 +1444,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
-                        "marginHorizontal": 8,
                       }
                     }
                   >
@@ -1499,6 +1499,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "borderWidth": 1.6,
                           "flexDirection": "row",
                           "minHeight": 56,
+                          "paddingHorizontal": 8,
                           "paddingVertical": 8,
                           "textAlign": "left",
                           "width": 156,
@@ -1520,7 +1521,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
-                        "marginHorizontal": 8,
                       }
                     }
                   >
@@ -1576,6 +1576,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "borderWidth": 1.6,
                           "flexDirection": "row",
                           "minHeight": 56,
+                          "paddingHorizontal": 8,
                           "paddingVertical": 8,
                           "textAlign": "left",
                           "width": 156,
@@ -1597,7 +1598,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
-                        "marginHorizontal": 8,
                       }
                     }
                   >
@@ -1653,6 +1653,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           "borderWidth": 1.6,
                           "flexDirection": "row",
                           "minHeight": 56,
+                          "paddingHorizontal": 8,
                           "paddingVertical": 8,
                           "textAlign": "left",
                           "width": 156,
@@ -1674,7 +1675,6 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
-                        "marginHorizontal": 8,
                       }
                     }
                   >

--- a/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
+++ b/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
@@ -9,6 +9,42 @@ exports[`<WebShareModal/> should render correctly when hidden 1`] = `
 
 exports[`<WebShareModal/> should render correctly when shown 1`] = `
 .c0 {
+  display: -webkit-box;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.0625rem;
+  line-height: 1.7rem;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.c5 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 0.75rem;
+  line-height: 1.2rem;
+}
+
+.c3 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-SemiBold;
+  font-size: 1rem;
+  line-height: 1.375rem;
+}
+
+.c1 {
   flex-direction: row;
   align-items: center;
   justify-content: center;
@@ -29,60 +65,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
   box-sizing: border-box;
 }
 
-.c0:disabled {
-  cursor: initial;
-}
-
-.c1 {
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  border-radius: 8px;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  padding-left: 2px;
-  padding-right: 2px;
-  width: auto;
-  max-width: 500px;
-  border-width: 0;
-  background-color: transparent;
-  cursor: pointer;
-  outline: none;
-  display: inline-flex;
-  overflow: hidden;
-  text-decoration: none;
-  box-sizing: border-box;
-}
-
 .c1:disabled {
-  cursor: initial;
-}
-
-.c3 {
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  border-radius: 8px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  padding-left: 12px;
-  padding-right: 12px;
-  width: 100%;
-  max-width: 500px;
-  align-self: center;
-  border-style: solid;
-  border-color: #6123df;
-  border-width: 1px;
-  background-color: #6123df;
-  cursor: pointer;
-  outline: none;
-  display: inline-flex;
-  overflow: hidden;
-  text-decoration: none;
-  box-sizing: border-box;
-}
-
-.c3:disabled {
   cursor: initial;
 }
 
@@ -108,6 +91,59 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
 }
 
 .c2:disabled {
+  cursor: initial;
+}
+
+.c6 {
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 12px;
+  padding-right: 12px;
+  width: 100%;
+  max-width: 500px;
+  align-self: center;
+  border-style: solid;
+  border-color: #6123df;
+  border-width: 1px;
+  background-color: #6123df;
+  cursor: pointer;
+  outline: none;
+  display: inline-flex;
+  overflow: hidden;
+  text-decoration: none;
+  box-sizing: border-box;
+}
+
+.c6:disabled {
+  cursor: initial;
+}
+
+.c4 {
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  padding-left: 2px;
+  padding-right: 2px;
+  width: auto;
+  max-width: 500px;
+  border-width: 0;
+  background-color: transparent;
+  cursor: pointer;
+  outline: none;
+  display: inline-flex;
+  overflow: hidden;
+  text-decoration: none;
+  box-sizing: border-box;
+}
+
+.c4:disabled {
   cursor: initial;
 }
 
@@ -161,12 +197,8 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                     class="css-view-175oi2r r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-1777fci r-paddingInline-3o4zer r-zIndex-184en5c"
                   >
                     <h1
-                      aria-level="1"
-                      class="css-text-146c3p1 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-1wf0xld r-lineHeight-1ln193j r-textAlign-q4m81j"
-                      data-testid="modalHeaderTitle"
-                      dir="ltr"
-                      id="testUuidV4"
-                      role="heading"
+                      class="c0"
+                      style="text-align: center;"
                     >
                       Partager l’offre
                     </h1>
@@ -176,7 +208,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                   >
                     <button
                       aria-label="Fermer la modale"
-                      class="c0"
+                      class="c1"
                       data-testid="Fermer la modale"
                       tabindex="0"
                       type="button"
@@ -232,7 +264,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                           >
                             <button
                               aria-label="Copier le lien"
-                              class="c1"
+                              class="c2"
                               data-testid="Copier le lien"
                               tabindex="0"
                               type="button"
@@ -254,13 +286,12 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                     </div>
                                   </div>
                                 </div>
-                                <div
-                                  class="css-text-146c3p1 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-7sbvxv"
-                                  dir="ltr"
-                                  style="color: rgb(22, 22, 23); max-width: 100%; min-width: 0px; flex-shrink: 1;"
+                                <p
+                                  class="c3"
+                                  style="color: rgb(22, 22, 23); max-width: 100%; min-width: 0; flex-shrink: 1;"
                                 >
                                   Copier
-                                </div>
+                                </p>
                               </div>
                             </button>
                           </div>
@@ -269,7 +300,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                           >
                             <a
                               aria-label="Ouvrir le gestionnaire mail"
-                              class="c2"
+                              class="c4"
                               data-testid="Ouvrir le gestionnaire mail"
                               href="mailto:?subject=Je t’invite à découvrir une super offre sur le pass Culture !&body=Voici%20une%20super%20offre%C2%A0!%0Ahttps%3A%2F%2Furl.com%2Foffer"
                               tabindex="0"
@@ -292,13 +323,12 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                     </div>
                                   </div>
                                 </div>
-                                <div
-                                  class="css-text-146c3p1 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-7sbvxv"
-                                  dir="ltr"
-                                  style="color: rgb(22, 22, 23); max-width: 100%; min-width: 0px; flex-shrink: 1;"
+                                <p
+                                  class="c3"
+                                  style="color: rgb(22, 22, 23); max-width: 100%; min-width: 0; flex-shrink: 1;"
                                 >
                                   E-mail
-                                </div>
+                                </p>
                               </div>
                             </a>
                           </div>
@@ -330,12 +360,12 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                   undefined-SVG-Mock
                                 </div>
                               </div>
-                              <div
-                                class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8 r-marginTop-knv0ih"
-                                dir="ltr"
+                              <p
+                                class="c5"
+                                style="margin-top: 8px;"
                               >
                                 Facebook
-                              </div>
+                              </p>
                             </a>
                           </li>
                           <li
@@ -358,12 +388,12 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                   undefined-SVG-Mock
                                 </div>
                               </div>
-                              <div
-                                class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8 r-marginTop-knv0ih"
-                                dir="ltr"
+                              <p
+                                class="c5"
+                                style="margin-top: 8px;"
                               >
                                 X
-                              </div>
+                              </p>
                             </a>
                           </li>
                           <li
@@ -386,12 +416,12 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                   undefined-SVG-Mock
                                 </div>
                               </div>
-                              <div
-                                class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8 r-marginTop-knv0ih"
-                                dir="ltr"
+                              <p
+                                class="c5"
+                                style="margin-top: 8px;"
                               >
                                 WhatsApp
-                              </div>
+                              </p>
                             </a>
                           </li>
                           <li
@@ -414,18 +444,18 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                   undefined-SVG-Mock
                                 </div>
                               </div>
-                              <div
-                                class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8 r-marginTop-knv0ih"
-                                dir="ltr"
+                              <p
+                                class="c5"
+                                style="margin-top: 8px;"
                               >
                                 Telegram
-                              </div>
+                              </p>
                             </a>
                           </li>
                         </ul>
                         <button
                           aria-label="Annuler"
-                          class="c3"
+                          class="c6"
                           data-testid="Annuler"
                           tabindex="0"
                           type="button"
@@ -433,13 +463,12 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                           <div
                             class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz r-justifyContent-1777fci r-width-13qz1uu"
                           >
-                            <div
-                              class="css-text-146c3p1 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-7sbvxv"
-                              dir="ltr"
-                              style="color: rgb(255, 255, 255); max-width: 100%; min-width: 0px; flex-shrink: 1; flex-grow: 1; flex-basis: 0px; text-align: center;"
+                            <p
+                              class="c3"
+                              style="color: rgb(255, 255, 255); max-width: 100%; min-width: 0; flex-shrink: 1; flex-grow: 1; flex-basis: 0px; text-align: center;"
                             >
                               Annuler
-                            </div>
+                            </p>
                           </div>
                         </button>
                       </div>

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -144,7 +144,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                       "flexShrink": 1,
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     }
                   }
                 >
@@ -3498,7 +3498,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                       "flexShrink": 1,
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     }
                   }
                 >
@@ -6852,7 +6852,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                       "flexShrink": 1,
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     }
                   }
                 >

--- a/__snapshots__/libs/network/OfflinePage.native.test.tsx.native-snap
+++ b/__snapshots__/libs/network/OfflinePage.native.test.tsx.native-snap
@@ -148,7 +148,7 @@ exports[`<OfflinePage /> should match snapshot with button 1`] = `
                 "flexShrink": 1,
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
-                "lineHeight": 16,
+                "lineHeight": 19.2,
               }
             }
           >

--- a/__snapshots__/ui/pages/PageWithHeader.web.test.tsx.web-snap
+++ b/__snapshots__/ui/pages/PageWithHeader.web.test.tsx.web-snap
@@ -1,6 +1,31 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<PageWithHeader/> should render correctly 1`] = `
+.c1 {
+  display: -webkit-box;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Bold;
+  font-size: 1.0625rem;
+  line-height: 1.7rem;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.c2 {
+  display: inline;
+  text-align: left;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+  color: #161617;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
+}
+
 .c0 {
   flex-direction: row;
   align-items: center;
@@ -87,10 +112,8 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
           class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
         >
           <h1
-            aria-level="1"
-            class="css-text-146c3p1 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-1wf0xld r-lineHeight-1ln193j r-textAlign-q4m81j"
-            dir="ltr"
-            role="heading"
+            class="c1"
+            style="text-align: center;"
           >
             Page with header title
           </h1>
@@ -117,12 +140,11 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
               class="css-view-175oi2r"
               style="flex-grow: 1; flex-direction: column; padding: 65px 24px 24px 24px;"
             >
-              <div
-                class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
-                dir="ltr"
+              <p
+                class="c2"
               >
                 scroll children
-              </div>
+              </p>
               <div
                 class="css-view-175oi2r r-height-3da1kt"
               />
@@ -134,12 +156,11 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
           <div
             class="css-view-175oi2r r-backgroundColor-14lw9ot r-bottom-1p0dtai r-left-1d2f490 r-paddingBottom-qn3fzs r-paddingInline-cxgwc0 r-paddingTop-ttdzmv r-position-u8s1d r-right-zchlnj"
           >
-            <div
-              class="css-text-146c3p1 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
-              dir="ltr"
+            <p
+              class="c2"
             >
               fixed bottom children
-            </div>
+            </p>
             <div
               class="css-view-175oi2r r-height-3da1kt"
             />

--- a/doc/accessibility/audits/web/2026_09_26.md
+++ b/doc/accessibility/audits/web/2026_09_26.md
@@ -10,11 +10,12 @@
 **Ticket** : [PC-42992](https://passculture.atlassian.net/browse/PC-42992)  
 **PR** : [#10010](https://github.com/pass-culture/pass-culture-app-native/pull/10010)
 
+**Problème** 😱
 
-**Problème** 😱  
 - **[ P10 - Réservation d’une offre ]**: L'indication de filtre actif dans le bloc "Distribution" est donnée uniquement par la couleur.
 
-**Correction** 💡  
+**Correction** 💡
+
 - **[ P10 - Réservation d’une offre ]**: Après vérification, il y a bien une bordure qui change d'épaisseur (en plus de la couleur), il n'y a pas de non-conformité.
 
 **Retours audit** 🔥  
@@ -32,12 +33,67 @@ Texte
 **Ticket** : [PC-42998](https://passculture.atlassian.net/browse/PC-42998)  
 **PR** : [#9979](https://github.com/pass-culture/pass-culture-app-native/pull/9979)
 
+**Problème** 😱
 
-**Problème** 😱  
 - **[ Toutes les pages ]**: Le titre des pages dans l'onglet du navigateur n'est pas pertinent.
 
-**Correction** 💡  
+**Correction** 💡
+
 - **[ Toutes les pages ]** : Ajout d'un titre de page pertinent dans l'onglet du navigateur.
+
+**Retours audit** 🔥  
+Texte
+
+</details>
+
+<br>
+
+<details>
+
+<summary> ⏳ Critère 8.9 - Dans chaque page web, les balises ne doivent pas être utilisées uniquement à des fins de présentation ?</summary>
+
+**RGAA** : [Critère 8.9](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#8.9)  
+**Ticket** : [PC-42999](https://passculture.atlassian.net/browse/PC-42999)  
+**PR** : [#9992](https://github.com/pass-culture/pass-culture-app-native/pull/9992)
+
+**Problème** 😱
+
+- **[ P01 - Création de compte]**: Au moins une balise est utilisée uniquement pour créer des effets de présentation, notamment des <div> à la place de <p>.
+- **[ P03 - Accessibilité]**: L'ensemble des textes sont uniquement structurés avec des <div>.
+- **[ P08 - Recherche]**: Le texte "29 résultats" est uniquement structuré avec des <div>.
+
+**Correction** 💡
+
+- **[ P01 - Création de compte]**: Utilisation de balises <p> à la place des balises <span> ou <div> pour les paragraphes.
+- **[ P03 - Accessibilité]**: Utilisation de balises <p> à la place des balises <span> ou <div> pour les paragraphes.
+- **[ P08 - Recherche]**: Utilisation de balises <p> à la place des balises <span> ou <div> pour les paragraphes.
+
+**Retours audit** 🔥  
+Texte
+
+</details>
+
+<br>
+
+<details>
+
+<summary> ⏳ Critère 9.1 - Dans chaque page web, l'information est-elle structurée par l'utilisation appropriée de titres ?</summary>
+
+**RGAA** : [Critère 9.1](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#9.1)  
+**Ticket** : [PC-43000](https://passculture.atlassian.net/browse/PC-43000)  
+**PR** : [#9992](https://github.com/pass-culture/pass-culture-app-native/pull/9992)
+
+**Problème** 😱
+
+- **[ P01 - Création de compte]**: La hiérarchie des titres n'est pas cohérente (il manque des titres, ou des titres ne sont pas pertinents).
+- **[ P10 - Réservation d’une offre]**: La hiérarchie des titres n'est pas cohérente (il manque des titres, ou des titres ne sont pas pertinents)
+- **[ P12 - Lieu]**: La hiérarchie des titres n'est pas cohérente (il manque des titres, ou des titres ne sont pas pertinents)
+
+**Correction** 💡
+
+- **[ P01 - Création de compte]**: Utilisation des bonnes balises de titres.
+- **[ P10 - Réservation d’une offre]**: Utilisation des bonnes balises de titres.
+- **[ P12 - Lieu]**: Utilisation des bonnes balises de titres.
 
 **Retours audit** 🔥  
 Texte
@@ -54,11 +110,12 @@ Texte
 **Ticket** : [PC-42948](https://passculture.atlassian.net/browse/PC-42948)  
 **PR** : [#9980](https://github.com/pass-culture/pass-culture-app-native/pull/9980)
 
+**Problème** 😱
 
-**Problème** 😱  
-- **[ P03 - Accessibilité ]**: La prise de focus n'est pas visible pour tous les éléments de la page. 
+- **[ P03 - Accessibilité ]**: La prise de focus n'est pas visible pour tous les éléments de la page.
 
-**Correction** 💡  
+**Correction** 💡
+
 - **[ P03 - Accessibilité ]** : Suppression de `outline: none` sur le composant `Link`.
 
 **Retours audit** 🔥  
@@ -76,11 +133,12 @@ Texte
 **Ticket** : [PC-43010](https://passculture.atlassian.net/browse/PC-43010)  
 **PR** : [#9994](https://github.com/pass-culture/pass-culture-app-native/pull/9994)
 
+**Problème** 😱
 
-**Problème** 😱  
-- **[ P03 - Accessibilité ]**: La documentation du site ne décrit pas (ou ne décrit pas toutes) les fonctionnalités d'accessibilité de la plateforme. 
+- **[ P03 - Accessibilité ]**: La documentation du site ne décrit pas (ou ne décrit pas toutes) les fonctionnalités d'accessibilité de la plateforme.
 
-**Correction** 💡  
+**Correction** 💡
+
 - **[ P03 - Accessibilité ]** : Ajout dans la déclaration d'accessibilité web et mobile des fonctionnalitées d'accessibilité.
 
 **Retours audit** 🔥  

--- a/src/features/home/components/modules/venues/VenueTile.tsx
+++ b/src/features/home/components/modules/venues/VenueTile.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import React, { memo } from 'react'
-import { View } from 'react-native'
+import { View, Platform } from 'react-native'
 import { useTheme } from 'styled-components'
 import styled from 'styled-components/native'
 
@@ -54,6 +54,7 @@ const UnmemoizedVenueTile = (props: VenueTileProps) => {
   )
 
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.VENUE, { ...venue, distance })
+  const headingProps = Platform.OS === 'web' ? {} : getHeadingAttrs(3)
 
   function handlePressVenue() {
     // We pre-populate the query-cache with the data from the search result for a smooth transition
@@ -69,7 +70,7 @@ const UnmemoizedVenueTile = (props: VenueTileProps) => {
   }
 
   return (
-    <View {...getHeadingAttrs(3)}>
+    <View {...headingProps}>
       <StyledTouchableLink
         width={width}
         navigateTo={{ screen: 'Venue', params: { id: venue.id } }}

--- a/src/features/identityCheck/components/Summary.tsx
+++ b/src/features/identityCheck/components/Summary.tsx
@@ -16,7 +16,7 @@ export const Summary: FC<{ title: string; data: InfoListItemProps[] }> = ({ data
 
   return (
     <ViewGap gap={5}>
-      <AccessibleTitle3>{title}</AccessibleTitle3>
+      <Typo.Title3 {...getNoHeadingAttrs()}>{title}</Typo.Title3>
       <BodyContainer gap={6}>
         {filteredData.map((item) => (
           <SummaryItem key={item.title} {...item} />
@@ -30,14 +30,10 @@ const SummaryItem: FC<InfoListItemProps> = ({ testID, title, value }) => {
   return (
     <ViewGap gap={1}>
       <Typo.BodyXs>{title}</Typo.BodyXs>
-      <Typo.BodyAccent testID={testID} {...getNoHeadingAttrs()}>
-        {value}
-      </Typo.BodyAccent>
+      <Typo.BodyAccent testID={testID}>{value}</Typo.BodyAccent>
     </ViewGap>
   )
 }
-
-const AccessibleTitle3 = styled(Typo.Title3).attrs(getNoHeadingAttrs())``
 
 const BodyContainer = styled(ViewGap)(({ theme }) => ({
   backgroundColor: theme.designSystem.color.background.subtle,

--- a/src/features/offer/components/OfferTile/OfferTile.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useEffect } from 'react'
-import { View } from 'react-native'
+import { View, Platform } from 'react-native'
 import styled from 'styled-components/native'
 
 import { getInteractionTagLabel } from 'features/offer/components/InteractionTag/getInteractionTagLabel'
@@ -60,6 +60,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
     subcategoryId
   )
 
+  const headingProps = Platform.OS === 'web' ? {} : getHeadingAttrs(3)
   const interactionTagLabel = getInteractionTagLabel(interactionTag)
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.OFFER, {
     ...offer,
@@ -96,7 +97,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
 
   return (
     <StyledContainer
-      {...getHeadingAttrs(3)}
+      {...headingProps}
       testID="OfferTile"
       renderToHardwareTextureAndroid
       shouldRasterizeIOS

--- a/src/features/onboarding/components/OnboardingTimeline.stories.tsx
+++ b/src/features/onboarding/components/OnboardingTimeline.stories.tsx
@@ -24,14 +24,6 @@ const variantConfig: Variants<typeof OnboardingTimeline> = [
     label: 'OnboardingTimeline Seventeen',
     props: { age: 17 },
   },
-  {
-    label: 'OnboardingTimeline Sixteen',
-    props: { age: 16 },
-  },
-  {
-    label: 'OnboardingTimeline Fifteen',
-    props: { age: 15 },
-  },
 ]
 
 export const Template: VariantsStory<typeof OnboardingTimeline> = {

--- a/src/features/onboarding/components/OnboardingTimeline.tsx
+++ b/src/features/onboarding/components/OnboardingTimeline.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { CreditComponentProps, CreditTimeline } from 'features/onboarding/components/CreditTimeline'
 import { useDepositAmountsByAge } from 'shared/user/useDepositAmountsByAge'
-import { Typo, getSpacingString } from 'ui/theme'
+import { Typo } from 'ui/theme'
 
 interface Props {
   age: 15 | 16 | 17 | 18
@@ -45,7 +45,6 @@ const stepperPropsMapping = new Map<Props['age'], CreditComponentProps[]>([
 
 const DescriptionText = styled(Typo.BodyAccentXs)(({ theme }) => ({
   fontSize: theme.tabBar.fontSize,
-  lineHeight: getSpacingString(3),
   marginTop: theme.designSystem.size.spacing.xs,
   color: theme.designSystem.color.text.subtle,
 }))

--- a/src/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.tsx
@@ -23,7 +23,7 @@ type AgeButtonProps = {
 
 export const OnboardingAgeSelectionFork: FunctionComponent = () => {
   const onAgeChoice = async (age: NonEligible | EligibleAges) => {
-    analytics.logSelectAge({ age })
+    void analytics.logSelectAge({ age })
     await storage.saveObject('user_age', age)
   }
 
@@ -80,9 +80,11 @@ export const OnboardingAgeSelectionFork: FunctionComponent = () => {
     </TutorialPage>
   )
 }
+
 const Separator = styled.View(({ theme }) => ({
   height: theme.designSystem.size.spacing.l,
 }))
+
 const StyledTitle4 = styled(Typo.Title4).attrs(getNoHeadingAttrs)(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))

--- a/src/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.web.test.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.web.test.tsx
@@ -1,16 +1,14 @@
 import React from 'react'
 
 import { OnboardingAgeSelectionFork } from 'features/onboarding/pages/onboarding/OnboardingAgeSelectionFork'
-import { checkAccessibilityFor, render } from 'tests/utils/web'
+import { render } from 'tests/utils/web'
 
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('OnboardingAgeSelectionFork', () => {
-  it('should not have basic accessibility', async () => {
+  it('should render null in web', () => {
     const { container } = render(<OnboardingAgeSelectionFork />)
 
-    const results = await checkAccessibilityFor(container)
-
-    expect(results).toHaveNoViolations()
+    expect(container).toBeEmptyDOMElement()
   })
 })

--- a/src/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.web.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.web.tsx
@@ -1,0 +1,1 @@
+export const OnboardingAgeSelectionFork = () => null

--- a/src/features/search/components/FilterSwitchWithLabel/FilterSwitchWithLabel.tsx
+++ b/src/features/search/components/FilterSwitchWithLabel/FilterSwitchWithLabel.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useMemo } from 'react'
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -8,7 +8,7 @@ import FilterSwitch from 'ui/components/FilterSwitch'
 import { InputLabel } from 'ui/components/InputLabel/InputLabel'
 import { styledInputLabel } from 'ui/components/InputLabel/styledInputLabel'
 import { Typo } from 'ui/theme'
-import { HeadingLevel, getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type Props = {
   isActive: boolean
@@ -16,7 +16,6 @@ type Props = {
   label: string
   testID?: string
   subtitle?: string
-  accessibilityLevel?: HeadingLevel
   disabled?: boolean
 }
 
@@ -26,7 +25,6 @@ export const FilterSwitchWithLabel: FunctionComponent<Props> = ({
   label,
   testID,
   subtitle,
-  accessibilityLevel,
   disabled,
 }) => {
   const checkboxID = uuidv4()
@@ -36,12 +34,11 @@ export const FilterSwitchWithLabel: FunctionComponent<Props> = ({
 
   const computedAccessibilityLabel = getComputedAccessibilityLabel(label, subtitle)
 
-  const TitleWithSubtitle = useMemo(
-    () => (
-      <View
-        accessibilityLabel={computedAccessibilityLabel}
-        {...getHeadingAttrs(accessibilityLevel ?? 2)}
-        accessible>
+  const TitleWithSubtitle = useMemo(() => {
+    const headingProps = Platform.OS === 'web' ? {} : getHeadingAttrs(2)
+
+    return (
+      <View {...headingProps} accessibilityLabel={computedAccessibilityLabel} accessible>
         <StyledInputLabel
           id={labelID}
           htmlFor={checkboxID}
@@ -50,18 +47,8 @@ export const FilterSwitchWithLabel: FunctionComponent<Props> = ({
         </StyledInputLabel>
         {subtitle ? <Subtitle nativeID={labelDescriptionID}>{subtitle}</Subtitle> : null}
       </View>
-    ),
-
-    [
-      accessibilityLevel,
-      computedAccessibilityLabel,
-      labelID,
-      checkboxID,
-      labelDescriptionID,
-      label,
-      subtitle,
-    ]
-  )
+    )
+  }, [computedAccessibilityLabel, labelID, checkboxID, labelDescriptionID, label, subtitle])
 
   return (
     <Container inverseLayout={!!isDesktopViewport}>

--- a/src/features/search/components/SearchHeader/SearchHeader.native.test.tsx
+++ b/src/features/search/components/SearchHeader/SearchHeader.native.test.tsx
@@ -1,6 +1,5 @@
 import { useRoute } from '@react-navigation/native'
 import React from 'react'
-import { v4 as uuidv4 } from 'uuid'
 
 import { SearchHeader } from 'features/search/components/SearchHeader/SearchHeader'
 import { initialSearchState } from 'features/search/context/reducer'
@@ -158,12 +157,9 @@ function renderSearchHeader({
   isDesktopViewport,
   isMobileViewport,
 }: RenderSearchHeaderProps) {
-  const searchInputID = uuidv4()
-
   return render(
     reactQueryProviderHOC(
       <SearchHeader
-        searchInputID={searchInputID}
         shouldDisplaySubtitle={shouldDisplaySubtitle}
         addSearchHistory={jest.fn()}
         searchInHistory={jest.fn()}

--- a/src/features/search/components/SearchHeader/SearchHeader.tsx
+++ b/src/features/search/components/SearchHeader/SearchHeader.tsx
@@ -16,7 +16,6 @@ import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Spacer } from 'ui/theme'
 
 type Props = {
-  searchInputID: string
   addSearchHistory: (item: CreateHistoryItem) => void
   searchInHistory: (search: string) => void
   offerCategories?: SearchGroupNameEnumv2[]
@@ -28,7 +27,6 @@ type Props = {
 }
 
 export const SearchHeader = ({
-  searchInputID,
   addSearchHistory,
   searchInHistory,
   shouldDisplaySubtitle = false,
@@ -70,11 +68,7 @@ export const SearchHeader = ({
                 />
               </StyledView>
             ) : null}
-            <SearchTitleAndWidget
-              searchInputID={searchInputID}
-              shouldDisplaySubtitle={shouldDisplaySubtitle}
-              title={title}
-            />
+            <SearchTitleAndWidget shouldDisplaySubtitle={shouldDisplaySubtitle} title={title} />
           </RowContainer>
         ) : null}
         <Container>

--- a/src/features/search/components/SearchHeader/SearchHeader.web.test.tsx
+++ b/src/features/search/components/SearchHeader/SearchHeader.web.test.tsx
@@ -1,6 +1,5 @@
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { v4 as uuidv4 } from 'uuid'
 
 import { initialSearchState } from 'features/search/context/reducer'
 import { ISearchContext } from 'features/search/context/SearchWrapper'
@@ -21,8 +20,6 @@ jest.mock('react-instantsearch-core', () => ({
     hits: [],
   }),
 }))
-
-const searchInputID = uuidv4()
 
 const mockDispatch = jest.fn()
 const mockShowSuggestions = jest.fn()
@@ -54,7 +51,6 @@ describe('SearchHeader component', () => {
   it('should focus on location widget button', async () => {
     render(
       <SearchHeader
-        searchInputID={searchInputID}
         addSearchHistory={jest.fn()}
         searchInHistory={jest.fn()}
         shouldDisplaySubtitle
@@ -89,14 +85,7 @@ describe('SearchHeader component', () => {
       searchState: { ...modifiedSearchState, minPrice: 10, maxPrice: 300 },
     })
 
-    render(
-      <SearchHeader
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-        withArrow
-      />
-    )
+    render(<SearchHeader addSearchHistory={jest.fn()} searchInHistory={jest.fn()} withArrow />)
     await userEvent.click(screen.getByLabelText('Revenir en arrière'))
 
     await waitFor(() => {
@@ -119,7 +108,6 @@ describe('SearchHeader component', () => {
     it('should not render a button to focus on suggestion', async () => {
       render(
         <SearchHeader
-          searchInputID={searchInputID}
           addSearchHistory={jest.fn()}
           searchInHistory={jest.fn()}
           shouldDisplaySubtitle

--- a/src/features/search/components/SearchTitleAndWidget/SearchTitleAndWidget.tsx
+++ b/src/features/search/components/SearchTitleAndWidget/SearchTitleAndWidget.tsx
@@ -37,8 +37,8 @@ export const SearchTitleAndWidget: FunctionComponent<Props> = ({
         <TitleMainWrapper>
           <StyledTitleMainView>
             <StyledTitleMainText
-              htmlFor={searchInputID}
               {...getHeadingAttrs(1)}
+              htmlFor={searchInputID}
               small={shouldDisplayMobileLocationSmallWidget}>
               {title}
             </StyledTitleMainText>

--- a/src/features/search/components/SearchTitleAndWidget/SearchTitleAndWidget.tsx
+++ b/src/features/search/components/SearchTitleAndWidget/SearchTitleAndWidget.tsx
@@ -8,19 +8,16 @@ import { LocationWidgetBadge } from 'features/location/components/LocationWidget
 import { SearchLocationWidgetDesktopView } from 'features/location/components/SearchLocationWidgetDesktopView'
 import { ScreenOrigin } from 'features/location/enums'
 import { SearchView } from 'features/search/types'
-import { InputLabel } from 'ui/components/InputLabel/InputLabel'
 import { styledInputLabel } from 'ui/components/InputLabel/styledInputLabel'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { Typo } from 'ui/theme'
 
 type Props = {
   shouldDisplaySubtitle?: boolean
-  searchInputID: string
   title: string
 }
 
 export const SearchTitleAndWidget: FunctionComponent<Props> = ({
   shouldDisplaySubtitle = false,
-  searchInputID,
   title,
 }) => {
   const { isMobileViewport, isDesktopViewport } = useTheme()
@@ -36,10 +33,7 @@ export const SearchTitleAndWidget: FunctionComponent<Props> = ({
       <TitleContainer testID="SearchHeaderTitleContainer">
         <TitleMainWrapper>
           <StyledTitleMainView>
-            <StyledTitleMainText
-              {...getHeadingAttrs(1)}
-              htmlFor={searchInputID}
-              small={shouldDisplayMobileLocationSmallWidget}>
+            <StyledTitleMainText small={shouldDisplayMobileLocationSmallWidget}>
               {title}
             </StyledTitleMainText>
           </StyledTitleMainView>
@@ -60,7 +54,7 @@ export const SearchTitleAndWidget: FunctionComponent<Props> = ({
   )
 }
 
-const StyledTitleMainText = styledInputLabel(InputLabel)<{ small?: boolean }>(
+const StyledTitleMainText = styledInputLabel(Typo.Title1)<{ small?: boolean }>(
   ({ theme, small = false }) => ({
     ...(small ? theme.designSystem.typography.title3 : theme.designSystem.typography.title1),
     color: theme.designSystem.color.text.default,

--- a/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
+++ b/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react'
-import { View } from 'react-native'
+import { View, Platform } from 'react-native'
 import { useTheme } from 'styled-components'
 import styled from 'styled-components/native'
 
@@ -54,6 +54,7 @@ const UnmemoizedSearchVenueItem = ({
   const { lat, lng } = venue._geoloc
   const distance = getDistance({ lat, lng }, { userLocation, selectedPlace, selectedLocationMode })
 
+  const headingProps = Platform.OS === 'web' ? {} : getHeadingAttrs(3)
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.VENUE, {
     ...venue,
     distance: distance ? `à ${distance}` : undefined,
@@ -77,7 +78,7 @@ const UnmemoizedSearchVenueItem = ({
   }
 
   return (
-    <View {...getHeadingAttrs(3)}>
+    <View {...headingProps}>
       <SearchVenueTouchableLink
         width={width}
         navigateTo={{

--- a/src/features/search/components/SelectionLabel/SelectionLabel.tsx
+++ b/src/features/search/components/SelectionLabel/SelectionLabel.tsx
@@ -18,16 +18,18 @@ export const SelectionLabel: React.FC<Props> = ({ label, selected, onPress }) =>
   return (
     <StyledTouchableOpacity
       selected={selected}
-      {...accessibleCheckboxProps({ checked: selected, label })}
-      onPress={onPress}>
+      onPress={onPress}
+      {...accessibleCheckboxProps({ checked: selected, label })}>
       {selected ? (
         <IconContainer>
           <ValidateWhite />
         </IconContainer>
       ) : undefined}
-      <Label numberOfLines={1} selected={selected}>
-        {label}
-      </Label>
+      <LabelContainer selected={selected}>
+        <Label numberOfLines={1} selected={selected}>
+          {label}
+        </Label>
+      </LabelContainer>
       <HiddenCheckbox name={label} checked={selected} accessibilityLabel={label} />
     </StyledTouchableOpacity>
   )
@@ -62,9 +64,18 @@ const StyledTouchableOpacity = styled(TouchableOpacity)<{ selected: boolean }>(
   })
 )
 
-const Label = styled(Typo.BodyAccent)<{ selected: boolean }>(({ theme, selected }) => ({
+const LabelContainer = styled.View<{ selected: boolean }>(({ theme, selected }) => ({
   marginLeft: selected ? undefined : theme.designSystem.size.spacing.xl,
   marginRight: selected ? theme.designSystem.size.spacing.s : theme.designSystem.size.spacing.xl,
   marginVertical: theme.designSystem.size.spacing.m,
+  flex: 1,
+  minWidth: 0,
+}))
+
+const Label = styled(Typo.BodyAccent)<{ selected: boolean }>(({ theme, selected }) => ({
   color: selected ? theme.designSystem.color.text.inverted : theme.designSystem.color.text.default,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  display: 'block',
 }))

--- a/src/features/search/pages/SearchLanding/SearchLanding.tsx
+++ b/src/features/search/pages/SearchLanding/SearchLanding.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react'
 import { Configure, InstantSearch } from 'react-instantsearch-core'
 import AlgoliaSearchInsights from 'search-insights'
 import styled from 'styled-components/native'
-import { v4 as uuidv4 } from 'uuid'
 
 import { CategoriesList } from 'features/search/components/CategoriesList/CategoriesList'
 import { SearchHeader } from 'features/search/components/SearchHeader/SearchHeader'
@@ -22,7 +21,6 @@ import { useIsLandscape } from 'shared/useIsLandscape/useIsLandscape'
 import { Form } from 'ui/components/Form'
 import { Page } from 'ui/pages/Page'
 
-const searchInputID = uuidv4()
 const suggestionsIndex = env.ALGOLIA_SUGGESTIONS_INDEX_NAME
 
 export const SearchLanding = () => {
@@ -48,7 +46,6 @@ export const SearchLanding = () => {
   const searchHeader = (
     <Container>
       <SearchHeader
-        searchInputID={searchInputID}
         shouldDisplaySubtitle
         addSearchHistory={addToHistory}
         searchInHistory={setQueryHistoryMemoized}

--- a/src/features/search/pages/SearchResults/v1/SearchResults.tsx
+++ b/src/features/search/pages/SearchResults/v1/SearchResults.tsx
@@ -26,7 +26,6 @@ import { Form } from 'ui/components/Form'
 import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { Page } from 'ui/pages/Page'
 
-const searchInputID = uuidv4()
 const suggestionsIndex = env.ALGOLIA_SUGGESTIONS_INDEX_NAME
 
 export const SearchResults: FC = () => {
@@ -125,7 +124,6 @@ export const SearchResults: FC = () => {
   const searchHeader = (
     <Container>
       <SearchHeader
-        searchInputID={searchInputID}
         addSearchHistory={addToHistory}
         searchInHistory={setQueryHistoryMemoized}
         withFilterButton={!isFocusOnSuggestions}

--- a/src/features/search/pages/SearchResults/v2/SearchResults.tsx
+++ b/src/features/search/pages/SearchResults/v2/SearchResults.tsx
@@ -35,7 +35,6 @@ import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHe
 import { useIsLandscape } from 'shared/useIsLandscape/useIsLandscape'
 import { Page } from 'ui/pages/Page'
 
-const searchInputID = uuidv4()
 const searchIdGenerated = uuidv4()
 const suggestionsIndex = env.ALGOLIA_SUGGESTIONS_INDEX_NAME
 
@@ -101,7 +100,6 @@ export const SearchResults: FC = () => {
   const searchHeader = (
     <Container>
       <SearchHeader
-        searchInputID={searchInputID}
         addSearchHistory={addToHistory}
         searchInHistory={setQueryHistoryMemoized}
         withFilterButton={!isFocusOnSuggestions}

--- a/src/features/search/pages/ThematicSearch/ThematicSearchBar.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearchBar.tsx
@@ -2,7 +2,6 @@ import React, { FC, PropsWithChildren, useCallback } from 'react'
 import { Configure, InstantSearch } from 'react-instantsearch-core'
 import AlgoliaSearchInsights from 'search-insights'
 import styled from 'styled-components/native'
-import { v4 as uuidv4 } from 'uuid'
 
 import { SearchGroupNameEnumv2 } from 'api/gen'
 import { SearchHeader } from 'features/search/components/SearchHeader/SearchHeader'
@@ -12,8 +11,6 @@ import { getSearchClient } from 'features/search/helpers/getSearchClient'
 import { useSearchHistory } from 'features/search/helpers/useSearchHistory/useSearchHistory'
 import { FACETS_FILTERS_ENUM } from 'libs/algolia/enums/facetsEnums'
 import { env } from 'libs/environment/env'
-
-const searchInputID = uuidv4()
 
 const suggestionsIndex = env.ALGOLIA_SUGGESTIONS_INDEX_NAME
 
@@ -54,7 +51,6 @@ export const ThematicSearchBar: FC<PropsWithChildren<Props>> = ({
           title={title}
           withArrow
           shouldDisplayHeader={!isFocusOnSuggestions}
-          searchInputID={searchInputID}
           addSearchHistory={addToHistory}
           searchInHistory={setQueryHistoryMemoized}
           offerCategories={offerCategories}

--- a/src/features/venue/components/Placeholders/NoOfferPlaceholder.tsx
+++ b/src/features/venue/components/Placeholders/NoOfferPlaceholder.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { NoOffer } from 'ui/svg/icons/NoOffer'
 import { Typo } from 'ui/theme'
+import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
 
 type Props = {
   isOpenToPublic: boolean
@@ -12,7 +13,7 @@ type Props = {
 export const NoOfferPlaceholder = ({ isOpenToPublic }: Props) => (
   <Container gap={2}>
     <NoOfferIllustration />
-    <Text>
+    <Text {...getNoHeadingAttrs()}>
       {isOpenToPublic
         ? 'Il n’y a pas encore d’offre disponible dans ce lieu'
         : 'Cette structure ne propose pas encore d’offre'}

--- a/src/shared/categoryButton/CategoryButton.tsx
+++ b/src/shared/categoryButton/CategoryButton.tsx
@@ -52,9 +52,9 @@ export const CategoryButton: FunctionComponent<CategoryButtonProps> = ({
       borderColor={borderColor}
       style={style}
       height={effectiveHeight}>
-      <LabelContainer>
-        <Label>{label.toUpperCase()}</Label>
-      </LabelContainer>
+      {/* <LabelContainer> */}
+      <Label>{label.toUpperCase()}</Label>
+      {/* </LabelContainer> */}
     </TouchableContainer>
   )
 }
@@ -78,16 +78,19 @@ const TouchableContainer: typeof InternalTouchableLink = styled(InternalTouchabl
   backgroundColor: baseColor,
   borderColor,
   borderWidth: '1.6px',
-  flexDirection: 'column',
-  display: 'flex',
+  // flexDirection: 'column',
+  // alignItems: 'flex-start',
+  // display: 'flex',
   justifyContent: height ? 'flex-end' : undefined,
+  padding: theme.designSystem.size.spacing.s,
+  // width: '100%',
+  // flex: 1,
 }))
 
-const LabelContainer = styled.View(({ theme }) => ({
-  padding: theme.designSystem.size.spacing.s,
-  width: '100%',
-  alignItems: 'flex-start',
-}))
+// const LabelContainer = styled.View(({ theme }) => ({
+//   flex: 1,
+//   minWidth: 0,
+// }))
 
 const Label = styled(Typo.BodyAccentS).attrs({ numberOfLines: 4 })(({ theme }) => ({
   textAlign: 'left',

--- a/src/shared/categoryButton/CategoryButton.tsx
+++ b/src/shared/categoryButton/CategoryButton.tsx
@@ -78,19 +78,9 @@ const TouchableContainer: typeof InternalTouchableLink = styled(InternalTouchabl
   backgroundColor: baseColor,
   borderColor,
   borderWidth: '1.6px',
-  // flexDirection: 'column',
-  // alignItems: 'flex-start',
-  // display: 'flex',
   justifyContent: height ? 'flex-end' : undefined,
   padding: theme.designSystem.size.spacing.s,
-  // width: '100%',
-  // flex: 1,
 }))
-
-// const LabelContainer = styled.View(({ theme }) => ({
-//   flex: 1,
-//   minWidth: 0,
-// }))
 
 const Label = styled(Typo.BodyAccentS).attrs({ numberOfLines: 4 })(({ theme }) => ({
   textAlign: 'left',

--- a/src/ui/components/Accordion.tsx
+++ b/src/ui/components/Accordion.tsx
@@ -137,7 +137,7 @@ export const Accordion = ({
           {...focusProps}
           {...accessibilityProps}>
           <StyledTitleContainer nativeID={accordionLabelId} style={titleStyle}>
-            <Title {...getHeadingAttrs(2)}>{title}</Title>
+            <Title {...getHeadingAttrs(3)}>{title}</Title>
             <StyledArrowAnimatedView
               style={{ transform: [{ rotateZ: arrowAngle }] }}
               testID="accordionArrow">

--- a/src/ui/components/ActionCardBase.tsx
+++ b/src/ui/components/ActionCardBase.tsx
@@ -10,6 +10,7 @@ import { ArrowRight } from 'ui/svg/icons/ArrowRight'
 import { Typo } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
 
 type ActionCardLayout = 'split' | 'overlay'
 
@@ -72,12 +73,12 @@ export const ActionCardBase: FunctionComponent<Props> = ({
         </DateText>
       ) : null}
       {title ? (
-        <Title testID="firstLine" numberOfLines={3} {...getHeadingAttrs(1)}>
+        <Title testID="firstLine" numberOfLines={3} {...getHeadingAttrs(2)}>
           {title}
         </Title>
       ) : null}
       {subtitle ? (
-        <Subtitle testID="secondLine" numberOfLines={3} {...getHeadingAttrs(2)}>
+        <Subtitle testID="secondLine" numberOfLines={3} {...getNoHeadingAttrs()}>
           {subtitle}
         </Subtitle>
       ) : null}

--- a/src/ui/components/Badge/Badge.tsx
+++ b/src/ui/components/Badge/Badge.tsx
@@ -15,7 +15,7 @@ export const Badge: FunctionComponent<Props> = ({ value, ...props }) => {
   return (
     <Container {...props}>
       <Wrapper BADGE_SIZE={BADGE_SIZE}>
-        <Caption BADGE_SIZE={BADGE_SIZE}>{value}</Caption>
+        <Caption>{value}</Caption>
       </Wrapper>
     </Container>
   )
@@ -36,8 +36,7 @@ const Wrapper = styled.View<{ BADGE_SIZE: number }>(({ BADGE_SIZE, theme }) => (
   paddingHorizontal: theme.designSystem.size.spacing.xxs,
 }))
 
-const Caption = styled(Typo.BodyAccentXs)<{ BADGE_SIZE: number }>(({ BADGE_SIZE, theme }) => ({
+const Caption = styled(Typo.BodyAccentXs)(({ theme }) => ({
   textAlign: 'center',
   color: theme.designSystem.color.text.inverted,
-  lineHeight: `${BADGE_SIZE}px`,
 }))

--- a/src/ui/components/InputLabel/InputLabel.web.tsx
+++ b/src/ui/components/InputLabel/InputLabel.web.tsx
@@ -16,7 +16,6 @@ const StyledLabel = styled.label<{ color?: TextColorKey }>(({ theme }) => ({
   cursor: 'pointer',
 }))
 
-// Trouver un moyen d'utiliser le getHeadingAttrs() + role label en web
 export const InputLabel: React.FC<InputLabelProps> = ({ children, ...props }) => {
   return <StyledLabel {...props}>{children}</StyledLabel>
 }

--- a/src/ui/components/InputLabel/InputLabel.web.tsx
+++ b/src/ui/components/InputLabel/InputLabel.web.tsx
@@ -16,6 +16,7 @@ const StyledLabel = styled.label<{ color?: TextColorKey }>(({ theme }) => ({
   cursor: 'pointer',
 }))
 
+// Trouver un moyen d'utiliser le getHeadingAttrs() + role label en web
 export const InputLabel: React.FC<InputLabelProps> = ({ children, ...props }) => {
   return <StyledLabel {...props}>{children}</StyledLabel>
 }

--- a/src/ui/components/StepButton/StepButton.tsx
+++ b/src/ui/components/StepButton/StepButton.tsx
@@ -117,6 +117,7 @@ type BaseContainerProps = {
   LeftIcon?: React.ReactElement
   style?: StyleProp<ViewStyle>
 }
+
 const BaseContainer: FunctionComponent<BaseContainerProps> = ({ LeftIcon, style, children }) => (
   <BaseStyleComponent style={style}>
     {LeftIcon ? <IconContainer>{LeftIcon}</IconContainer> : null}
@@ -158,15 +159,12 @@ const IconContainer = styled.View(({ theme }) => ({ padding: theme.designSystem.
 
 const ChildrenContainer = styled.View(({ theme }) => ({
   flexDirection: 'column',
-  flex: 1,
   paddingRight: theme.designSystem.size.spacing.l,
 }))
 
 const StyledInternalTouchableLink: typeof InternalTouchableLink = styled(
   InternalTouchableLink
-).attrs<{
-  color: ColorsType
-}>(({ color }) => ({
+).attrs<{ color: ColorsType }>(({ color }) => ({
   hoverUnderlineColor: color,
 }))<{ isFocus: boolean }>(({ theme, isFocus }) => ({
   width: '100%',

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButton.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButton.tsx
@@ -81,17 +81,18 @@ const StyledInternalTouchable: typeof InternalTouchableLink = styled(InternalTou
   borderWidth: 1.6,
   borderStyle: 'solid',
   borderRadius: theme.designSystem.size.borderRadius.m,
-  ...customFocusOutline({ theme, isFocus }),
   textAlign: 'left',
   alignItems: 'center',
   paddingVertical: theme.designSystem.size.spacing.s,
-  ...(Platform.OS === 'web' && { paddingHorizontal: theme.designSystem.size.spacing.s }),
+  ...customFocusOutline({ theme, isFocus }),
+  ...(Platform.OS === 'web'
+    ? { paddingHorizontal: theme.designSystem.size.spacing.l }
+    : { paddingHorizontal: theme.designSystem.size.spacing.s }),
 }))
 
 const StyledText = styled(Typo.BodyAccentXs).attrs({
   ellipsizeMode: 'tail',
   numberOfLines: 3,
 })<{ isHover?: boolean }>(({ theme, isHover }) => ({
-  marginHorizontal: Number(theme.designSystem.size.spacing.s),
   ...getHoverStyle({ underlineColor: theme.designSystem.color.text.default, isHover }),
 }))

--- a/src/ui/components/eventCard/EventCard.tsx
+++ b/src/ui/components/eventCard/EventCard.tsx
@@ -93,7 +93,6 @@ const SubtitleLeft = styled(Typo.BodyAccentXs)<{
   hasSubtitleRight: boolean
 }>(({ theme, disabled, hasSubtitleRight }) => ({
   color: disabled ? theme.designSystem.color.text.disabled : theme.designSystem.color.text.subtle,
-  lineHeight: `${theme.designSystem.size.spacing.xl}px`,
   textAlign: 'left',
   flex: hasSubtitleRight ? 'auto' : 1,
 }))

--- a/src/ui/designSystem/Tag/Tag.tsx
+++ b/src/ui/designSystem/Tag/Tag.tsx
@@ -11,9 +11,7 @@ import { getTagColors } from 'ui/designSystem/Tag/helper/getTagColors'
 import { getTagIcon } from 'ui/designSystem/Tag/helper/getTagIcon'
 import { renderTagIcon } from 'ui/designSystem/Tag/helper/renderTagIcon'
 import { TagProps, TagVariant } from 'ui/designSystem/Tag/types'
-import { Typo, getSpacingString } from 'ui/theme'
-
-const NUMBER_OF_SPACES_LINE_HEIGHT = 4
+import { Typo } from 'ui/theme'
 
 export const Tag: FunctionComponent<TagProps> = ({
   label,
@@ -62,7 +60,6 @@ const Wrapper = styled.View<{ backgroundColor: string; isZoomed: boolean }>(
 )
 
 const LabelText = styled(Typo.BodyAccentXs)<{ isZoomed: boolean }>(({ isZoomed }) => ({
-  lineHeight: getSpacingString(NUMBER_OF_SPACES_LINE_HEIGHT),
   flexShrink: isZoomed ? 1 : undefined,
   ...(Platform.OS === 'web' && { textWrap: 'nowrap' }),
 }))

--- a/src/ui/storybook/AssetGridTemplate.tsx
+++ b/src/ui/storybook/AssetGridTemplate.tsx
@@ -53,7 +53,9 @@ export const AssetGridTemplate: React.FC<AssetGridTemplateProps> = ({
 
   return (
     <React.Fragment>
-      <StyledTitle2>{title}</StyledTitle2>
+      <TitleContainer>
+        <Typo.Title2>{title}</Typo.Title2>
+      </TitleContainer>
       <GridContainer>
         {sortedIcons.map(([name, Icon]) => {
           const isCopied = copiedAssetName === name
@@ -100,7 +102,7 @@ export const AssetGridTemplate: React.FC<AssetGridTemplateProps> = ({
   )
 }
 
-const StyledTitle2 = styled(Typo.Title2)(({ theme }) => ({
+const TitleContainer = styled.View(({ theme }) => ({
   marginVertical: theme.designSystem.size.spacing.m,
 }))
 

--- a/src/ui/theme/isHeadingLevel.ts
+++ b/src/ui/theme/isHeadingLevel.ts
@@ -1,0 +1,5 @@
+import { HeadingLevel } from 'ui/theme/typographyAttrs/types'
+
+export const isHeadingLevel = (level: unknown): level is Exclude<HeadingLevel, 'p'> => {
+  return typeof level === 'number' && [1, 2, 3, 4].includes(level)
+}

--- a/src/ui/theme/typography.tsx
+++ b/src/ui/theme/typography.tsx
@@ -4,29 +4,19 @@ import styled from 'styled-components/native'
 // eslint-disable-next-line local-rules/no-theme-from-theme
 import { theme } from 'theme'
 import { TextColorKey } from 'theme/types'
-import { getHeadingAttrs, HeadingLevel } from 'ui/theme/typographyAttrs/getHeadingAttrs'
-
-// Function to validate if a value is a HeadingLevel valid to correct typing
-const isHeadingLevel = (level: unknown): level is HeadingLevel => {
-  return typeof level === 'number' && [1, 2, 3, 4, 5, 6].includes(level)
-}
+import { isHeadingLevel } from 'ui/theme/isHeadingLevel'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { HeadingLevel } from 'ui/theme/typographyAttrs/types'
 
 const DEFAULT_COLOR_TEXT = 'default'
-
-type HeadingProps = {
-  accessibilityLevel?: HeadingLevel
-  noHeading?: boolean
-}
 
 const createStyledText = (
   typographyStyle: keyof typeof theme.designSystem.typography,
   defaultLevel?: HeadingLevel
 ) => {
-  return styled(RNText).attrs<HeadingProps>(({ accessibilityLevel, noHeading }) => {
-    if (noHeading) return getHeadingAttrs(undefined)
+  return styled(RNText).attrs<{ accessibilityLevel?: HeadingLevel }>(({ accessibilityLevel }) => {
     if (isHeadingLevel(accessibilityLevel)) return getHeadingAttrs(accessibilityLevel)
-    if (isHeadingLevel(defaultLevel)) return getHeadingAttrs(defaultLevel)
-
+    else if (isHeadingLevel(defaultLevel)) return getHeadingAttrs(defaultLevel)
     return {}
   })<{ color?: TextColorKey }>(({ theme, color }) => ({
     ...theme.designSystem.typography[typographyStyle],
@@ -34,34 +24,19 @@ const createStyledText = (
   }))
 }
 
-const Title1 = createStyledText('title1', 1)
-const Title2 = createStyledText('title2', 2)
-const Title3 = createStyledText('title3', 3)
-const Title4 = createStyledText('title4', 4)
-const Body = createStyledText('body')
-const BodyS = createStyledText('bodyS')
-const BodyXs = createStyledText('bodyXs')
-const BodyAccent = createStyledText('bodyAccent')
-const BodyAccentS = createStyledText('bodyAccentS')
-const BodyAccentXs = createStyledText('bodyAccentXs')
-const BodyItalic = createStyledText('bodyItalic')
-const BodyItalicAccent = createStyledText('bodyItalicAccent')
-const Button = createStyledText('button')
-const ButtonS = createStyledText('buttonS')
-
 export const Typo = {
-  Title1,
-  Title2,
-  Title3,
-  Title4,
-  Body,
-  BodyS,
-  BodyXs,
-  BodyAccent,
-  BodyAccentS,
-  BodyAccentXs,
-  BodyItalic,
-  BodyItalicAccent,
-  Button,
-  ButtonS,
+  Title1: createStyledText('title1', 1),
+  Title2: createStyledText('title2', 2),
+  Title3: createStyledText('title3', 3),
+  Title4: createStyledText('title4', 4),
+  Body: createStyledText('body'),
+  BodyS: createStyledText('bodyS'),
+  BodyXs: createStyledText('bodyXs'),
+  BodyAccent: createStyledText('bodyAccent'),
+  BodyAccentS: createStyledText('bodyAccentS'),
+  BodyAccentXs: createStyledText('bodyAccentXs'),
+  BodyItalic: createStyledText('bodyItalic'),
+  BodyItalicAccent: createStyledText('bodyItalicAccent'),
+  Button: createStyledText('button'),
+  ButtonS: createStyledText('buttonS'),
 }

--- a/src/ui/theme/typography.tsx
+++ b/src/ui/theme/typography.tsx
@@ -13,16 +13,20 @@ const isHeadingLevel = (level: unknown): level is HeadingLevel => {
 
 const DEFAULT_COLOR_TEXT = 'default'
 
+type HeadingProps = {
+  accessibilityLevel?: HeadingLevel
+  noHeading?: boolean
+}
+
 const createStyledText = (
   typographyStyle: keyof typeof theme.designSystem.typography,
   defaultLevel?: HeadingLevel
 ) => {
-  return styled(RNText).attrs<{ accessibilityLevel?: HeadingLevel }>(({ accessibilityLevel }) => {
-    if (isHeadingLevel(accessibilityLevel)) {
-      return getHeadingAttrs(accessibilityLevel)
-    } else if (isHeadingLevel(defaultLevel)) {
-      return getHeadingAttrs(defaultLevel)
-    }
+  return styled(RNText).attrs<HeadingProps>(({ accessibilityLevel, noHeading }) => {
+    if (noHeading) return getHeadingAttrs(undefined)
+    if (isHeadingLevel(accessibilityLevel)) return getHeadingAttrs(accessibilityLevel)
+    if (isHeadingLevel(defaultLevel)) return getHeadingAttrs(defaultLevel)
+
     return {}
   })<{ color?: TextColorKey }>(({ theme, color }) => ({
     ...theme.designSystem.typography[typographyStyle],

--- a/src/ui/theme/typography.web.tsx
+++ b/src/ui/theme/typography.web.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import styled from 'styled-components'
+
+// eslint-disable-next-line local-rules/no-theme-from-theme
+import { theme } from 'theme'
+import { TextColorKey } from 'theme/types'
+import { isHeadingLevel } from 'ui/theme/isHeadingLevel'
+import { HeadingLevel } from 'ui/theme/typographyAttrs/types'
+
+const DEFAULT_COLOR_TEXT = 'default'
+
+const createStyledText = (
+  typographyStyle: keyof typeof theme.designSystem.typography,
+  defaultLevel?: HeadingLevel
+) => {
+  const StyledText = styled.p<{ theme; color?: TextColorKey; numberOfLines?: number }>(
+    ({ theme, color, numberOfLines }) => ({
+      display: 'inline',
+      textAlign: 'left',
+      overflowWrap: 'anywhere',
+      whiteSpace: 'pre-line',
+      color: theme.designSystem.color.text[color ?? DEFAULT_COLOR_TEXT],
+      ...theme.designSystem.typography[typographyStyle],
+      ...(numberOfLines
+        ? {
+            overflow: 'hidden',
+            display: '-webkit-box',
+            WebkitBoxOrient: 'vertical',
+            WebkitLineClamp: numberOfLines,
+          }
+        : {}),
+    })
+  )
+
+  type Props = React.ComponentPropsWithoutRef<typeof StyledText> & {
+    accessibilityLevel?: HeadingLevel
+    numberOfLines?: number
+    color?: TextColorKey
+  }
+
+  const Component = ({ accessibilityLevel, numberOfLines, ...props }: Props) => {
+    const level = accessibilityLevel ?? defaultLevel
+    const isValidHeading = level !== 'p' && isHeadingLevel(level)
+    const tag = isValidHeading ? `h${level}` : 'p'
+
+    return <StyledText as={tag} numberOfLines={numberOfLines} {...props} />
+  }
+
+  Component.displayName = typographyStyle
+  return Component
+}
+
+export const Typo = {
+  Title1: createStyledText('title1', 1),
+  Title2: createStyledText('title2', 2),
+  Title3: createStyledText('title3', 3),
+  Title4: createStyledText('title4', 4),
+  Body: createStyledText('body'),
+  BodyS: createStyledText('bodyS'),
+  BodyXs: createStyledText('bodyXs'),
+  BodyAccent: createStyledText('bodyAccent'),
+  BodyAccentS: createStyledText('bodyAccentS'),
+  BodyAccentXs: createStyledText('bodyAccentXs'),
+  BodyItalic: createStyledText('bodyItalic'),
+  BodyItalicAccent: createStyledText('bodyItalicAccent'),
+  Button: createStyledText('button'),
+  ButtonS: createStyledText('buttonS'),
+}

--- a/src/ui/theme/typographyAttrs/getHeadingAttrs.ts
+++ b/src/ui/theme/typographyAttrs/getHeadingAttrs.ts
@@ -3,6 +3,7 @@ import { Platform } from 'react-native'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 
 export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6
+
 export const getHeadingAttrs = (level: HeadingLevel) => {
   return Platform.OS === 'web'
     ? {

--- a/src/ui/theme/typographyAttrs/getHeadingAttrs.ts
+++ b/src/ui/theme/typographyAttrs/getHeadingAttrs.ts
@@ -1,17 +1,7 @@
-import { Platform } from 'react-native'
-
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import { HeadingAttrs, HeadingLevel } from 'ui/theme/typographyAttrs/types'
 
-export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6
-
-export const getHeadingAttrs = (level: HeadingLevel) => {
-  return Platform.OS === 'web'
-    ? {
-        accessibilityRole: AccessibilityRole.HEADING,
-        accessibilityLevel: level,
-      }
-    : {
-        accessibilityRole: AccessibilityRole.HEADER,
-        accessibilityLevel: undefined,
-      }
-}
+export const getHeadingAttrs = (_level: HeadingLevel): HeadingAttrs => ({
+  accessibilityRole: AccessibilityRole.HEADER,
+  accessibilityLevel: undefined,
+})

--- a/src/ui/theme/typographyAttrs/getHeadingAttrs.web.test.ts
+++ b/src/ui/theme/typographyAttrs/getHeadingAttrs.web.test.ts
@@ -1,22 +1,17 @@
-import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 describe('getHeadingAttrs()', () => {
   it.each`
-    headingLevel | accessibilityLevel | accessibilityRole
-    ${1}         | ${1}               | ${AccessibilityRole.HEADING}
-    ${2}         | ${2}               | ${AccessibilityRole.HEADING}
-    ${3}         | ${3}               | ${AccessibilityRole.HEADING}
-    ${4}         | ${4}               | ${AccessibilityRole.HEADING}
-    ${5}         | ${5}               | ${AccessibilityRole.HEADING}
-    ${6}         | ${6}               | ${AccessibilityRole.HEADING}
-  `(
-    "getHeadingAttrs($headingLevel) = {accessibilityRole: $accessibilityRole, accessibilityLevel: $accessibilityLevel, dir: 'ltr'}",
-    ({ headingLevel, accessibilityLevel, accessibilityRole }) => {
-      expect(getHeadingAttrs(headingLevel)).toEqual({
-        accessibilityRole,
-        accessibilityLevel,
-      })
-    }
-  )
+    accessibilityLevel
+    ${1}
+    ${2}
+    ${3}
+    ${4}
+    ${'p'}
+  `('should return accessibilityLevel $accessibilityLevel', ({ accessibilityLevel }) => {
+    expect(getHeadingAttrs(accessibilityLevel)).toEqual({
+      accessibilityRole: undefined,
+      accessibilityLevel,
+    })
+  })
 })

--- a/src/ui/theme/typographyAttrs/getHeadingAttrs.web.ts
+++ b/src/ui/theme/typographyAttrs/getHeadingAttrs.web.ts
@@ -1,0 +1,6 @@
+import { HeadingAttrs, HeadingLevel } from 'ui/theme/typographyAttrs/types'
+
+export const getHeadingAttrs = (level: HeadingLevel): HeadingAttrs => ({
+  accessibilityRole: undefined,
+  accessibilityLevel: level,
+})

--- a/src/ui/theme/typographyAttrs/getNoHeadingAttrs.ts
+++ b/src/ui/theme/typographyAttrs/getNoHeadingAttrs.ts
@@ -1,10 +1,3 @@
-import { Platform } from 'react-native'
-
 export const getNoHeadingAttrs = () => ({
-  ...(Platform.OS === 'web'
-    ? {
-        accessibilityRole: undefined,
-        accessibilityLevel: undefined,
-      }
-    : {}),
+  noHeading: true,
 })

--- a/src/ui/theme/typographyAttrs/getNoHeadingAttrs.web.test.ts
+++ b/src/ui/theme/typographyAttrs/getNoHeadingAttrs.web.test.ts
@@ -1,10 +1,10 @@
 import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
 
 describe('getNoHeadingAttrs()', () => {
-  it('should return accessibility attribute with no values', () => {
+  it('should return accessibilityLevel as p', () => {
     expect(getNoHeadingAttrs()).toEqual({
       accessibilityRole: undefined,
-      accessibilityLevel: undefined,
+      accessibilityLevel: 'p',
     })
   })
 })

--- a/src/ui/theme/typographyAttrs/getNoHeadingAttrs.web.ts
+++ b/src/ui/theme/typographyAttrs/getNoHeadingAttrs.web.ts
@@ -2,5 +2,5 @@ import { HeadingAttrs } from 'ui/theme/typographyAttrs/types'
 
 export const getNoHeadingAttrs = (): HeadingAttrs => ({
   accessibilityRole: undefined,
-  accessibilityLevel: undefined,
+  accessibilityLevel: 'p',
 })

--- a/src/ui/theme/typographyAttrs/types.ts
+++ b/src/ui/theme/typographyAttrs/types.ts
@@ -1,0 +1,8 @@
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+
+export type HeadingLevel = 1 | 2 | 3 | 4 | 'p'
+
+export type HeadingAttrs = {
+  accessibilityRole?: AccessibilityRole
+  accessibilityLevel?: HeadingLevel
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43000

## Context

- Ajout de balise `<p>` sur tous les paragraphes à la place des `<div>`

- `getNoHeadingAttrs` ne fonctionnait plus en mobile, c'est corrigé. 

- J'ai créé une version web et une version mobile de `getNoHeadingAttrs`, `getHeadingAttrs` et `typography``
- Maintenant si il ne s'agit pas d'un `Typo.TitleX` par défaut c'est automatiquement une balise `<p>` en web et pas de rôle heading en mobile.

- On utilisait des `getHeadingAttrs` sur des `div` ou des `Typo` qui n'était pas des Title, ce qui n'était pas bon car ajoutait des mauvais rôles non supporté (notamment sur les div). 

- Suppression des `lineHeight` custom sur les `Typo` pour respecter le design system. L'impact c'est que les Tag ou Badge sont légèrement plus grand, mais quasiment invisible à l'oeil nu. 

- Aucune différences en mobile pour les textes. 


## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |     <img width="355" height="336" alt="Capture d’écran 2026-08-07 à 11 58 39" src="https://github.com/user-attachments/assets/44de9ebe-7d05-4da2-bcde-640c3ae6b166" />  |     <img width="296" height="379" alt="Capture d’écran 2026-08-07 à 11 58 01" src="https://github.com/user-attachments/assets/c18af3ac-2f21-4a9f-9dac-67e194e4aec5" />  |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
