### PR TITLE
(PC-43168) feat(a11y): add <span> in web typography

### DIFF
--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -117,7 +117,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
           "bottom": 0,
           "height": 1334,
           "left": 0,
-          "opacity": 0,
+          "opacity": 0.7,
           "position": "absolute",
           "right": 0,
           "top": 0,
@@ -156,7 +156,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
           "top": "auto",
           "transform": [
             {
-              "translateY": 1334,
+              "translateY": 0,
             },
           ],
         }

--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -117,7 +117,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
           "bottom": 0,
           "height": 1334,
           "left": 0,
-          "opacity": 0.7,
+          "opacity": 0,
           "position": "absolute",
           "right": 0,
           "top": 0,
@@ -156,7 +156,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
           "top": "auto",
           "transform": [
             {
-              "translateY": 0,
+              "translateY": 1334,
             },
           ],
         }
@@ -244,6 +244,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                 testID="back-button-container"
               />
               <Text
+                accessibilityLevel={1}
                 accessibilityRole="header"
                 nativeID="testUuidV4"
                 numberOfLines={1}

--- a/__snapshots__/features/achievements/pages/Achievements.native.test.tsx.native-snap
+++ b/__snapshots__/features/achievements/pages/Achievements.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<Achievements/> should match snapshot 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -276,6 +277,7 @@ exports[`<Achievements/> should match snapshot 1`] = `
                 >
                   <View>
                     <Text
+                      accessibilityLevel={2}
                       accessibilityRole="header"
                       style={
                         {

--- a/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -258,6 +259,7 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
         >
           <View>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -320,6 +321,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
         >
           <View>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -76,6 +76,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -259,6 +260,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                 </View>
               </View>
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -265,6 +266,7 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/auth/pages/login/LoginMethods.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/login/LoginMethods.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<LoginMethods/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -258,6 +259,7 @@ exports[`<LoginMethods/> should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
@@ -31,6 +31,7 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={2}
           accessibilityRole="header"
           style={
             {
@@ -835,6 +836,7 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
         }
       >
         <Text
+          accessibilityLevel={2}
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
@@ -151,6 +151,7 @@ exports[`<AccountCreated /> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -169,6 +170,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
               C’est pour bientôt !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
@@ -265,6 +265,7 @@ exports[`QuitSignupModal should render correctly 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={1}
                     accessibilityRole="header"
                     style={
                       {
@@ -279,6 +280,7 @@ exports[`QuitSignupModal should render correctly 1`] = `
                     Veux-tu abandonner l’inscription ?
                   </Text>
                   <Text
+                    accessibilityLevel={2}
                     accessibilityRole="header"
                     style={
                       {

--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -18,6 +18,7 @@ exports[`<SetBirthday /> should render correctly 1`] = `
     }
   >
     <Text
+      accessibilityLevel={2}
       accessibilityRole="header"
       style={
         {
@@ -969,6 +970,7 @@ exports[`<SetBirthday /> should render correctly when account creation token and
     }
   >
     <Text
+      accessibilityLevel={2}
       accessibilityRole="header"
       style={
         {

--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
@@ -1416,12 +1416,12 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz r-justifyContent-1777fci r-width-13qz1uu"
             >
-              <p
+              <span
                 class="c11"
                 style="color: rgb(105, 106, 111); max-width: 100%; min-width: 0; flex-shrink: 1; flex-grow: 1; flex-basis: 0px; text-align: center;"
               >
                 Continuer
-              </p>
+              </span>
             </div>
           </button>
         </div>
@@ -2547,12 +2547,12 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz r-justifyContent-1777fci r-width-13qz1uu"
             >
-              <p
+              <span
                 class="c6"
                 style="color: rgb(105, 106, 111); max-width: 100%; min-width: 0; flex-shrink: 1; flex-grow: 1; flex-basis: 0px; text-align: center;"
               >
                 Continuer
-              </p>
+              </span>
             </div>
           </button>
         </div>

--- a/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
@@ -18,6 +18,7 @@ exports[`SetPassword Page should render correctly 1`] = `
     }
   >
     <Text
+      accessibilityLevel={2}
       accessibilityRole="header"
       style={
         {

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
@@ -174,6 +174,7 @@ exports[`<EmailResendModal /> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -291,6 +292,7 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
                   </View>
                 </View>
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -161,6 +161,7 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -250,6 +251,7 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
         }
       >
         <Text
+          accessibilityLevel={2}
           accessibilityRole="header"
           style={
             {
@@ -775,6 +777,7 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -934,6 +937,7 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
           }
         >
           <Text
+            accessibilityLevel={2}
             accessibilityRole="header"
             style={
               {
@@ -1565,6 +1569,7 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -1724,6 +1729,7 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
           }
         >
           <Text
+            accessibilityLevel={2}
             accessibilityRole="header"
             style={
               {
@@ -2821,6 +2827,7 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -2993,6 +3000,7 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/auth/pages/signup/SignupMethods/SignupMethods.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupMethods/SignupMethods.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<SignupMethods /> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -258,6 +259,7 @@ exports[`<SignupMethods /> should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
@@ -134,6 +134,7 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
@@ -151,6 +151,7 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -165,6 +166,7 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
               Ton compte a été réactivé
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -169,6 +170,7 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
               Ton compte est désactivé
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -151,6 +151,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -165,6 +166,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
               Tu as 18 ans !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -169,6 +170,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
               Réservation confirmée !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -169,6 +170,7 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
               Réservation introuvable !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
@@ -41,6 +41,7 @@ exports[`Bookings should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityLevel={1}
         accessibilityRole="header"
         numberOfLines={1}
         style={

--- a/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
@@ -192,6 +192,7 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={1}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
@@ -94,6 +94,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={3}
             accessibilityRole="header"
             style={
               {
@@ -207,6 +208,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
     }
   >
     <Text
+      accessibilityLevel={2}
       accessibilityRole="header"
       style={
         {
@@ -560,6 +562,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={3}
             accessibilityRole="header"
             style={
               {
@@ -908,6 +911,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={3}
             accessibilityRole="header"
             style={
               {
@@ -1256,6 +1260,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={3}
             accessibilityRole="header"
             style={
               {
@@ -1607,6 +1612,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={3}
               accessibilityRole="header"
               style={
                 {
@@ -1921,6 +1927,7 @@ Ils permettent à YouTube d’assurer le bon fonctionnement de la lecture, de co
           }
         >
           <Text
+            accessibilityLevel={3}
             accessibilityRole="header"
             style={
               {
@@ -2090,6 +2097,7 @@ Ils permettent à YouTube d’assurer le bon fonctionnement de la lecture, de co
     }
   >
     <Text
+      accessibilityLevel={2}
       accessibilityRole="header"
       style={
         {

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
@@ -156,6 +156,7 @@ exports[`CulturalSurveyIntro should render the page with correct layout and cont
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -170,6 +171,7 @@ exports[`CulturalSurveyIntro should render the page with correct layout and cont
               Tu y es presque !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx.native-snap
@@ -217,6 +217,7 @@ exports[`CulturalSurveyQuestions should render the page with correct layout 1`] 
         </View>
       </View>
       <Text
+        accessibilityLevel={1}
         accessibilityRole="header"
         numberOfLines={1}
         style={
@@ -271,6 +272,7 @@ exports[`CulturalSurveyQuestions should render the page with correct layout 1`] 
           }
         >
           <Text
+            accessibilityLevel={2}
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
@@ -151,6 +151,7 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -165,6 +166,7 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
               Un grand merci pour tes réponses !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/culturalSurvey/pages/FAQWebview.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/FAQWebview.native.test.tsx.native-snap
@@ -149,6 +149,7 @@ exports[`FAQVebview page should render the page with correct layout 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/errors/pages/AsyncErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/AsyncErrorBoundary.native.test.tsx.native-snap
@@ -123,6 +123,7 @@ exports[`AsyncErrorBoundary component should render 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           style={
             {
@@ -137,6 +138,7 @@ exports[`AsyncErrorBoundary component should render 1`] = `
           Oups !
         </Text>
         <Text
+          accessibilityLevel={2}
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/errors/pages/AsyncErrorBoundary.web.test.tsx.web-snap
+++ b/__snapshots__/features/errors/pages/AsyncErrorBoundary.web.test.tsx.web-snap
@@ -175,12 +175,12 @@ exports[`AsyncErrorBoundary component should render correctly 1`] = `
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz r-justifyContent-1777fci r-width-13qz1uu"
             >
-              <p
+              <span
                 class="c5"
                 style="color: rgb(255, 255, 255); max-width: 100%; min-width: 0; flex-shrink: 1; flex-grow: 1; flex-basis: 0px; text-align: center;"
               >
                 Réessayer
-              </p>
+              </span>
             </div>
           </button>
         </div>

--- a/__snapshots__/features/errors/pages/BannedCountryError.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/BannedCountryError.native.test.tsx.native-snap
@@ -65,6 +65,7 @@ exports[`BannedCountryError should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           style={
             {
@@ -79,6 +80,7 @@ exports[`BannedCountryError should render correctly 1`] = `
           Tu n’es pas en France ?
         </Text>
         <Text
+          accessibilityLevel={2}
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/favorites/pages/Favorites.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/Favorites.native.test.tsx.native-snap
@@ -43,6 +43,7 @@ exports[`<Favorites/> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityLevel={1}
         accessibilityRole="header"
         numberOfLines={1}
         style={

--- a/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -273,6 +274,7 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/favorites/pages/NotConnectedFavorites.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/NotConnectedFavorites.native.test.tsx.native-snap
@@ -71,6 +71,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             style={
               {
@@ -85,6 +86,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
             Identifie-toi pour retrouver tes favoris
           </Text>
           <Text
+            accessibilityLevel={2}
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/forceUpdate/pages/ForceUpdateWithResetErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/forceUpdate/pages/ForceUpdateWithResetErrorBoundary.native.test.tsx.native-snap
@@ -65,6 +65,7 @@ exports[`<ForceUpdateWithResetErrorBoundary/> should match snapshot 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           style={
             {
@@ -79,6 +80,7 @@ exports[`<ForceUpdateWithResetErrorBoundary/> should match snapshot 1`] = `
           Mise à jour requise !
         </Text>
         <Text
+          accessibilityLevel={2}
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/home/pages/GenericHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/GenericHome.native.test.tsx.native-snap
@@ -136,6 +136,7 @@ exports[`GenericHome With not displayed skeleton by default should display real 
             testID="listHeader"
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -218,6 +219,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
   >
     <View>
       <Text
+        accessibilityLevel={1}
         accessibilityRole="header"
         style={
           {
@@ -4479,6 +4481,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
             testID="listHeader"
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
@@ -176,6 +176,7 @@ exports[`Home page should render correctly 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={1}
                     accessibilityRole="header"
                     numberOfLines={2}
                     style={

--- a/__snapshots__/features/home/pages/NoContentError.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/NoContentError.native.test.tsx.native-snap
@@ -65,6 +65,7 @@ exports[`NoContentError should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           style={
             {
@@ -79,6 +80,7 @@ exports[`NoContentError should render correctly 1`] = `
           Oups !
         </Text>
         <Text
+          accessibilityLevel={2}
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
@@ -484,6 +484,7 @@ exports[`ThematicHome should render correctly 1`] = `
       >
         <Text
           accessibilityHidden={true}
+          accessibilityLevel={1}
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}
@@ -629,6 +630,7 @@ exports[`ThematicHome should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={4}
               accessibilityRole="header"
               numberOfLines={1}
               style={
@@ -667,6 +669,7 @@ exports[`ThematicHome should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 numberOfLines={1}
                 style={

--- a/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
@@ -174,6 +174,7 @@ exports[`<DMSModal/> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
@@ -266,6 +266,7 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={1}
                     accessibilityRole="header"
                     style={
                       {
@@ -280,6 +281,7 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
                     Veux-tu abandonner la vérification d’identité ?
                   </Text>
                   <Text
+                    accessibilityLevel={2}
                     accessibilityRole="header"
                     style={
                       {

--- a/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<DisableActivation/> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -560,6 +561,7 @@ exports[`<DisableActivation/> with RemoteActivationBanner informations should re
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
@@ -53,6 +53,7 @@ exports[`Stepper navigation should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -151,6 +151,7 @@ exports[`BeneficiaryAccountCreated should render correctly for 18 year-old benef
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -165,6 +166,7 @@ exports[`BeneficiaryAccountCreated should render correctly for 18 year-old benef
               Bonne nouvelle !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {
@@ -589,6 +591,7 @@ exports[`BeneficiaryAccountCreated should render correctly for underage benefici
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -603,6 +606,7 @@ exports[`BeneficiaryAccountCreated should render correctly for underage benefici
               Bonne nouvelle !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -169,6 +170,7 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
               Demande envoyée !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/confirmation/FreeBeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/FreeBeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -151,6 +151,7 @@ exports[`FreeBeneficiaryAccountCreated should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/confirmation/IdentityCheckHonor.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/IdentityCheckHonor.native.test.tsx.native-snap
@@ -36,6 +36,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
         }
       />
       <Text
+        accessibilityLevel={1}
         accessibilityRole="header"
         style={
           {
@@ -57,6 +58,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={2}
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -275,6 +276,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
@@ -243,6 +243,7 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -891,6 +892,7 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -293,6 +294,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={2}
                     accessibilityRole="header"
                     style={
                       {

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
@@ -279,12 +279,12 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
                     </div>
                   </div>
                 </div>
-                <p
+                <span
                   class="c6"
                   style="color: rgb(255, 255, 255); max-width: 100%; min-width: 0; flex-shrink: 1;"
                 >
                   Ouvrir un onglet ÉduConnect
-                </p>
+                </span>
               </div>
             </button>
             <div

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -266,6 +267,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
               }
             >
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
@@ -264,12 +264,12 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
               <div
                 class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz"
               >
-                <p
+                <span
                   class="c6"
                   style="color: rgb(255, 255, 255); max-width: 100%; min-width: 0; flex-shrink: 1;"
                 >
                   Continuer
-                </p>
+                </span>
               </div>
             </button>
             <div

--- a/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
@@ -146,6 +146,7 @@ exports[`NotEligibleEduConnect should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
@@ -242,6 +242,7 @@ exports[`ComeBackLater should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
@@ -242,6 +242,7 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.native.test.tsx.native-snap
@@ -54,6 +54,7 @@ exports[`<IdentityCheckEnd/> should render correctly 1`] = `
       }
     >
       <Text
+        accessibilityLevel={1}
         accessibilityRole="header"
         style={
           {

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
@@ -156,6 +156,7 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`SelectIDOrigin should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -293,6 +294,7 @@ exports[`SelectIDOrigin should render correctly 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -273,6 +274,7 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
@@ -260,6 +260,7 @@ exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -267,6 +268,7 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/identityCheck/pages/profile/ActivationProfileRecap.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/ActivationProfileRecap.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<ActivationProfileRecap /> ff WIP_PHONE_NUMBER_IN_PROFILE_STEPPER is en
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -259,6 +260,7 @@ exports[`<ActivationProfileRecap /> ff WIP_PHONE_NUMBER_IN_PROFILE_STEPPER is en
               }
             >
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -912,6 +914,7 @@ exports[`<ActivationProfileRecap /> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -1016,6 +1019,7 @@ exports[`<ActivationProfileRecap /> should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/identityCheck/pages/profile/ProfileInformationValidationCreate.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/ProfileInformationValidationCreate.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`ProfileInformationValidationCreate should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -259,6 +260,7 @@ exports[`ProfileInformationValidationCreate should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -266,6 +267,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -771,6 +773,7 @@ exports[`<SetAddress/> when ff phoneNumberInProfileStepper is enabled should ren
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -875,6 +878,7 @@ exports[`<SetAddress/> when ff phoneNumberInProfileStepper is enabled should ren
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<SetCity/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -266,6 +267,7 @@ exports[`<SetCity/> should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<SetName/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -266,6 +267,7 @@ exports[`<SetName/> should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/identityCheck/pages/profile/SetPhoneNumber.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetPhoneNumber.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<SetPhoneNumber/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -274,6 +275,7 @@ exports[`<SetPhoneNumber/> should render correctly 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<SetProfileBookingError/> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
@@ -149,6 +149,7 @@ exports[`<SetStatus/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -209,6 +210,7 @@ exports[`<SetStatus/> should render correctly 1`] = `
             />
             <Styled(View)>
               <Styled(Text)
+                accessibilityLevel={2}
                 accessibilityRole="header"
               >
                 Sélectionne ton statut
@@ -333,6 +335,7 @@ exports[`<SetStatus/> should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
@@ -161,6 +161,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -235,6 +236,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
         >
           <View>
             <Text
+              accessibilityLevel={4}
               accessibilityRole="header"
               style={
                 {
@@ -318,6 +320,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={3}
                     accessibilityRole="header"
                     style={
                       {
@@ -2287,6 +2290,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={3}
                     accessibilityRole="header"
                     style={
                       {
@@ -2573,6 +2577,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={3}
                     accessibilityRole="header"
                     style={
                       {
@@ -3531,6 +3536,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
         >
           <View>
             <Text
+              accessibilityLevel={4}
               accessibilityRole="header"
               style={
                 {
@@ -3621,6 +3627,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
           }
         >
           <Text
+            accessibilityLevel={4}
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/internal/pages/UTMParameters.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/UTMParameters.native.test.tsx.native-snap
@@ -161,6 +161,7 @@ exports[`<UTMParameters /> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
@@ -140,6 +140,7 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               nativeID="testUuidV4"
               style={
@@ -487,6 +488,7 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
@@ -133,6 +133,7 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               nativeID="testUuidV4"
               style={
@@ -466,6 +467,7 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
@@ -140,6 +140,7 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               nativeID="testUuidV4"
               style={
@@ -487,6 +488,7 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/maintenance/pages/Maintenance.native.test.tsx.native-snap
+++ b/__snapshots__/features/maintenance/pages/Maintenance.native.test.tsx.native-snap
@@ -65,6 +65,7 @@ exports[`<Maintenance /> should match snapshot with custom message 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           style={
             {
@@ -79,6 +80,7 @@ exports[`<Maintenance /> should match snapshot with custom message 1`] = `
           Maintenance en cours
         </Text>
         <Text
+          accessibilityLevel={2}
           accessibilityRole="header"
           style={
             {
@@ -163,6 +165,7 @@ exports[`<Maintenance /> should match snapshot with default message 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           style={
             {
@@ -177,6 +180,7 @@ exports[`<Maintenance /> should match snapshot with default message 1`] = `
           Maintenance en cours
         </Text>
         <Text
+          accessibilityLevel={2}
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
@@ -168,6 +168,7 @@ exports[`<PageNotFound/> should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={1}
                 accessibilityRole="header"
                 style={
                   {
@@ -182,6 +183,7 @@ exports[`<PageNotFound/> should render correctly 1`] = `
                 Page introuvable !
               </Text>
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
@@ -127,6 +127,7 @@ exports[`PushNotificationsModal should render properly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             style={

--- a/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
@@ -174,6 +174,7 @@ exports[`FavoriteAuthModal should match previous snapshot 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/offer/components/NotificationAuthModal/NotificationAuthModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/NotificationAuthModal/NotificationAuthModal.native.test.tsx.native-snap
@@ -174,6 +174,7 @@ exports[`NotificationAuthModal should match previous snapshot 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -169,6 +170,7 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
               Offre introuvable !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
@@ -219,6 +219,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             numberOfLines={3}
             style={
@@ -249,6 +250,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
             }
           >
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {
@@ -1205,6 +1207,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             numberOfLines={3}
             style={
@@ -1235,6 +1238,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
             }
           >
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.native.test.tsx.native-snap
@@ -160,6 +160,7 @@ exports[`OnboardingAgeSelectionFork should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             numberOfLines={3}
             style={

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
@@ -237,6 +237,7 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -251,6 +252,7 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
               Explore, découvre, profite
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
@@ -151,6 +151,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -165,6 +166,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
               Découvre les offres près de chez toi
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
@@ -237,6 +237,7 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -251,6 +252,7 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
               Encore un peu de patience !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingWelcome.native.test.tsx.native-snap
@@ -106,6 +106,7 @@ exports[`OnboardingWelcome should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/profile/components/Modals/ExpiredCreditModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/Modals/ExpiredCreditModal.native.test.tsx.native-snap
@@ -127,6 +127,7 @@ exports[`<ExpiredCreditModal/> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/profile/containers/ProfileLoggedIn/ProfileLoggedIn.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/containers/ProfileLoggedIn/ProfileLoggedIn.native.test.tsx.native-snap
@@ -50,6 +50,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               numberOfLines={3}
               style={
@@ -135,6 +136,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
             testID="credit-info"
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -398,6 +400,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
   >
     <View>
       <Text
+        accessibilityLevel={2}
         accessibilityRole="header"
         style={
           {
@@ -678,6 +681,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
+        accessibilityLevel={2}
         accessibilityRole="header"
         style={
           {
@@ -959,6 +963,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
+        accessibilityLevel={2}
         accessibilityRole="header"
         style={
           {
@@ -1226,6 +1231,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
+        accessibilityLevel={2}
         accessibilityRole="header"
         style={
           {
@@ -1744,6 +1750,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
+        accessibilityLevel={2}
         accessibilityRole="header"
         style={
           {
@@ -1964,6 +1971,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
+        accessibilityLevel={2}
         accessibilityRole="header"
         style={
           {

--- a/__snapshots__/features/profile/containers/ProfileLoggedOut/ProfileLoggedOut.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/containers/ProfileLoggedOut/ProfileLoggedOut.native.test.tsx.native-snap
@@ -24,6 +24,7 @@ exports[`<ProfileLoggedOut /> should match snapshot 1`] = `
       }
     >
       <Text
+        accessibilityLevel={1}
         accessibilityRole="header"
         numberOfLines={2}
         style={
@@ -302,6 +303,7 @@ exports[`<ProfileLoggedOut /> should match snapshot 1`] = `
   >
     <View>
       <Text
+        accessibilityLevel={2}
         accessibilityRole="header"
         style={
           {
@@ -583,6 +585,7 @@ exports[`<ProfileLoggedOut /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
+        accessibilityLevel={2}
         accessibilityRole="header"
         style={
           {
@@ -953,6 +956,7 @@ exports[`<ProfileLoggedOut /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
+        accessibilityLevel={2}
         accessibilityRole="header"
         style={
           {
@@ -1352,6 +1356,7 @@ exports[`<ProfileLoggedOut /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
+        accessibilityLevel={2}
         accessibilityRole="header"
         style={
           {
@@ -1572,6 +1577,7 @@ exports[`<ProfileLoggedOut /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
+        accessibilityLevel={2}
         accessibilityRole="header"
         style={
           {

--- a/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`Accessibility should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -319,6 +320,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -368,6 +370,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -455,6 +458,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -480,6 +484,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 Les contenus listés ci-dessous ne sont pas accessibles pour les raisons suivantes.
               </Text>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -725,6 +730,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 </View>
               </View>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -750,6 +756,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 Aucune
               </Text>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -961,6 +968,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -1139,6 +1147,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -1166,6 +1175,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 Cette déclaration a été établie le lundi 8 décembre 2025.
               </Text>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -1356,6 +1366,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 </View>
               </View>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -1570,6 +1581,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -1660,6 +1672,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -319,6 +320,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -368,6 +370,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -455,6 +458,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -480,6 +484,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 Les contenus listés ci-dessous ne sont pas accessibles pour les raisons suivantes.
               </Text>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -725,6 +730,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 </View>
               </View>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -750,6 +756,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 Aucune
               </Text>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -961,6 +968,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -1139,6 +1147,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -1166,6 +1175,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 Cette déclaration a été établie le lundi 8 décembre 2025.
               </Text>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -1356,6 +1366,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 </View>
               </View>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -1625,6 +1636,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -1715,6 +1727,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -317,6 +318,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -440,6 +442,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 , en raison des non-conformités énumérées dans la section « Résultats des tests ».
               </Text>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -490,6 +493,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -515,6 +519,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 Les contenus listés ci-dessous ne sont pas accessibles pour les raisons suivantes.
               </Text>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -1640,6 +1645,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 </View>
               </View>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -1665,6 +1671,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 Pas de dérogation identifiée
               </Text>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -1699,6 +1706,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -1877,6 +1885,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -1906,6 +1915,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 .
               </Text>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -2096,6 +2106,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 </View>
               </View>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -2420,6 +2431,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 La vérification de l’accessibilité est le résultat de tests manuels, assistés par des outils (feuilles CSS dédiés, extensions HeadingsMaps et WebDeveloper Toolbar, Color Contrast Analyser).
               </Text>
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {
@@ -3169,6 +3181,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -3262,6 +3275,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 }
               />
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/Appearance/Appearance.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Appearance/Appearance.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`Appearance should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -278,6 +279,7 @@ exports[`Appearance should render correctly 1`] = `
                 >
                   <View
                     accessibilityLabel="Permettre l’orientation - L’affichage en mode paysage peut être moins optimal"
+                    accessibilityLevel={2}
                     accessibilityRole="header"
                     accessible={true}
                   >
@@ -453,6 +455,7 @@ exports[`Appearance should render correctly 1`] = `
                     }
                   >
                     <Text
+                      accessibilityLevel={2}
                       accessibilityRole="header"
                       style={
                         {

--- a/__snapshots__/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<SetAddress/> from mandatory udpate personal data screen should render 
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -266,6 +267,7 @@ exports[`<SetAddress/> from mandatory udpate personal data screen should render 
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -823,6 +825,7 @@ exports[`<SetAddress/> without previous screen should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -927,6 +930,7 @@ exports[`<SetAddress/> without previous screen should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`ChangeCity from mandatory udpate personal data screen should render cor
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -265,6 +266,7 @@ exports[`ChangeCity from mandatory udpate personal data screen should render cor
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -880,6 +882,7 @@ exports[`ChangeCity from profil personal data screen should render correctly 1`]
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -983,6 +986,7 @@ exports[`ChangeCity from profil personal data screen should render correctly 1`]
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -1598,6 +1602,7 @@ exports[`ChangeCity without previous screen should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -1701,6 +1706,7 @@ exports[`ChangeCity without previous screen should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
@@ -321,12 +321,12 @@ exports[`ChangeCity should render correctly 1`] = `
               <div
                 class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz"
               >
-                <p
+                <span
                   class="c9"
                   style="color: rgb(105, 106, 111); max-width: 100%; min-width: 0; flex-shrink: 1;"
                 >
                   Valider ma ville de résidence
-                </p>
+                </span>
               </div>
             </button>
             <div

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -169,6 +170,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
               Oups !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {
@@ -588,6 +590,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -602,6 +605,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
               Oups !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -274,6 +275,7 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`ChangePassword should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
@@ -149,6 +149,7 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -209,6 +210,7 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
             />
             <Styled(View)>
               <Styled(Text)
+                accessibilityLevel={2}
                 accessibilityRole="header"
               >
                 Sélectionne ton statut
@@ -333,6 +335,7 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -2207,6 +2210,7 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -2267,6 +2271,7 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
             />
             <Styled(View)>
               <Styled(Text)
+                accessibilityLevel={2}
                 accessibilityRole="header"
               >
                 Sélectionne ton statut
@@ -2391,6 +2396,7 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -4265,6 +4271,7 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -4325,6 +4332,7 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
             />
             <Styled(View)>
               <Styled(Text)
+                accessibilityLevel={2}
                 accessibilityRole="header"
               >
                 Sélectionne ton statut
@@ -4449,6 +4457,7 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/Chatbot/components/ChatbotContainer.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Chatbot/components/ChatbotContainer.native.test.tsx.native-snap
@@ -142,6 +142,7 @@ exports[`ChatbotContainer should render webview correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
@@ -156,6 +156,7 @@ exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -281,6 +282,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
               Tu peux choisir d’accepter ou non l’activation de leur suivi.
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {
@@ -634,6 +636,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={3}
                     accessibilityRole="header"
                     style={
                       {
@@ -982,6 +985,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={3}
                     accessibilityRole="header"
                     style={
                       {
@@ -1330,6 +1334,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={3}
                     accessibilityRole="header"
                     style={
                       {
@@ -1681,6 +1686,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                     }
                   >
                     <Text
+                      accessibilityLevel={3}
                       accessibilityRole="header"
                       style={
                         {
@@ -1995,6 +2001,7 @@ Ils permettent à YouTube d’assurer le bon fonctionnement de la lecture, de co
                   }
                 >
                   <Text
+                    accessibilityLevel={3}
                     accessibilityRole="header"
                     style={
                       {
@@ -2155,6 +2162,7 @@ Ils permettent à YouTube d’assurer le bon fonctionnement de la lecture, de co
               }
             />
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DebugScreen/DebugScreen.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DebugScreen/DebugScreen.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`DebugScreen should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -258,6 +259,7 @@ exports[`DebugScreen should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
@@ -241,6 +241,7 @@ exports[`ConfirmDeleteProfile should render confirm delete profile 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`DeactivateProfileSuccess should render deactivate profile success 1`] =
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
@@ -241,6 +241,7 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
@@ -241,6 +241,7 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
@@ -241,6 +241,7 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
@@ -241,6 +241,7 @@ exports[`DeleteProfileContactSupport should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
@@ -241,6 +241,7 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`DeleteProfileSuccess should render delete profile success 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
@@ -234,6 +234,7 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -264,6 +265,7 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
                   <Styled(Styled(SadFaceSvg)) />
                   <Styled(View)>
                     <Styled(Text)
+                      accessibilityLevel={1}
                       accessibilityRole="header"
                     >
                       Pourquoi souhaites-tu supprimer ton compte ?
@@ -408,6 +410,7 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
                       }
                     >
                       <Text
+                        accessibilityLevel={1}
                         accessibilityRole="header"
                         style={
                           {

--- a/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -274,6 +275,7 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={1}
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`LegalNotices should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -267,6 +268,7 @@ exports[`LegalNotices should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<MandatoryUpdatePersonalData /> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -169,6 +170,7 @@ exports[`<MandatoryUpdatePersonalData /> should render correctly 1`] = `
               Mets à jour ton profil
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/ProfileInformationValidationUpdate.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/ProfileInformationValidationUpdate.native.test.tsx.native-snap
@@ -76,6 +76,7 @@ exports[`ProfileInformationValidationUpdate should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -180,6 +181,7 @@ exports[`ProfileInformationValidationUpdate should render correctly 1`] = `
               }
             >
               <Text
+                accessibilityLevel={3}
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<UpdatePersonalDataConfirmation /> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -169,6 +170,7 @@ exports[`<UpdatePersonalDataConfirmation /> should render correctly 1`] = `
               C’est noté !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<NewEmailSelection /> should match snapshot 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -266,6 +267,7 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
               }
             >
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -664,6 +666,7 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
                   }
                 />
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {
@@ -2259,6 +2262,7 @@ exports[`NotificationsSettings should render correctly when user is not logged i
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -2425,6 +2429,7 @@ exports[`NotificationsSettings should render correctly when user is not logged i
                 </View>
               </View>
               <Text
+                accessibilityLevel={2}
                 accessibilityRole="header"
                 style={
                   {
@@ -2829,6 +2834,7 @@ exports[`NotificationsSettings should render correctly when user is not logged i
                   }
                 />
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -273,7 +273,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c6"
-                          for="186"
+                          for="182"
                         >
                           <p
                             class="c7"
@@ -476,15 +476,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="css-view-175oi2r r-backgroundColor-14a9t8x r-height-109y4c4 r-marginBottom-zd98yo r-marginTop-1wzrnnt r-width-13qz1uu"
-                  />
-                  <h2
-                    class="c3"
-                  >
-                    Tes thèmes suivis
-                  </h2>
-                  <div
-                    class="css-view-175oi2r r-marginBottom-5oul0u r-marginTop-11c0sde"
+                    class="css-view-175oi2r r-paddingBlock-w7s2jr"
                   >
                     <div
                       class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6 r-justifyContent-1h0z5md"
@@ -507,21 +499,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                         class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
                       >
                         <div
-                          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
-                        >
-                          <label
-                            class="c6"
-                            for="188"
-                          >
-                            <p
-                              class="c7"
-                            >
-                              Suivre tous les thèmes
-                            </p>
-                          </label>
-                        </div>
-                        <div
-                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
+                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
                         >
                           <div
                             aria-checked="false"
@@ -580,7 +558,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <p
                             class="c7"
                           >
-                            Cinéma
+                            Musique
                           </p>
                         </label>
                       </div>
@@ -647,7 +625,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <p
                             class="c7"
                           >
-                            Lecture
+                            Spectacles
                           </p>
                         </label>
                       </div>
@@ -714,7 +692,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <p
                             class="c7"
                           >
-                            Musique
+                            Activités créatives
                           </p>
                         </label>
                       </div>
@@ -781,7 +759,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <p
                             class="c7"
                           >
-                            Spectacles
+                            Visites et sorties
                           </p>
                         </label>
                       </div>
@@ -825,140 +803,6 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <input
                             hidden=""
                             id="196"
-                            readonly=""
-                            type="checkbox"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="css-view-175oi2r r-paddingBlock-w7s2jr"
-                  >
-                    <div
-                      class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6 r-justifyContent-1h0z5md"
-                    >
-                      <div
-                        class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
-                      >
-                        <label
-                          class="c6"
-                          for="198"
-                        >
-                          <p
-                            class="c7"
-                          >
-                            Activités créatives
-                          </p>
-                        </label>
-                      </div>
-                      <div
-                        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
-                      >
-                        <div
-                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-                        >
-                          <div
-                            aria-checked="false"
-                            aria-disabled="true"
-                            aria-label="Activités créatives - Interrupteur à bascule - non coché"
-                            aria-labelledby="197"
-                            class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
-                            data-testid="Activités créatives - Interrupteur à bascule - non coché"
-                            role="switch"
-                            style="transition-duration: 0s;"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="css-view-175oi2r r-backgroundColor-1ru0s5g r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-1r8g8re r-justifyContent-1777fci r-width-7a29px"
-                            >
-                              <div
-                                class="css-view-175oi2r r-alignItems-1awozwy r-aspectRatio-1ujkv8a r-backgroundColor-14lw9ot r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-mabqd8 r-justifyContent-1777fci r-width-1yvhtrz"
-                                style="transform: translateX(2px);"
-                              >
-                                <div
-                                  class="css-view-175oi2r"
-                                >
-                                  <div
-                                    class="css-text-146c3p1"
-                                    dir="ltr"
-                                  >
-                                    undefined-SVG-Mock
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <input
-                            hidden=""
-                            id="198"
-                            readonly=""
-                            type="checkbox"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="css-view-175oi2r r-paddingBlock-w7s2jr"
-                  >
-                    <div
-                      class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6 r-justifyContent-1h0z5md"
-                    >
-                      <div
-                        class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
-                      >
-                        <label
-                          class="c6"
-                          for="200"
-                        >
-                          <p
-                            class="c7"
-                          >
-                            Visites et sorties
-                          </p>
-                        </label>
-                      </div>
-                      <div
-                        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
-                      >
-                        <div
-                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-                        >
-                          <div
-                            aria-checked="false"
-                            aria-disabled="true"
-                            aria-label="Visites et sorties - Interrupteur à bascule - non coché"
-                            aria-labelledby="199"
-                            class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
-                            data-testid="Visites et sorties - Interrupteur à bascule - non coché"
-                            role="switch"
-                            style="transition-duration: 0s;"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="css-view-175oi2r r-backgroundColor-1ru0s5g r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-1r8g8re r-justifyContent-1777fci r-width-7a29px"
-                            >
-                              <div
-                                class="css-view-175oi2r r-alignItems-1awozwy r-aspectRatio-1ujkv8a r-backgroundColor-14lw9ot r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-mabqd8 r-justifyContent-1777fci r-width-1yvhtrz"
-                                style="transform: translateX(2px);"
-                              >
-                                <div
-                                  class="css-view-175oi2r"
-                                >
-                                  <div
-                                    class="css-text-146c3p1"
-                                    dir="ltr"
-                                  >
-                                    undefined-SVG-Mock
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <input
-                            hidden=""
-                            id="200"
                             readonly=""
                             type="checkbox"
                           />

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -273,7 +273,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       >
                         <label
                           class="c6"
-                          for="182"
+                          for="186"
                         >
                           <p
                             class="c7"
@@ -476,7 +476,15 @@ exports[`NotificationsSettings should render correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="css-view-175oi2r r-paddingBlock-w7s2jr"
+                    class="css-view-175oi2r r-backgroundColor-14a9t8x r-height-109y4c4 r-marginBottom-zd98yo r-marginTop-1wzrnnt r-width-13qz1uu"
+                  />
+                  <h2
+                    class="c3"
+                  >
+                    Tes thèmes suivis
+                  </h2>
+                  <div
+                    class="css-view-175oi2r r-marginBottom-5oul0u r-marginTop-11c0sde"
                   >
                     <div
                       class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6 r-justifyContent-1h0z5md"
@@ -499,7 +507,21 @@ exports[`NotificationsSettings should render correctly 1`] = `
                         class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
                       >
                         <div
-                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+                          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
+                        >
+                          <label
+                            class="c6"
+                            for="188"
+                          >
+                            <p
+                              class="c7"
+                            >
+                              Suivre tous les thèmes
+                            </p>
+                          </label>
+                        </div>
+                        <div
+                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
                         >
                           <div
                             aria-checked="false"
@@ -558,7 +580,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <p
                             class="c7"
                           >
-                            Musique
+                            Cinéma
                           </p>
                         </label>
                       </div>
@@ -625,7 +647,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <p
                             class="c7"
                           >
-                            Spectacles
+                            Lecture
                           </p>
                         </label>
                       </div>
@@ -692,7 +714,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <p
                             class="c7"
                           >
-                            Activités créatives
+                            Musique
                           </p>
                         </label>
                       </div>
@@ -759,7 +781,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <p
                             class="c7"
                           >
-                            Visites et sorties
+                            Spectacles
                           </p>
                         </label>
                       </div>
@@ -803,6 +825,140 @@ exports[`NotificationsSettings should render correctly 1`] = `
                           <input
                             hidden=""
                             id="196"
+                            readonly=""
+                            type="checkbox"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="css-view-175oi2r r-paddingBlock-w7s2jr"
+                  >
+                    <div
+                      class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6 r-justifyContent-1h0z5md"
+                    >
+                      <div
+                        class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
+                      >
+                        <label
+                          class="c6"
+                          for="198"
+                        >
+                          <p
+                            class="c7"
+                          >
+                            Activités créatives
+                          </p>
+                        </label>
+                      </div>
+                      <div
+                        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
+                      >
+                        <div
+                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+                        >
+                          <div
+                            aria-checked="false"
+                            aria-disabled="true"
+                            aria-label="Activités créatives - Interrupteur à bascule - non coché"
+                            aria-labelledby="197"
+                            class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
+                            data-testid="Activités créatives - Interrupteur à bascule - non coché"
+                            role="switch"
+                            style="transition-duration: 0s;"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="css-view-175oi2r r-backgroundColor-1ru0s5g r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-1r8g8re r-justifyContent-1777fci r-width-7a29px"
+                            >
+                              <div
+                                class="css-view-175oi2r r-alignItems-1awozwy r-aspectRatio-1ujkv8a r-backgroundColor-14lw9ot r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-mabqd8 r-justifyContent-1777fci r-width-1yvhtrz"
+                                style="transform: translateX(2px);"
+                              >
+                                <div
+                                  class="css-view-175oi2r"
+                                >
+                                  <div
+                                    class="css-text-146c3p1"
+                                    dir="ltr"
+                                  >
+                                    undefined-SVG-Mock
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <input
+                            hidden=""
+                            id="198"
+                            readonly=""
+                            type="checkbox"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="css-view-175oi2r r-paddingBlock-w7s2jr"
+                  >
+                    <div
+                      class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6 r-justifyContent-1h0z5md"
+                    >
+                      <div
+                        class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-gap-1cmwbt1"
+                      >
+                        <label
+                          class="c6"
+                          for="200"
+                        >
+                          <p
+                            class="c7"
+                          >
+                            Visites et sorties
+                          </p>
+                        </label>
+                      </div>
+                      <div
+                        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-f4gmv6"
+                      >
+                        <div
+                          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+                        >
+                          <div
+                            aria-checked="false"
+                            aria-disabled="true"
+                            aria-label="Visites et sorties - Interrupteur à bascule - non coché"
+                            aria-labelledby="199"
+                            class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-12vffkv"
+                            data-testid="Visites et sorties - Interrupteur à bascule - non coché"
+                            role="switch"
+                            style="transition-duration: 0s;"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="css-view-175oi2r r-backgroundColor-1ru0s5g r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-1r8g8re r-justifyContent-1777fci r-width-7a29px"
+                            >
+                              <div
+                                class="css-view-175oi2r r-alignItems-1awozwy r-aspectRatio-1ujkv8a r-backgroundColor-14lw9ot r-borderBottomLeftRadius-17st2r6 r-borderBottomRightRadius-1dcumfp r-borderTopLeftRadius-1xhec65 r-borderTopRightRadius-1y08a0c r-height-mabqd8 r-justifyContent-1777fci r-width-1yvhtrz"
+                                style="transform: translateX(2px);"
+                              >
+                                <div
+                                  class="css-view-175oi2r"
+                                >
+                                  <div
+                                    class="css-text-146c3p1"
+                                    dir="ltr"
+                                  >
+                                    undefined-SVG-Mock
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <input
+                            hidden=""
+                            id="200"
                             readonly=""
                             type="checkbox"
                           />

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -979,12 +979,12 @@ exports[`NotificationsSettings should render correctly 1`] = `
                       <div
                         class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz"
                       >
-                        <p
+                        <span
                           class="c9"
                           style="color: rgb(105, 106, 111); max-width: 100%; min-width: 0; flex-shrink: 1;"
                         >
                           Enregistrer
-                        </p>
+                        </span>
                       </div>
                     </button>
                   </div>

--- a/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`PersonalData should render personal data success 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`TrackEmailChange account with password should render correctly when cho
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -258,6 +259,7 @@ exports[`TrackEmailChange account with password should render correctly when cho
         >
           <View>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {
@@ -1177,6 +1179,7 @@ exports[`TrackEmailChange account with password should render correctly when con
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -1273,6 +1276,7 @@ exports[`TrackEmailChange account with password should render correctly when con
         >
           <View>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {
@@ -2203,6 +2207,7 @@ exports[`TrackEmailChange account with password should render correctly when val
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -2299,6 +2304,7 @@ exports[`TrackEmailChange account with password should render correctly when val
         >
           <View>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {
@@ -3207,6 +3213,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -3303,6 +3310,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         >
           <View>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {
@@ -4444,6 +4452,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -4540,6 +4549,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         >
           <View>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {
@@ -5703,6 +5713,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -5799,6 +5810,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         >
           <View>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {
@@ -6951,6 +6963,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -7047,6 +7060,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         >
           <View>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/Tutorial/TutorialPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Tutorial/TutorialPage.native.test.tsx.native-snap
@@ -175,6 +175,7 @@ exports[`TutorialPage should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             numberOfLines={3}
             style={

--- a/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
@@ -46,6 +46,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification disabled shou
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           style={
             {
@@ -59,6 +60,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification disabled shou
           Comment ça marche ?
         </Text>
         <Text
+          accessibilityLevel={2}
           accessibilityRole="header"
           style={
             {
@@ -203,6 +205,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification disabled shou
                     à 17 ans
                   </Text>
                   <Text
+                    accessibilityLevel={3}
                     accessibilityRole="header"
                     style={
                       {
@@ -473,6 +476,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification disabled shou
                     à 18 ans
                   </Text>
                   <Text
+                    accessibilityLevel={3}
                     accessibilityRole="header"
                     style={
                       {
@@ -1170,6 +1174,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification disabled shou
       >
         <Text
           accessibilityHidden={true}
+          accessibilityLevel={1}
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}
@@ -1247,6 +1252,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           style={
             {
@@ -1260,6 +1266,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
           Comment ça marche ?
         </Text>
         <Text
+          accessibilityLevel={2}
           accessibilityRole="header"
           style={
             {
@@ -1404,6 +1411,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
                     à 17 ans
                   </Text>
                   <Text
+                    accessibilityLevel={3}
                     accessibilityRole="header"
                     style={
                       {
@@ -1674,6 +1682,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
                     à 18 ans
                   </Text>
                   <Text
+                    accessibilityLevel={3}
                     accessibilityRole="header"
                     style={
                       {
@@ -2120,6 +2129,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
                   }
                 >
                   <Text
+                    accessibilityLevel={3}
                     accessibilityRole="header"
                     style={
                       {
@@ -3315,6 +3325,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
       >
         <Text
           accessibilityHidden={true}
+          accessibilityLevel={1}
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<SearchFilter/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
@@ -102,6 +102,7 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={1}
                     accessibilityRole="header"
                     small={false}
                     style={
@@ -447,6 +448,7 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
       >
         <View>
           <Text
+            accessibilityLevel={2}
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
@@ -200,6 +200,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={1}
                     accessibilityRole="header"
                     small={false}
                     style={
@@ -654,6 +655,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                         }
                       >
                         <Text
+                          accessibilityLevel={3}
                           accessibilityRole="header"
                           style={
                             {
@@ -1622,6 +1624,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                     }
                   >
                     <Text
+                      accessibilityLevel={3}
                       accessibilityRole="header"
                       style={
                         {

--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -191,6 +191,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                 }
               >
                 <Text
+                  accessibilityLevel={1}
                   accessibilityRole="header"
                   small={true}
                   style={
@@ -531,6 +532,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
           }
         >
           <Text
+            accessibilityLevel={2}
             accessibilityRole="header"
             style={
               {
@@ -1780,6 +1782,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     >
                       <Text
                         accessibilityLabel="GTL playlist"
+                        accessibilityLevel={2}
                         accessibilityRole="header"
                         numberOfLines={2}
                         style={
@@ -1793,6 +1796,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                       >
                         <Text
                           accessibilityElementsHidden={true}
+                          accessibilityLevel={2}
                           accessibilityRole="header"
                           accessible={false}
                           importantForAccessibility="no"
@@ -2776,6 +2780,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                       }
                     >
                       <View
+                        accessibilityLevel={3}
                         accessibilityRole="header"
                         renderToHardwareTextureAndroid={true}
                         shouldRasterizeIOS={true}
@@ -3064,6 +3069,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                       }
                     >
                       <View
+                        accessibilityLevel={3}
                         accessibilityRole="header"
                         renderToHardwareTextureAndroid={true}
                         shouldRasterizeIOS={true}
@@ -3352,6 +3358,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                       }
                     >
                       <View
+                        accessibilityLevel={3}
                         accessibilityRole="header"
                         renderToHardwareTextureAndroid={true}
                         shouldRasterizeIOS={true}
@@ -3640,6 +3647,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                       }
                     >
                       <View
+                        accessibilityLevel={3}
                         accessibilityRole="header"
                         renderToHardwareTextureAndroid={true}
                         shouldRasterizeIOS={true}

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -183,6 +183,7 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
               testID="back-button-container"
             />
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               nativeID="testUuidV4"
               numberOfLines={1}

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -183,6 +183,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
               testID="back-button-container"
             />
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               nativeID="testUuidV4"
               numberOfLines={1}
@@ -332,6 +333,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
               >
                 <View
                   accessibilityLabel="Uniquement les offres duo - Seules les sorties seront affichées"
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   accessible={true}
                 >

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -183,6 +183,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
               testID="back-button-container"
             />
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               nativeID="testUuidV4"
               numberOfLines={1}
@@ -401,6 +402,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                 >
                   <View
                     accessibilityLabel="Uniquement les offres gratuites"
+                    accessibilityLevel={2}
                     accessibilityRole="header"
                     accessible={true}
                   >
@@ -564,6 +566,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                 >
                   <View
                     accessibilityLabel="Limiter la recherche à mon crédit"
+                    accessibilityLevel={2}
                     accessibilityRole="header"
                     accessible={true}
                   >

--- a/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
@@ -269,6 +269,7 @@ exports[`VenueModal should render correctly 1`] = `
               </View>
             </View>
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               nativeID="testUuidV4"
               numberOfLines={1}

--- a/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
@@ -190,6 +190,7 @@ exports[`ShareAppModal should match snapshot 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               nativeID="testUuidV4"
               style={

--- a/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
@@ -172,6 +172,7 @@ exports[`ShareAppModalVersionA should match snapshot 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
@@ -172,6 +172,7 @@ exports[`ShareAppModalVersionB should match snapshot 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
+++ b/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
@@ -286,12 +286,12 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                     </div>
                                   </div>
                                 </div>
-                                <p
+                                <span
                                   class="c3"
                                   style="color: rgb(22, 22, 23); max-width: 100%; min-width: 0; flex-shrink: 1;"
                                 >
                                   Copier
-                                </p>
+                                </span>
                               </div>
                             </button>
                           </div>
@@ -323,12 +323,12 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                     </div>
                                   </div>
                                 </div>
-                                <p
+                                <span
                                   class="c3"
                                   style="color: rgb(22, 22, 23); max-width: 100%; min-width: 0; flex-shrink: 1;"
                                 >
                                   E-mail
-                                </p>
+                                </span>
                               </div>
                             </a>
                           </div>
@@ -471,12 +471,12 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                           <div
                             class="css-view-175oi2r r-alignItems-1awozwy r-columnGap-1ta3fxp r-flexDirection-18u37iz r-justifyContent-1777fci r-width-13qz1uu"
                           >
-                            <p
+                            <span
                               class="c3"
                               style="color: rgb(255, 255, 255); max-width: 100%; min-width: 0; flex-shrink: 1; flex-grow: 1; flex-basis: 0px; text-align: center;"
                             >
                               Annuler
-                            </p>
+                            </span>
                           </div>
                         </button>
                       </div>

--- a/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
@@ -174,6 +174,7 @@ exports[`<NotificationsLoggedOutModal /> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
@@ -174,6 +174,7 @@ exports[`<NotificationsSettingsModal /> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
@@ -174,6 +174,7 @@ exports[`<OnboardingSubscriptionModal /> should display correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
@@ -174,6 +174,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for activites_crea
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -777,6 +778,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for cinema 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -1380,6 +1382,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for lecture 1`] = 
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -1983,6 +1986,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for musique 1`] = 
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -2586,6 +2590,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for spectacles 1`]
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -3189,6 +3194,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for visites 1`] = 
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
@@ -174,6 +174,7 @@ exports[`<UnsubscribingConfirmationModal /> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/subscription/page/OnboardingSubscription.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/page/OnboardingSubscription.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`OnboardingSubscription should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -280,6 +281,7 @@ exports[`OnboardingSubscription should render correctly 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={2}
                     accessibilityRole="header"
                     style={
                       {

--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -827,6 +828,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -1397,6 +1399,7 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -241,6 +241,7 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -169,6 +170,7 @@ exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
               Oups !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<Venue /> should match snapshot 1`] = `
             >
               <Text
                 accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
+                accessibilityLevel={1}
                 accessibilityRole="header"
                 adjustsFontSizeToFit={true}
                 style={
@@ -729,6 +730,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={2}
                     accessibilityRole="header"
                     style={
                       {
@@ -1109,6 +1111,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                             >
                               <Text
                                 accessibilityLabel="Toutes les offres"
+                                accessibilityLevel={2}
                                 accessibilityRole="header"
                                 numberOfLines={2}
                                 style={
@@ -1122,6 +1125,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                               >
                                 <Text
                                   accessibilityElementsHidden={true}
+                                  accessibilityLevel={2}
                                   accessibilityRole="header"
                                   accessible={false}
                                   importantForAccessibility="no"
@@ -1486,6 +1490,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                               }
                             >
                               <View
+                                accessibilityLevel={3}
                                 accessibilityRole="header"
                                 renderToHardwareTextureAndroid={true}
                                 shouldRasterizeIOS={true}
@@ -1694,6 +1699,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                               }
                             >
                               <View
+                                accessibilityLevel={3}
                                 accessibilityRole="header"
                                 renderToHardwareTextureAndroid={true}
                                 shouldRasterizeIOS={true}
@@ -1902,6 +1908,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                               }
                             >
                               <View
+                                accessibilityLevel={3}
                                 accessibilityRole="header"
                                 renderToHardwareTextureAndroid={true}
                                 shouldRasterizeIOS={true}
@@ -2163,6 +2170,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {
@@ -2353,6 +2361,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {
@@ -3046,6 +3055,7 @@ d’options
       >
         <Text
           accessibilityHidden={true}
+          accessibilityLevel={1}
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}
@@ -3516,6 +3526,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
             >
               <Text
                 accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
+                accessibilityLevel={1}
                 accessibilityRole="header"
                 adjustsFontSizeToFit={true}
                 style={
@@ -4083,6 +4094,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                   }
                 >
                   <Text
+                    accessibilityLevel={2}
                     accessibilityRole="header"
                     style={
                       {
@@ -4463,6 +4475,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                             >
                               <Text
                                 accessibilityLabel="Toutes les offres"
+                                accessibilityLevel={2}
                                 accessibilityRole="header"
                                 numberOfLines={2}
                                 style={
@@ -4476,6 +4489,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                               >
                                 <Text
                                   accessibilityElementsHidden={true}
+                                  accessibilityLevel={2}
                                   accessibilityRole="header"
                                   accessible={false}
                                   importantForAccessibility="no"
@@ -4840,6 +4854,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                               }
                             >
                               <View
+                                accessibilityLevel={3}
                                 accessibilityRole="header"
                                 renderToHardwareTextureAndroid={true}
                                 shouldRasterizeIOS={true}
@@ -5048,6 +5063,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                               }
                             >
                               <View
+                                accessibilityLevel={3}
                                 accessibilityRole="header"
                                 renderToHardwareTextureAndroid={true}
                                 shouldRasterizeIOS={true}
@@ -5256,6 +5272,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                               }
                             >
                               <View
+                                accessibilityLevel={3}
                                 accessibilityRole="header"
                                 renderToHardwareTextureAndroid={true}
                                 shouldRasterizeIOS={true}
@@ -5517,6 +5534,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {
@@ -5707,6 +5725,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {
@@ -6400,6 +6419,7 @@ d’options
       >
         <Text
           accessibilityHidden={true}
+          accessibilityLevel={1}
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}
@@ -6870,6 +6890,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
             >
               <Text
                 accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
+                accessibilityLevel={1}
                 accessibilityRole="header"
                 adjustsFontSizeToFit={true}
                 style={
@@ -7445,6 +7466,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                     }
                   >
                     <Text
+                      accessibilityLevel={2}
                       accessibilityRole="header"
                       style={
                         {
@@ -7488,6 +7510,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                     }
                   >
                     <Text
+                      accessibilityLevel={2}
                       accessibilityRole="header"
                       style={
                         {
@@ -7531,6 +7554,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                     }
                   >
                     <Text
+                      accessibilityLevel={2}
                       accessibilityRole="header"
                       style={
                         {
@@ -7876,6 +7900,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                     }
                   >
                     <Text
+                      accessibilityLevel={2}
                       accessibilityRole="header"
                       style={
                         {
@@ -8026,6 +8051,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                               }
                             >
                               <Text
+                                accessibilityLevel={3}
                                 accessibilityRole="header"
                                 style={
                                   {
@@ -8302,6 +8328,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                               }
                             >
                               <Text
+                                accessibilityLevel={3}
                                 accessibilityRole="header"
                                 style={
                                   {
@@ -8565,6 +8592,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                               }
                             >
                               <Text
+                                accessibilityLevel={3}
                                 accessibilityRole="header"
                                 style={
                                   {
@@ -8942,6 +8970,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                               }
                             >
                               <Text
+                                accessibilityLevel={3}
                                 accessibilityRole="header"
                                 style={
                                   {
@@ -9267,6 +9296,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                     }
                   >
                     <Text
+                      accessibilityLevel={2}
                       accessibilityRole="header"
                       style={
                         {
@@ -9663,6 +9693,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {
@@ -9853,6 +9884,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                 }
               >
                 <Text
+                  accessibilityLevel={2}
                   accessibilityRole="header"
                   style={
                     {
@@ -10546,6 +10578,7 @@ d’options
       >
         <Text
           accessibilityHidden={true}
+          accessibilityLevel={1}
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}

--- a/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -169,6 +170,7 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
               Lieu introuvable !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/libs/location/components/GeolocationActivationModal.native.test.tsx.native-snap
+++ b/__snapshots__/libs/location/components/GeolocationActivationModal.native.test.tsx.native-snap
@@ -127,6 +127,7 @@ exports[`GeolocationActivationModal should render properly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             style={

--- a/__snapshots__/libs/network/OfflinePage.native.test.tsx.native-snap
+++ b/__snapshots__/libs/network/OfflinePage.native.test.tsx.native-snap
@@ -58,6 +58,7 @@ exports[`<OfflinePage /> should match snapshot with button 1`] = `
       }
     >
       <Text
+        accessibilityLevel={1}
         accessibilityRole="header"
         style={
           {
@@ -72,6 +73,7 @@ exports[`<OfflinePage /> should match snapshot with button 1`] = `
         Oups, pas de réseau !
       </Text>
       <Text
+        accessibilityLevel={2}
         accessibilityRole="header"
         style={
           {
@@ -339,6 +341,7 @@ exports[`<OfflinePage /> should match snapshot with default message 1`] = `
       }
     >
       <Text
+        accessibilityLevel={1}
         accessibilityRole="header"
         style={
           {
@@ -353,6 +356,7 @@ exports[`<OfflinePage /> should match snapshot with default message 1`] = `
         Oups, pas de réseau !
       </Text>
       <Text
+        accessibilityLevel={2}
         accessibilityRole="header"
         style={
           {

--- a/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
@@ -174,6 +174,7 @@ exports[`<ApplicationProcessingModal /> should match previous snapshot 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
@@ -174,6 +174,7 @@ exports[`<AuthenticationModal /> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
@@ -174,6 +174,7 @@ exports[`<ErrorApplicationModal /> should match previous snapshot 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
@@ -174,6 +174,7 @@ exports[`<FinishSubscriptionModal /> should display correct body when user needs
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -674,6 +675,7 @@ exports[`<FinishSubscriptionModal /> should render correctly with eighteen years
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -1174,6 +1176,7 @@ exports[`<FinishSubscriptionModal /> should render correctly with undefined depo
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/shared/verticalPlaylist/components/VerticalPlaylistOffersView.native.test.tsx.native-snap
+++ b/__snapshots__/shared/verticalPlaylist/components/VerticalPlaylistOffersView.native.test.tsx.native-snap
@@ -37,6 +37,7 @@ exports[`<VerticalPlaylistOffersView /> should render correctly 1`] = `
           height={65}
         />
         <Styled(Text)
+          accessibilityLevel={1}
           accessibilityRole="header"
         >
           My title
@@ -208,6 +209,7 @@ exports[`<VerticalPlaylistOffersView /> should render correctly 1`] = `
           }
         />
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           style={
             {
@@ -1417,6 +1419,7 @@ exports[`<VerticalPlaylistOffersView /> should render correctly 1`] = `
       >
         <Text
           accessibilityHidden={true}
+          accessibilityLevel={1}
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}

--- a/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
@@ -155,6 +155,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -169,6 +170,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
               Oups !
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/ui/components/modals/AppModal.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/modals/AppModal.native.test.tsx.native-snap
@@ -179,6 +179,7 @@ exports[`<AppModal /> on big screen 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -431,6 +432,7 @@ exports[`<AppModal /> on small screen 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -649,6 +651,7 @@ exports[`<AppModal /> with backdrop disabled 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -901,6 +904,7 @@ exports[`<AppModal /> with backdrop enabled by default 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -1153,6 +1157,7 @@ exports[`<AppModal /> with backdrop explicitly enabled 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -1491,6 +1496,7 @@ exports[`<AppModal /> with left icon render 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -1743,6 +1749,7 @@ exports[`<AppModal /> with minimal props 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -1995,6 +2002,7 @@ exports[`<AppModal /> with right icon render 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -2334,6 +2342,7 @@ exports[`<AppModal /> without children 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/ui/components/modals/MarketingModal.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/modals/MarketingModal.native.test.tsx.native-snap
@@ -190,6 +190,7 @@ exports[`MarketingModal should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               nativeID="testUuidV4"
               style={

--- a/__snapshots__/ui/pages/GenericErrorPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericErrorPage.native.test.tsx.native-snap
@@ -66,6 +66,7 @@ exports[`<GenericErrorPage /> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           style={
             {
@@ -80,6 +81,7 @@ exports[`<GenericErrorPage /> should render correctly 1`] = `
           GenericErrorPage
         </Text>
         <Text
+          accessibilityLevel={2}
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
@@ -320,6 +320,7 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
             }
           >
             <Text
+              accessibilityLevel={1}
               accessibilityRole="header"
               style={
                 {
@@ -334,6 +335,7 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
               Title
             </Text>
             <Text
+              accessibilityLevel={2}
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/ui/pages/GenericOfficialPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericOfficialPage.native.test.tsx.native-snap
@@ -134,6 +134,7 @@ exports[`<GenericOfficialPage /> should render correctly 1`] = `
           }
         >
           <Text
+            accessibilityLevel={1}
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/ui/pages/PageWithHeader.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/PageWithHeader.native.test.tsx.native-snap
@@ -162,6 +162,7 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -504,6 +505,7 @@ exports[`<PageWithHeader/> should render correctly on Android, with white header
         }
       >
         <Text
+          accessibilityLevel={1}
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/src/features/achievements/pages/Achievements.tsx
+++ b/src/features/achievements/pages/Achievements.tsx
@@ -18,7 +18,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { getSpacing, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const emptyAchievement = {
   name: 'empty' as AchievementEnum,
@@ -57,7 +57,7 @@ const Achievements = () => {
               <ViewGap gap={4} key={category.name}>
                 <AchievementsGroupeHeader>
                   <View>
-                    <Typo.Title4 {...getHeadingAttrs(2)}>
+                    <Typo.Title4 {...getTextSemanticAttrs(2)}>
                       {achievementCategoryDisplayTitles[category.name]}
                     </Typo.Title4>
                     <StyledBody>{category.remainingAchievementsText}</StyledBody>

--- a/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
+++ b/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
@@ -13,7 +13,7 @@ import { SeeAllButton } from 'ui/components/SeeAllButton/SeeAllButton'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
 import { AVATAR_MEDIUM } from 'ui/theme/constants'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   artistId: string
@@ -82,7 +82,7 @@ export const ArtistSimilarArtists: FunctionComponent<Props> = ({ artistId }) => 
   )
 }
 
-const TitleLevel2 = styled(Typo.Title3).attrs(getHeadingAttrs(2))``
+const TitleLevel2 = styled(Typo.Title3).attrs(getTextSemanticAttrs(2))``
 
 const HeaderContainer = styled.View(({ theme }) => ({
   marginHorizontal: theme.contentPage.marginHorizontal,

--- a/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtistsSkeleton.tsx
+++ b/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtistsSkeleton.tsx
@@ -6,7 +6,7 @@ import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
 import { SkeletonTile } from 'ui/components/placeholders/SkeletonTile'
 import { Typo } from 'ui/theme'
 import { AVATAR_MEDIUM } from 'ui/theme/constants'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const NUMBER_OF_AVATARS = 10
 const AVATAR_SKELETON_KEYS = Array.from(
@@ -48,7 +48,7 @@ export const ArtistSimilarArtistsSkeleton: FunctionComponent<Props> = ({ title }
   )
 }
 
-const TitleLevel2 = styled(Typo.Title3).attrs(getHeadingAttrs(2))``
+const TitleLevel2 = styled(Typo.Title3).attrs(getTextSemanticAttrs(2))``
 
 const HeaderContainer = styled.View(({ theme }) => ({
   marginHorizontal: theme.contentPage.marginHorizontal,

--- a/src/features/auth/components/EmailSentGeneric.tsx
+++ b/src/features/auth/components/EmailSentGeneric.tsx
@@ -13,7 +13,7 @@ import { ButtonContainerFlexStart } from 'ui/designSystem/Button/ButtonContainer
 import { EmailSent } from 'ui/svg/icons/EmailSent'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   title: string
@@ -39,7 +39,7 @@ export const EmailSentGeneric: FunctionComponent<Props> = ({
       <IllustrationContainer>
         <StyledEmailSent />
       </IllustrationContainer>
-      <Typo.Title3 {...getHeadingAttrs(2)}>{title}</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs(2)}>{title}</Typo.Title3>
       <Typo.Body>Tu as reçu un lien à l’adresse&nbsp;:</Typo.Body>
       <Typo.Body>{email}</Typo.Body>
       <Typo.Body>L’e-mail peut prendre quelques minutes pour arriver.</Typo.Body>

--- a/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
+++ b/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
@@ -9,7 +9,7 @@ import { Form } from 'ui/components/Form'
 import { Button } from 'ui/designSystem/Button/Button'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const ForgottenPassword = () => {
   const { data: isRecaptchaEnabled, isLoading: areSettingsLoading } = useIsRecaptchaEnabled()
@@ -43,7 +43,7 @@ export const ForgottenPassword = () => {
               isVisible={isDoingReCaptchaChallenge}
             />
           ) : null}
-          <Typo.Title3 {...getHeadingAttrs(2)}>Mot de passe oublié&nbsp;?</Typo.Title3>
+          <Typo.Title3 {...getTextSemanticAttrs(2)}>Mot de passe oublié&nbsp;?</Typo.Title3>
           <Container>
             <Typo.Body>
               Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton

--- a/src/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
+++ b/src/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
@@ -21,7 +21,7 @@ import { showErrorSnackBar, showSuccessSnackBar } from 'ui/designSystem/Snackbar
 import { LoadingPage } from 'ui/pages/LoadingPage'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type ReinitializePasswordFormData = {
   newPassword: string
@@ -111,7 +111,7 @@ export const ReinitializePassword = () => {
       RightButton={<RightButtonText onClose={navigateToHome} wording="Quitter" />}
       scrollChildren={
         <React.Fragment>
-          <Typo.Title3 {...getHeadingAttrs(2)}>Choisis un nouveau mot de passe</Typo.Title3>
+          <Typo.Title3 {...getTextSemanticAttrs(2)}>Choisis un nouveau mot de passe</Typo.Title3>
           <Form.MaxWidth>
             <Container>
               <PasswordInputController

--- a/src/features/auth/pages/login/Login.tsx
+++ b/src/features/auth/pages/login/Login.tsx
@@ -34,7 +34,7 @@ import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Key } from 'ui/svg/icons/Key'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type LoginFormData = { email: string; password: string }
 type Props = { doNotNavigateOnSigninSuccess?: boolean }
@@ -189,7 +189,7 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
         scrollChildren={
           <React.Fragment>
             <TitleContainer>
-              <Typo.Title3 {...getHeadingAttrs(2)}>Connecte-toi</Typo.Title3>
+              <Typo.Title3 {...getTextSemanticAttrs(2)}>Connecte-toi</Typo.Title3>
             </TitleContainer>
             <Form.MaxWidth>
               <InputError

--- a/src/features/auth/pages/login/LoginMethods.tsx
+++ b/src/features/auth/pages/login/LoginMethods.tsx
@@ -28,7 +28,7 @@ import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { StepperValidate } from 'ui/svg/icons/StepperValidate'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const LoginMethods = () => {
   const { navigate } = useNavigation<UseNavigationType>()
@@ -93,7 +93,7 @@ export const LoginMethods = () => {
       scrollChildren={
         <React.Fragment>
           <TitleContainer>
-            <Typo.Title3 {...getHeadingAttrs(2)}>Connecte-toi</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs(2)}>Connecte-toi</Typo.Title3>
           </TitleContainer>
           <SeparatorWithText label="Méthode recommandée" icon={StepperValidate} color="primary" />
           <Form.MaxWidth>

--- a/src/features/auth/pages/signup/SetBirthday/SetBirthday.tsx
+++ b/src/features/auth/pages/signup/SetBirthday/SetBirthday.tsx
@@ -19,7 +19,7 @@ import { Banner } from 'ui/designSystem/Banner/Banner'
 import { Button } from 'ui/designSystem/Button/Button'
 import { IdCard } from 'ui/svg/icons/IdCard'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type BirthdayForm = {
   birthdate: Date
@@ -102,7 +102,7 @@ export const SetBirthday: FunctionComponent<PreValidationSignupNormalStepProps> 
   return (
     <SetContainer>
       <Form.MaxWidth>
-        <Typo.Title3 {...getHeadingAttrs(2)}>{pageTitle}</Typo.Title3>
+        <Typo.Title3 {...getTextSemanticAttrs(2)}>{pageTitle}</Typo.Title3>
         {isSSOSubscriptionFromLogin ? (
           <StyledView>
             <Typo.Body>

--- a/src/features/auth/pages/signup/SetEmail/SetEmail.tsx
+++ b/src/features/auth/pages/signup/SetEmail/SetEmail.tsx
@@ -12,7 +12,7 @@ import { Form } from 'ui/components/Form'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type FormValues = { email: string; marketingEmailSubscription: boolean }
 
@@ -47,7 +47,7 @@ export const SetEmail: FunctionComponent<PreValidationSignupNormalStepProps> = (
 
   return (
     <Form.MaxWidth>
-      <Typo.Title3 {...getHeadingAttrs(2)}>Crée-toi un compte</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs(2)}>Crée-toi un compte</Typo.Title3>
       <ControllersContainer gap={5}>
         <EmailInputController
           label="Adresse e-mail"

--- a/src/features/auth/pages/signup/SetPassword/SetPassword.tsx
+++ b/src/features/auth/pages/signup/SetPassword/SetPassword.tsx
@@ -10,7 +10,7 @@ import { PasswordInputController } from 'shared/forms/controllers/PasswordInputC
 import { Form } from 'ui/components/Form'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type FormValues = {
   password: string
@@ -39,7 +39,7 @@ export const SetPassword: FunctionComponent<PreValidationSignupNormalStepProps> 
   return (
     <SetContainer>
       <Form.MaxWidth>
-        <Typo.Title3 {...getHeadingAttrs(2)}>Choisis un mot de passe</Typo.Title3>
+        <Typo.Title3 {...getTextSemanticAttrs(2)}>Choisis un mot de passe</Typo.Title3>
         <PasswordInputContainer>
           <PasswordInputController
             label="Mot de passe"

--- a/src/features/auth/pages/signup/SignupMethods/SignupMethods.tsx
+++ b/src/features/auth/pages/signup/SignupMethods/SignupMethods.tsx
@@ -24,7 +24,7 @@ import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { StepperValidate } from 'ui/svg/icons/StepperValidate'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const SignupMethods: FunctionComponent = () => {
   const { params } = useRoute<UseRouteType<'SignupMethods'>>()
@@ -58,7 +58,7 @@ export const SignupMethods: FunctionComponent = () => {
       scrollChildren={
         <React.Fragment>
           <TitleContainer>
-            <Typo.Title3 {...getHeadingAttrs(2)}>Crée-toi un compte</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs(2)}>Crée-toi un compte</Typo.Title3>
           </TitleContainer>
           <SeparatorWithText label="Méthode recommandée" icon={StepperValidate} color="primary" />
           <StyledViewGap gap={4}>

--- a/src/features/bonification/pages/BonificationBirthDate.tsx
+++ b/src/features/bonification/pages/BonificationBirthDate.tsx
@@ -24,7 +24,7 @@ import { ButtonContainerFlexStart } from 'ui/designSystem/Button/ButtonContainer
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type BirthdayForm = {
   birthdate: Date
@@ -74,7 +74,7 @@ export const BonificationBirthDate = () => {
         <Form.MaxWidth>
           <StyledBodyXsSteps>Étape 3 sur 5</StyledBodyXsSteps>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getHeadingAttrs(2)}>
+            <Typo.Title3 {...getTextSemanticAttrs(2)}>
               Quelle est la date de naissance de ton représentant légal&nbsp;?
             </Typo.Title3>
 

--- a/src/features/bonification/pages/BonificationBirthPlace.tsx
+++ b/src/features/bonification/pages/BonificationBirthPlace.tsx
@@ -29,7 +29,7 @@ import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export type FormValues = {
   birthCountrySelection: InseeCountry
@@ -108,7 +108,7 @@ export const BonificationBirthPlace = () => {
         <Form.MaxWidth>
           <StyledBodyXsSteps>{step}</StyledBodyXsSteps>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getHeadingAttrs(2)}>{title}</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs(2)}>{title}</Typo.Title3>
             <Controller
               control={control}
               name="birthCountrySelection"

--- a/src/features/bonification/pages/BonificationExplanations.tsx
+++ b/src/features/bonification/pages/BonificationExplanations.tsx
@@ -28,7 +28,7 @@ import { Speaker } from 'ui/svg/icons/Speaker'
 import { WarningFilled } from 'ui/svg/icons/WarningFilled'
 import { Typo } from 'ui/theme'
 import { SPACE } from 'ui/theme/constants'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const BonificationExplanations = () => {
   const { navigate } = useNavigation<UseNavigationType>()
@@ -68,7 +68,7 @@ export const BonificationExplanations = () => {
             <Container>
               <StyledSpeaker />
             </Container>
-            <StyledTitle3 {...getHeadingAttrs(2)}>
+            <StyledTitle3 {...getTextSemanticAttrs(2)}>
               Quel est ce bonus et comment en bénéficier&nbsp;?
             </StyledTitle3>
             <Typo.Body>

--- a/src/features/bonification/pages/BonificationNames.tsx
+++ b/src/features/bonification/pages/BonificationNames.tsx
@@ -22,7 +22,7 @@ import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type FormValues = {
   firstNames: string[]
@@ -69,7 +69,7 @@ export const BonificationNames = () => {
         <Form.MaxWidth>
           <StyledBodyXsSteps>Étape 1 sur 5</StyledBodyXsSteps>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getHeadingAttrs(2)}>
+            <Typo.Title3 {...getTextSemanticAttrs(2)}>
               Quels sont les noms et prénoms de ton représentant légal&nbsp;?
             </Typo.Title3>
             <Controller

--- a/src/features/bonification/pages/BonificationRequiredInformation.tsx
+++ b/src/features/bonification/pages/BonificationRequiredInformation.tsx
@@ -19,7 +19,7 @@ import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { IdCardWithMagnifyingGlass as InitialIdCardWithMagnifyingGlass } from 'ui/svg/icons/IdCardWithMagnifyingGlass'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const BonificationRequiredInformation = () => {
   const { params } = useRoute<UseRouteType<'BonificationRequiredInformation'>>()
@@ -55,7 +55,7 @@ export const BonificationRequiredInformation = () => {
             <Container>
               <IdCardWithMagnifyingGlass />
             </Container>
-            <StyledTitle3 {...getHeadingAttrs(2)}>{title}</StyledTitle3>
+            <StyledTitle3 {...getTextSemanticAttrs(2)}>{title}</StyledTitle3>
             <Typo.Body>Munis-toi des informations suivantes pour faire ta demande&nbsp;:</Typo.Body>
             <VerticalUl>
               {isDisabilityBonification ? (

--- a/src/features/bonification/pages/BonificationTitle.tsx
+++ b/src/features/bonification/pages/BonificationTitle.tsx
@@ -16,7 +16,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export type Title = 'Madame' | 'Monsieur'
 
@@ -47,7 +47,7 @@ export const BonificationTitle = () => {
       scrollChildren={
         <React.Fragment>
           <StyledBodyXsSteps>Étape 2 sur 5</StyledBodyXsSteps>
-          <Typo.Title3 {...getHeadingAttrs(2)}>
+          <Typo.Title3 {...getTextSemanticAttrs(2)}>
             Quelle est la civilité de ton représentant légal&nbsp;?
           </Typo.Title3>
           <SelectorContainer

--- a/src/features/bookOffer/components/BookDateChoice.tsx
+++ b/src/features/bookOffer/components/BookDateChoice.tsx
@@ -10,7 +10,7 @@ import { getDistinctPricesFromAllStock } from 'features/bookOffer/helpers/bookin
 import { formatToCompleteFrenchDate } from 'libs/parsers/formatDates'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 interface Props {
   stocks: OfferStockResponse[]
@@ -35,7 +35,7 @@ export const BookDateChoice = ({ stocks, userRemainingCredit }: Props) => {
     : ''
   return (
     <StyledView>
-      <Typo.Title3 {...getHeadingAttrs(3)} testID="DateStep">
+      <Typo.Title3 {...getTextSemanticAttrs(3)} testID="DateStep">
         Date
       </Typo.Title3>
       {bookingState.step === Step.DATE ? (

--- a/src/features/bookOffer/components/BookHourChoice.tsx
+++ b/src/features/bookOffer/components/BookHourChoice.tsx
@@ -24,7 +24,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { RadioButtonGroup } from 'ui/designSystem/RadioButtonGroup/RadioButtonGroup'
 import { RadioButtonGroupOption } from 'ui/designSystem/RadioButtonGroup/types'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const radioGroupLabel = 'Horaires'
 
@@ -129,7 +129,7 @@ export const BookHourChoice = () => {
     </View>
   ) : (
     <ViewGap gap={4}>
-      <Typo.Title3 {...getHeadingAttrs(3)}>{radioGroupLabel}</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs(3)}>{radioGroupLabel}</Typo.Title3>
       <TouchableOpacity onPress={changeHour}>
         <Typo.Button>{buttonTitle}</Typo.Button>
       </TouchableOpacity>

--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -39,7 +39,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { Error } from 'ui/svg/icons/Error'
 import { LocationBuilding } from 'ui/svg/icons/LocationBuilding'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export interface BookingDetailsProps {
   stocks: OfferStockResponse[]
@@ -200,7 +200,7 @@ export const BookingDetails = ({ stocks, onPressBookOffer, isLoading }: BookingD
         Icon={Error}
       />
       <Container>
-        <Typo.Title4 {...getHeadingAttrs(2)}>Informations</Typo.Title4>
+        <Typo.Title4 {...getTextSemanticAttrs(2)}>Informations</Typo.Title4>
       </Container>
       <BookingInformationsContainer>
         <BookingInformations />
@@ -333,7 +333,7 @@ const VenueTitleContainer = styled.View(({ theme }) => ({
   marginBottom: theme.designSystem.size.spacing.l,
 }))
 
-const VenueTitleText = styled(Typo.Title4).attrs(getHeadingAttrs(2))({
+const VenueTitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))({
   flexShrink: 1,
 })
 

--- a/src/features/bookOffer/components/Calendar/MonthHeader.tsx
+++ b/src/features/bookOffer/components/Calendar/MonthHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { CAPITALIZED_MONTHS } from 'shared/date/months'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   date: Date
@@ -11,7 +11,7 @@ type Props = {
 export const MonthHeader: React.FC<Props> = ({ date }) => {
   const month = `${CAPITALIZED_MONTHS[date.getMonth()]} ${date.getFullYear()}`
   return (
-    <Typo.Body {...getHeadingAttrs(2)} accessibilityLiveRegion="polite">
+    <Typo.Body {...getTextSemanticAttrs(2)} accessibilityLiveRegion="polite">
       {month}
     </Typo.Body>
   )

--- a/src/features/bookOffer/components/CancellationDetails.tsx
+++ b/src/features/bookOffer/components/CancellationDetails.tsx
@@ -5,7 +5,7 @@ import { formatToCompleteFrenchDateTime } from 'libs/parsers/formatDates'
 import { useBookingOfferQuery } from 'queries/offer/useBookingOfferQuery'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const NOT_CANCELLABLE_MESSAGE =
   'En confirmant la réservation, j’accepte son exécution immédiate et renonce à mon droit de rétractation. Une confirmation de cet accord me sera envoyée par email.'
@@ -32,7 +32,7 @@ export const CancellationDetails: React.FC = () => {
 
   return (
     <ViewGap gap={2}>
-      <Typo.Title4 {...getHeadingAttrs(2)}>Conditions d’annulation</Typo.Title4>
+      <Typo.Title4 {...getTextSemanticAttrs(2)}>Conditions d’annulation</Typo.Title4>
       <Typo.BodyAccentXs>{message}</Typo.BodyAccentXs>
     </ViewGap>
   )

--- a/src/features/bookOffer/components/CguDetails.tsx
+++ b/src/features/bookOffer/components/CguDetails.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react'
 
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   children: ReactNode
@@ -11,7 +11,7 @@ type Props = {
 export const CguDetails: React.FC<Props> = ({ children }) => {
   return (
     <ViewGap gap={4}>
-      <Typo.Title4 {...getHeadingAttrs(2)}>Conditions d’utilisation</Typo.Title4>
+      <Typo.Title4 {...getTextSemanticAttrs(2)}>Conditions d’utilisation</Typo.Title4>
       {children}
     </ViewGap>
   )

--- a/src/features/bookings/components/Ticket/TicketBottomPart/TicketCodeTitle.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/TicketCodeTitle.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const TicketCodeTitle = ({
   accessibilityLabel,
@@ -20,7 +20,7 @@ export const TicketCodeTitle = ({
   </StyledTouchable>
 )
 
-const StyledTitle = styled(Typo.Title4).attrs(getHeadingAttrs(2))(({ theme }) => ({
+const StyledTitle = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))(({ theme }) => ({
   color: theme.designSystem.color.text.brandPrimary,
 }))
 

--- a/src/features/bookings/components/Ticket/TicketTopPart.tsx
+++ b/src/features/bookings/components/Ticket/TicketTopPart.tsx
@@ -12,7 +12,7 @@ import { ClockFilled } from 'ui/svg/icons/ClockFilled'
 import { ProfileFilled } from 'ui/svg/icons/ProfileFilled'
 import { Stock } from 'ui/svg/icons/Stock'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type TicketTopPartProps = {
   title: string
@@ -43,7 +43,7 @@ export const TicketTopPart = ({
 }: TicketTopPartProps) => {
   return (
     <ViewGap gap={6}>
-      <Typo.Title2 {...getHeadingAttrs(1)}>{title}</Typo.Title2>
+      <Typo.Title2 {...getTextSemanticAttrs(1)}>{title}</Typo.Title2>
       <ViewGap gap={2}>
         {user.firstName && user.lastName ? (
           <Row>

--- a/src/features/cookies/components/CookiesSettings.tsx
+++ b/src/features/cookies/components/CookiesSettings.tsx
@@ -18,7 +18,7 @@ import { InputLabel } from 'ui/components/InputLabel/InputLabel'
 import { styledInputLabel } from 'ui/components/InputLabel/styledInputLabel'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const checkboxID = uuidv4()
 const labelID = uuidv4()
@@ -71,7 +71,7 @@ export const CookiesSettings = ({
 
   return (
     <React.Fragment>
-      <Typo.Title4 {...getHeadingAttrs(2)}>
+      <Typo.Title4 {...getTextSemanticAttrs(2)}>
         À quoi servent tes cookies et tes données&nbsp;?
       </Typo.Title4>
       <ChoiceContainer>

--- a/src/features/cookies/pages/CookiesDetails.tsx
+++ b/src/features/cookies/pages/CookiesDetails.tsx
@@ -10,7 +10,7 @@ import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouch
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Link } from 'ui/designSystem/Link/Link'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const CookiesDetails = (props: CookiesChoiceSettings) => {
   return (
@@ -28,7 +28,7 @@ export const CookiesDetails = (props: CookiesChoiceSettings) => {
         <CookiesSettings {...props} />
       </CookiesSettingsContainer>
       <ViewGap gap={4}>
-        <Typo.Title4 {...getHeadingAttrs(2)}>Tu as la main dessus</Typo.Title4>
+        <Typo.Title4 {...getTextSemanticAttrs(2)}>Tu as la main dessus</Typo.Title4>
         <Typo.Body>
           Ton choix est conservé pendant 6 mois et tu pourras le modifier dans les paramètres de
           confidentialité de ton profil à tout moment.

--- a/src/features/culturalSurvey/components/CulturalSurveyPageHeader.tsx
+++ b/src/features/culturalSurvey/components/CulturalSurveyPageHeader.tsx
@@ -7,7 +7,7 @@ import { useGoBack } from 'features/navigation/useGoBack'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ArrowPrevious as DefaultArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 interface Props {
   title: string
@@ -41,7 +41,7 @@ const BarAndTitle = styled.View(({ theme }) => ({
   flex: 1,
 }))
 
-const Title = styled(Typo.Title4).attrs(() => ({ ...getHeadingAttrs(1), numberOfLines: 1 }))(
+const Title = styled(Typo.Title4).attrs(() => ({ ...getTextSemanticAttrs(1), numberOfLines: 1 }))(
   ({ theme }) => ({
     flex: 1,
     marginRight: theme.designSystem.size.spacing.xl,

--- a/src/features/favorites/components/NumberOfResults.tsx
+++ b/src/features/favorites/components/NumberOfResults.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { plural } from 'libs/plural'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const NumberOfResults: React.FC<{ nbFavorites: number }> = ({ nbFavorites }) => {
   if (!nbFavorites) return null
@@ -24,6 +24,6 @@ const Container = styled.View(({ theme }) => ({
   marginBottom: theme.designSystem.size.spacing.l,
 }))
 
-const Caption = styled(Typo.BodyAccentXs).attrs(() => getHeadingAttrs(2))(({ theme }) => ({
+const Caption = styled(Typo.BodyAccentXs).attrs(() => getTextSemanticAttrs(2))(({ theme }) => ({
   color: theme.designSystem.color.text.subtle,
 }))

--- a/src/features/favorites/pages/NotConnectedFavorites.tsx
+++ b/src/features/favorites/pages/NotConnectedFavorites.tsx
@@ -11,7 +11,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { Page } from 'ui/pages/Page'
 import { UserFavorite } from 'ui/svg/icons/UserFavorite'
 import { Spacer, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const NotConnectedFavorites = () => {
   const { bottom } = useSafeAreaInsets()
@@ -33,10 +33,10 @@ export const NotConnectedFavorites = () => {
             <Illustration />
           </IllustrationContainer>
           <TextContainer gap={4}>
-            <StyledTitle2 {...getHeadingAttrs(1)}>
+            <StyledTitle2 {...getTextSemanticAttrs(1)}>
               Identifie-toi pour retrouver tes favoris
             </StyledTitle2>
-            <StyledBody {...getHeadingAttrs(2)}>
+            <StyledBody {...getTextSemanticAttrs(2)}>
               Ton compte te permettra de retrouver tous tes bons plans en un clin d’oeil&nbsp;!
             </StyledBody>
           </TextContainer>

--- a/src/features/home/components/modules/venues/VenueTile.tsx
+++ b/src/features/home/components/modules/venues/VenueTile.tsx
@@ -19,7 +19,7 @@ import { ImageTile } from 'ui/components/ImageTile'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Tag } from 'ui/designSystem/Tag/Tag'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export interface VenueTileProps {
   venue: VenueHit
@@ -54,7 +54,7 @@ const UnmemoizedVenueTile = (props: VenueTileProps) => {
   )
 
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.VENUE, { ...venue, distance })
-  const headingProps = Platform.OS === 'web' ? {} : getHeadingAttrs(3)
+  const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs(3)
 
   function handlePressVenue() {
     // We pre-populate the query-cache with the data from the search result for a smooth transition

--- a/src/features/home/components/modules/video/VideoModuleHeader.tsx
+++ b/src/features/home/components/modules/video/VideoModuleHeader.tsx
@@ -14,7 +14,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { Tag } from 'ui/designSystem/Tag/Tag'
 import { TagVariant } from 'ui/designSystem/Tag/types'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   analyticsParams: OfferAnalyticsParams
@@ -49,7 +49,7 @@ export const VideoModuleHeader: FunctionComponent<Props> = ({
         <Tag label={videoTag} variant={TagVariant.DEFAULT} />
       </StyledTagContainer>
 
-      <Typo.Title3 {...getHeadingAttrs(1)}>{moduleName}</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs(1)}>{moduleName}</Typo.Title3>
 
       <StyledCaptionDate>{`Publiée le ${formatToFrenchDate(
         new Date(videoPublicationDate)
@@ -62,7 +62,7 @@ export const VideoModuleHeader: FunctionComponent<Props> = ({
       ) : null}
 
       <OfferTitleContainer>
-        <Typo.Title4 {...getHeadingAttrs(2)}>{offerTitle}</Typo.Title4>
+        <Typo.Title4 {...getTextSemanticAttrs(2)}>{offerTitle}</Typo.Title4>
       </OfferTitleContainer>
 
       {!isMultiOffer && offers[0] && !hasThematicHomeEntry ? (

--- a/src/features/identityCheck/components/CenteredTitle.tsx
+++ b/src/features/identityCheck/components/CenteredTitle.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const CenteredTitle = ({ title, titleID }: { title: string; titleID?: string }) => (
   <TitleContainer>
@@ -15,6 +15,6 @@ const TitleContainer = styled.View({
   width: '100%',
 })
 
-const Title = styled(Typo.Title4).attrs(() => getHeadingAttrs(2))({
+const Title = styled(Typo.Title4).attrs(() => getTextSemanticAttrs(2))({
   textAlign: 'center',
 })

--- a/src/features/identityCheck/components/JustifiedLeftTitle.tsx
+++ b/src/features/identityCheck/components/JustifiedLeftTitle.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const JustifiedLeftTitle = ({ title, titleID }: { title: string; titleID?: string }) => (
   <TitleContainer>
@@ -16,4 +16,4 @@ const TitleContainer = styled.View(({ theme }) => ({
   marginBottom: theme.designSystem.size.spacing.xxl,
 }))
 
-const Title = styled(Typo.Title3).attrs(() => getHeadingAttrs(2))({})
+const Title = styled(Typo.Title3).attrs(() => getTextSemanticAttrs(2))({})

--- a/src/features/identityCheck/pages/Stepper.tsx
+++ b/src/features/identityCheck/pages/Stepper.tsx
@@ -30,7 +30,7 @@ import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { Page } from 'ui/pages/Page'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const Stepper = () => {
   useShowDisableActivation()
@@ -159,7 +159,7 @@ export const Stepper = () => {
   )
 }
 
-const StyledTitle1 = styled(Typo.Title1).attrs(() => getHeadingAttrs(1))``
+const StyledTitle1 = styled(Typo.Title1).attrs(() => getTextSemanticAttrs(1))``
 
 const TitleContainer = styled.View(({ theme }) => ({
   marginTop: theme.isDesktopViewport ? getSpacing(16) : theme.designSystem.size.spacing.l,

--- a/src/features/identityCheck/pages/confirmation/IdentityCheckHonor.tsx
+++ b/src/features/identityCheck/pages/confirmation/IdentityCheckHonor.tsx
@@ -19,7 +19,7 @@ import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { Page } from 'ui/pages/Page'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const IdentityCheckHonor = () => {
   const headerHeight = useGetHeaderHeight()
@@ -63,11 +63,11 @@ export const IdentityCheckHonor = () => {
     <Page>
       <StyledScrollView>
         <HeaderHeightSpacer headerHeight={headerHeight} />
-        <Typo.Title2 {...getHeadingAttrs(1)}>
+        <Typo.Title2 {...getTextSemanticAttrs(1)}>
           Les informations que tu as renseignées sont-elles correctes&nbsp;?
         </Typo.Title2>
         <TextContainer>
-          <Typo.Title4 {...getHeadingAttrs(2)}>
+          <Typo.Title4 {...getTextSemanticAttrs(2)}>
             &quot;Je déclare que l’ensemble des informations que j’ai renseignées durant mon
             inscription sont correctes.&quot;
           </Typo.Title4>

--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.tsx
@@ -10,7 +10,7 @@ import { Page } from 'ui/pages/Page'
 import { EmailSent } from 'ui/svg/icons/EmailSent'
 import { Typo } from 'ui/theme'
 import { illustrationSizes } from 'ui/theme/illustrationSizes'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const IdentityCheckEnd: FC = () => {
   const { designSystem } = useTheme()
@@ -43,7 +43,7 @@ export const IdentityCheckEnd: FC = () => {
           />
         </IllustrationContainer>
         <TextContainer>
-          <StyledTitle2 {...getHeadingAttrs(1)}>
+          <StyledTitle2 {...getTextSemanticAttrs(1)}>
             Ta pièce d’identité a bien été transmise&nbsp;!
           </StyledTitle2>
         </TextContainer>

--- a/src/features/identityCheck/pages/identification/ubble/SelectIDOrigin.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectIDOrigin.tsx
@@ -12,7 +12,7 @@ import { Earth as InitialEarth } from 'ui/svg/icons/Earth'
 import { France as FranceIcon } from 'ui/svg/icons/France'
 import { IdCardWithMagnifyingGlass as InitialIdCardWithMagnifyingGlass } from 'ui/svg/icons/IdCardWithMagnifyingGlass'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const SelectIDOrigin: FunctionComponent = () => (
   <PageWithHeader
@@ -79,7 +79,7 @@ const IdCardWithMagnifyingGlass = styled(InitialIdCardWithMagnifyingGlass).attrs
   color: theme.designSystem.color.icon.brandPrimary,
 }))``
 
-const StyledTitle4 = styled(Typo.Title4).attrs(getHeadingAttrs(2))({
+const StyledTitle4 = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))({
   textAlign: 'center',
 })
 

--- a/src/features/identityCheck/pages/identification/ubble/SelectIDStatus.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectIDStatus.tsx
@@ -22,7 +22,7 @@ import { IdCard as InitialIdCard } from 'ui/svg/icons/IdCard'
 import { LostId as InitialLostId } from 'ui/svg/icons/LostId'
 import { NoId as InitialNoId } from 'ui/svg/icons/NoId'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const SelectIDStatus: FunctionComponent = () => {
   const { data: subscription } = useGetStepperInfoQuery()
@@ -146,7 +146,7 @@ const Container = styled.View(({ theme }) => ({
   marginVertical: theme.designSystem.size.spacing.xxl,
 }))
 
-const StyledTitle4 = styled(Typo.Title4).attrs(getHeadingAttrs(2))({
+const StyledTitle4 = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))({
   textAlign: 'center',
 })
 

--- a/src/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.tsx
@@ -9,7 +9,7 @@ import { NoPhone } from 'ui/svg/icons/NoPhone'
 import { PhonePending as InitialPhonePending } from 'ui/svg/icons/PhonePending'
 import { Smartphone } from 'ui/svg/icons/Smartphone'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const SelectPhoneStatus: FunctionComponent = () => {
   return (
@@ -75,7 +75,7 @@ const PhonePending = styled(InitialPhonePending).attrs(({ theme }) => ({
   size: theme.illustrations.sizes.fullPage,
 }))``
 
-const StyledTitle4 = styled(Typo.Title4).attrs(getHeadingAttrs(2))({
+const StyledTitle4 = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))({
   textAlign: 'center',
 })
 const StyledBody = styled(Typo.Body)({

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
@@ -24,7 +24,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { TextInput } from 'ui/designSystem/TextInput/TextInput'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const SetPhoneNumberWithoutValidation = () => {
   const { dispatch, phoneValidation } = useSubscriptionContext()
@@ -82,7 +82,7 @@ export const SetPhoneNumberWithoutValidation = () => {
       scrollChildren={
         <ViewGap gap={8}>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getHeadingAttrs(2)}>Saisis ton numéro de téléphone</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs(2)}>Saisis ton numéro de téléphone</Typo.Title3>
             <Banner label="Ton numéro pourra être utilisé pour recevoir des infos sur tes futures réservations." />
           </ViewGap>
           <Form.MaxWidth>

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -29,7 +29,7 @@ import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const snackbarMessage =
   'Nous avons eu un problème pour trouver l’adresse associée à ton code postal. Réessaie plus tard.'
@@ -149,7 +149,7 @@ export const SetAddress = () => {
       scrollChildren={
         <React.Fragment>
           <Form.MaxWidth>
-            <Typo.Title3 {...getHeadingAttrs(2)}>{pageConfigByType[type].title}</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs(2)}>{pageConfigByType[type].title}</Typo.Title3>
             <Container>
               <SearchInput
                 onChangeText={onChangeAddress}

--- a/src/features/identityCheck/pages/profile/SetCity.tsx
+++ b/src/features/identityCheck/pages/profile/SetCity.tsx
@@ -15,7 +15,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export type CityForm = { city: SuggestedCity }
 
@@ -78,7 +78,7 @@ export const SetCity = () => {
       title={pageConfigByType[type].headerTitle}
       scrollChildren={
         <ViewGap gap={5}>
-          <Typo.Title3 {...getHeadingAttrs(2)}>Renseigne ta ville de résidence</Typo.Title3>
+          <Typo.Title3 {...getTextSemanticAttrs(2)}>Renseigne ta ville de résidence</Typo.Title3>
           <Controller
             control={control}
             name="city"

--- a/src/features/identityCheck/pages/profile/SetName.tsx
+++ b/src/features/identityCheck/pages/profile/SetName.tsx
@@ -20,7 +20,7 @@ import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { IdCard } from 'ui/svg/icons/IdCard'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type FormValues = {
   firstName: string
@@ -92,7 +92,7 @@ export const SetName = () => {
       title={pageConfigByType[type].headerTitle}
       scrollChildren={
         <Form.MaxWidth>
-          <Typo.Title3 {...getHeadingAttrs(2)}>{pageConfigByType[type].title}</Typo.Title3>
+          <Typo.Title3 {...getTextSemanticAttrs(2)}>{pageConfigByType[type].title}</Typo.Title3>
           <BannerContainer>
             <Banner Icon={IdCard} label={pageConfigByType[type].bannerMessage} />
           </BannerContainer>

--- a/src/features/identityCheck/pages/profile/SetPhoneNumber.tsx
+++ b/src/features/identityCheck/pages/profile/SetPhoneNumber.tsx
@@ -31,7 +31,7 @@ import { TextInput } from 'ui/designSystem/TextInput/TextInput'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const SetPhoneNumber = () => {
   const { params } = useRoute<UseRouteType<'SetPhoneNumber'>>()
@@ -86,7 +86,7 @@ export const SetPhoneNumber = () => {
       scrollChildren={
         <ViewGap gap={8}>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getHeadingAttrs(2)}>Saisis ton numéro de téléphone</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs(2)}>Saisis ton numéro de téléphone</Typo.Title3>
             <Banner label="Ton numéro pourra être utilisé pour recevoir des infos sur tes futures réservations." />
           </ViewGap>
           <Form.MaxWidth>

--- a/src/features/identityCheck/pages/profile/StatusFlatList.tsx
+++ b/src/features/identityCheck/pages/profile/StatusFlatList.tsx
@@ -15,7 +15,7 @@ import { Spinner } from 'ui/components/Spinner'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Page } from 'ui/pages/Page'
 import { Spacer, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const VIEWABILITY_CONFIG = { itemVisiblePercentThreshold: 100 }
 
@@ -108,7 +108,7 @@ export function StatusFlatList({
               <React.Fragment>
                 <HeaderHeightSpacer headerHeight={headerHeight} />
                 <Container>
-                  <Typo.Title3 {...getHeadingAttrs(2)}>Sélectionne ton statut</Typo.Title3>
+                  <Typo.Title3 {...getTextSemanticAttrs(2)}>Sélectionne ton statut</Typo.Title3>
                 </Container>
               </React.Fragment>
             }

--- a/src/features/offer/components/OfferAbout/OfferAbout.tsx
+++ b/src/features/offer/components/OfferAbout/OfferAbout.tsx
@@ -7,7 +7,7 @@ import { OfferMetadataList } from 'features/offer/components/OfferMetadataList/O
 import { CollapsibleText } from 'ui/components/CollapsibleText/CollapsibleText'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   offer: OfferResponse
@@ -18,7 +18,7 @@ type Props = {
 export const OfferAbout: FunctionComponent<Props> = ({ offer, metadata, hasMetadata }) => {
   return (
     <ViewGap gap={2}>
-      <Typo.Title3 {...getHeadingAttrs(2)}>À propos</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs(2)}>À propos</Typo.Title3>
       <ViewGap gap={2}>
         {hasMetadata ? <OfferMetadataList metadata={metadata} /> : null}
 

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
@@ -24,7 +24,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { Typo } from 'ui/theme'
 import { AVATAR_MEDIUM, AVATAR_SMALL } from 'ui/theme/constants'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 interface Props {
   artists: OfferArtist[]
@@ -122,7 +122,7 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
     <ViewGap gap={4}>
       <SeeAllButtonContainer gap={3}>
         <TitleContainer>
-          <Typo.Title4 {...getHeadingAttrs(2)}>{title}</Typo.Title4>
+          <Typo.Title4 {...getTextSemanticAttrs(2)}>{title}</Typo.Title4>
         </TitleContainer>
         {artists.length > 1 ? (
           <SeeAllButton

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -37,7 +37,7 @@ import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GroupTags } from 'ui/GroupTags/GroupTags'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   offer: OfferResponse
@@ -154,7 +154,7 @@ export const OfferBody: FunctionComponent<Props> = ({
         </GroupWithoutGap>
 
         {prices.length > 0 ? (
-          <Typo.Title3 {...getHeadingAttrs(2)}>{displayedPrice}</Typo.Title3>
+          <Typo.Title3 {...getTextSemanticAttrs(2)}>{displayedPrice}</Typo.Title3>
         ) : null}
 
         <OfferReactionSection

--- a/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
+++ b/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
@@ -12,7 +12,7 @@ import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { Venue } from 'ui/svg/icons/Venue'
 import { Typo } from 'ui/theme'
 import { AVATAR_SMALL } from 'ui/theme/constants'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type ProposedBySectionProps = {
   name: string
@@ -53,7 +53,7 @@ export const ProposedBySection: FunctionComponent<ProposedBySectionProps> = ({
   return (
     <Wrapper>
       <ViewGap gap={4}>
-        <Typo.Title3 {...getHeadingAttrs(2)}>Proposé par</Typo.Title3>
+        <Typo.Title3 {...getTextSemanticAttrs(2)}>Proposé par</Typo.Title3>
         {navigateTo ? (
           <InternalTouchableLink navigateTo={navigateTo} accessibilityLabel={name}>
             {content}

--- a/src/features/offer/components/OfferCine/OfferCineBlock.tsx
+++ b/src/features/offer/components/OfferCine/OfferCineBlock.tsx
@@ -16,7 +16,7 @@ import { AnchorNames } from 'ui/components/anchor/anchor-name'
 import { useScrollToAnchor } from 'ui/components/anchor/AnchorContext'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo, getSpacing } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   title: string
@@ -58,7 +58,7 @@ export const OfferCineBlock: FC<Props> = ({ title, onSeeVenuePress, offer }) => 
             showButton(!inView)
           }}>
           <TitleContainer>
-            <Typo.Title3 {...getHeadingAttrs(2)}>{title}</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs(2)}>{title}</Typo.Title3>
           </TitleContainer>
         </InView>
       </Anchor>

--- a/src/features/offer/components/OfferCine/OfferCineBlockV2.tsx
+++ b/src/features/offer/components/OfferCine/OfferCineBlockV2.tsx
@@ -15,7 +15,7 @@ import { AnchorNames } from 'ui/components/anchor/anchor-name'
 import { useScrollToAnchor } from 'ui/components/anchor/AnchorContext'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo, getSpacing } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   title: string
@@ -77,7 +77,7 @@ export const OfferCineBlockV2: FC<Props> = ({
             showButton(!inView)
           }}>
           <TitleContainer>
-            <Typo.Title3 {...getHeadingAttrs(2)}>{title}</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs(2)}>{title}</Typo.Title3>
           </TitleContainer>
         </InView>
       </Anchor>

--- a/src/features/offer/components/OfferContent/ClubAdviceSection/ClubAdviceSection.web.tsx
+++ b/src/features/offer/components/OfferContent/ClubAdviceSection/ClubAdviceSection.web.tsx
@@ -12,7 +12,6 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Show } from 'ui/svg/icons/Show'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const ClubAdviceSection = (props: ClubAdviceSectionProps) => {
   const { isDesktopViewport } = useTheme()
@@ -38,9 +37,7 @@ export const ClubAdviceSection = (props: ClubAdviceSectionProps) => {
         <View style={style}>
           <Gutter>
             <Row>
-              <StyledTitle3
-                withBorderRight={shouldDisplayAllReviewsButton}
-                {...getTextSemanticAttrs(3)}>
+              <StyledTitle3 withBorderRight={shouldDisplayAllReviewsButton}>
                 {variantInfo.titleSection}
               </StyledTitle3>
               {showSectionTag && variantInfo.sectionTag ? (

--- a/src/features/offer/components/OfferContent/ClubAdviceSection/ClubAdviceSection.web.tsx
+++ b/src/features/offer/components/OfferContent/ClubAdviceSection/ClubAdviceSection.web.tsx
@@ -12,7 +12,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Show } from 'ui/svg/icons/Show'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const ClubAdviceSection = (props: ClubAdviceSectionProps) => {
   const { isDesktopViewport } = useTheme()
@@ -38,7 +38,9 @@ export const ClubAdviceSection = (props: ClubAdviceSectionProps) => {
         <View style={style}>
           <Gutter>
             <Row>
-              <StyledTitle3 withBorderRight={shouldDisplayAllReviewsButton} {...getHeadingAttrs(3)}>
+              <StyledTitle3
+                withBorderRight={shouldDisplayAllReviewsButton}
+                {...getTextSemanticAttrs(3)}>
                 {variantInfo.titleSection}
               </StyledTitle3>
               {showSectionTag && variantInfo.sectionTag ? (

--- a/src/features/offer/components/OfferContent/ClubAdviceSection/ClubAdviceSectionBase.tsx
+++ b/src/features/offer/components/OfferContent/ClubAdviceSection/ClubAdviceSectionBase.tsx
@@ -9,7 +9,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { Button } from 'ui/designSystem/Button/Button'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const ClubAdviceSectionBase = ({
   data,
@@ -30,7 +30,7 @@ export const ClubAdviceSectionBase = ({
     <View style={style}>
       <Gutter>
         <Row>
-          <StyledTitle3 {...getHeadingAttrs(3)}>{variantInfo.titleSection}</StyledTitle3>
+          <StyledTitle3 {...getTextSemanticAttrs(3)}>{variantInfo.titleSection}</StyledTitle3>
           {showSectionTag && variantInfo.sectionTag ? (
             <TagContainer>{variantInfo.sectionTag}</TagContainer>
           ) : null}

--- a/src/features/offer/components/OfferTile/OfferTile.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.tsx
@@ -13,7 +13,7 @@ import { NAVIGATION_METHOD } from 'shared/constants'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 import { PlaylistCardOffer } from './PlaylistCardOffer'
 
@@ -60,7 +60,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
     subcategoryId
   )
 
-  const headingProps = Platform.OS === 'web' ? {} : getHeadingAttrs(3)
+  const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs(3)
   const interactionTagLabel = getInteractionTagLabel(interactionTag)
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.OFFER, {
     ...offer,

--- a/src/features/offer/components/OfferTitle/OfferTitle.tsx
+++ b/src/features/offer/components/OfferTitle/OfferTitle.tsx
@@ -3,7 +3,7 @@ import { useTheme } from 'styled-components/native'
 
 import { accessibilityAndTestId } from 'libs/accessibilityAndTestId'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 interface Props {
   offerName: string
@@ -18,7 +18,7 @@ export const OfferTitle: FunctionComponent<Props> = ({ offerName }) => {
       adjustsFontSizeToFit
       allowFontScaling={false}
       {...accessibilityAndTestId(`Nom de l’offre\u00a0: ${offerName}`)}
-      {...getHeadingAttrs(1)}>
+      {...getTextSemanticAttrs(1)}>
       {offerName}
     </TitleComponent>
   )

--- a/src/features/offer/components/OfferVenueBlock/OfferVenueBlock.tsx
+++ b/src/features/offer/components/OfferVenueBlock/OfferVenueBlock.tsx
@@ -13,7 +13,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { Duplicate } from 'ui/svg/icons/Duplicate'
 import { EditPen } from 'ui/svg/icons/EditPen'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   title: string
@@ -49,7 +49,7 @@ export function OfferVenueBlock({
 
   return (
     <Wrapper>
-      <Typo.Title3 {...getHeadingAttrs(2)}>{title}</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs(2)}>{title}</Typo.Title3>
 
       <Container>
         <VenueBlock

--- a/src/features/onboarding/pages/onboarding/OnboardingAgeInformation.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingAgeInformation.tsx
@@ -14,7 +14,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { ClockFilled } from 'ui/svg/icons/ClockFilled'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = NativeStackScreenProps<OnboardingStackParamList, 'OnboardingAgeInformation'>
 
@@ -72,7 +72,7 @@ export const OnboardingAgeInformation = ({ route }: Props): React.JSX.Element | 
   return (
     <TutorialPage title={`À ${userAge} ans, profite de ton pass Culture\u00a0!`} buttons={buttons}>
       <ViewGap gap={2}>
-        <Typo.Title4 {...getHeadingAttrs(2)}>Comment ça marche&nbsp;?</Typo.Title4>
+        <Typo.Title4 {...getTextSemanticAttrs(2)}>Comment ça marche&nbsp;?</Typo.Title4>
         <OnboardingTimeline age={userAge} />
       </ViewGap>
     </TutorialPage>

--- a/src/features/profile/components/AccessibilityFeatures/AccessibilityFeatures.tsx
+++ b/src/features/profile/components/AccessibilityFeatures/AccessibilityFeatures.tsx
@@ -7,7 +7,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { VerticalUl } from 'ui/components/Ul'
 import { Link } from 'ui/designSystem/Link/Link'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const AccessibilityFeatures = () => (
   <React.Fragment>
@@ -43,4 +43,4 @@ export const AccessibilityFeatures = () => (
   </React.Fragment>
 )
 
-const TitleText = styled(Typo.Title4).attrs(getHeadingAttrs(2))``
+const TitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))``

--- a/src/features/profile/components/ProfileContentLayout/ProfileContentLayout.tsx
+++ b/src/features/profile/components/ProfileContentLayout/ProfileContentLayout.tsx
@@ -7,7 +7,7 @@ import { AccessibleUnorderedList } from 'ui/components/accessibility/AccessibleU
 import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Section = {
   section: string
@@ -39,9 +39,11 @@ const Container = styled(ViewGap)(({ theme }) => ({
   marginTop: theme.designSystem.size.spacing.xl,
 }))
 
-const CaptionNeutralInfo = styled(Typo.BodyAccentXs).attrs(getHeadingAttrs(2))(({ theme }) => ({
-  color: theme.designSystem.color.text.subtle,
-}))
+const CaptionNeutralInfo = styled(Typo.BodyAccentXs).attrs(getTextSemanticAttrs(2))(
+  ({ theme }) => ({
+    color: theme.designSystem.color.text.subtle,
+  })
+)
 
 const StyledSeparator = styled(Separator.Horizontal)(({ theme }) => ({
   marginTop: theme.designSystem.size.spacing.s,

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileBase.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileBase.tsx
@@ -15,7 +15,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Link } from 'ui/designSystem/Link/Link'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Spacer, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   appVersion: string
@@ -267,6 +267,6 @@ export function AccessibilityDeclarationMobileBase({
   )
 }
 
-const TitleText = styled(Typo.Title4).attrs(getHeadingAttrs(2))``
+const TitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))``
 
-const SubtitleText = styled(Typo.BodyAccent).attrs(getHeadingAttrs(3))``
+const SubtitleText = styled(Typo.BodyAccent).attrs(getTextSemanticAttrs(3))``

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
@@ -20,7 +20,7 @@ import { Link } from 'ui/designSystem/Link/Link'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Spacer, Typo } from 'ui/theme'
 import { SPACE } from 'ui/theme/constants'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const appVersion = '1.395.0'
 const auditDate = '22 juillet 2026'
@@ -431,6 +431,6 @@ export const AccessibilityDeclarationWeb = () => {
   )
 }
 
-const TitleText = styled(Typo.Title4).attrs(getHeadingAttrs(2))``
+const TitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))``
 
-const SubtitleText = styled(Typo.BodyAccent).attrs(getHeadingAttrs(3))``
+const SubtitleText = styled(Typo.BodyAccent).attrs(getTextSemanticAttrs(3))``

--- a/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
+++ b/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
@@ -12,7 +12,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { SearchInput } from 'ui/designSystem/SearchInput/SearchInput'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 import { useSubmitChangeAddress } from './useSubmitChangeAddress'
 
@@ -44,7 +44,7 @@ export const ChangeAddress = () => {
       scrollChildren={
         <React.Fragment>
           <Form.MaxWidth>
-            <Typo.Title3 {...getHeadingAttrs(2)}>Renseigne ton adresse</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs(2)}>Renseigne ton adresse</Typo.Title3>
             <Container>
               <Controller
                 control={control}

--- a/src/features/profile/pages/ChangeCity/ChangeCity.tsx
+++ b/src/features/profile/pages/ChangeCity/ChangeCity.tsx
@@ -6,7 +6,7 @@ import { CitySearchInput } from 'features/profile/components/CitySearchInput/Cit
 import { Button } from 'ui/designSystem/Button/Button'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 import { useSubmitChangeCity } from './useSubmitChangeCity'
 
@@ -21,7 +21,7 @@ export const ChangeCity = () => {
       scrollChildren={
         <React.Fragment>
           <Container>
-            <Typo.Title3 {...getHeadingAttrs(2)}>Renseigne ta ville de résidence</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs(2)}>Renseigne ta ville de résidence</Typo.Title3>
           </Container>
           <Controller
             control={control}

--- a/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.tsx
+++ b/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.tsx
@@ -18,7 +18,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { showErrorSnackBar, showSuccessSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type FormValues = {
   newPassword: string
@@ -73,7 +73,7 @@ export const ChangeEmailSetPassword = () => {
       scrollChildren={
         <StyledView paddingBottom={Platform.OS === 'ios' ? keyboardHeight : 0}>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getHeadingAttrs(2)}>Crée ton mot de passe</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs(2)}>Crée ton mot de passe</Typo.Title3>
             <Typo.Body>
               Tu t’es inscrit via Google, tu ne possèdes donc pas de mot de passe actuellement.
             </Typo.Body>

--- a/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
+++ b/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
@@ -36,7 +36,7 @@ import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Close } from 'ui/svg/icons/Close'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const ConsentSettings = () => {
   const { popTo, addListener, dispatch } = useNavigation<UseNavigationType>()
@@ -182,7 +182,7 @@ export const ConsentSettings = () => {
                 setSettingsCookiesChoice={setCurrentCookieChoices}
                 offerId={offerId}
               />
-              <StyledTitle4 {...getHeadingAttrs(2)}>Tu as la main dessus</StyledTitle4>
+              <StyledTitle4 {...getTextSemanticAttrs(2)}>Tu as la main dessus</StyledTitle4>
               <StyledBody>
                 Ton choix est enregistré pour 6 mois et tu peux changer d’avis à tout moment.
               </StyledBody>

--- a/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.tsx
+++ b/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.tsx
@@ -14,7 +14,7 @@ import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { SadFace } from 'ui/svg/icons/SadFace'
 import { Spacer, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const VIEWABILITY_CONFIG = { itemVisiblePercentThreshold: 100 }
 
@@ -106,7 +106,7 @@ export function DeleteProfileReason() {
             <HeaderContainer>
               <StyledIcon />
               <TitlesContainer>
-                <Typo.Title3 {...getHeadingAttrs(1)}>
+                <Typo.Title3 {...getTextSemanticAttrs(1)}>
                   Pourquoi souhaites-tu supprimer ton compte&nbsp;?
                 </Typo.Title3>
                 <Typo.Body>

--- a/src/features/profile/pages/FeedbackInApp/FeedbackInApp.tsx
+++ b/src/features/profile/pages/FeedbackInApp/FeedbackInApp.tsx
@@ -19,7 +19,7 @@ import { showSuccessSnackBar, showErrorSnackBar } from 'ui/designSystem/Snackbar
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Spacer, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type FormValue = {
   feedback: string
@@ -65,7 +65,7 @@ export const FeedbackInApp = () => {
       scrollChildren={
         <StyledViewGap gap={6}>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getHeadingAttrs(1)}>
+            <Typo.Title3 {...getTextSemanticAttrs(1)}>
               Comment pourrions-nous améliorer l’application&nbsp;?
             </Typo.Title3>
             <Typo.Body>

--- a/src/features/profile/pages/LegalNotices/LegalNotices.tsx
+++ b/src/features/profile/pages/LegalNotices/LegalNotices.tsx
@@ -16,7 +16,7 @@ import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Typo } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export function LegalNotices() {
   const { goBack } = useGoBack(...getTabHookConfig('Profile'))
@@ -30,7 +30,7 @@ export function LegalNotices() {
       onGoBack={goBack}
       scrollChildren={
         <Container gap={5}>
-          <Typo.Title4 {...getHeadingAttrs(2)}>ÉDITEUR SAS pass Culture</Typo.Title4>
+          <Typo.Title4 {...getTextSemanticAttrs(2)}>ÉDITEUR SAS pass Culture</Typo.Title4>
           <Typo.Body>
             Éditeur du site&nbsp;:&nbsp;
             <ExternalTouchableLink

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -31,7 +31,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { showErrorSnackBar, showSuccessSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const NotificationsSettings = () => {
   const { isLoggedIn, user } = useAuthContext()
@@ -145,7 +145,7 @@ export const NotificationsSettings = () => {
               <Banner label="Tu dois être connecté pour activer les notifications et rester informé des bons plans sur le pass Culture." />
             </BannerContainer>
           )}
-          <Typo.Title4 {...getHeadingAttrs(2)}>Type d’alerte</Typo.Title4>
+          <Typo.Title4 {...getTextSemanticAttrs(2)}>Type d’alerte</Typo.Title4>
           <TextContainer>
             <Typo.Body>
               Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
@@ -177,7 +177,7 @@ export const NotificationsSettings = () => {
               </SectionWithSwitchContainer>
             )}
             <StyledSeparator />
-            <Typo.Title4 {...getHeadingAttrs(2)}>Tes thèmes suivis</Typo.Title4>
+            <Typo.Title4 {...getTextSemanticAttrs(2)}>Tes thèmes suivis</Typo.Title4>
             {!isLoggedIn || areNotificationsEnabled ? null : (
               <BannerThemeContainer>
                 <Banner label="Pour suivre un thème, tu dois accepter l’envoi d’e-mails ou de notifications." />

--- a/src/features/profile/pages/TrackEmailChange/TrackEmailChange.tsx
+++ b/src/features/profile/pages/TrackEmailChange/TrackEmailChange.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { TrackEmailChangeContent } from 'features/profile/pages/TrackEmailChange/TrackEmailChangeContent'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const TrackEmailChange = () => (
   <PageWithHeader
@@ -11,7 +11,7 @@ export const TrackEmailChange = () => (
     title="Modifier mon e-mail"
     scrollChildren={
       <React.Fragment>
-        <Typo.Title3 {...getHeadingAttrs(2)}>Suivi de ton changement d’e-mail</Typo.Title3>
+        <Typo.Title3 {...getTextSemanticAttrs(2)}>Suivi de ton changement d’e-mail</Typo.Title3>
         <TrackEmailChangeContent />
       </React.Fragment>
     }

--- a/src/features/profile/pages/Tutorial/TutorialPage.tsx
+++ b/src/features/profile/pages/Tutorial/TutorialPage.tsx
@@ -7,7 +7,7 @@ import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHe
 import { EmptyHeader } from 'ui/components/headers/EmptyHeader'
 import { Page } from 'ui/pages/Page'
 import { Spacer, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 interface Props {
   title?: string
@@ -44,7 +44,7 @@ export const TutorialPage: FunctionComponent<Props> = ({
         <Container buttons={buttons}>
           {title ? (
             <TitleContainer>
-              <Typo.Title3 numberOfLines={numberOfLines} {...getHeadingAttrs(1)}>
+              <Typo.Title3 numberOfLines={numberOfLines} {...getTextSemanticAttrs(1)}>
                 {title}
               </Typo.Title3>
             </TitleContainer>

--- a/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.tsx
+++ b/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.tsx
@@ -22,7 +22,7 @@ import { ContentHeader } from 'ui/components/headers/ContentHeader'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Page } from 'ui/pages/Page'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const headerTitle = 'Comment ça marche\u00a0?'
 
@@ -54,8 +54,8 @@ export const ProfileTutorialAgeInformationCredit = () => {
       <StyledScrollView onScroll={onScroll} scrollEventThrottle={16}>
         <Placeholder height={headerHeight} />
         <Container gap={6}>
-          <Typo.Title3 {...getHeadingAttrs(1)}>{headerTitle}</Typo.Title3>
-          <Typo.BodyS {...getHeadingAttrs(2)}>
+          <Typo.Title3 {...getTextSemanticAttrs(1)}>{headerTitle}</Typo.Title3>
+          <Typo.BodyS {...getTextSemanticAttrs(2)}>
             De 17 à 18 ans, le pass Culture offre un crédit à dépenser dans l’application pour des
             activités culturelles.
           </Typo.BodyS>

--- a/src/features/reactions/components/ReactionChoiceModalBodyWithRedirection/ReactionChoiceModalBodyWithRedirection.tsx
+++ b/src/features/reactions/components/ReactionChoiceModalBodyWithRedirection/ReactionChoiceModalBodyWithRedirection.tsx
@@ -8,7 +8,7 @@ import { OfferImage } from 'ui/components/tiles/OfferImage'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { MultipleThumbs } from 'ui/svg/icons/MultipleThumbs'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   offerImages: OfferImageBasicProps[]
@@ -44,7 +44,7 @@ export const ReactionChoiceModalBodyWithRedirection: FunctionComponent<Props> = 
         </ThumbsImageContainer>
       )}
 
-      <StyledTitle3 {...getHeadingAttrs(2)}>
+      <StyledTitle3 {...getTextSemanticAttrs(2)}>
         Qu’as-tu pensé de tes dernières réservations&nbsp;?
       </StyledTitle3>
     </Container>

--- a/src/features/search/components/AutocompleteSection/AutocompleteSection.tsx
+++ b/src/features/search/components/AutocompleteSection/AutocompleteSection.tsx
@@ -6,7 +6,7 @@ import { styled } from 'styled-components/native'
 import { Li } from 'ui/components/Li'
 import { VerticalUl } from 'ui/components/Ul'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props<T> = {
   title: string
@@ -29,7 +29,7 @@ export function AutocompleteSection<T>({ title, renderItem, ...props }: Props<T>
   )
 }
 
-const Title = styled(Typo.BodyAccentXs).attrs(getHeadingAttrs(2))(({ theme }) => ({
+const Title = styled(Typo.BodyAccentXs).attrs(getTextSemanticAttrs(2))(({ theme }) => ({
   color: theme.designSystem.color.text.subtle,
 }))
 

--- a/src/features/search/components/CategoriesListDumb/CategoriesListDumb.tsx
+++ b/src/features/search/components/CategoriesListDumb/CategoriesListDumb.tsx
@@ -8,7 +8,7 @@ import { CategoryButton } from 'shared/categoryButton/CategoryButton'
 import { NewCategoryButton } from 'shared/categoryButton/NewCategoryButton'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   sortedCategories: ListCategoryButtonProps
@@ -135,7 +135,7 @@ const CategoriesButtonsContainer = styled.View(({ theme }) => ({
 
 const CategoriesTitleV2 = styled(Typo.Title4).attrs({
   children: 'Parcours les catégories',
-  ...getHeadingAttrs(2),
+  ...getTextSemanticAttrs(2),
 })(({ theme }) => ({
   width: '100%',
   marginTop: theme.designSystem.size.spacing.l,

--- a/src/features/search/components/FilterSwitchWithLabel/FilterSwitchWithLabel.tsx
+++ b/src/features/search/components/FilterSwitchWithLabel/FilterSwitchWithLabel.tsx
@@ -8,7 +8,7 @@ import FilterSwitch from 'ui/components/FilterSwitch'
 import { InputLabel } from 'ui/components/InputLabel/InputLabel'
 import { styledInputLabel } from 'ui/components/InputLabel/styledInputLabel'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   isActive: boolean
@@ -35,7 +35,7 @@ export const FilterSwitchWithLabel: FunctionComponent<Props> = ({
   const computedAccessibilityLabel = getComputedAccessibilityLabel(label, subtitle)
 
   const TitleWithSubtitle = useMemo(() => {
-    const headingProps = Platform.OS === 'web' ? {} : getHeadingAttrs(2)
+    const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs(2)
 
     return (
       <View {...headingProps} accessibilityLabel={computedAccessibilityLabel} accessible>

--- a/src/features/search/components/NoSearchResult/NoSearchResult.tsx
+++ b/src/features/search/components/NoSearchResult/NoSearchResult.tsx
@@ -10,7 +10,7 @@ import { SuggestedPlace } from 'libs/place/types'
 import { Button } from 'ui/designSystem/Button/Button'
 import { NoOffer } from 'ui/svg/icons/NoOffer'
 import { Typo, getSpacing } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type NoSearchResultProps = {
   setSelectedLocationMode: (locationMode: LocationMode) => void
@@ -112,7 +112,7 @@ const ContainerText = styled.View(({ theme }) => ({
 }))
 
 const Title = styled(Typo.Title4).attrs({
-  ...getHeadingAttrs(2),
+  ...getTextSemanticAttrs(2),
 })(({ theme }) => ({
   marginTop: theme.designSystem.size.spacing.l,
 }))

--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -252,7 +252,9 @@ export const SearchBox: React.FunctionComponent<Props> = ({
   return (
     <RowContainer>
       {accessibleHiddenTitle ? (
-        <HiddenAccessibleText {...getTextSemanticAttrs(1)}>{accessibleHiddenTitle}</HiddenAccessibleText>
+        <HiddenAccessibleText {...getTextSemanticAttrs(1)}>
+          {accessibleHiddenTitle}
+        </HiddenAccessibleText>
       ) : null}
       <SearchInputContainer {...props}>
         <SearchInputA11yContainer>

--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -26,7 +26,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { SearchInput } from 'ui/designSystem/SearchInput/SearchInput'
 import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const SEARCH_DEBOUNCE_MS = 500
 
@@ -252,7 +252,7 @@ export const SearchBox: React.FunctionComponent<Props> = ({
   return (
     <RowContainer>
       {accessibleHiddenTitle ? (
-        <HiddenAccessibleText {...getHeadingAttrs(1)}>{accessibleHiddenTitle}</HiddenAccessibleText>
+        <HiddenAccessibleText {...getTextSemanticAttrs(1)}>{accessibleHiddenTitle}</HiddenAccessibleText>
       ) : null}
       <SearchInputContainer {...props}>
         <SearchInputA11yContainer>

--- a/src/features/search/components/SearchCustomModalHeader.tsx
+++ b/src/features/search/components/SearchCustomModalHeader.tsx
@@ -12,7 +12,7 @@ import { CloseButton } from 'ui/components/headers/CloseButton'
 import { Button } from 'ui/designSystem/Button/Button'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Typo, getSpacing } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 interface Props {
   title: string
@@ -53,7 +53,7 @@ export const SearchCustomModalHeader: React.FC<Props> = ({
             />
           ) : null}
         </ButtonContainer>
-        <StyledTitle4 numberOfLines={numberOfLine} nativeID={titleId} {...getHeadingAttrs(1)}>
+        <StyledTitle4 numberOfLines={numberOfLine} nativeID={titleId} {...getTextSemanticAttrs(1)}>
           {title}
         </StyledTitle4>
         <ButtonContainer positionInHeader="right" testID="close-button-container">

--- a/src/features/search/components/SearchHistory/SearchHistory.tsx
+++ b/src/features/search/components/SearchHistory/SearchHistory.tsx
@@ -10,7 +10,7 @@ import { Touchable } from 'ui/components/touchable/Touchable'
 import { VerticalUl } from 'ui/components/Ul'
 import { Close as DefaultClose } from 'ui/svg/icons/Close'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   history: HistoryItem[]
@@ -55,9 +55,11 @@ const StyledVerticalUl = styled(VerticalUl)(({ theme }) => ({
   marginTop: theme.designSystem.size.spacing.l,
 }))
 
-const SearchHistoryTitleText = styled(Typo.BodyAccentXs).attrs(getHeadingAttrs(2))(({ theme }) => ({
-  color: theme.designSystem.color.text.subtle,
-}))
+const SearchHistoryTitleText = styled(Typo.BodyAccentXs).attrs(getTextSemanticAttrs(2))(
+  ({ theme }) => ({
+    color: theme.designSystem.color.text.subtle,
+  })
+)
 
 const Container = styled.View<{ isEmptyQuery: boolean }>(({ isEmptyQuery, theme }) => ({
   flexDirection: 'row',

--- a/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
+++ b/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
@@ -21,7 +21,7 @@ import { ImageTile } from 'ui/components/ImageTile'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Tag } from 'ui/designSystem/Tag/Tag'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 interface SearchVenueItemProps {
   venue: AlgoliaVenue
@@ -54,7 +54,7 @@ const UnmemoizedSearchVenueItem = ({
   const { lat, lng } = venue._geoloc
   const distance = getDistance({ lat, lng }, { userLocation, selectedPlace, selectedLocationMode })
 
-  const headingProps = Platform.OS === 'web' ? {} : getHeadingAttrs(3)
+  const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs(3)
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.VENUE, {
     ...venue,
     distance: distance ? `à ${distance}` : undefined,

--- a/src/features/search/pages/ThematicSearch/ThematicSearchSubcategories.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearchSubcategories.tsx
@@ -16,7 +16,7 @@ import { SubcategoryButton } from 'ui/components/buttons/SubcategoryButton/Subca
 import { ContentHeader } from 'ui/components/headers/ContentHeader'
 import { Page } from 'ui/pages/Page'
 import { Spacer, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const TITLE = 'Tout parcourir'
 const MOBILE_MIN_WIDTH = '40%'
@@ -72,7 +72,7 @@ export const ThematicSearchSubcategories = () => {
     <Page>
       <StyledScrollView onScroll={onScroll} scrollEventThrottle={16}>
         <Placeholder height={headerHeight} />
-        <Title {...getHeadingAttrs(1)}>{TITLE}</Title>
+        <Title {...getTextSemanticAttrs(1)}>{TITLE}</Title>
         <SubcategoryButtonsContainer>
           {subcategoryButtonContent.map((item) => (
             <StyledSubcategoryButton

--- a/src/features/share/components/MessagingApps/MessagingApps.tsx
+++ b/src/features/share/components/MessagingApps/MessagingApps.tsx
@@ -11,7 +11,7 @@ import { ShareMessagingAppOther } from 'ui/components/ShareMessagingAppOther'
 import { Ul } from 'ui/components/Ul'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   shareContent: ShareContent
@@ -36,7 +36,7 @@ export const MessagingApps = ({ shareContent, share, messagingAppAnalytics }: Pr
 
   return (
     <ViewGap gap={4}>
-      <Typo.Title3 {...getHeadingAttrs(2)}>{'Passe le bon plan\u00a0!'}</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs(2)}>{'Passe le bon plan\u00a0!'}</Typo.Title3>
       <IconsWrapper>
         <StyledUl>
           <InstalledMessagingApps

--- a/src/features/subscription/components/ThematicSubscriptionBlock.tsx
+++ b/src/features/subscription/components/ThematicSubscriptionBlock.tsx
@@ -10,7 +10,7 @@ import { ButtonContainerFlexStart } from 'ui/designSystem/Button/ButtonContainer
 import { Bell } from 'ui/svg/icons/Bell'
 import { BellFilled } from 'ui/svg/icons/BellFilled'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 interface Props {
   thematic: SubscriptionTheme
@@ -37,7 +37,7 @@ export const ThematicSubscriptionBlock = ({
     <Container>
       <SubscriptionThematicIllustration thematic={thematic} size="medium" />
       <ContentContainer>
-        <Typo.BodyAccent {...getHeadingAttrs(2)}>{title}</Typo.BodyAccent>
+        <Typo.BodyAccent {...getTextSemanticAttrs(2)}>{title}</Typo.BodyAccent>
         <Subtitle>{subtitle}</Subtitle>
         <ButtonContainerFlexStart>
           <Button

--- a/src/features/venue/components/PracticalInformation/PracticalInformation.tsx
+++ b/src/features/venue/components/PracticalInformation/PracticalInformation.tsx
@@ -9,7 +9,7 @@ import { BasicAccessibilityInfo } from 'ui/components/accessibility/BasicAccessi
 import { DetailedAccessibilityInfo } from 'ui/components/accessibility/DetailedAccessibilityInfo'
 import { Separator } from 'ui/components/Separator'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 import { OpeningHours } from '../OpeningHours/OpeningHours'
 
@@ -135,7 +135,7 @@ const SectionComponent: FunctionComponent<{ title: string; children?: ReactNode 
   children,
 }) => (
   <StyledViewGap>
-    <Typo.BodyAccentXs {...getHeadingAttrs(2)}>{title}</Typo.BodyAccentXs>
+    <Typo.BodyAccentXs {...getTextSemanticAttrs(2)}>{title}</Typo.BodyAccentXs>
     {children}
   </StyledViewGap>
 )

--- a/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.tsx
+++ b/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.tsx
@@ -12,7 +12,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   venue: VenueResponse
@@ -38,7 +38,7 @@ export const VenueAdvicesSection: FunctionComponent<Props> = ({
   return (
     <Container gap={4}>
       <Gutter>
-        <StyledTitle3 {...getHeadingAttrs(3)} numberOfLines={2}>
+        <StyledTitle3 {...getTextSemanticAttrs(3)} numberOfLines={2}>
           {`Les avis par “${venue.name}”`}
         </StyledTitle3>
       </Gutter>

--- a/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.web.tsx
+++ b/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.web.tsx
@@ -15,7 +15,7 @@ import { TagVariant } from 'ui/designSystem/Tag/types'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Show } from 'ui/svg/icons/Show'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   venue: VenueResponse
@@ -44,7 +44,7 @@ export const VenueAdvicesSection: FunctionComponent<Props> = ({
   const TitleContent = (
     <Row>
       <StyledTitle3
-        {...getHeadingAttrs(3)}
+        {...getTextSemanticAttrs(3)}
         numberOfLines={2}
         enableNewTagProAdvices={enableNewTagProAdvices}>
         {`Les avis par “${venue.name}”`}

--- a/src/features/venue/components/VenueBody/VenueBody.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.tsx
@@ -20,7 +20,7 @@ import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 interface Props {
   venue: VenueResponse
@@ -93,7 +93,7 @@ export const VenueBody: FunctionComponent<Props> = ({
       <React.Fragment>
         {headlineOfferData ? (
           <MarginContainer>
-            <StyledTitle3 {...getHeadingAttrs(2)}>À la une</StyledTitle3>
+            <StyledTitle3 {...getTextSemanticAttrs(2)}>À la une</StyledTitle3>
             <HeadlineOffer
               navigateTo={{ screen: 'Offer', params: { id: headlineOfferData.id } }}
               {...headlineOfferData}

--- a/src/features/venue/components/VenueOffers/VenueMovies.tsx
+++ b/src/features/venue/components/VenueOffers/VenueMovies.tsx
@@ -18,7 +18,7 @@ import { useScrollToAnchor } from 'ui/components/anchor/AnchorContext'
 import { PassPlaylist } from 'ui/components/PassPlaylist'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 import { LENGTH_M, RATIO_HOME_IMAGE, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const cinemaCTAButtonName = 'Accéder aux séances'
 const playlistTitle = 'Les autres offres'
@@ -116,7 +116,7 @@ const Container = styled.View(({ theme }) => ({
     : theme.designSystem.size.spacing.xl,
 }))
 
-const StyledTitle3 = styled(Typo.Title3).attrs(getHeadingAttrs(2))(({ theme }) => ({
+const StyledTitle3 = styled(Typo.Title3).attrs(getTextSemanticAttrs(2))(({ theme }) => ({
   marginLeft: theme.designSystem.size.spacing.xl,
 }))
 

--- a/src/features/venue/components/VenueOffers/VenueMoviesV2.tsx
+++ b/src/features/venue/components/VenueOffers/VenueMoviesV2.tsx
@@ -18,7 +18,7 @@ import { useScrollToAnchor } from 'ui/components/anchor/AnchorContext'
 import { PassPlaylist } from 'ui/components/PassPlaylist'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 import { LENGTH_M, RATIO_HOME_IMAGE, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const cinemaCTAButtonName = 'Accéder aux séances'
 const playlistTitle = 'Les autres offres'
@@ -117,7 +117,7 @@ const Container = styled.View(({ theme }) => ({
     : theme.designSystem.size.spacing.xl,
 }))
 
-const StyledTitle3 = styled(Typo.Title3).attrs(getHeadingAttrs(2))(({ theme }) => ({
+const StyledTitle3 = styled(Typo.Title3).attrs(getTextSemanticAttrs(2))(({ theme }) => ({
   marginLeft: theme.designSystem.size.spacing.xl,
 }))
 

--- a/src/features/venue/components/VenueOffers/VenueOffersList.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffersList.tsx
@@ -33,7 +33,7 @@ import { CustomListRenderItem } from 'ui/components/Playlist'
 import { SeeAllButton } from 'ui/components/SeeAllButton/SeeAllButton'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { getSpacing, LENGTH_M, RATIO_HOME_IMAGE, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const keyExtractor = (item: Offer) => item.objectID
 
@@ -218,7 +218,7 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
         <ArtistsPlaylistContainer gap={2}>
           <SeeAllButtonContainer gap={3}>
             <TitleContainer>
-              <Typo.Title3 {...getHeadingAttrs(2)}>{playlistTitle}</Typo.Title3>
+              <Typo.Title3 {...getTextSemanticAttrs(2)}>{playlistTitle}</Typo.Title3>
             </TitleContainer>
             {artists.length > 1 ? (
               <SeeAllButton

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
@@ -21,7 +21,7 @@ import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GroupTags } from 'ui/GroupTags/GroupTags'
 import { Typo, getSpacing } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   venue: VenueResponse
@@ -184,7 +184,7 @@ const TopContainer = styled.View<{ hasVolunteer?: boolean }>(({ theme, hasVolunt
   }
 })
 
-const VenueTitle = styled(Typo.Title3).attrs(getHeadingAttrs(1))``
+const VenueTitle = styled(Typo.Title3).attrs(getTextSemanticAttrs(1))``
 
 const MarginContainer = styled.View(({ theme }) => ({
   marginLeft: theme.isDesktopViewport ? getSpacing(13.5) : theme.designSystem.size.spacing.xl,

--- a/src/libs/network/OfflinePage.tsx
+++ b/src/libs/network/OfflinePage.tsx
@@ -11,7 +11,7 @@ import { BrokenConnection as InitialBrokenConnection } from 'ui/svg/BrokenConnec
 import { Bookings } from 'ui/svg/icons/Bookings'
 import { Connect } from 'ui/svg/icons/Connect'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const OfflinePage = () => {
   const { isLoggedIn } = useAuthContext()
@@ -58,11 +58,11 @@ const Container = styled(Page)({
   alignItems: 'center',
 })
 
-const StyledTitle2 = styled(Typo.Title2).attrs(() => getHeadingAttrs(1))({
+const StyledTitle2 = styled(Typo.Title2).attrs(() => getTextSemanticAttrs(1))({
   textAlign: 'center',
 })
 
-const StyledBody = styled(Typo.Body).attrs(() => getHeadingAttrs(2))({
+const StyledBody = styled(Typo.Body).attrs(() => getTextSemanticAttrs(2))({
   textAlign: 'center',
 })
 

--- a/src/shared/verticalPlaylist/components/VerticalPlaylistOffersView.tsx
+++ b/src/shared/verticalPlaylist/components/VerticalPlaylistOffersView.tsx
@@ -30,7 +30,7 @@ import { Page } from 'ui/pages/Page'
 import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { RATIO_HOME_IMAGE, Spacer, Typo } from 'ui/theme'
 import { AVATAR_SMALL } from 'ui/theme/constants'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 const isWeb = Platform.OS === 'web'
 const numColumns = 2
@@ -158,7 +158,7 @@ export const VerticalPlaylistOffersView = ({
           <React.Fragment>
             <Placeholder height={headerHeight} />
 
-            <Typo.Title2 {...getHeadingAttrs(1)}>{title}</Typo.Title2>
+            <Typo.Title2 {...getTextSemanticAttrs(1)}>{title}</Typo.Title2>
             {artist ? (
               <InternalTouchableLink
                 navigateTo={{ screen: 'Artist', params: { id: artist.id } }}

--- a/src/shared/verticalPlaylist/pages/VerticalPlaylistArtists.tsx
+++ b/src/shared/verticalPlaylist/pages/VerticalPlaylistArtists.tsx
@@ -15,7 +15,7 @@ import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition
 import { ContentHeader } from 'ui/components/headers/ContentHeader'
 import { Page } from 'ui/pages/Page'
 import { Spacer, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const VerticalPlaylistArtists = () => {
   const headerHeight = useGetHeaderHeight()
@@ -47,7 +47,7 @@ export const VerticalPlaylistArtists = () => {
         ListHeaderComponent={
           <React.Fragment>
             <Placeholder height={headerHeight} />
-            <Typo.Title2 {...getHeadingAttrs(1)}>{title}</Typo.Title2>
+            <Typo.Title2 {...getTextSemanticAttrs(1)}>{title}</Typo.Title2>
             {subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
             <TitleContainer>
               <NumberOfItems nbItems={nbItems} type="artists" />

--- a/src/shared/verticalPlaylist/pages/VerticalPlaylistVenues.tsx
+++ b/src/shared/verticalPlaylist/pages/VerticalPlaylistVenues.tsx
@@ -16,7 +16,7 @@ import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition
 import { ContentHeader } from 'ui/components/headers/ContentHeader'
 import { Page } from 'ui/pages/Page'
 import { Spacer, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const VerticalPlaylistVenues = () => {
   const { params } = useRoute<UseRouteType<'VerticalPlaylistVenues'>>()
@@ -79,7 +79,7 @@ export const VerticalPlaylistVenues = () => {
         ListHeaderComponent={
           <React.Fragment>
             <Placeholder height={headerHeight} />
-            <Typo.Title2 {...getHeadingAttrs(1)}>{title}</Typo.Title2>
+            <Typo.Title2 {...getTextSemanticAttrs(1)}>{title}</Typo.Title2>
             {subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
             <TitleContainer>
               <NumberOfItems nbItems={nbItems} type="venues" />

--- a/src/ui/components/Accordion.tsx
+++ b/src/ui/components/Accordion.tsx
@@ -20,7 +20,7 @@ import { extractTextFromReactNode } from 'shared/extractTextFromReactNode/extrac
 import { ANIMATION_USE_NATIVE_DRIVER } from 'ui/components/animationUseNativeDriver'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 import { ArrowNext as DefaultArrowNext } from '../svg/icons/ArrowNext'
 import { Typo } from '../theme'
@@ -137,7 +137,7 @@ export const Accordion = ({
           {...focusProps}
           {...accessibilityProps}>
           <StyledTitleContainer nativeID={accordionLabelId} style={titleStyle}>
-            <Title {...getHeadingAttrs(3)}>{title}</Title>
+            <Title {...getTextSemanticAttrs(3)}>{title}</Title>
             <StyledArrowAnimatedView
               style={{ transform: [{ rotateZ: arrowAngle }] }}
               testID="accordionArrow">

--- a/src/ui/components/ActionCardBase.tsx
+++ b/src/ui/components/ActionCardBase.tsx
@@ -9,7 +9,7 @@ import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ArrowRight } from 'ui/svg/icons/ArrowRight'
 import { Typo } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
 
 type ActionCardLayout = 'split' | 'overlay'
@@ -73,7 +73,7 @@ export const ActionCardBase: FunctionComponent<Props> = ({
         </DateText>
       ) : null}
       {title ? (
-        <Title testID="firstLine" numberOfLines={3} {...getHeadingAttrs(2)}>
+        <Title testID="firstLine" numberOfLines={3} {...getTextSemanticAttrs(2)}>
           {title}
         </Title>
       ) : null}

--- a/src/ui/components/ActionCardBase.tsx
+++ b/src/ui/components/ActionCardBase.tsx
@@ -9,8 +9,8 @@ import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ArrowRight } from 'ui/svg/icons/ArrowRight'
 import { Typo } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type ActionCardLayout = 'split' | 'overlay'
 

--- a/src/ui/components/InputLabel/InputLabel.web.tsx
+++ b/src/ui/components/InputLabel/InputLabel.web.tsx
@@ -16,7 +16,6 @@ const StyledLabel = styled.label<{ color?: TextColorKey }>(({ theme }) => ({
   cursor: 'pointer',
 }))
 
-// Trouver un moyen d'utiliser le getHeadingAttrs() + role label en web
 export const InputLabel: React.FC<InputLabelProps> = ({ children, ...props }) => {
   return <StyledLabel {...props}>{children}</StyledLabel>
 }

--- a/src/ui/components/InputLabel/InputLabel.web.tsx
+++ b/src/ui/components/InputLabel/InputLabel.web.tsx
@@ -16,6 +16,7 @@ const StyledLabel = styled.label<{ color?: TextColorKey }>(({ theme }) => ({
   cursor: 'pointer',
 }))
 
+// Trouver un moyen d'utiliser le getHeadingAttrs() + role label en web
 export const InputLabel: React.FC<InputLabelProps> = ({ children, ...props }) => {
   return <StyledLabel {...props}>{children}</StyledLabel>
 }

--- a/src/ui/components/PassPlaylist.tsx
+++ b/src/ui/components/PassPlaylist.tsx
@@ -12,7 +12,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Tag } from 'ui/designSystem/Tag/Tag'
 import { TagVariant } from 'ui/designSystem/Tag/types'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 import { SeeAllButton } from './SeeAllButton/SeeAllButton'
 
@@ -144,7 +144,7 @@ const StyledViewGap = styled(ViewGap)<{ noMarginBottom?: boolean }>(
   })
 )
 
-const TitleLevel2 = styled(Typo.Title3).attrs(getHeadingAttrs(2))``
+const TitleLevel2 = styled(Typo.Title3).attrs(getTextSemanticAttrs(2))``
 
 const StyledSubtitle = styled(Typo.BodyAccentXs).attrs<{
   windowWidth?: number

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonList.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonList.tsx
@@ -11,7 +11,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type SubcategoryButtonListProps = {
   subcategoryButtonContent: SubcategoryButtonItem[]
@@ -134,7 +134,7 @@ const Header = ({
   onBeforeSeeAllNavigate,
 }: HeaderProps) => (
   <HeaderContainer>
-    <Typo.Title4 {...getHeadingAttrs(2)}>Tout parcourir</Typo.Title4>
+    <Typo.Title4 {...getTextSemanticAttrs(2)}>Tout parcourir</Typo.Title4>
     {shouldDisplaySeeAllButton && seeAllNavigateTo ? (
       <InternalTouchableLink
         as={Button}

--- a/src/ui/components/headers/ContentHeader.tsx
+++ b/src/ui/components/headers/ContentHeader.tsx
@@ -12,7 +12,7 @@ import { BlurryWrapper } from 'ui/components/BlurryWrapper/BlurryWrapper'
 import { Button } from 'ui/designSystem/Button/Button'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Typo, getSpacing } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type AnimatedBlurHeaderFullProps = {
   headerTitle?: string
@@ -73,7 +73,7 @@ export const ContentHeader = ({
         {LeftElement}
         <TitleContainer>
           <Title
-            {...getHeadingAttrs(1)}
+            {...getTextSemanticAttrs(1)}
             testID={titleTestID}
             style={{
               opacity: customHeaderTitleTransition ?? headerTransition,

--- a/src/ui/components/headers/PageHeaderWithoutPlaceholder.tsx
+++ b/src/ui/components/headers/PageHeaderWithoutPlaceholder.tsx
@@ -10,7 +10,7 @@ import { useGetHeaderHeightDS } from 'shared/header/useGetHeaderHeight'
 import { Button } from 'ui/designSystem/Button/Button'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Spacer, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 interface Props {
   title?: string
@@ -102,7 +102,7 @@ const TitleContainer = styled.View({ flex: 1, alignItems: 'center' })
 
 const Title = styled(Typo.Title4).attrs<{ numberOfLines?: number }>(({ numberOfLines }) => ({
   numberOfLines,
-  ...getHeadingAttrs(1),
+  ...getTextSemanticAttrs(1),
 }))({
   textAlign: 'center',
 })

--- a/src/ui/components/modals/MarketingModal.tsx
+++ b/src/ui/components/modals/MarketingModal.tsx
@@ -8,7 +8,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { getSpacing, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 interface Props {
   visible: boolean
@@ -71,7 +71,7 @@ const Gradient = styled(LinearGradient).attrs<{ colors?: string[] }>(({ theme })
   marginTop: -GRADIENT_SIZE,
 })
 
-const Title = styled(Typo.Title3).attrs(() => getHeadingAttrs(1))({
+const Title = styled(Typo.Title3).attrs(() => getTextSemanticAttrs(1))({
   textAlign: 'center',
 })
 

--- a/src/ui/components/modals/ModalHeader.tsx
+++ b/src/ui/components/modals/ModalHeader.tsx
@@ -8,7 +8,7 @@ import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHe
 import { ModalSpacing } from 'ui/components/modals/enum'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 import { ModalIconProps } from './types'
 
@@ -111,6 +111,6 @@ const HeaderActionContainer = styled.View<{ justifyContent: 'left' | 'right' }>(
   }
 )
 
-const Title = styled(Typo.Title4).attrs(() => getHeadingAttrs(1))({
+const Title = styled(Typo.Title4).attrs(() => getTextSemanticAttrs(1))({
   textAlign: 'center',
 })

--- a/src/ui/designSystem/Button/ButtonBase.tsx
+++ b/src/ui/designSystem/Button/ButtonBase.tsx
@@ -12,6 +12,7 @@ import { useHandleHover } from 'libs/hooks/useHandleHover'
 import { getComputedAccessibilityLabel } from 'shared/accessibility/helpers/getComputedAccessibilityLabel'
 import { ColorsType } from 'theme/types'
 import { Typo } from 'ui/theme'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 import { getButtonColors } from './Button.colors'
 import {
@@ -130,6 +131,7 @@ export const ButtonBase: FunctionComponent<ButtonBaseProps> = ({
           {leftIcon ? <IconWrapper style={iconAnimatedStyle}>{leftIcon}</IconWrapper> : null}
           {labelText ? (
             <LabelTypo
+              {...getTextSemanticAttrs('span')}
               style={labelStyle}
               numberOfLines={numberOfLines}
               ellipsizeMode={ellipsizeMode}>

--- a/src/ui/designSystem/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/ui/designSystem/CheckboxGroup/CheckboxGroup.tsx
@@ -18,7 +18,7 @@ import {
 } from 'ui/designSystem/CheckboxGroup/types'
 import { SelectableVariant } from 'ui/designSystem/types'
 import { Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export const CheckboxGroup = <T extends string = string>({
   label,
@@ -59,7 +59,7 @@ export const CheckboxGroup = <T extends string = string>({
   }
 
   const headingAttrs = labelTagOverrideForAccessibility
-    ? getHeadingAttrs(labelTagOverrideForAccessibility)
+    ? getTextSemanticAttrs(labelTagOverrideForAccessibility)
     : {}
 
   return (

--- a/src/ui/pages/GenericErrorPage.tsx
+++ b/src/ui/pages/GenericErrorPage.tsx
@@ -11,7 +11,7 @@ import { Page } from 'ui/pages/Page'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { Typo } from 'ui/theme'
 import { illustrationSizes } from 'ui/theme/illustrationSizes'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type ButtonProps = {
   wording: string
@@ -87,9 +87,9 @@ export const GenericErrorPage: FunctionComponent<Props> = ({
               ) : null}
             </IllustrationContainer>
             <TextContainer gap={4}>
-              <StyledTitle {...getHeadingAttrs(1)}>{title}</StyledTitle>
+              <StyledTitle {...getTextSemanticAttrs(1)}>{title}</StyledTitle>
               {subtitle ? (
-                <StyledSubtitle {...getHeadingAttrs(2)}>{subtitle}</StyledSubtitle>
+                <StyledSubtitle {...getTextSemanticAttrs(2)}>{subtitle}</StyledSubtitle>
               ) : null}
             </TextContainer>
             {children ? <ChildrenContainer>{children}</ChildrenContainer> : null}

--- a/src/ui/pages/GenericInfoPage.tsx
+++ b/src/ui/pages/GenericInfoPage.tsx
@@ -27,7 +27,7 @@ import { Page } from 'ui/pages/Page'
 import { AccessibleIcon, AccessibleRectangleIcon } from 'ui/svg/icons/types'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { illustrationSizes } from 'ui/theme/illustrationSizes'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 export type ButtonProps = {
   wording: string
@@ -164,8 +164,8 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
               ) : null}
             </IllustrationContainer>
             <TextContainer gap={4} flex={flexMobile}>
-              <StyledTitle2 {...getHeadingAttrs(1)}>{title}</StyledTitle2>
-              {subtitle ? <StyledBody {...getHeadingAttrs(2)}>{subtitle}</StyledBody> : null}
+              <StyledTitle2 {...getTextSemanticAttrs(1)}>{title}</StyledTitle2>
+              {subtitle ? <StyledBody {...getTextSemanticAttrs(2)}>{subtitle}</StyledBody> : null}
             </TextContainer>
 
             {children ? <ChildrenContainer>{children}</ChildrenContainer> : null}

--- a/src/ui/pages/GenericOfficialPage.tsx
+++ b/src/ui/pages/GenericOfficialPage.tsx
@@ -6,7 +6,7 @@ import { Page } from 'ui/pages/Page'
 import { LogoPassCulture } from 'ui/svg/icons/LogoPassCulture'
 import { LogoFrenchRepublic } from 'ui/svg/LogoFrenchRepublic'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
 type Props = {
   noIndex?: boolean
@@ -49,7 +49,7 @@ export function GenericOfficialPage({
       <Content>
         {isTouch ? <TopTouch /> : null}
         <TitleContainer>
-          <Typo.Title2 {...getHeadingAttrs(1)}>{title}</Typo.Title2>
+          <Typo.Title2 {...getTextSemanticAttrs(1)}>{title}</Typo.Title2>
         </TitleContainer>
         {children}
         {isTouch ? <BottomTouch marginTop={getButtonSpaces()} /> : null}

--- a/src/ui/theme/isHeadingLevel.ts
+++ b/src/ui/theme/isHeadingLevel.ts
@@ -1,5 +1,7 @@
-import { HeadingLevel } from 'ui/theme/typographyAttrs/types'
+import { TextSemanticLevel } from 'ui/theme/typographyAttrs/types'
 
-export const isHeadingLevel = (level: unknown): level is Exclude<HeadingLevel, 'p'> => {
+export const isHeadingLevel = (
+  level: unknown
+): level is Exclude<TextSemanticLevel, 'p' | 'span'> => {
   return typeof level === 'number' && [1, 2, 3, 4].includes(level)
 }

--- a/src/ui/theme/typography.tsx
+++ b/src/ui/theme/typography.tsx
@@ -5,20 +5,23 @@ import styled from 'styled-components/native'
 import { theme } from 'theme'
 import { TextColorKey } from 'theme/types'
 import { isHeadingLevel } from 'ui/theme/isHeadingLevel'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
-import { HeadingLevel } from 'ui/theme/typographyAttrs/types'
+import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { TextSemanticLevel } from 'ui/theme/typographyAttrs/types'
 
 const DEFAULT_COLOR_TEXT = 'default'
 
 const createStyledText = (
   typographyStyle: keyof typeof theme.designSystem.typography,
-  defaultLevel?: HeadingLevel
+  defaultLevel?: TextSemanticLevel
 ) => {
-  return styled(RNText).attrs<{ accessibilityLevel?: HeadingLevel }>(({ accessibilityLevel }) => {
-    if (isHeadingLevel(accessibilityLevel)) return getHeadingAttrs(accessibilityLevel)
-    else if (isHeadingLevel(defaultLevel)) return getHeadingAttrs(defaultLevel)
-    return {}
-  })<{ color?: TextColorKey }>(({ theme, color }) => ({
+  return styled(RNText).attrs<{ accessibilityLevel?: TextSemanticLevel }>(
+    ({ accessibilityLevel }) => {
+      const level = accessibilityLevel ?? defaultLevel
+      if (isHeadingLevel(level)) return getTextSemanticAttrs(level)
+      return getNoHeadingAttrs()
+    }
+  )<{ color?: TextColorKey }>(({ theme, color }) => ({
     ...theme.designSystem.typography[typographyStyle],
     color: theme.designSystem.color.text[color ?? DEFAULT_COLOR_TEXT],
   }))

--- a/src/ui/theme/typography.tsx
+++ b/src/ui/theme/typography.tsx
@@ -10,11 +10,6 @@ import { HeadingLevel } from 'ui/theme/typographyAttrs/types'
 
 const DEFAULT_COLOR_TEXT = 'default'
 
-type HeadingProps = {
-  accessibilityLevel?: HeadingLevel
-  noHeading?: boolean
-}
-
 const createStyledText = (
   typographyStyle: keyof typeof theme.designSystem.typography,
   defaultLevel?: HeadingLevel

--- a/src/ui/theme/typography.tsx
+++ b/src/ui/theme/typography.tsx
@@ -10,6 +10,11 @@ import { HeadingLevel } from 'ui/theme/typographyAttrs/types'
 
 const DEFAULT_COLOR_TEXT = 'default'
 
+type HeadingProps = {
+  accessibilityLevel?: HeadingLevel
+  noHeading?: boolean
+}
+
 const createStyledText = (
   typographyStyle: keyof typeof theme.designSystem.typography,
   defaultLevel?: HeadingLevel

--- a/src/ui/theme/typography.web.tsx
+++ b/src/ui/theme/typography.web.tsx
@@ -42,7 +42,6 @@ const createStyledText = (
     const level = accessibilityLevel ?? defaultLevel
     let tag: React.ElementType = 'p'
     if (level === 'span') tag = 'span'
-    else if (level === 'p') tag = 'p'
     else if (isHeadingLevel(level)) tag = `h${level}`
     return <StyledText as={tag} numberOfLines={numberOfLines} {...props} />
   }

--- a/src/ui/theme/typography.web.tsx
+++ b/src/ui/theme/typography.web.tsx
@@ -5,13 +5,13 @@ import styled from 'styled-components'
 import { theme } from 'theme'
 import { TextColorKey } from 'theme/types'
 import { isHeadingLevel } from 'ui/theme/isHeadingLevel'
-import { HeadingLevel } from 'ui/theme/typographyAttrs/types'
+import { TextSemanticLevel } from 'ui/theme/typographyAttrs/types'
 
 const DEFAULT_COLOR_TEXT = 'default'
 
 const createStyledText = (
   typographyStyle: keyof typeof theme.designSystem.typography,
-  defaultLevel?: HeadingLevel
+  defaultLevel?: TextSemanticLevel
 ) => {
   const StyledText = styled.p<{ theme; color?: TextColorKey; numberOfLines?: number }>(
     ({ theme, color, numberOfLines }) => ({
@@ -33,16 +33,17 @@ const createStyledText = (
   )
 
   type Props = React.ComponentPropsWithoutRef<typeof StyledText> & {
-    accessibilityLevel?: HeadingLevel
+    accessibilityLevel?: TextSemanticLevel
     numberOfLines?: number
     color?: TextColorKey
   }
 
   const Component = ({ accessibilityLevel, numberOfLines, ...props }: Props) => {
     const level = accessibilityLevel ?? defaultLevel
-    const isValidHeading = level !== 'p' && isHeadingLevel(level)
-    const tag = isValidHeading ? `h${level}` : 'p'
-
+    let tag: React.ElementType = 'p'
+    if (level === 'span') tag = 'span'
+    else if (level === 'p') tag = 'p'
+    else if (isHeadingLevel(level)) tag = `h${level}`
     return <StyledText as={tag} numberOfLines={numberOfLines} {...props} />
   }
 

--- a/src/ui/theme/typographyAttrs/getHeadingAttrs.ts
+++ b/src/ui/theme/typographyAttrs/getHeadingAttrs.ts
@@ -1,7 +1,0 @@
-import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
-import { HeadingAttrs, HeadingLevel } from 'ui/theme/typographyAttrs/types'
-
-export const getHeadingAttrs = (_level: HeadingLevel): HeadingAttrs => ({
-  accessibilityRole: AccessibilityRole.HEADER,
-  accessibilityLevel: undefined,
-})

--- a/src/ui/theme/typographyAttrs/getHeadingAttrs.web.ts
+++ b/src/ui/theme/typographyAttrs/getHeadingAttrs.web.ts
@@ -1,6 +1,0 @@
-import { HeadingAttrs, HeadingLevel } from 'ui/theme/typographyAttrs/types'
-
-export const getHeadingAttrs = (level: HeadingLevel): HeadingAttrs => ({
-  accessibilityRole: undefined,
-  accessibilityLevel: level,
-})

--- a/src/ui/theme/typographyAttrs/getTextSemanticAttrs.native.test.ts
+++ b/src/ui/theme/typographyAttrs/getTextSemanticAttrs.native.test.ts
@@ -1,7 +1,7 @@
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
-describe('getHeadingAttrs()', () => {
+describe('getTextSemanticAttrs()', () => {
   it.each`
     headingLevel | accessibilityLevel | accessibilityRole
     ${1}         | ${undefined}       | ${AccessibilityRole.HEADER}
@@ -11,9 +11,9 @@ describe('getHeadingAttrs()', () => {
     ${5}         | ${undefined}       | ${AccessibilityRole.HEADER}
     ${6}         | ${undefined}       | ${AccessibilityRole.HEADER}
   `(
-    "getHeadingAttrs($headingLevel) = {accessibilityRole: $accessibilityRole, accessibilityLevel: $accessibilityLevel, dir: 'ltr'}",
+    "getTextSemanticAttrs($headingLevel) = {accessibilityRole: $accessibilityRole, accessibilityLevel: $accessibilityLevel, dir: 'ltr'}",
     ({ headingLevel, accessibilityLevel, accessibilityRole }) => {
-      expect(getHeadingAttrs(headingLevel)).toEqual({
+      expect(getTextSemanticAttrs(headingLevel)).toEqual({
         accessibilityRole,
         accessibilityLevel,
       })

--- a/src/ui/theme/typographyAttrs/getTextSemanticAttrs.native.test.ts
+++ b/src/ui/theme/typographyAttrs/getTextSemanticAttrs.native.test.ts
@@ -4,12 +4,12 @@ import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAt
 describe('getTextSemanticAttrs()', () => {
   it.each`
     headingLevel | accessibilityLevel | accessibilityRole
-    ${1}         | ${undefined}       | ${AccessibilityRole.HEADER}
-    ${2}         | ${undefined}       | ${AccessibilityRole.HEADER}
-    ${3}         | ${undefined}       | ${AccessibilityRole.HEADER}
-    ${4}         | ${undefined}       | ${AccessibilityRole.HEADER}
-    ${5}         | ${undefined}       | ${AccessibilityRole.HEADER}
-    ${6}         | ${undefined}       | ${AccessibilityRole.HEADER}
+    ${1}         | ${1}               | ${AccessibilityRole.HEADER}
+    ${2}         | ${2}               | ${AccessibilityRole.HEADER}
+    ${3}         | ${3}               | ${AccessibilityRole.HEADER}
+    ${4}         | ${4}               | ${AccessibilityRole.HEADER}
+    ${'p'}       | ${'p'}             | ${AccessibilityRole.HEADER}
+    ${'span'}    | ${'span'}          | ${AccessibilityRole.HEADER}
   `(
     "getTextSemanticAttrs($headingLevel) = {accessibilityRole: $accessibilityRole, accessibilityLevel: $accessibilityLevel, dir: 'ltr'}",
     ({ headingLevel, accessibilityLevel, accessibilityRole }) => {

--- a/src/ui/theme/typographyAttrs/getTextSemanticAttrs.ts
+++ b/src/ui/theme/typographyAttrs/getTextSemanticAttrs.ts
@@ -1,0 +1,7 @@
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import { HeadingAttrs, TextSemanticLevel } from 'ui/theme/typographyAttrs/types'
+
+export const getTextSemanticAttrs = (level: TextSemanticLevel): HeadingAttrs => ({
+  accessibilityRole: AccessibilityRole.HEADER,
+  accessibilityLevel: level,
+})

--- a/src/ui/theme/typographyAttrs/getTextSemanticAttrs.web.test.ts
+++ b/src/ui/theme/typographyAttrs/getTextSemanticAttrs.web.test.ts
@@ -8,6 +8,7 @@ describe('getTextSemanticAttrs()', () => {
     ${3}
     ${4}
     ${'p'}
+    ${'span'}
   `('should return accessibilityLevel $accessibilityLevel', ({ accessibilityLevel }) => {
     expect(getTextSemanticAttrs(accessibilityLevel)).toEqual({
       accessibilityRole: undefined,

--- a/src/ui/theme/typographyAttrs/getTextSemanticAttrs.web.test.ts
+++ b/src/ui/theme/typographyAttrs/getTextSemanticAttrs.web.test.ts
@@ -1,6 +1,6 @@
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 
-describe('getHeadingAttrs()', () => {
+describe('getTextSemanticAttrs()', () => {
   it.each`
     accessibilityLevel
     ${1}
@@ -9,7 +9,7 @@ describe('getHeadingAttrs()', () => {
     ${4}
     ${'p'}
   `('should return accessibilityLevel $accessibilityLevel', ({ accessibilityLevel }) => {
-    expect(getHeadingAttrs(accessibilityLevel)).toEqual({
+    expect(getTextSemanticAttrs(accessibilityLevel)).toEqual({
       accessibilityRole: undefined,
       accessibilityLevel,
     })

--- a/src/ui/theme/typographyAttrs/getTextSemanticAttrs.web.ts
+++ b/src/ui/theme/typographyAttrs/getTextSemanticAttrs.web.ts
@@ -1,0 +1,6 @@
+import { HeadingAttrs, TextSemanticLevel } from 'ui/theme/typographyAttrs/types'
+
+export const getTextSemanticAttrs = (level: TextSemanticLevel): HeadingAttrs => ({
+  accessibilityRole: undefined,
+  accessibilityLevel: level,
+})

--- a/src/ui/theme/typographyAttrs/types.ts
+++ b/src/ui/theme/typographyAttrs/types.ts
@@ -1,8 +1,8 @@
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 
-export type HeadingLevel = 1 | 2 | 3 | 4 | 'p'
+export type TextSemanticLevel = 1 | 2 | 3 | 4 | 'p' | 'span'
 
 export type HeadingAttrs = {
   accessibilityRole?: AccessibilityRole
-  accessibilityLevel?: HeadingLevel
+  accessibilityLevel?: TextSemanticLevel
 }

--- a/src/web/BrowserNotSupportedPage.web.tsx
+++ b/src/web/BrowserNotSupportedPage.web.tsx
@@ -12,7 +12,7 @@ import { Validate } from 'ui/svg/icons/Validate'
 import { Typo } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
 import { illustrationSizes } from 'ui/theme/illustrationSizes'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
 import { supportedBrowsers } from 'web/supportedBrowsers'
 
 type SupportedBrowsers = typeof supportedBrowsers
@@ -63,8 +63,8 @@ export const BrowserNotSupportedPage: React.FC<{
           />
         </IllustrationContainer>
         <TextContainer gap={4}>
-          <StyledTitle2 {...getHeadingAttrs(1)}>{message?.title}</StyledTitle2>
-          <Typo.Body {...getHeadingAttrs(2)}>{message?.description}</Typo.Body>
+          <StyledTitle2 {...getTextSemanticAttrs(1)}>{message?.title}</StyledTitle2>
+          <Typo.Body {...getTextSemanticAttrs(2)}>{message?.description}</Typo.Body>
 
           <AccessibleUnorderedList
             withPadding


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43000

## Context

- Ajout de la possibilité de créer des balises `<span>` sur les textes, à utiliser pour les textes des boutons 
- Renommage de `getHeadingAttrs` en `getTextSemanticAttrs` pour être plus large que uniquement les titres (h1, h2, etc.)
- Ajout du `accessibilityLevel` en mobile, même si pas d'impact, ça aide a mieux comprendre les snapshots

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
