### PR TITLE
(PC-43109) fix(ui): display correctly see all button in web desktop

### DIFF
--- a/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
@@ -680,7 +680,8 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       <View
                         style={
                           {
-                            "flexShrink": 1,
+                            "flexDirection": "row",
+                            "flexGrow": 1,
                           }
                         }
                       >

--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -1831,7 +1831,8 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     <View
                       style={
                         {
-                          "flexShrink": 1,
+                          "flexDirection": "row",
+                          "flexGrow": 1,
                         }
                       }
                     >

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -1151,7 +1151,8 @@ exports[`<Venue /> should match snapshot 1`] = `
                             <View
                               style={
                                 {
-                                  "flexShrink": 1,
+                                  "flexDirection": "row",
+                                  "flexGrow": 1,
                                 }
                               }
                             >
@@ -4504,7 +4505,8 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                             <View
                               style={
                                 {
-                                  "flexShrink": 1,
+                                  "flexDirection": "row",
+                                  "flexGrow": 1,
                                 }
                               }
                             >

--- a/src/ui/components/SeeAllButton/SeeAllButtonWrapper.tsx
+++ b/src/ui/components/SeeAllButton/SeeAllButtonWrapper.tsx
@@ -12,7 +12,8 @@ export const SeeAllButtonWrapper: React.FC<PropsWithChildren> = ({ children }) =
 }
 
 const Container = styled.View({
-  flexShrink: 1,
+  flexDirection: 'row',
+  flexGrow: 1,
 })
 
 const TitleSeparator = styled.View(({ theme }) => ({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43109

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-03 at 15 13 01" src="https://github.com/user-attachments/assets/676c44bf-2144-4076-b7c1-03273f268b06" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-03 at 15 00 55" src="https://github.com/user-attachments/assets/648e8264-e000-4b97-9277-a80f1a503cd5" />|
| Android          |               |       |
| Phone - Chrome   |<img width="397" height="679" alt="Capture d’écran 2026-08-03 à 15 12 44" src="https://github.com/user-attachments/assets/c05c9e0d-c341-4daa-bb17-7614e9a4750a" />|<img width="396" height="691" alt="Capture d’écran 2026-08-03 à 14 57 22" src="https://github.com/user-attachments/assets/909dcf94-94dd-4d75-9ba7-68ef81988b9a" />|
| Desktop - Chrome |<img width="1504" height="758" alt="Capture d’écran 2026-08-03 à 15 12 32" src="https://github.com/user-attachments/assets/aa7659e7-cebd-4fa3-a2c7-13f1b076bb30" />|<img width="1029" height="765" alt="Capture d’écran 2026-08-03 à 14 57 02" src="https://github.com/user-attachments/assets/873d6070-ce76-4bb8-b0c6-26eadff18dfb" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
