### PR TITLE
(PC-42997) refactor(ui): add status role on password rules text

### DIFF
--- a/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
@@ -526,6 +526,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
                 </View>
                 <Text
                   displayBlock={true}
+                  role="none"
                   style={
                     {
                       "display": "none",

--- a/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
@@ -202,6 +202,7 @@ exports[`SetPassword Page should render correctly 1`] = `
       </View>
       <Text
         displayBlock={true}
+        role="none"
         style={
           {
             "display": "none",

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -1121,6 +1121,7 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
             </View>
             <Text
               displayBlock={true}
+              role="none"
               style={
                 {
                   "display": "none",

--- a/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
@@ -508,6 +508,7 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
                   </View>
                   <Text
                     displayBlock={true}
+                    role="none"
                     style={
                       {
                         "display": "none",

--- a/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
@@ -640,6 +640,7 @@ exports[`ChangePassword should render correctly 1`] = `
                 </View>
                 <Text
                   displayBlock={true}
+                  role="none"
                   style={
                     {
                       "display": "none",

--- a/doc/accessibility/audits/web/2026_09_26.md
+++ b/doc/accessibility/audits/web/2026_09_26.md
@@ -51,6 +51,28 @@ Texte
 
 <details>
 
+<summary> ⏳ Critère 7.5 - Dans chaque page web, les messages de statut sont-ils correctement restitués par les technologies d'assistance ?</summary>
+
+**RGAA** : [Critère 7.5](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#7.5)  
+**Ticket** : [PC-42997](https://passculture.atlassian.net/browse/PC-42997)  
+**PR** : [#10026](https://github.com/pass-culture/pass-culture-app-native/pull/10026)
+
+
+**Problème** 😱  
+- **[ P01 - Création de compte ]**: Lorsque l'utilisateur modifie la zone de saisie du mot de passe, les critères de validation du mot de passe ne sont pas relus.
+
+**Correction** 💡  
+- **[ P01 - Création de compte ]**: Lorsque l'utilisateur modifie la zone de saisie du mot de passe, les critères de validation du mot de passe sont relus.
+
+**Retours audit** 🔥  
+Texte
+
+</details>
+
+<br>
+
+<details>
+
 <summary> ⏳ Critère 8.6 - Pour chaque page web ayant un titre de page, ce titre est-il pertinent ?</summary>
 
 **RGAA** : [Critère 8.6](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#8.6)  

--- a/src/ui/designSystem/PasswordInput/components/PasswordRules.tsx
+++ b/src/ui/designSystem/PasswordInput/components/PasswordRules.tsx
@@ -6,6 +6,7 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { hiddenFromScreenReader } from 'shared/accessibility/helpers/hiddenFromScreenReader'
 import { HiddenAccessibleText } from 'ui/components/HiddenAccessibleText'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -27,7 +28,9 @@ export const PasswordRules: FunctionComponent<Props> = ({ password, visible }) =
   if (visible)
     return (
       <React.Fragment>
-        <HiddenAccessibleText displayBlock>{hiddenAccessibleText}</HiddenAccessibleText>
+        <HiddenAccessibleText displayBlock role={AccessibilityRole.STATUS}>
+          {hiddenAccessibleText}
+        </HiddenAccessibleText>
         <RulesContainer {...hiddenFromScreenReader()} gap={1}>
           {DISPLAYED_PASSWORD_RULES.map((rule) => (
             <PasswordRule


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42997

## Context
L'objectif de cette PR est d'ajouter le role "status" au label de validation des critères du mot de passe de manière à ce qu'il soit relu quand la zone de texte est modifiée.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
