### PR TITLE
(PC-43049) fix(home): avoid tooltip crop on thematic home header

### DIFF
--- a/src/features/home/components/SubscribeButtonWithTooltip.tsx
+++ b/src/features/home/components/SubscribeButtonWithTooltip.tsx
@@ -92,7 +92,7 @@ export const SubscribeButtonWithTooltip = (props: {
       <Button {...buttonProps} />
       <StyledTooltip
         label="Suis ce thème pour recevoir de l’actualité sur ce sujet&nbsp;!"
-        pointerDirection="top"
+        pointerDirection="bottom"
         isVisible={isTooltipVisible}
         onHide={hideTooltip}
         onCloseIconPress={onCloseIconPress}
@@ -106,7 +106,7 @@ const TooltipAnchor = styled.View({ alignSelf: 'flex-start', position: 'relative
 
 const StyledTooltip = styled(Tooltip)<{ offset: number }>(({ theme, offset }) => ({
   position: 'absolute',
-  top: offset,
+  bottom: offset,
   right: 0,
   zIndex: theme.zIndex.header,
   width: TOOLTIP_WIDTH,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43049

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 17 05 43" src="https://github.com/user-attachments/assets/cfda66a4-65df-4e57-b6f2-5c57337e1fd8" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 17 06 17" src="https://github.com/user-attachments/assets/05b6ec4d-812f-4e5c-a41b-495bb81d5922" />|
| Android          |<img width="1080" height="2400" alt="Screenshot_1785338411" src="https://github.com/user-attachments/assets/19a935fe-d9a5-4e36-ba91-42fb3da89229" />|<img width="1080" height="2400" alt="Screenshot_1785338173" src="https://github.com/user-attachments/assets/ba8551af-f68d-4213-97aa-4b0ea064b99e" />|
| Phone - Chrome   |<img width="430" height="697" alt="Capture d’écran 2026-07-29 à 16 46 17" src="https://github.com/user-attachments/assets/c4124f97-c162-4222-81aa-a16c15786b63" />|<img width="413" height="698" alt="Capture d’écran 2026-07-29 à 16 42 20" src="https://github.com/user-attachments/assets/a5f5bf57-f0eb-42b9-983f-16c7a8c28789" />|
| Desktop - Chrome |<img width="1506" height="764" alt="Capture d’écran 2026-07-29 à 16 46 35" src="https://github.com/user-attachments/assets/22c105a5-3341-48cc-a04c-c43108044485" />|<img width="1915" height="928" alt="Capture d’écran 2026-07-29 à 17 40 05" src="https://github.com/user-attachments/assets/4f0d6204-cbb7-42d0-800b-1f973b0f5a53" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
