### PR TITLE
(PC-43029) fix(search): sync search state with navigation parameters

### DIFF
--- a/src/features/search/helpers/syncSearchStateFromRouteParams.native.test.ts
+++ b/src/features/search/helpers/syncSearchStateFromRouteParams.native.test.ts
@@ -1,0 +1,52 @@
+import { initialSearchState } from 'features/search/context/reducer'
+
+import { syncSearchStateFromRouteParams } from './syncSearchStateFromRouteParams'
+
+describe('syncSearchStateFromRouteParams', () => {
+  const dispatch = jest.fn()
+
+  beforeEach(() => {
+    dispatch.mockClear()
+  })
+
+  it('should do nothing when params are undefined', () => {
+    syncSearchStateFromRouteParams(undefined, dispatch)
+
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('should dispatch search state from route params', () => {
+    const params = {
+      query: 'cinema',
+      venue: {
+        label: 'VESOUL MUSIQUE',
+        info: 'Vesoul',
+        venueId: 25761,
+        activity: null,
+        isOpenToPublic: true,
+      },
+    }
+
+    syncSearchStateFromRouteParams(params, dispatch)
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'SET_STATE',
+      payload: { ...initialSearchState, ...params },
+    })
+  })
+
+  it('should omit accessibilityFilter from search state', () => {
+    syncSearchStateFromRouteParams(
+      {
+        query: 'theatre',
+        accessibilityFilter: { isAudioDisabilityCompliant: true },
+      },
+      dispatch
+    )
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'SET_STATE',
+      payload: { ...initialSearchState, query: 'theatre' },
+    })
+  })
+})

--- a/src/features/search/helpers/syncSearchStateFromRouteParams.ts
+++ b/src/features/search/helpers/syncSearchStateFromRouteParams.ts
@@ -1,0 +1,15 @@
+import { SearchStackParamList } from 'features/navigation/navigators/SearchStackNavigator/types'
+import { Action, initialSearchState } from 'features/search/context/reducer'
+
+export const syncSearchStateFromRouteParams = (
+  params: SearchStackParamList['SearchResults'],
+  dispatch: (action: Action) => void
+) => {
+  if (!params) return
+
+  const { accessibilityFilter: _accessibilityFilter, ...searchParams } = params
+  dispatch({
+    type: 'SET_STATE',
+    payload: { ...initialSearchState, ...searchParams },
+  })
+}

--- a/src/features/search/pages/SearchResults/SearchResultsContainer.tsx
+++ b/src/features/search/pages/SearchResults/SearchResultsContainer.tsx
@@ -1,13 +1,31 @@
-import React, { FC } from 'react'
+import { useFocusEffect, useRoute } from '@react-navigation/native'
+import React, { FC, useCallback, useEffect, useRef } from 'react'
 
+import { UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
+import { useSearch } from 'features/search/context/SearchWrapper'
+import { syncSearchStateFromRouteParams } from 'features/search/helpers/syncSearchStateFromRouteParams'
 import { SearchResults as SearchResultsV1 } from 'features/search/pages/SearchResults/v1/SearchResults'
 import { SearchResults } from 'features/search/pages/SearchResults/v2/SearchResults'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 
 export const SearchResultsContainer: FC = () => {
+  const { params } = useRoute<UseRouteType<'SearchResults'>>()
+  const { dispatch } = useSearch()
+  const paramsRef = useRef(params)
+
+  useEffect(() => {
+    paramsRef.current = params
+  }, [params])
+
   const enableNewSearchResultsPage = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_NEW_SEARCH_RESULTS_PAGE
+  )
+
+  useFocusEffect(
+    useCallback(() => {
+      syncSearchStateFromRouteParams(paramsRef.current, dispatch)
+    }, [dispatch])
   )
 
   return enableNewSearchResultsPage ? <SearchResults /> : <SearchResultsV1 />


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43029

## Contexte

La suppression du useSync prenait en compte:
- l'arrivée sur l'app depuis un deeplink
- le changement de filtres à la volée
- le changement de localisation

Mais ne prenais pas en compte la navigation vers une page de résultats de recherche avec des paramètres de filtrage.
Résultat on arrive sur la page de résultats de recherche comme s'il n'y avait pas de paramètres.

## Implémentation

Ajout d'une fonction qui mettra à jour l'état de la recherche au focus sur la page de résultats de recherche.
On ne veut déclencher cette fonction que à l'arrivée sur la page, c'est pour cela que l'état de recherche a été placé dans une `ref`. Cette ref est mise à jour dans un `useEffect` pour respecter les règles du compilateur React.

La fonction est testée en dehors de React mais je me questionne sur l'utilité de tests qui ne peuvent pas tester la fonctionnalité en globalité. RNTL étant plutot limité sur la partie navigation, il faudrait peut-être écrire des tests e2e pour être résilients au changement.

## Screenshots

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |<video src="https://github.com/user-attachments/assets/53b93685-d15c-4f9c-9569-9638dc81abd1" />|<video src="https://github.com/user-attachments/assets/96760d53-3774-4995-864f-c9b41a0c9db5">|
