### PR TITLE
(PC-43107) fix(home): avoid Cannot read property 'fill' of undefined on CategoryListModule

### DIFF
--- a/src/features/home/components/modules/categories/CategoryListModule.tsx
+++ b/src/features/home/components/modules/categories/CategoryListModule.tsx
@@ -67,11 +67,11 @@ export const CategoryListModule = ({
           const categoryColorMapping = colorMapping[color] ?? colorMapping.Information04
 
           const fillFromDesignSystem = enableNewCategoryBlocks
-            ? designSystem.color.illustration[categoryColorMapping.fill ?? 'default']
-            : designSystem.color.background[categoryColorMapping.fill ?? 'default']
+            ? designSystem.color.illustration[categoryColorMapping?.fill ?? 'default']
+            : designSystem.color.background[categoryColorMapping?.fill ?? 'default']
 
           const borderFromDesignSystem =
-            designSystem.color.border[categoryColorMapping.border ?? 'default']
+            designSystem.color.border[categoryColorMapping?.border ?? 'default']
           return enableNewCategoryBlocks ? (
             <StyledNewCategoryButton
               key={item.id}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43107

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
