### PR TITLE
(PC-42653) feat(auth): use oauth sso v2 routes

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -2327,6 +2327,27 @@ export interface OAuthSigninRequest {
 }
 /**
  * @export
+ * @interface OAuthSigninRequestV2
+ */
+export interface OAuthSigninRequestV2 {
+  /**
+   * @type {string}
+   * @memberof OAuthSigninRequestV2
+   */
+  authorizationCode: string
+  /**
+   * @type {DeviceInfoV2}
+   * @memberof OAuthSigninRequestV2
+   */
+  deviceInfo: DeviceInfoV2
+  /**
+   * @type {string}
+   * @memberof OAuthSigninRequestV2
+   */
+  oauthStateToken: string
+}
+/**
+ * @export
  * @interface SSOAccountRequest
  */
 export interface SSOAccountRequest {
@@ -2766,6 +2787,17 @@ export interface OauthStateResponse {
   /**
    * @type {string}
    * @memberof OauthStateResponse
+   */
+  oauthStateToken: string
+}
+/**
+ * @export
+ * @interface OauthStateResponseV2
+ */
+export interface OauthStateResponseV2 {
+  /**
+   * @type {string}
+   * @memberof OauthStateResponseV2
    */
   oauthStateToken: string
 }
@@ -6668,6 +6700,22 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
       }
     },
     /**
+     * @summary sso_oauth_state <GET>
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getNativeV2OauthState(options: any = {}): Promise<FetchArgs> {
+      let pathname = `/native/v2/oauth/state`
+      let secureOptions = Object.assign(options, { credentials: 'omit' })
+      const localVarRequestOptions = Object.assign({ method: 'GET' }, secureOptions)
+      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
+      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
+      return {
+        url: pathname,
+        options: localVarRequestOptions,
+      }
+    },
+    /**
      * @summary get_offer_v2 <GET>
      * @deprecated
      * @param {number} offer_id
@@ -7849,6 +7897,44 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
       }
     },
     /**
+     * @summary sso_authorize <POST>
+     * @param {OAuthSigninRequestV2} body
+     * @param {string} sso_provider
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async postNativeV2OauthssoProviderAuthorize(body: OAuthSigninRequestV2, sso_provider: string, options: any = {}): Promise<FetchArgs> {
+      // verify required parameter 'body' is not null or undefined
+      if (body === null || body === undefined) {
+        throw new RequiredError(
+          'body',
+          'Required parameter body was null or undefined when calling postNativeV2OauthssoProviderAuthorize.'
+        )
+      }
+      // verify required parameter 'sso_provider' is not null or undefined
+      if (sso_provider === null || sso_provider === undefined) {
+        throw new RequiredError(
+          'sso_provider',
+          'Required parameter sso_provider was null or undefined when calling postNativeV2OauthssoProviderAuthorize.'
+        )
+      }
+      let pathname = `/native/v2/oauth/{sso_provider}/authorize`.replace(
+        `{${'sso_provider'}}`,
+        encodeURIComponent(String(sso_provider))
+      )
+      let secureOptions = Object.assign(options, { credentials: 'omit' })
+      const localVarRequestOptions = Object.assign({ method: 'POST' }, secureOptions)
+      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
+      localVarHeaderParameter['Content-Type'] = 'application/json'
+      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
+      const needsSerialization = (<any>"OAuthSigninRequestV2" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json'
+      localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "")
+      return {
+        url: pathname,
+        options: localVarRequestOptions,
+      }
+    },
+    /**
      * @summary get_offers_and_stocks <POST>
      * @param {OffersStocksRequest} body
      * @param {*} [options] Override http request option.
@@ -8508,6 +8594,17 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     },
     /**
      *
+     * @summary sso_oauth_state <GET>
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getNativeV2OauthState(options?: any): Promise<OauthStateResponseV2> {
+      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV2OauthState(options)
+      const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
+    },
+    /**
+     *
      * @summary get_email_update_status <GET>
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -9015,6 +9112,19 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
      */
     async postNativeV1ValidateEmail(body: ValidateEmailRequest, options?: any): Promise<ValidateEmailResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV1ValidateEmail(body, options)
