### PR TITLE
(PC-42434) feat(clubs): add tracking for clubs

### DIFF
--- a/src/features/advices/fixtures/adviceVariantInfo.fixture.ts
+++ b/src/features/advices/fixtures/adviceVariantInfo.fixture.ts
@@ -1,6 +1,7 @@
 import { AdviceVariantInfo } from 'features/advices/types'
 
 export const adviceVariantInfoFixture: AdviceVariantInfo = {
+  adviceType: 'book_club',
   labelReaction: 'book club',
   titleSection: 'La reco du book club',
   subtitleSection: 'Notre communauté de lecteurs te partage leur avis sur ce livre\u00a0!',

--- a/src/features/advices/types.ts
+++ b/src/features/advices/types.ts
@@ -1,6 +1,7 @@
 import { ReactElement, ReactNode } from 'react'
 import { FlatListProps, StyleProp, ViewStyle } from 'react-native'
 
+import { AdviceType } from 'libs/analytics/types'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { TagProps } from 'ui/designSystem/Tag/types'
 
@@ -18,6 +19,7 @@ export type AdviceCardData = {
 }
 
 export type AdviceVariantInfo = {
+  adviceType: AdviceType
   labelReaction: string
   titleSection: string
   subtitleSection: string

--- a/src/features/clubAdvices/constants.tsx
+++ b/src/features/clubAdvices/constants.tsx
@@ -64,6 +64,7 @@ export const SCENE_CLUB_SUBCATEGORIES = [
 
 export const PRO_ADVICE_VARIANT_CONFIG = {
   subcategories: [],
+  adviceType: 'pro',
   labelReaction: 'avis des pros',
   titleSection: 'Les avis des pros',
   subtitleSection: 'Les professionnels qui proposent cette offre te partagent leurs avis\u00a0!',
@@ -77,6 +78,7 @@ export const PRO_ADVICE_VARIANT_CONFIG = {
 
 const BOOK_CLUB_VARIANT_CONFIG = {
   subcategories: BOOK_CLUB_SUBCATEGORIES,
+  adviceType: 'book_club',
   labelReaction: 'book club',
   titleSection: 'Les avis du book club',
   subtitleSection: 'Notre communauté de lecteurs te partage leur avis sur ce livre\u00a0!',
@@ -92,6 +94,7 @@ const BOOK_CLUB_VARIANT_CONFIG = {
 
 const CINE_CLUB_VARIANT_CONFIG = {
   subcategories: CINE_CLUB_SUBCATEGORIES,
+  adviceType: 'cine_club',
   labelReaction: 'ciné club',
   titleSection: 'Les avis du ciné club',
   subtitleSection: 'Notre communauté de cinéphiles te partage leur avis sur ce film\u00a0!',
@@ -107,6 +110,7 @@ const CINE_CLUB_VARIANT_CONFIG = {
 
 const SCENE_CLUB_VARIANT_CONFIG = {
   subcategories: SCENE_CLUB_SUBCATEGORIES,
+  adviceType: 'scene_club',
   labelReaction: 'scène club',
   titleSection: 'Les avis de la scène club',
   subtitleSection: 'La communauté de jeunes passionnés te partage leur avis\u00a0!',

--- a/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.native.test.tsx
+++ b/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.native.test.tsx
@@ -163,6 +163,7 @@ describe('ClubAdvices', () => {
         categoryName: 'CINEMA',
         from: 'chronicles',
         offerId: '116656',
+        adviceType: 'cine_club',
       })
     })
   })
@@ -244,6 +245,7 @@ describe('ClubAdvices', () => {
             categoryName: 'CINEMA',
             from: 'chronicles',
             offerId: '116656',
+            adviceType: 'cine_club',
           })
         })
       })

--- a/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.tsx
+++ b/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.tsx
@@ -31,6 +31,7 @@ export const ClubAdvices: FunctionComponent = () => {
       categoryName: offer?.subcategoryId
         ? subcategoriesMapping[offer.subcategoryId].categoryId
         : '',
+      adviceType: adviceVariantInfo?.adviceType,
     })
     runAfterInteractionsMobile(() => {
       navigate('ThematicHome', { homeId: '4mlVpAZySUZO6eHazWKZeV', from: 'chronicles' })

--- a/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.web.test.tsx
+++ b/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.web.test.tsx
@@ -5,11 +5,12 @@ import { SubcategoryIdEnum } from 'api/gen'
 import { offerClubAdvicesFixture } from 'features/clubAdvices/fixtures/clubAdvices.fixture'
 import { ClubAdvices } from 'features/clubAdvices/pages/ClubAdvices/ClubAdvices'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
+import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen } from 'tests/utils/web'
+import { fireEvent, render, screen, waitFor } from 'tests/utils/web'
 
 useRoute.mockReturnValue({
   params: {
@@ -86,6 +87,28 @@ describe('ClubAdvices', () => {
         expect(navigate).toHaveBeenCalledWith('Offer', {
           id: offerResponseSnap.id,
           from: 'chronicles',
+        })
+      })
+
+      it('should trigger ClickAllClubRecos log with advice type when pressing "Voir tous les avis des clubs" button', async () => {
+        render(reactQueryProviderHOC(<ClubAdvices />), {
+          theme: {
+            isDesktopViewport: true,
+          },
+        })
+
+        await screen.findByText('Tous les avis du ciné club')
+
+        fireEvent.click(screen.getByText('Qui écrit les avis du ciné club ?'))
+        fireEvent.click(await screen.findByText('Voir tous les avis des clubs'))
+
+        await waitFor(() => {
+          expect(analytics.logClickAllClubRecos).toHaveBeenNthCalledWith(1, {
+            categoryName: 'CINEMA',
+            from: 'chronicles',
+            offerId: '116656',
+            adviceType: 'cine_club',
+          })
         })
       })
     })

--- a/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.web.tsx
+++ b/src/features/clubAdvices/pages/ClubAdvices/ClubAdvices.web.tsx
@@ -34,12 +34,13 @@ export const ClubAdvices: FunctionComponent = () => {
   }
 
   const handleOnShowRecoButtonPress = () => {
-    analytics.logClickAllClubRecos({
+    void analytics.logClickAllClubRecos({
       offerId: offerId.toString(),
       from: 'chronicles',
       categoryName: offer?.subcategoryId
         ? subcategoriesMapping[offer.subcategoryId].categoryId
         : '',
+      adviceType: adviceVariantInfo?.adviceType,
     })
     navigate('ThematicHome', { homeId: '4mlVpAZySUZO6eHazWKZeV', from: 'chronicles' })
   }

--- a/src/features/clubAdvices/pages/ClubAdvices/ClubAdvicesBase.tsx
+++ b/src/features/clubAdvices/pages/ClubAdvices/ClubAdvicesBase.tsx
@@ -78,6 +78,7 @@ export const ClubAdvicesBase: FunctionComponent<Props> = ({
       offerId: offerId.toString(),
       from: 'chronicles',
       categoryName: offerCategoryId,
+      adviceType: variantInfo.adviceType,
     })
     showModal()
   }

--- a/src/features/offer/components/InteractionTag/InteractionTag.native.test.tsx
+++ b/src/features/offer/components/InteractionTag/InteractionTag.native.test.tsx
@@ -1,5 +1,8 @@
 import { SubcategoryIdEnum } from 'api/gen'
-import { getTagProps } from 'features/offer/components/InteractionTag/InteractionTag'
+import {
+  getDisplayedClubAdviceType,
+  getTagProps,
+} from 'features/offer/components/InteractionTag/InteractionTag'
 import { computedTheme } from 'tests/computedTheme'
 import { TagVariant } from 'ui/designSystem/Tag/types'
 
@@ -183,4 +186,59 @@ describe('getTagProps', () => {
       ).toBeNull()
     }
   )
+})
+
+describe('getDisplayedClubAdviceType', () => {
+  it.each([
+    [SubcategoryIdEnum.LIVRE_PAPIER, 'book_club'],
+    [SubcategoryIdEnum.SEANCE_CINE, 'cine_club'],
+    [SubcategoryIdEnum.SPECTACLE_REPRESENTATION, 'scene_club'],
+  ])('should return %s advice type for subcategory %s', (subcategoryId, expectedAdviceType) => {
+    expect(
+      getDisplayedClubAdviceType({
+        theme: computedTheme,
+        clubAdvicesCount: 3,
+        subcategoryId,
+        enableSceneClubTag: true,
+      })
+    ).toEqual(expectedAdviceType)
+  })
+
+  it('should return undefined when there is no club advice', () => {
+    expect(
+      getDisplayedClubAdviceType({ theme: computedTheme, clubAdvicesCount: 0, subcategoryId })
+    ).toBeUndefined()
+  })
+
+  it('should return undefined when subcategory belongs to no club', () => {
+    expect(
+      getDisplayedClubAdviceType({
+        theme: computedTheme,
+        clubAdvicesCount: 3,
+        subcategoryId: SubcategoryIdEnum.CONCERT,
+        enableSceneClubTag: true,
+      })
+    ).toBeUndefined()
+  })
+
+  it('should return undefined for a scene club subcategory when scene club tag is disabled', () => {
+    expect(
+      getDisplayedClubAdviceType({
+        theme: computedTheme,
+        clubAdvicesCount: 3,
+        subcategoryId: SubcategoryIdEnum.SPECTACLE_REPRESENTATION,
+      })
+    ).toBeUndefined()
+  })
+
+  it('should return undefined when the coming soon tag takes precedence', () => {
+    expect(
+      getDisplayedClubAdviceType({
+        theme: computedTheme,
+        clubAdvicesCount: 3,
+        subcategoryId,
+        isComingSoonOffer: true,
+      })
+    ).toBeUndefined()
+  })
 })

--- a/src/features/offer/components/InteractionTag/InteractionTag.tsx
+++ b/src/features/offer/components/InteractionTag/InteractionTag.tsx
@@ -6,6 +6,7 @@ import { isBookClubSubcategory } from 'features/clubAdvices/helpers/isBookClubSu
 import { isCineClubSubcategory } from 'features/clubAdvices/helpers/isCineClubSubcategory'
 import { isSceneClubSubcategory } from 'features/clubAdvices/helpers/isSceneClubSubcategory'
 import { formatLikesCounter } from 'features/offer/helpers/formatLikesCounter/formatLikesCounter'
+import { ClubAdviceType } from 'libs/analytics/types'
 import { Tag } from 'ui/designSystem/Tag/Tag'
 import { TagProps, TagVariant } from 'ui/designSystem/Tag/types'
 import { ClockFilled } from 'ui/svg/icons/ClockFilled'
@@ -23,21 +24,46 @@ type InteractionTagParams = {
 
 type ClubTagConfig = {
   isClubSubcategory: (subcategoryId: SubcategoryIdEnum) => boolean
+  adviceType: ClubAdviceType
   wording: string
   variant: TagVariant
   isBehindSceneClubFlag?: boolean
 }
 
 const CLUB_TAGS: ClubTagConfig[] = [
-  { isClubSubcategory: isBookClubSubcategory, wording: 'book club', variant: TagVariant.BOOKCLUB },
-  { isClubSubcategory: isCineClubSubcategory, wording: 'ciné club', variant: TagVariant.CINECLUB },
+  {
+    isClubSubcategory: isBookClubSubcategory,
+    adviceType: 'book_club',
+    wording: 'book club',
+    variant: TagVariant.BOOKCLUB,
+  },
+  {
+    isClubSubcategory: isCineClubSubcategory,
+    adviceType: 'cine_club',
+    wording: 'ciné club',
+    variant: TagVariant.CINECLUB,
+  },
   {
     isClubSubcategory: isSceneClubSubcategory,
+    adviceType: 'scene_club',
     wording: 'scène club',
     variant: TagVariant.SCENECLUB,
     isBehindSceneClubFlag: true,
   },
 ]
+
+const findClubTag = ({
+  clubAdvicesCount = 0,
+  subcategoryId,
+  enableSceneClubTag,
+}: InteractionTagParams): ClubTagConfig | undefined => {
+  if (clubAdvicesCount === 0) return undefined
+
+  return CLUB_TAGS.find(
+    ({ isClubSubcategory, isBehindSceneClubFlag }) =>
+      isClubSubcategory(subcategoryId) && (!isBehindSceneClubFlag || enableSceneClubTag)
+  )
+}
 
 export const renderInteractionTag = (params: InteractionTagParams): ReactNode | undefined => {
   const tagProps = getTagProps(params)
@@ -46,24 +72,24 @@ export const renderInteractionTag = (params: InteractionTagParams): ReactNode | 
   return <Tag testID="interaction-tag" {...tagProps} />
 }
 
-const getClubTagProps = ({
-  clubAdvicesCount = 0,
-  subcategoryId,
-  hasSmallLayout,
-  enableSceneClubTag,
-}: InteractionTagParams): TagProps | null => {
-  if (clubAdvicesCount === 0) return null
+const getClubTagProps = (params: InteractionTagParams): TagProps | null => {
+  const { clubAdvicesCount = 0, hasSmallLayout } = params
 
-  const club = CLUB_TAGS.find(
-    ({ isClubSubcategory, isBehindSceneClubFlag }) =>
-      isClubSubcategory(subcategoryId) && (!isBehindSceneClubFlag || enableSceneClubTag)
-  )
+  const club = findClubTag(params)
   if (!club) return null
 
   return {
     label: hasSmallLayout ? `${clubAdvicesCount} avis` : `${clubAdvicesCount} avis ${club.wording}`,
     variant: club.variant,
   }
+}
+
+export const getDisplayedClubAdviceType = (
+  params: InteractionTagParams
+): ClubAdviceType | undefined => {
+  if (params.isComingSoonOffer) return undefined
+
+  return findClubTag(params)?.adviceType
 }
 
 export const getTagProps = (params: InteractionTagParams): TagProps | null => {

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -18,6 +18,7 @@ import {
 } from 'api/gen'
 import { adviceVariantInfoFixture } from 'features/advices/fixtures/adviceVariantInfo.fixture'
 import { offerProAdvicesCardDataFixture } from 'features/advices/fixtures/offerProAdvices.fixture'
+import { AdviceVariantInfo } from 'features/advices/types'
 import { ALL_OPTIONAL_COOKIES, COOKIES_BY_CATEGORY } from 'features/cookies/CookiesPolicy'
 import { ConsentState } from 'features/cookies/enums'
 import * as Cookies from 'features/cookies/helpers/useCookies'
@@ -719,7 +720,7 @@ describe('<OfferContent />', () => {
         })
       })
 
-      it('should log consultChronicle when pressing "Voir plus" button', async () => {
+      it('should log consultAdvice with club advice type when pressing "Voir plus" button', async () => {
         renderOfferContent({
           offer: { ...offerResponseSnap, subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER },
         })
@@ -733,9 +734,44 @@ describe('<OfferContent />', () => {
         const seeMoreButton = screen.getByLabelText(`Voir plus à propos de ${authorLabel}`)
         await user.press(seeMoreButton)
 
-        expect(analytics.logConsultChronicle).toHaveBeenNthCalledWith(1, {
-          offerId: 116656,
-          chronicleId: 1,
+        expect(analytics.logConsultAdvice).toHaveBeenNthCalledWith(1, {
+          from: 'offer',
+          offerId: '116656',
+          originDetails: adviceVariantInfoFixture.titleSection,
+          adviceType: 'book_club',
+          chronicleId: '1',
+        })
+      })
+
+      it('should log consultAdvice with scene club advice type when pressing "Voir plus" button', async () => {
+        const sceneClubVariantInfo: AdviceVariantInfo = {
+          ...adviceVariantInfoFixture,
+          adviceType: 'scene_club',
+          titleSection: 'Les avis de la scène club',
+        }
+        renderOfferContent({
+          offer: {
+            ...offerResponseSnap,
+            subcategoryId: SubcategoryIdEnum.SPECTACLE_REPRESENTATION,
+          },
+          adviceVariantInfo: sceneClubVariantInfo,
+        })
+
+        const descriptions = screen.getAllByTestId('description')
+
+        await act(async () => {
+          descriptions[0]?.props.onLayout(mockOnLayoutWithButton)
+        })
+
+        const seeMoreButton = screen.getByLabelText(`Voir plus à propos de ${authorLabel}`)
+        await user.press(seeMoreButton)
+
+        expect(analytics.logConsultAdvice).toHaveBeenNthCalledWith(1, {
+          from: 'offer',
+          offerId: '116656',
+          originDetails: sceneClubVariantInfo.titleSection,
+          adviceType: 'scene_club',
+          chronicleId: '1',
         })
       })
 
@@ -1065,6 +1101,7 @@ function renderOfferContent({
   clubAdvices,
   proAdvices,
   proAdvicesCount,
+  adviceVariantInfo = adviceVariantInfoFixture,
 }: RenderOfferContentType) {
   const subtitle = 'Membre du Book Club'
   const clubAdvicesData =
@@ -1079,7 +1116,7 @@ function renderOfferContent({
           clubAdvices={clubAdvicesData}
           proAdvices={proAdvices}
           proAdvicesCount={proAdvicesCount}
-          adviceVariantInfo={adviceVariantInfoFixture}
+          adviceVariantInfo={adviceVariantInfo}
           onShowClubAdviceWritersModal={jest.fn()}
           hasVideoCookiesConsent
           onVideoConsentPress={jest.fn()}

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -260,7 +260,14 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
   const onSeeMoreButtonPress = (adviceId: number) => {
     // It's dirty but necessary to use from parameter for the logs
     navigate('ClubAdvices', { offerId: offer.id, adviceId, from: 'chronicles' })
-    void analytics.logConsultChronicle({ offerId: offer.id, chronicleId: adviceId })
+    if (!adviceVariantInfo) return
+    void analytics.logConsultAdvice({
+      from: 'offer',
+      offerId: offer.id.toString(),
+      originDetails: adviceVariantInfo.titleSection,
+      adviceType: adviceVariantInfo.adviceType,
+      chronicleId: adviceId.toString(),
+    })
   }
 
   const handleOnSeeAllReviewsPress = () => {

--- a/src/features/offer/components/OfferPlaylistItem/OfferPlaylistItem.tsx
+++ b/src/features/offer/components/OfferPlaylistItem/OfferPlaylistItem.tsx
@@ -3,7 +3,10 @@ import { DefaultTheme } from 'styled-components/native'
 
 import { OfferResponse, RecommendationApiParams } from 'api/gen'
 import { Referrals } from 'features/navigation/navigators/RootNavigator/types'
-import { renderInteractionTag } from 'features/offer/components/InteractionTag/InteractionTag'
+import {
+  getDisplayedClubAdviceType,
+  renderInteractionTag,
+} from 'features/offer/components/InteractionTag/InteractionTag'
 import { OfferTile } from 'features/offer/components/OfferTile/OfferTile'
 import { PlaylistType } from 'features/offer/enums'
 import { getIsAComingSoonOffer } from 'features/offer/helpers/getIsAComingSoonOffer'
@@ -61,7 +64,7 @@ export const OfferPlaylistItem = ({
     const timestampsInMillis = item.offer.dates && getTimeStampInMillis(item.offer.dates)
     const categoryLabel = item.offer.bookFormat || labelMapping[item.offer.subcategoryId] || ''
     const categoryId = categoryMapping[item.offer.subcategoryId]
-    const tag = renderInteractionTag({
+    const interactionTagParams = {
       theme,
       likesCount: item.offer.likes,
       clubAdvicesCount: item.offer.chroniclesCount,
@@ -70,7 +73,9 @@ export const OfferPlaylistItem = ({
       subcategoryId: item.offer.subcategoryId,
       proAdvicesCount: enableProAdvicesTag ? item.offer.proAdvicesCount : undefined,
       enableSceneClubTag,
-    })
+    }
+    const tag = renderInteractionTag(interactionTagParams)
+    const clubAdviceType = getDisplayedClubAdviceType(interactionTagParams)
     return (
       <OfferTile
         offerLocation={item._geoloc}
@@ -93,6 +98,7 @@ export const OfferPlaylistItem = ({
         originDetails={originDetails}
         navigationMethod={navigationMethod}
         interactionTag={tag}
+        clubAdviceType={clubAdviceType}
       />
     )
   }

--- a/src/features/offer/components/OfferTile/OfferTile.native.test.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.native.test.tsx
@@ -136,6 +136,19 @@ describe('OfferTile component', () => {
       })
     })
 
+    it('should log ConsultOffer with the club advice type when the tile displays a club advices counter', async () => {
+      render(reactQueryProviderHOC(<OfferTile {...props} clubAdviceType="scene_club" />))
+      await user.press(screen.getByTestId('tileImage'))
+
+      expect(analytics.logConsultOffer).toHaveBeenCalledWith({
+        offerId: String(OFFER_ID),
+        from: 'home',
+        moduleName: props.moduleName,
+        isHeadline: false,
+        adviceType: 'scene_club',
+      })
+    })
+
     it('should log ConsultOffer that user opened the offer from the list of similar offers', async () => {
       const propsFromSimilarOffers = {
         ...props,

--- a/src/features/offer/components/OfferTile/OfferTile.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.tsx
@@ -35,6 +35,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
     artistName,
     originDetails,
     interactionTag,
+    clubAdviceType,
     navigationMethod = NAVIGATION_METHOD.NAVIGATE,
     containerWidth,
     withCenterAlign = true,
@@ -89,6 +90,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
       index,
       artistName,
       originDetails,
+      adviceType: clubAdviceType,
     })
   }
 

--- a/src/features/offer/components/OfferTile/OfferTileWrapper.native.test.tsx
+++ b/src/features/offer/components/OfferTile/OfferTileWrapper.native.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+
+import { Referrals } from 'features/navigation/navigators/RootNavigator/types'
+import { OfferTileWrapper } from 'features/offer/components/OfferTile/OfferTileWrapper'
+import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
+import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { render, screen, userEvent } from 'tests/utils'
+
+jest.mock('libs/firebase/analytics/analytics')
+jest.mock('queries/subcategories/useSubcategoriesQuery')
+
+const BOOK_HIT = mockedAlgoliaResponse.hits[0]
+
+const props = {
+  analyticsFrom: 'home' as Referrals,
+  moduleName: 'Module Name',
+  width: 100,
+  height: 100,
+}
+
+const user = userEvent.setup()
+
+jest.useFakeTimers()
+
+describe('OfferTileWrapper component', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
+  it('should log ConsultOffer with the club advice type when the offer has club advices', async () => {
+    const item = { ...BOOK_HIT, offer: { ...BOOK_HIT.offer, chroniclesCount: 5 } }
+    render(reactQueryProviderHOC(<OfferTileWrapper item={item} {...props} />))
+
+    await user.press(screen.getByTestId('tileImage'))
+
+    expect(analytics.logConsultOffer).toHaveBeenCalledWith(
+      expect.objectContaining({ adviceType: 'book_club' })
+    )
+  })
+
+  it('should log ConsultOffer without advice type when the offer has no club advices', async () => {
+    render(reactQueryProviderHOC(<OfferTileWrapper item={BOOK_HIT} {...props} />))
+
+    await user.press(screen.getByTestId('tileImage'))
+
+    expect(analytics.logConsultOffer).toHaveBeenCalledWith(
+      expect.objectContaining({ adviceType: undefined })
+    )
+  })
+})

--- a/src/features/offer/components/OfferTile/OfferTileWrapper.tsx
+++ b/src/features/offer/components/OfferTile/OfferTileWrapper.tsx
@@ -2,7 +2,10 @@ import React from 'react'
 import { useTheme } from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { renderInteractionTag } from 'features/offer/components/InteractionTag/InteractionTag'
+import {
+  getDisplayedClubAdviceType,
+  renderInteractionTag,
+} from 'features/offer/components/InteractionTag/InteractionTag'
 import { OfferTile } from 'features/offer/components/OfferTile/OfferTile'
 import { getIsAComingSoonOffer } from 'features/offer/helpers/getIsAComingSoonOffer'
 import { OfferTileProps } from 'features/offer/types'
@@ -54,7 +57,7 @@ export const OfferTileWrapper = React.memo(function OfferTileWrapper(props: Prop
     })
   )
 
-  const tag = renderInteractionTag({
+  const interactionTagParams = {
     theme,
     likesCount: likes,
     clubAdvicesCount: chroniclesCount,
@@ -63,7 +66,9 @@ export const OfferTileWrapper = React.memo(function OfferTileWrapper(props: Prop
     subcategoryId: item.offer.subcategoryId,
     proAdvicesCount: enableProAdvicesTag ? item.offer.proAdvicesCount : undefined,
     enableSceneClubTag,
-  })
+  }
+  const tag = renderInteractionTag(interactionTagParams)
+  const clubAdviceType = getDisplayedClubAdviceType(interactionTagParams)
 
   return (
     <OfferTile
@@ -77,6 +82,7 @@ export const OfferTileWrapper = React.memo(function OfferTileWrapper(props: Prop
       thumbUrl={thumbUrl}
       price={formattedPrice}
       interactionTag={tag}
+      clubAdviceType={clubAdviceType}
       {...props}
       venueId={props.venueId ?? item.venue.id}
       withCenterAlign={withCenterAlign}

--- a/src/features/offer/pages/Offer/Offer.native.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.native.test.tsx
@@ -269,6 +269,7 @@ describe('<Offer />', () => {
       categoryName: 'CINEMA',
       from: 'offer',
       offerId: '116656',
+      adviceType: 'cine_club',
     })
   })
 
@@ -311,6 +312,22 @@ describe('<Offer />', () => {
       await screen.findByTestId('offerv2-container')
 
       expect(screen.queryByText('Les avis de la scène club')).not.toBeOnTheScreen()
+    })
+
+    it('should trigger ClickWhatsClub log with scène club advice type', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_SCENE_CLUB])
+      renderOfferPage({ mockOffer: sceneClubOffer })
+
+      await screen.findByText('Les avis de la scène club')
+
+      await user.press(screen.getByText('Qui écrit les avis de la scène club ?'))
+
+      expect(analytics.logClickWhatsClub).toHaveBeenNthCalledWith(1, {
+        categoryName: 'SPECTACLE',
+        from: 'offer',
+        offerId: '116656',
+        adviceType: 'scene_club',
+      })
     })
   })
 

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -82,6 +82,7 @@ export function Offer() {
   const categoryId = offer?.subcategoryId
     ? subcategoriesMapping[offer?.subcategoryId]?.categoryId
     : ''
+  const adviceVariantInfo = useClubAdviceVariant(offer?.subcategoryId)
   const handleSaveReaction = useCallback(
     ({ offerId, reactionType }: { offerId: number; reactionType: ReactionTypeEnum }) => {
       saveReaction({ reactions: [{ offerId, reactionType }] })
@@ -95,6 +96,7 @@ export function Offer() {
       offerId: offerId.toString(),
       from: 'offer',
       categoryName: categoryId,
+      adviceType: adviceVariantInfo?.adviceType,
     })
     hideChroniclesWritersModal()
     runAfterInteractionsMobile(() => {
@@ -107,6 +109,7 @@ export function Offer() {
       offerId: offerId.toString(),
       from: 'offer',
       categoryName: categoryId,
+      adviceType: adviceVariantInfo?.adviceType,
     })
     showChroniclesWritersModal()
   }
@@ -133,8 +136,6 @@ export function Offer() {
     }),
   })
   const proAdvices = enableProAdvices ? proAdvicesData : undefined
-
-  const adviceVariantInfo = useClubAdviceVariant(offer?.subcategoryId)
 
   if (!offer || !subcategories || !subcategoriesMapping?.[offer?.subcategoryId]) return null
 

--- a/src/features/offer/types.ts
+++ b/src/features/offer/types.ts
@@ -14,6 +14,7 @@ import { AdviceCardData, AdviceVariantInfo } from 'features/advices/types'
 import { Referrals } from 'features/navigation/navigators/RootNavigator/types'
 import { PlaylistType } from 'features/offer/enums'
 import { AlgoliaGeoloc } from 'libs/algolia/types'
+import { ClubAdviceType } from 'libs/analytics/types'
 import { Subcategory } from 'libs/subcategories/types'
 import { NAVIGATION_METHOD } from 'shared/constants'
 
@@ -48,6 +49,7 @@ export interface OfferTileProps {
   originDetails?: string
   navigationMethod?: NavigationMethod
   interactionTag?: ReactNode
+  clubAdviceType?: ClubAdviceType
   containerWidth?: number
   withCenterAlign?: boolean
 }

--- a/src/features/venue/components/VenueOffers/VenueOffersList.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffersList.tsx
@@ -8,7 +8,10 @@ import { ReactionTypeEnum } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { GtlPlaylist } from 'features/gtlPlaylist/components/GtlPlaylist'
 import { UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
-import { renderInteractionTag } from 'features/offer/components/InteractionTag/InteractionTag'
+import {
+  getDisplayedClubAdviceType,
+  renderInteractionTag,
+} from 'features/offer/components/InteractionTag/InteractionTag'
 import { OfferTile } from 'features/offer/components/OfferTile/OfferTile'
 import { getIsAComingSoonOffer } from 'features/offer/helpers/getIsAComingSoonOffer'
 import { VenueAdvicesSection } from 'features/venue/components/VenueAdvicesSection/VenueAdvicesSection'
@@ -86,7 +89,7 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
 
   const renderItem: CustomListRenderItem<Offer> = ({ item, width, height }) => {
     const timestampsInMillis = item.offer.dates && getTimeStampInMillis(item.offer.dates)
-    const tag = renderInteractionTag({
+    const interactionTagParams = {
       theme,
       likesCount: item.offer.likes,
       clubAdvicesCount: item.offer.chroniclesCount,
@@ -95,7 +98,9 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
       proAdvicesCount:
         enableProAdvicesTag && shouldDisplayAdvicesSection ? item.offer.proAdvicesCount : undefined,
       enableSceneClubTag,
-    })
+    }
+    const tag = renderInteractionTag(interactionTagParams)
+    const clubAdviceType = getDisplayedClubAdviceType(interactionTagParams)
 
     return (
       <OfferTile
@@ -122,6 +127,7 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
         height={height}
         searchId={routeParams?.searchId}
         interactionTag={tag}
+        clubAdviceType={clubAdviceType}
       />
     )
   }

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueMapOfferPlaylist.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueMapOfferPlaylist.tsx
@@ -4,7 +4,10 @@ import { ViewToken } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 import styled, { useTheme } from 'styled-components/native'
 
-import { renderInteractionTag } from 'features/offer/components/InteractionTag/InteractionTag'
+import {
+  getDisplayedClubAdviceType,
+  renderInteractionTag,
+} from 'features/offer/components/InteractionTag/InteractionTag'
 import { OfferTile } from 'features/offer/components/OfferTile/OfferTile'
 import { PlaylistType } from 'features/offer/enums'
 import { getIsAComingSoonOffer } from 'features/offer/helpers/getIsAComingSoonOffer'
@@ -55,7 +58,7 @@ export const VenueMapOfferPlaylist = ({
 
   const renderItem: CustomListRenderItem<Offer> = useCallback(
     ({ item }) => {
-      const tag = renderInteractionTag({
+      const interactionTagParams = {
         theme,
         likesCount: item.offer.likes,
         clubAdvicesCount: item.offer.chroniclesCount,
@@ -64,7 +67,9 @@ export const VenueMapOfferPlaylist = ({
         subcategoryId: item.offer.subcategoryId,
         proAdvicesCount: enableProAdvicesTag ? item.offer.proAdvicesCount : undefined,
         enableSceneClubTag,
-      })
+      }
+      const tag = renderInteractionTag(interactionTagParams)
+      const clubAdviceType = getDisplayedClubAdviceType(interactionTagParams)
       return (
         <OfferTile
           offerId={Number(item.objectID)}
@@ -80,6 +85,7 @@ export const VenueMapOfferPlaylist = ({
           height={PLAYLIST_ITEM_HEIGHT}
           playlistType={playlistType}
           interactionTag={tag}
+          clubAdviceType={clubAdviceType}
         />
       )
     },

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -50,7 +50,6 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logConsultArtistFakeDoor: jest.fn(),
   logConsultAuthenticationModal: jest.fn(),
   logConsultAvailableDates: jest.fn(),
-  logConsultChronicle: jest.fn(),
   logConsultDescriptionDetails: jest.fn(),
   logConsultDisclaimerValidationMail: jest.fn(),
   logConsultErrorApplicationModal: jest.fn(),

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -38,7 +38,7 @@ import { ShareAppModalType } from 'features/share/types'
 import { SubscriptionAnalyticsParams } from 'features/subscription/types'
 import { buildPerformSearchState, urlWithValueMaxLength } from 'libs/analytics'
 import { analytics } from 'libs/analytics/provider'
-import { ConsultOfferLogParams } from 'libs/analytics/types'
+import { AdviceType, ConsultOfferLogParams } from 'libs/analytics/types'
 import { buildAccessibilityFilterParam, buildModuleDisplayedOnHomepage } from 'libs/analytics/utils'
 import { ContentTypes } from 'libs/contentful/types'
 import { AnalyticsEvent } from 'libs/firebase/analytics/events'
@@ -208,8 +208,12 @@ export const logEventAnalytics = {
   logChooseEduConnectMethod: () =>
     analytics.logEvent({ firebase: AnalyticsEvent.CHOOSE_EDUCONNECT_METHOD }),
   logChooseUbbleMethod: () => analytics.logEvent({ firebase: AnalyticsEvent.CHOOSE_UBBLE_METHOD }),
-  logClickAllClubRecos: (params: { offerId: string; from: Referrals; categoryName: string }) =>
-    analytics.logEvent({ firebase: AnalyticsEvent.CLICK_ALL_CLUB_RECOS }, params),
+  logClickAllClubRecos: (params: {
+    offerId: string
+    from: Referrals
+    categoryName: string
+    adviceType?: AdviceType
+  }) => analytics.logEvent({ firebase: AnalyticsEvent.CLICK_ALL_CLUB_RECOS }, params),
   logClickBookOffer: (params: {
     offerId: number
     from?: Referrals
@@ -250,8 +254,12 @@ export const logEventAnalytics = {
     analytics.logEvent({ firebase: AnalyticsEvent.CLICK_SOCIAL_NETWORK }, { network }),
   logClickVolunteerCTA: (params: { from: Referrals; venueId: string }) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CLICK_VOLUNTEER_CTA }, params),
-  logClickWhatsClub: (params: { offerId: string; from: Referrals; categoryName: string }) =>
-    analytics.logEvent({ firebase: AnalyticsEvent.CLICK_WHATS_CLUB }, params),
+  logClickWhatsClub: (params: {
+    offerId: string
+    from: Referrals
+    categoryName: string
+    adviceType?: AdviceType
+  }) => analytics.logEvent({ firebase: AnalyticsEvent.CLICK_WHATS_CLUB }, params),
   logConfirmBookingCancellation: (offerId: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONFIRM_BOOKING_CANCELLATION }, { offerId }),
   logConnectionInfo: (params: { type: string; generation?: string | null }) =>
@@ -268,9 +276,10 @@ export const logEventAnalytics = {
   logConsultAdvice: (params: {
     from: Referrals
     originDetails: string
-    adviceType: 'book_club' | 'cine_club' | 'pro'
+    adviceType: AdviceType
     offerId?: string
     venueId?: string
+    chronicleId?: string
   }) => analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_ADVICE }, params),
   logConsultApplicationProcessingModal: (offerId: number) =>
     analytics.logEvent(
@@ -294,8 +303,6 @@ export const logEventAnalytics = {
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_AUTHENTICATION_MODAL }, { offerId }),
   logConsultAvailableDates: (offerId: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_AVAILABLE_DATES }, { offerId }),
-  logConsultChronicle: (params: { offerId?: number; chronicleId?: number }) =>
-    analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_CHRONICLE }, params),
   logConsultDescriptionDetails: (offerId: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_DESCRIPTION_DETAILS }, { offerId }),
   logConsultDisclaimerValidationMail: () =>
@@ -334,7 +341,7 @@ export const logEventAnalytics = {
     homeEntryId?: string
     searchId?: string
     originDetails?: string
-    adviceType?: 'book_club' | 'cine_club' | 'pro'
+    adviceType?: AdviceType
     offerId?: string
   }) => analytics.logEvent({ firebase: AnalyticsEvent.CONSULT_VENUE }, params),
   logConsultVenueMap: ({ from, searchId }: { from: Referrals; searchId?: string }) =>

--- a/src/libs/analytics/types.ts
+++ b/src/libs/analytics/types.ts
@@ -14,6 +14,10 @@ export type AnalyticsProvider = {
 
 export type LocationType = 'UserGeolocation' | 'UserSpecificLocation' | 'undefined'
 
+export type ClubAdviceType = 'book_club' | 'cine_club' | 'scene_club'
+
+export type AdviceType = ClubAdviceType | 'pro'
+
 export type OfferAnalyticsParams = {
   from: Referrals
   query?: string
@@ -45,6 +49,6 @@ export type ConsultOfferLogParams = {
   index?: number
   artistName?: string
   isHeadline?: boolean
-  adviceType?: 'book_club' | 'cine_club' | 'pro'
+  adviceType?: AdviceType
   originDetails?: string
 }

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -52,7 +52,6 @@ export enum AnalyticsEvent {
   CONSULT_ARTIST_FAKE_DOOR = 'ConsultArtistFakeDoor',
   CONSULT_AUTHENTICATION_MODAL = 'ConsultAuthenticationModal',
   CONSULT_AVAILABLE_DATES = 'ConsultAvailableDates',
-  CONSULT_CHRONICLE = 'ConsultChronicle',
   CONSULT_DESCRIPTION_DETAILS = 'ConsultDescriptionDetails',
   CONSULT_DISCLAIMER_VALIDATION_MAIL = 'ConsultDisclaimerValidationMail',
   CONSULT_ERROR_APPLICATION_MODAL = 'ConsultErrorApplicationModal',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42434

## Context

Le tracking des avis clubs (book, ciné, scène) n'était pas homogène avec celui des avis pros : le clic sur un avis club émettait `ConsultChronicle` (héritage de l'époque book club seul), non typé, alors que les avis pros émettaient déjà `ConsultAdvice` avec un `adviceType`. Aucune comparaison book / ciné / scène / pro n'était possible.

Cette PR unifie le tracking des avis sur un seul event typé, pour les 4 dimensions :

- **Union type étendue** : nouveaux types `ClubAdviceType` (`book_club` | `cine_club` | `scene_club`) et `AdviceType` (`ClubAdviceType` | `pro`) dans `libs/analytics/types.ts`, réutilisés par `ConsultOffer`, `ConsultAdvice` et `ConsultVenue`. Chaque config de variante (`clubAdvices/constants.tsx`) porte désormais son `adviceType`.
- **Migration `ConsultChronicle` → `ConsultAdvice`** : le clic « Voir plus » sur un avis club émet `ConsultAdvice` (`from`, `offerId`, `originDetails`, `adviceType`, `chronicleId`). `logConsultChronicle` et l'event `CONSULT_CHRONICLE` sont supprimés pour éviter tout double comptage. Le `chronicleId` (id de l'avis précis cliqué) est conservé pour ne pas perdre de granularité par rapport à l'ancien event.
- **`ConsultOffer` typé sur les vignettes avec compteur d'avis club** : nouveau helper `getDisplayedClubAdviceType`, fidèle à la logique d'affichage du tag (compteur > 0, sous-catégorie club, feature flag scène club, priorité du tag « Bientôt dispo »), branché sur les 4 surfaces qui affichent le compteur : `OfferTileWrapper`, `OfferPlaylistItem`, `VenueOffersList`, `VenueMapOfferPlaylist`. Si le tag n'est pas affiché, `adviceType` n'est pas envoyé — aucune donnée fausse possible.
- **Segmentation de l'entrée dans la page « Tous les avis »** : `adviceType` ajouté aux events existants `ClickAllClubRecos` et `ClickWhatsClub` (page Offre, page ClubAdvices native et web).
