### PR TITLE
(PC-43127) fix(SafeAreaInsets): fix SafeAreaInsets on Android

### DIFF
--- a/__snapshots__/ui/pages/PageWithHeader.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/PageWithHeader.native.test.tsx.native-snap
@@ -602,11 +602,11 @@ exports[`<PageWithHeader/> should render correctly on Android, with white header
               scroll children
             </Text>
             <View
-              customHeight={8}
+              customHeight={16}
               enable={true}
               style={
                 {
-                  "height": 8,
+                  "height": 16,
                 }
               }
             />
@@ -669,11 +669,11 @@ exports[`<PageWithHeader/> should render correctly on Android, with white header
             fixed bottom children
           </Text>
           <View
-            customHeight={8}
+            customHeight={16}
             enable={true}
             style={
               {
-                "height": 8,
+                "height": 16,
               }
             }
           />

--- a/src/ui/theme/useCustomSafeInsets.tsx
+++ b/src/ui/theme/useCustomSafeInsets.tsx
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useTheme } from 'styled-components/native'
 
@@ -11,10 +12,11 @@ export const useCustomSafeInsets = () => {
   const {
     tabBar: { height },
   } = useTheme()
+  const computedBottomInset = Platform.OS === 'android' ? bottom : 0.5 * bottom
 
   return {
-    bottom: 0.5 * bottom,
-    tabBarHeight: 0.5 * bottom + height,
+    bottom: computedBottomInset,
+    tabBarHeight: computedBottomInset + height,
     top,
     right,
     left,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43127

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