+      const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
+      return handleGeneratedApiResponse(response, localVarFetchArgs.options)
+    },
+    /**
+     *
+     * @summary sso_authorize <POST>
+     * @param {OAuthSigninRequestV2} body
+     * @param {string} sso_provider
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async postNativeV2OauthssoProviderAuthorize(body: OAuthSigninRequestV2, sso_provider: string, options?: any): Promise<SigninResponseV2> {
+      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postNativeV2OauthssoProviderAuthorize(body, sso_provider, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
       return handleGeneratedApiResponse(response, localVarFetchArgs.options)
     },
@@ -9540,6 +9650,17 @@ export class DefaultApi extends BaseAPI {
   }
   /**
     *
+    * @summary sso_oauth_state <GET>
+    * @param {*} [options] Override http request option.
+    * @throws {RequiredError}
+    * @memberof DefaultApi
+    */
+  public async getNativeV2OauthState(options?: any) {
+    const configuration = this.getConfiguration()
+    return DefaultApiFp(this, configuration).getNativeV2OauthState(options)
+  }
+  /**
+    *
     * @summary get_email_update_status <GET>
     * @param {*} [options] Override http request option.
     * @throws {RequiredError}
@@ -10052,6 +10173,19 @@ export class DefaultApi extends BaseAPI {
   }
   /**
     * 
+    * @summary sso_authorize <POST>
+    * @param {OAuthSigninRequestV2} body
+    * @param {string} sso_provider
+    * @param {*} [options] Override http request option.
+    * @throws {RequiredError}
+    * @memberof DefaultApi
+    */
+  public async postNativeV2OauthssoProviderAuthorize(body: OAuthSigninRequestV2, sso_provider: string, options?: any) {
+    const configuration = this.getConfiguration()
+    return DefaultApiFp(this, configuration).postNativeV2OauthssoProviderAuthorize(body, sso_provider, options)
+  }
+  /**
+    *
     * @summary get_offers_and_stocks <POST>
     * @param {OffersStocksRequest} body
     * @param {*} [options] Override http request option.

--- a/src/features/auth/components/SSOButton/SSOButtonApple.native.test.tsx
+++ b/src/features/auth/components/SSOButton/SSOButtonApple.native.test.tsx
@@ -3,7 +3,7 @@ import appleAuth from '@invertase/react-native-apple-authentication'
 import React from 'react'
 
 import * as API from 'api/api'
-import { AccountState, OauthStateResponse, SigninResponse, UserProfileResponse } from 'api/gen'
+import { AccountState, OauthStateResponseV2, SigninResponseV2, UserProfileResponse } from 'api/gen'
 import { SSOButtonApple } from 'features/auth/components/SSOButton/SSOButtonApple'
 import { beneficiaryUserFromAPI } from 'fixtures/user'
 import { analytics } from 'libs/analytics/provider'
@@ -27,7 +27,7 @@ jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({
 
 jest.mock('libs/network/NetInfoWrapper')
 
-const apiPostOAuthAuthorize = jest.spyOn(API.api, 'postNativeV1OauthssoProviderAuthorize')
+const apiPostOAuthAuthorize = jest.spyOn(API.api, 'postNativeV2OauthssoProviderAuthorize')
 const onSignInFailureSpy = jest.fn()
 const showErrorSnackBarSpy = jest.spyOn(snackBarStoreModule, 'showErrorSnackBar')
 
@@ -46,7 +46,7 @@ const useRemoteConfigSpy = jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuer
 
 describe('<SSOButtonApple />', () => {
   beforeEach(() => {
-    mockServer.getApi<OauthStateResponse>('/v1/oauth/state', {
+    mockServer.getApi<OauthStateResponseV2>('/v2/oauth/state', {
       oauthStateToken: 'oauth_state_token',
     })
     setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_APPLE_SSO])
@@ -58,7 +58,7 @@ describe('<SSOButtonApple />', () => {
   })
 
   it('should sign in with device info when sso button is clicked', async () => {
-    mockServer.postApi<SigninResponse>('/v1/oauth/apple/authorize', {
+    mockServer.postApi<SigninResponseV2>('/v2/oauth/apple/authorize', {
       accessToken: 'accessToken',
       refreshToken: 'refreshToken',
       accountState: AccountState.ACTIVE,
@@ -87,7 +87,7 @@ describe('<SSOButtonApple />', () => {
   })
 
   it('should call onSignInFailure when signin fails', async () => {
-    mockServer.postApi<SigninResponse>('/v1/oauth/apple/authorize', {
+    mockServer.postApi<SigninResponseV2>('/v2/oauth/apple/authorize', {
       responseOptions: { statusCode: 500 },
     })
 
@@ -125,7 +125,7 @@ describe('<SSOButtonApple />', () => {
   })
 
   it('should log analytics when logging in with sso from signup', async () => {
-    mockServer.postApi<SigninResponse>('/v1/oauth/apple/authorize', {
+    mockServer.postApi<SigninResponseV2>('/v2/oauth/apple/authorize', {
       accessToken: 'accessToken',
       refreshToken: 'refreshToken',
       accountState: AccountState.ACTIVE,
@@ -145,7 +145,7 @@ describe('<SSOButtonApple />', () => {
   })
 
   it('should log analytics when logging in with sso from login', async () => {
-    mockServer.postApi<SigninResponse>('/v1/oauth/apple/authorize', {
+    mockServer.postApi<SigninResponseV2>('/v2/oauth/apple/authorize', {
       accessToken: 'accessToken',
       refreshToken: 'refreshToken',
       accountState: AccountState.ACTIVE,

--- a/src/features/auth/components/SSOButton/SSOButtonGoogle.native.test.tsx
+++ b/src/features/auth/components/SSOButton/SSOButtonGoogle.native.test.tsx
@@ -3,7 +3,7 @@ import { GoogleSignin, statusCodes } from '@react-native-google-signin/google-si
 import React from 'react'
 
 import * as API from 'api/api'
-import { AccountState, OauthStateResponse, SigninResponse } from 'api/gen'
+import { AccountState, OauthStateResponseV2, SigninResponseV2 } from 'api/gen'
 import { SSOButtonGoogle } from 'features/auth/components/SSOButton/SSOButtonGoogle'
 import { UserProfile } from 'features/share/types'
 import { beneficiaryUser } from 'fixtures/user'
@@ -27,7 +27,7 @@ jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({
 
 jest.mock('libs/network/NetInfoWrapper')
 
-const apiPostOAuthAuthorize = jest.spyOn(API.api, 'postNativeV1OauthssoProviderAuthorize')
+const apiPostOAuthAuthorize = jest.spyOn(API.api, 'postNativeV2OauthssoProviderAuthorize')
 
 const onSignInFailureSpy = jest.fn()
 const showErrorSnackBarSpy = jest.spyOn(snackBarStoreModule, 'showErrorSnackBar')
@@ -47,7 +47,7 @@ const useRemoteConfigSpy = jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuer
 
 describe('<SSOButtonGoogle />', () => {
   beforeEach(() => {
-    mockServer.getApi<OauthStateResponse>('/v1/oauth/state', {
+    mockServer.getApi<OauthStateResponseV2>('/v2/oauth/state', {
       oauthStateToken: 'oauth_state_token',
     })
     deviceInfoStoreActions.setDeviceInfo({
@@ -58,7 +58,7 @@ describe('<SSOButtonGoogle />', () => {
   })
 
   it('should sign in with device info when sso button is clicked', async () => {
-    mockServer.postApi<SigninResponse>('/v1/oauth/google/authorize', {
+    mockServer.postApi<SigninResponseV2>('/v2/oauth/google/authorize', {
       accessToken: 'accessToken',
       refreshToken: 'refreshToken',
       accountState: AccountState.ACTIVE,
@@ -85,7 +85,7 @@ describe('<SSOButtonGoogle />', () => {
   })
 
   it('should call onSignInFailure when signin fails', async () => {
-    mockServer.postApi<SigninResponse>('/v1/oauth/google/authorize', {
+    mockServer.postApi<SigninResponseV2>('/v2/oauth/google/authorize', {
       responseOptions: { statusCode: 500 },
     })
 
@@ -126,7 +126,7 @@ describe('<SSOButtonGoogle />', () => {
   })
 
   it('should log analytics when logging in with sso from signup', async () => {
-    mockServer.postApi<SigninResponse>('/v1/oauth/google/authorize', {
+    mockServer.postApi<SigninResponseV2>('/v2/oauth/google/authorize', {
       accessToken: 'accessToken',
       refreshToken: 'refreshToken',
       accountState: AccountState.ACTIVE,
@@ -144,7 +144,7 @@ describe('<SSOButtonGoogle />', () => {
   })
 
   it('should log analytics when logging in with sso from login', async () => {
-    mockServer.postApi<SigninResponse>('/v1/oauth/google/authorize', {
+    mockServer.postApi<SigninResponseV2>('/v2/oauth/google/authorize', {
       accessToken: 'accessToken',
       refreshToken: 'refreshToken',
       accountState: AccountState.ACTIVE,

--- a/src/features/auth/pages/login/Login.native.test.tsx
+++ b/src/features/auth/pages/login/Login.native.test.tsx
@@ -6,7 +6,7 @@ import * as API from 'api/api'
 import {
   AccountState,
   FavoriteResponse,
-  OauthStateResponse,
+  OauthStateResponseV2,
   RecreditType,
   SigninResponseV2,
 } from 'api/gen'
@@ -69,7 +69,7 @@ describe('<Login/>', () => {
   beforeEach(() => {
     setFeatureFlags([])
     mockServer.postApi<FavoriteResponse>('/v1/me/favorites', favoriteResponseSnap)
-    mockServer.getApi<OauthStateResponse>('/v1/oauth/state', {
+    mockServer.getApi<OauthStateResponseV2>('/v2/oauth/state', {
       oauthStateToken: 'oauth_state_token',
     })
     simulateSignin200(AccountState.ACTIVE)

--- a/src/features/auth/pages/login/Login.web.test.tsx
+++ b/src/features/auth/pages/login/Login.web.test.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 
 import { useRoute } from '__mocks__/@react-navigation/native'
-import { OauthStateResponse } from 'api/gen'
+import { OauthStateResponseV2 } from 'api/gen'
 import { AuthContext } from 'features/auth/context/AuthContext'
 import { env } from 'libs/environment/fixtures'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
@@ -39,7 +39,7 @@ jest.mock('libs/firebase/analytics/analytics')
 describe('<Login/>', () => {
   beforeEach(() => {
     setFeatureFlags()
-    mockServer.getApi<OauthStateResponse>('/v1/oauth/state', {
+    mockServer.getApi<OauthStateResponseV2>('/v2/oauth/state', {
       oauthStateToken: 'oauth_state_token',
     })
   })

--- a/src/features/auth/pages/login/LoginMethods.native.test.tsx
+++ b/src/features/auth/pages/login/LoginMethods.native.test.tsx
@@ -2,13 +2,7 @@ import React from 'react'
 
 import { navigate, useRoute } from '__mocks__/@react-navigation/native'
 import * as API from 'api/api'
-import {
-  AccountState,
-  FavoriteResponse,
-  OauthStateResponse,
-  SigninResponse,
-  SigninResponseV2,
-} from 'api/gen'
+import { AccountState, FavoriteResponse, OauthStateResponseV2, SigninResponseV2 } from 'api/gen'
 import { AuthContext } from 'features/auth/context/AuthContext'
 import { SignInResponseFailure } from 'features/auth/types'
 import { favoriteResponseSnap } from 'features/favorites/fixtures/favoriteResponseSnap'
@@ -41,7 +35,7 @@ jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({
   useSubscriptionContext: jest.fn(() => ({ dispatch: mockIdentityCheckDispatch })),
 }))
 
-const apiPostOAuthAuthorize = jest.spyOn(API.api, 'postNativeV1OauthssoProviderAuthorize')
+const apiPostOAuthAuthorize = jest.spyOn(API.api, 'postNativeV2OauthssoProviderAuthorize')
 
 jest.useFakeTimers()
 const user = userEvent.setup()
@@ -50,7 +44,7 @@ describe('<LoginMethods/>', () => {
   beforeEach(() => {
     setFeatureFlags([])
     mockServer.postApi<FavoriteResponse>('/v1/me/favorites', favoriteResponseSnap)
-    mockServer.getApi<OauthStateResponse>('/v1/oauth/state', {
+    mockServer.getApi<OauthStateResponseV2>('/v2/oauth/state', {
       oauthStateToken: 'oauth_state_token',
     })
     simulateSignin200(AccountState.ACTIVE)
@@ -124,7 +118,7 @@ describe('<LoginMethods/>', () => {
 
   describe('generic SSO errors', () => {
     it('should display rate limit snackbar when too many attempts error occurs with Google', async () => {
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
         responseOptions: {
           statusCode: 429,
           data: { code: 'TOO_MANY_ATTEMPTS', general: [] },
@@ -143,7 +137,7 @@ describe('<LoginMethods/>', () => {
     })
 
     it('should display network error snackbar when network request failed', async () => {
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
         responseOptions: {
           statusCode: 500,
           data: { code: 'NETWORK_REQUEST_FAILED', general: [] },
@@ -162,7 +156,7 @@ describe('<LoginMethods/>', () => {
     })
 
     it('should fallback to SSO error message when error code is unknown', async () => {
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
         responseOptions: {
           statusCode: 500,
           data: {
@@ -188,7 +182,7 @@ describe('<LoginMethods/>', () => {
     })
 
     it('should log analytics when signing in with Apple SSO', async () => {
-      mockServer.postApi<SigninResponse>('/v1/oauth/apple/authorize', {
+      mockServer.postApi<SigninResponseV2>('/v2/oauth/apple/authorize', {
         accessToken: 'accessToken',
         refreshToken: 'refreshToken',
         accountState: AccountState.ACTIVE,
@@ -205,7 +199,7 @@ describe('<LoginMethods/>', () => {
     })
 
     it('should redirect to signup form when Apple SSO login fails because user does not exist', async () => {
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/apple/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/apple/authorize', {
         responseOptions: {
           statusCode: 401,
           data: {
@@ -232,7 +226,7 @@ describe('<LoginMethods/>', () => {
 
   describe('with Google SSO', () => {
     it('should sign in when SSO button is clicked with device info', async () => {
-      mockServer.postApi<SigninResponse>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SigninResponseV2>('/v2/oauth/google/authorize', {
         accessToken: 'accessToken',
         refreshToken: 'refreshToken',
         accountState: AccountState.ACTIVE,
@@ -258,7 +252,7 @@ describe('<LoginMethods/>', () => {
     })
 
     it('should show snackbar when SSO login fails because account is invalid', async () => {
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
         responseOptions: { statusCode: 400, data: { code: 'SSO_ERROR', general: [] } },
       })
 
@@ -274,7 +268,7 @@ describe('<LoginMethods/>', () => {
     })
 
     it('should redirect to signup form when SSO login fails because user does not exist', async () => {
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
         responseOptions: {
           statusCode: 401,
           data: {
@@ -299,7 +293,7 @@ describe('<LoginMethods/>', () => {
     })
 
     it('should log analytics when signing in with SSO', async () => {
-      mockServer.postApi<SigninResponse>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SigninResponseV2>('/v2/oauth/google/authorize', {
         accessToken: 'accessToken',
         refreshToken: 'refreshToken',
         accountState: AccountState.ACTIVE,
@@ -319,7 +313,7 @@ describe('<LoginMethods/>', () => {
   describe('with Apple SSO', () => {
     it('should show snackbar when Apple SSO login fails because account is invalid', async () => {
       setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_APPLE_SSO])
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/apple/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/apple/authorize', {
         responseOptions: { statusCode: 400, data: { code: 'SSO_ERROR', general: [] } },
       })
       renderLogin()

--- a/src/features/auth/pages/signup/SetEmail/SetEmail.native.test.tsx
+++ b/src/features/auth/pages/signup/SetEmail/SetEmail.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { OauthStateResponse } from 'api/gen'
+import { OauthStateResponseV2 } from 'api/gen'
 import { PreValidationSignupNormalStepProps } from 'features/auth/types'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
@@ -205,6 +205,8 @@ describe('<SetEmail />', () => {
 })
 
 const renderSetEmail = (props: PreValidationSignupNormalStepProps = defaultProps) => {
-  mockServer.getApi<OauthStateResponse>('/v1/oauth/state', { oauthStateToken: 'oauth_state_token' })
+  mockServer.getApi<OauthStateResponseV2>('/v2/oauth/state', {
+    oauthStateToken: 'oauth_state_token',
+  })
   render(reactQueryProviderHOC(<SetEmail {...props} />))
 }

--- a/src/features/auth/pages/signup/SignupForm.web.test.tsx
+++ b/src/features/auth/pages/signup/SignupForm.web.test.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 
 import { useRoute } from '__mocks__/@react-navigation/native'
-import { EmailValidationRemainingResendsResponse, OauthStateResponse } from 'api/gen'
+import { EmailValidationRemainingResendsResponse, OauthStateResponseV2 } from 'api/gen'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { env } from 'libs/environment/fixtures'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
@@ -46,7 +46,7 @@ describe('<SignupForm/>', () => {
     )
     useRoute.mockReturnValue({ params: { from: StepperOrigin.HOME } })
 
-    mockServer.getApi<OauthStateResponse>('/v1/oauth/state', {
+    mockServer.getApi<OauthStateResponseV2>('/v2/oauth/state', {
       responseOptions: { data: { oauthStateToken: 'oauth_state_token' } },
       requestOptions: { persist: true },
     })

--- a/src/features/auth/pages/signup/SignupMethods/SignupMethods.native.test.tsx
+++ b/src/features/auth/pages/signup/SignupMethods/SignupMethods.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { api } from 'api/api'
-import { AccountState, OauthStateResponse, SigninResponse } from 'api/gen'
+import { AccountState, OauthStateResponseV2, SigninResponseV2 } from 'api/gen'
 import { SignInResponseFailure } from 'features/auth/types'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { UserProfile } from 'features/share/types'
@@ -28,7 +28,7 @@ jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({
   useSubscriptionContext: jest.fn(() => ({ dispatch: jest.fn() })),
 }))
 
-const apiPostOAuthAuthorize = jest.spyOn(api, 'postNativeV1OauthssoProviderAuthorize')
+const apiPostOAuthAuthorize = jest.spyOn(api, 'postNativeV2OauthssoProviderAuthorize')
 
 const deviceInfo = {
   deviceId: 'ad7b7b5a169641e27cadbdb35adad9c4ca23099a',
@@ -42,7 +42,7 @@ const user = userEvent.setup()
 describe('<SignupMethods />', () => {
   beforeEach(() => {
     setFeatureFlags([])
-    mockServer.getApi<OauthStateResponse>('/v1/oauth/state', {
+    mockServer.getApi<OauthStateResponseV2>('/v2/oauth/state', {
       responseOptions: { data: { oauthStateToken: 'oauth_state_token' } },
     })
     deviceInfoStoreActions.setDeviceInfo(deviceInfo)
@@ -57,7 +57,7 @@ describe('<SignupMethods />', () => {
 
   describe('generic SSO errors', () => {
     it('should display rate limit snackbar when too many attempts error occurs with Google', async () => {
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
         responseOptions: {
           statusCode: 429,
           data: { code: 'TOO_MANY_ATTEMPTS', general: [] },
@@ -76,7 +76,7 @@ describe('<SignupMethods />', () => {
     })
 
     it('should display network error snackbar when network request failed', async () => {
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
         responseOptions: {
           statusCode: 500,
           data: { code: 'NETWORK_REQUEST_FAILED', general: [] },
@@ -95,7 +95,7 @@ describe('<SignupMethods />', () => {
     })
 
     it('should fallback to SSO error message when error code is unknown', async () => {
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
         responseOptions: {
           statusCode: 500,
           data: {
@@ -117,7 +117,7 @@ describe('<SignupMethods />', () => {
 
   describe('for SSO Google method', () => {
     it('should sign in when sso button is clicked and sso account already exists', async () => {
-      mockServer.postApi<SigninResponse>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SigninResponseV2>('/v2/oauth/google/authorize', {
         accessToken: 'accessToken',
         refreshToken: 'refreshToken',
         accountState: AccountState.ACTIVE,
@@ -142,7 +142,7 @@ describe('<SignupMethods />', () => {
     })
 
     it('should navigate to SignupMethods when clicking Google SSO button and account does not already exist', async () => {
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
         responseOptions: {
           statusCode: 401,
           data: {
@@ -167,7 +167,7 @@ describe('<SignupMethods />', () => {
     })
 
     it('should display snackbar when Google SSO account is invalid', async () => {
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
         responseOptions: { data: { code: 'SSO_ERROR', general: [] }, statusCode: 400 },
       })
 
@@ -184,7 +184,7 @@ describe('<SignupMethods />', () => {
     })
 
     it('should display rate limit snackbar when too many attempts error occurs', async () => {
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/google/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
         responseOptions: { statusCode: 429, data: { code: 'TOO_MANY_ATTEMPTS', general: [] } },
       })
 
@@ -217,7 +217,7 @@ describe('<SignupMethods />', () => {
     })
 
     it('should navigate to SignupMethods when clicking Apple SSO button and account does not already exist', async () => {
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/apple/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/apple/authorize', {
         responseOptions: {
           statusCode: 401,
           data: {
@@ -243,7 +243,7 @@ describe('<SignupMethods />', () => {
 
     it('should display snackbar when Apple SSO account is invalid', async () => {
       setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_APPLE_SSO])
-      mockServer.postApi<SignInResponseFailure['content']>('/v1/oauth/apple/authorize', {
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/apple/authorize', {
         responseOptions: { data: { code: 'SSO_ERROR', general: [] }, statusCode: 400 },
       })
 

--- a/src/features/auth/queries/useSignInMutation.ts
+++ b/src/features/auth/queries/useSignInMutation.ts
@@ -44,7 +44,7 @@ export const useSignInMutation = ({
       const isOAuth = isOAuthLoginRequest(requestBody)
       if (isOAuth) {
         const { provider, ...oauthBody } = requestBody
-        return api.postNativeV1OauthssoProviderAuthorize(oauthBody, provider, {
+        return api.postNativeV2OauthssoProviderAuthorize(oauthBody, provider, {
           credentials: 'omit',
         })
       }

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -1,4 +1,4 @@
-import { OAuthSigninRequest, SigninRequest } from 'api/gen'
+import { OAuthSigninRequestV2, SigninRequest } from 'api/gen'
 
 export type SignInResponseFailure = {
   isSuccess: false
@@ -47,7 +47,9 @@ export type PreValidationSignupLastStepProps = {
 }
 
 // Frontend discriminator to distinguish Apple from Google (same API shape)
-type OAuthLoginRequest = OAuthSigninRequest & { provider: 'google' | 'apple' }
+type OAuthLoginRequest = Omit<OAuthSigninRequestV2, 'deviceInfo'> & {
+  provider: 'google' | 'apple'
+}
 export type LoginRequest = SigninRequest | OAuthLoginRequest
 
 export const isOAuthLoginRequest = (req: LoginRequest): req is OAuthLoginRequest =>

--- a/src/libs/react-native-apple-sso/loginToApple.native.test.ts
+++ b/src/libs/react-native-apple-sso/loginToApple.native.test.ts
@@ -23,7 +23,7 @@ describe('loginToApple', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockedApi.getNativeV1OauthState.mockResolvedValue({ oauthStateToken: mockState })
+    mockedApi.getNativeV2OauthState.mockResolvedValue({ oauthStateToken: mockState })
     mockedAppleAuth.performRequest.mockResolvedValue({
       authorizationCode: mockAuthCode,
       identityToken: 'mockIdentityToken',
@@ -40,7 +40,7 @@ describe('loginToApple', () => {
   it('should call onSuccess with code and state when sign in is successful', async () => {
     await loginToApple({ onSuccess, onError })
 
-    expect(mockedApi.getNativeV1OauthState).toHaveBeenCalledWith()
+    expect(mockedApi.getNativeV2OauthState).toHaveBeenCalledWith()
     expect(mockedAppleAuth.performRequest).toHaveBeenCalledWith({
       requestedOperation: appleAuth.Operation.LOGIN,
       requestedScopes: [appleAuth.Scope.EMAIL, appleAuth.Scope.FULL_NAME],
@@ -68,9 +68,9 @@ describe('loginToApple', () => {
     expect(onSuccess).not.toHaveBeenCalled()
   })
 
-  it('should call onError when getNativeV1OauthState fails', async () => {
+  it('should call onError when getNativeV2OauthState fails', async () => {
     const error = new Error('OAuth state error')
-    mockedApi.getNativeV1OauthState.mockRejectedValueOnce(error)
+    mockedApi.getNativeV2OauthState.mockRejectedValueOnce(error)
 
     await loginToApple({ onSuccess, onError })
 

--- a/src/libs/react-native-apple-sso/loginToApple.ts
+++ b/src/libs/react-native-apple-sso/loginToApple.ts
@@ -6,7 +6,7 @@ import { AppleLoginOptions } from 'libs/react-native-apple-sso/types'
 
 export const loginToApple = async ({ onSuccess, onError }: AppleLoginOptions) => {
   try {
-    const { oauthStateToken } = await api.getNativeV1OauthState()
+    const { oauthStateToken } = await api.getNativeV2OauthState()
 
     const appleResponse = await appleAuth.performRequest({
       requestedOperation: appleAuth.Operation.LOGIN,

--- a/src/libs/react-native-apple-sso/loginToApple.web.test.ts
+++ b/src/libs/react-native-apple-sso/loginToApple.web.test.ts
@@ -21,7 +21,7 @@ describe('loginToApple (web)', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockedApi.getNativeV1OauthState.mockResolvedValue({ oauthStateToken: mockState })
+    mockedApi.getNativeV2OauthState.mockResolvedValue({ oauthStateToken: mockState })
     mockLoadAppleSSOContext.mockReturnValue({ type: 'login', oauthStateToken: '' })
     Object.defineProperty(env, 'APPLE_SERVICE_ID', { value: 'test.service.id', writable: true })
     Object.defineProperty(window, 'location', {
@@ -72,9 +72,9 @@ describe('loginToApple (web)', () => {
     expect(onError).toHaveBeenCalledWith(new Error('apple_service_id_not_configured'))
   })
 
-  it('should call onError when getNativeV1OauthState fails', async () => {
+  it('should call onError when getNativeV2OauthState fails', async () => {
     const error = new Error('Network error')
-    mockedApi.getNativeV1OauthState.mockRejectedValueOnce(error)
+    mockedApi.getNativeV2OauthState.mockRejectedValueOnce(error)
 
     await loginToApple({ onSuccess, onError })
 

--- a/src/libs/react-native-apple-sso/loginToApple.web.ts
+++ b/src/libs/react-native-apple-sso/loginToApple.web.ts
@@ -16,7 +16,7 @@ export const loginToApple = async ({ onError }: AppleLoginOptions) => {
   let oauthStateToken: string
 
   try {
-    oauthStateToken = (await api.getNativeV1OauthState()).oauthStateToken
+    oauthStateToken = (await api.getNativeV2OauthState()).oauthStateToken
   } catch (error) {
     onError?.(error)
     return

--- a/src/libs/react-native-google-sso/loginToGoogle.native.test.ts
+++ b/src/libs/react-native-google-sso/loginToGoogle.native.test.ts
@@ -21,7 +21,7 @@ describe('loginToGoogle', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockedApi.getNativeV1OauthState.mockResolvedValue({ oauthStateToken: mockState })
+    mockedApi.getNativeV2OauthState.mockResolvedValue({ oauthStateToken: mockState })
     mockedGoogleSignin.hasPlayServices.mockResolvedValue(true)
     mockedGoogleSignin.signIn.mockResolvedValue({
       serverAuthCode: mockServerAuthCode,
@@ -44,7 +44,7 @@ describe('loginToGoogle', () => {
       showPlayServicesUpdateDialog: true,
     })
     expect(mockedGoogleSignin.signIn).toHaveBeenCalledWith()
-    expect(mockedApi.getNativeV1OauthState).toHaveBeenCalledWith()
+    expect(mockedApi.getNativeV2OauthState).toHaveBeenCalledWith()
     expect(onSuccess).toHaveBeenCalledWith({ code: mockServerAuthCode, state: mockState })
     expect(onError).not.toHaveBeenCalled()
   })

--- a/src/libs/react-native-google-sso/loginToGoogle.ts
+++ b/src/libs/react-native-google-sso/loginToGoogle.ts
@@ -15,7 +15,7 @@ export const loginToGoogle = async ({ onSuccess, onError }: GoogleLoginOptions) 
     if (serverAuthCode) {
       onSuccess({
         code: serverAuthCode,
-        state: (await api.getNativeV1OauthState()).oauthStateToken,
+        state: (await api.getNativeV2OauthState()).oauthStateToken,
       })
     }
   } catch (error) {

--- a/src/libs/react-native-google-sso/loginToGoogle.web.test.ts
+++ b/src/libs/react-native-google-sso/loginToGoogle.web.test.ts
@@ -32,13 +32,13 @@ describe('loginToGoogle', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     initCodeClientMock.mockReturnValue({ requestCode: requestCodeMock })
-    mockedApi.getNativeV1OauthState.mockResolvedValue({ oauthStateToken: mockState })
+    mockedApi.getNativeV2OauthState.mockResolvedValue({ oauthStateToken: mockState })
   })
 
   it('should initialize code client and request code on success', async () => {
     await loginToGoogle({ onSuccess, onError })
 
-    expect(mockedApi.getNativeV1OauthState).toHaveBeenCalledWith()
+    expect(mockedApi.getNativeV2OauthState).toHaveBeenCalledWith()
     expect(initCodeClientMock).toHaveBeenCalledWith({
       client_id: 'mock-google-client-id',
       scope: 'openid profile email',
@@ -49,9 +49,9 @@ describe('loginToGoogle', () => {
     expect(requestCodeMock).toHaveBeenCalledWith()
   })
 
-  it('should call onError if getNativeV1OauthState fails', async () => {
+  it('should call onError if getNativeV2OauthState fails', async () => {
     const error = new Error('API Error')
-    mockedApi.getNativeV1OauthState.mockRejectedValueOnce(error)
+    mockedApi.getNativeV2OauthState.mockRejectedValueOnce(error)
 
     await loginToGoogle({ onSuccess, onError })
 

--- a/src/libs/react-native-google-sso/loginToGoogle.web.ts
+++ b/src/libs/react-native-google-sso/loginToGoogle.web.ts
@@ -7,7 +7,7 @@ export const loginToGoogle = async ({ onSuccess, onError }: GoogleLoginOptions) 
   let oauthStateToken: string
 
   try {
-    oauthStateToken = (await api.getNativeV1OauthState()).oauthStateToken
+    oauthStateToken = (await api.getNativeV2OauthState()).oauthStateToken
   } catch (error) {
     onError?.(error)
     return


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42653

## Context

Migration des routes OAuth SSO (Google et Apple) de la v1 vers la v2 de l'API native :

- `GET /native/v1/oauth/state` → `GET /native/v2/oauth/state` (récupération du `oauthStateToken` avant login Google/Apple, natif et web)
- `POST /native/v1/oauth/{provider}/authorize` → `POST /native/v2/oauth/{provider}/authorize` (échange du code d'autorisation lors du sign-in SSO)

Changements associés :

- Régénération du client API (`src/api/gen/api.ts`) : ajout des types `OAuthSigninRequestV2`, `OauthStateResponseV2` et des méthodes `getNativeV2OauthState` / `postNativeV2OauthssoProviderAuthorize`
- `OAuthLoginRequest` s'appuie désormais sur `OAuthSigninRequestV2` (sans `deviceInfo`, ajouté côté mutation)
- Mise à jour des tests (login, signup, boutons SSO, libs `loginToGoogle` / `loginToApple`) pour mocker les routes v2

Aucun changement fonctionnel ni UI : le comportement du login SSO reste identique