### PR TITLE
(PC-43114) refactor(ui): lot 3 illustration

### DIFF
--- a/src/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx
+++ b/src/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { nonBeneficiaryUser } from 'fixtures/user'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { storage } from 'libs/storage'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -62,5 +63,13 @@ describe('<EighteenBirthday />', () => {
 
     expect(screen.getByText('Vérifie ton identité pour débloquer tes 150 €.')).toBeOnTheScreen()
     expect(screen.getByText('Vérifier mon identité')).toBeOnTheScreen()
+  })
+
+  it('should render illustration rather than animation when wipNewVisionUi FF activated', () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_NEW_VISION_UI])
+
+    render(reactQueryProviderHOC(<EighteenBirthday />))
+
+    expect(screen.getByTestId('generic-info-page-remote-illustration')).toBeOnTheScreen()
   })
 })

--- a/src/features/birthdayNotifications/pages/EighteenBirthday.tsx
+++ b/src/features/birthdayNotifications/pages/EighteenBirthday.tsx
@@ -2,7 +2,10 @@ import React, { useEffect } from 'react'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { getSubscriptionPropConfig } from 'features/navigation/navigators/SubscriptionStackNavigator/getSubscriptionPropConfig'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { storage } from 'libs/storage'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { useDepositAmountsByAge } from 'shared/user/useDepositAmountsByAge'
 import BirthdayCake from 'ui/animations/onboarding_birthday_cake.json'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
@@ -11,6 +14,7 @@ import { ClockFilled } from 'ui/svg/icons/ClockFilled'
 export function EighteenBirthday() {
   const { user } = useAuthContext()
   const pageWording = useGetPageWording(user?.requiresIdCheck)
+  const enableNewVisionUi = useFeatureFlag(RemoteStoreFeatureFlags.WIP_NEW_VISION_UI)
 
   useEffect(() => {
     storage.saveObject('has_seen_eligible_card', true)
@@ -21,6 +25,14 @@ export function EighteenBirthday() {
       animation={BirthdayCake}
       animationColoringMode="targeted"
       animationTargetShapeNames={['Fond 1', 'Gradient Fill 1']}
+      remoteIllustration={
+        enableNewVisionUi
+          ? {
+              url: genericInfoPageIllustrationUrls.birthdayCake,
+              backgroundColor: 'information02',
+            }
+          : undefined
+      }
       title="Tu as 18 ans&nbsp;!"
       subtitle={pageWording.text}
       buttonPrimary={{

--- a/src/features/birthdayNotifications/pages/EighteenBirthday.web.test.tsx
+++ b/src/features/birthdayNotifications/pages/EighteenBirthday.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { useDepositAmountsByAge } from 'shared/user/useDepositAmountsByAge'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
@@ -12,6 +13,10 @@ mockUseDepositAmountsByAge.mockReturnValue({ eighteenYearsOldDeposit: '300 €' 
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<EighteenBirthday/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(<EighteenBirthday />)

--- a/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.native.test.tsx
+++ b/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.native.test.tsx
@@ -5,6 +5,7 @@ import { reset, replace } from '__mocks__/@react-navigation/native'
 import { RecreditType } from 'api/gen'
 import { underageBeneficiaryUser } from 'fixtures/user'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -58,6 +59,18 @@ describe('<RecreditBirthdayNotification />', () => {
     )
 
     expect(recreditText).toBeOnTheScreen()
+  })
+
+  it('should render illustration rather than animation when wipNewVisionUi FF activated', () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_NEW_VISION_UI])
+    mockAuthContextWithUser({
+      ...underageBeneficiaryUser,
+      birthDate: birthdate.toISOString(),
+      recreditAmountToShow: 15000,
+    })
+    renderRecreditBirthdayNotification()
+
+    expect(screen.getByTestId('generic-info-page-remote-illustration')).toBeOnTheScreen()
   })
 
   describe('when pressing "Continuer"', () => {

--- a/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.tsx
+++ b/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.tsx
@@ -6,11 +6,14 @@ import { RecreditType } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useNavigateToHomeWithReset } from 'features/navigation/helpers/useNavigateToHomeWithReset'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { storage } from 'libs/storage'
 import { useResetRecreditAmountToShowMutation } from 'queries/profile/useResetRecreditAmountToShowMutation'
 import { useBonificationBonusAmount, usePacificFrancToEuroRate } from 'queries/settings/useSettings'
 import { formatCurrencyFromCents } from 'shared/currency/formatCurrencyFromCents'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { getAge } from 'shared/user/getAge'
 import BirthdayCake from 'ui/animations/onboarding_birthday_cake.json'
 import { AnimatedProgressBar } from 'ui/components/bars/AnimatedProgressBar'
@@ -30,6 +33,7 @@ export const RecreditBirthdayNotification = () => {
   const currency = useGetCurrencyToDisplay()
   const { data: euroToPacificFrancRate } = usePacificFrancToEuroRate()
   const { data: bonificationBonusAmount } = useBonificationBonusAmount()
+  const enableNewVisionUi = useFeatureFlag(RemoteStoreFeatureFlags.WIP_NEW_VISION_UI)
 
   const hasAlsoBonusRecreditToShow = user?.recreditTypeToShow === RecreditType.BonusCredit
   const bonifAmountToShow = hasAlsoBonusRecreditToShow ? bonificationBonusAmount : 0
@@ -62,6 +66,14 @@ export const RecreditBirthdayNotification = () => {
       animation={BirthdayCake}
       animationColoringMode="targeted"
       animationTargetShapeNames={['Fond 1', 'Gradient Fill 1']}
+      remoteIllustration={
+        enableNewVisionUi
+          ? {
+              url: genericInfoPageIllustrationUrls.birthdayCake,
+              backgroundColor: 'information02',
+            }
+          : undefined
+      }
       title="Bonne nouvelle&nbsp;!"
       subtitle={recreditMessage}
       buttonPrimary={{

--- a/src/features/forceUpdate/components/ForceUpdateInfos.native.test.tsx
+++ b/src/features/forceUpdate/components/ForceUpdateInfos.native.test.tsx
@@ -4,6 +4,7 @@ import { Linking } from 'react-native'
 import { analytics } from 'libs/analytics/provider'
 import { WEBAPP_V2_URL } from 'libs/environment/useWebAppUrl'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import * as PackageJson from 'libs/packageJson'
 import { userEvent, render, screen } from 'tests/utils'
 
@@ -43,5 +44,12 @@ describe('<ForceUpdateInfos/>', () => {
     await user.press(goToWebappButton)
 
     expect(openURLSpy).toHaveBeenCalledWith(WEBAPP_V2_URL)
+  })
+
+  it('should display new vision ui illustration when wipNewVisionUi FF activated', () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_NEW_VISION_UI])
+    render(<ForceUpdateInfos />)
+
+    expect(screen.getByTestId('generic-info-page-remote-illustration')).toBeOnTheScreen()
   })
 })

--- a/src/features/forceUpdate/components/ForceUpdateInfos.tsx
+++ b/src/features/forceUpdate/components/ForceUpdateInfos.tsx
@@ -4,6 +4,9 @@ import { Platform } from 'react-native'
 import { BUTTON_TEXT_SCREEN, DESCRIPTION, TITLE } from 'features/forceUpdate/constants'
 import { onPressStoreLink } from 'features/forceUpdate/helpers/onPressStoreLink'
 import { WEBAPP_V2_URL } from 'libs/environment/useWebAppUrl'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { Button } from 'ui/designSystem/Button/Button'
 import { GenericErrorPage } from 'ui/pages/GenericErrorPage'
@@ -17,6 +20,8 @@ const isWeb = Platform.OS === 'web'
 // THE NAVIGATION CONTEXT IS NOT ALWAYS LOADED WHEN WE DISPLAY
 // EX: ScreenErrorProvider IS OUTSIDE NAVIGATION!
 export const ForceUpdateInfos = () => {
+  const enableNewVisionUi = useFeatureFlag(RemoteStoreFeatureFlags.WIP_NEW_VISION_UI)
+
   const buttonTertiaryWithNav = isWeb ? undefined : (
     <ExternalTouchableLink
       key={2}
@@ -33,6 +38,14 @@ export const ForceUpdateInfos = () => {
     <GenericErrorPage
       helmetTitle={TITLE}
       illustration={AgainIllustration}
+      remoteIllustration={
+        enableNewVisionUi
+          ? {
+              url: genericInfoPageIllustrationUrls.mobileDeviceAndParameters,
+              backgroundColor: 'pending01',
+            }
+          : undefined
+      }
       title={TITLE}
       subtitle={DESCRIPTION}
       buttonPrimary={{ wording: BUTTON_TEXT_SCREEN, onPress: onPressStoreLink }}

--- a/src/features/identityCheck/pages/DisableActivation.tsx
+++ b/src/features/identityCheck/pages/DisableActivation.tsx
@@ -7,6 +7,7 @@ import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
 import { useFeatureFlagOptionsQuery } from 'libs/firebase/firestore/featureFlags/queries/useFeatureFlagOptionsQuery'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { Hourglass } from 'ui/svg/icons/Hourglass'
 import { LINE_BREAK } from 'ui/theme/constants'
@@ -27,6 +28,10 @@ export const DisableActivation = () => {
   return (
     <GenericInfoPage
       illustration={Hourglass}
+      remoteIllustration={{
+        backgroundColor: 'pending01',
+        url: genericInfoPageIllustrationUrls.workedInPrgressSignSculptureLarge,
+      }}
       title={title}
       buttonPrimary={{
         wording: 'Retourner à l’accueil',

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/EduConnectErrorBoundary.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/EduConnectErrorBoundary.native.test.tsx
@@ -2,12 +2,17 @@ import React from 'react'
 
 import { EduConnectErrorBoundary } from 'features/identityCheck/pages/identification/errors/eduConnect/EduConnectErrorBoundary'
 import { EduConnectError } from 'features/identityCheck/pages/identification/errors/eduConnect/types'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { eventMonitoring } from 'libs/monitoring/services'
 import { render } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('EduConnectErrorBoundary component', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should not log error on sentry when error is an expected EduConnectError', () => {
     render(
       <EduConnectErrorBoundary

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen } from 'tests/utils'
 
 import { NotEligibleEduConnect } from './NotEligibleEduConnect'
@@ -24,6 +25,10 @@ jest.mock(
 )
 
 describe('NotEligibleEduConnect', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', async () => {
     render(
       <NotEligibleEduConnect

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -7,6 +7,7 @@ import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome
 import { analytics } from 'libs/analytics/provider'
 import { ScreenErrorProps } from 'libs/monitoring/errors'
 import { Helmet } from 'libs/react-helmet/Helmet'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { ButtonProps, GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { Typo } from 'ui/theme'
 
@@ -74,6 +75,10 @@ export const NotEligibleEduConnect = ({
       </Helmet>
       <GenericInfoPage
         illustration={Illustration}
+        remoteIllustration={{
+          backgroundColor: 'pending01',
+          url: genericInfoPageIllustrationUrls.workedInPrgressSignSculptureLarge,
+        }}
         title={title}
         buttonPrimary={buttonPrimary ?? defaultGoToHomeButton}
         buttonTertiary={isGoHomeTertiaryButtonVisible ? defaultGoToHomeButton : undefined}>

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.web.test.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
 import { NotEligibleEduConnect } from './NotEligibleEduConnect'
@@ -7,6 +8,10 @@ import { NotEligibleEduConnect } from './NotEligibleEduConnect'
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<NotEligibleEduConnect/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(

--- a/src/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx
@@ -4,6 +4,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { Adjust } from 'libs/adjust/adjust'
 import { analytics } from 'libs/analytics/__mocks__/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { userEvent, render, screen } from 'tests/utils'
@@ -26,6 +27,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('SuspendAccountConfirmationWithoutAuthentication', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', () => {
     renderSuspendAccountConfirmationWithoutAuthentication()
 

--- a/src/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.tsx
+++ b/src/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.tsx
@@ -11,6 +11,7 @@ import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { Adjust } from 'libs/adjust/adjust'
 import { analytics } from 'libs/analytics/provider'
 import { env } from 'libs/environment/env'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { BulletListItem } from 'ui/components/BulletListItem'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { VerticalUl } from 'ui/components/Ul'
@@ -49,6 +50,10 @@ export const SuspendAccountConfirmationWithoutAuthentication: FC = () => {
     <GenericInfoPage
       withGoBack
       illustration={UserError}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.cryingManPaintingLarge,
+        backgroundColor: 'negative01',
+      }}
       title="Souhaites-tu suspendre ton compte pass&nbsp;Culture&nbsp;?"
       buttonPrimary={{
         wording: 'Oui, suspendre mon compte',

--- a/src/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.web.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.web.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, checkAccessibilityFor } from 'tests/utils/web'
 
@@ -11,6 +12,10 @@ jest.spyOn(NavigationHelpers, 'openUrl')
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('SuspendAccountConfirmationWithoutAuthentication', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(

--- a/src/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx
+++ b/src/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { MandatoryUpdatePersonalData } from './MandatoryUpdatePersonalData'
@@ -23,6 +24,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('<MandatoryUpdatePersonalData />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', async () => {
     render(<MandatoryUpdatePersonalData />)
 

--- a/src/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.tsx
+++ b/src/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { getProfilePropConfig } from 'features/navigation/navigators/ProfileStackNavigator/getProfilePropConfig'
 import { env } from 'libs/environment/env'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { Button } from 'ui/designSystem/Button/Button'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
@@ -12,6 +13,10 @@ import { LINE_BREAK } from 'ui/theme/constants'
 export const MandatoryUpdatePersonalData = () => (
   <GenericInfoPage
     illustration={UserError}
+    remoteIllustration={{
+      url: genericInfoPageIllustrationUrls.signingDocumentPaintingLarge,
+      backgroundColor: 'information02',
+    }}
     title="Mets à jour ton profil"
     subtitle={`Pour mieux t’accompagner, on a besoin de vérifier que tes informations personnelles sont toujours à jour.${LINE_BREAK}C’est rapide, promis.`}
     buttonPrimary={{

--- a/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.native.test.tsx
+++ b/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.native.test.tsx
@@ -10,6 +10,7 @@ import { ProfileStackParamList } from 'features/navigation/navigators/ProfileSta
 import { RootStackParamList } from 'features/navigation/navigators/RootNavigator/types'
 import { SuspendAccountConfirmation } from 'features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation'
 import * as useEmailUpdateStatus from 'features/profile/queries/useEmailUpdateStatusQuery'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { render, screen, userEvent } from 'tests/utils'
 
 type useEmailUpdateStatusMock = ReturnType<
@@ -59,6 +60,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('<SuspendAccountConfirmation />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('should navigate to home', () => {
     it('When there is no email change', () => {
       useEmailUpdateStatusSpy.mockReturnValueOnce({

--- a/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.tsx
+++ b/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.tsx
@@ -9,6 +9,7 @@ import { getProfileHookConfig } from 'features/navigation/navigators/ProfileStac
 import { ProfileStackParamList } from 'features/navigation/navigators/ProfileStackNavigator/types'
 import { RootStackParamList } from 'features/navigation/navigators/RootNavigator/types'
 import { useEmailUpdateStatusQuery } from 'features/profile/queries/useEmailUpdateStatusQuery'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { Clear } from 'ui/svg/icons/Clear'
@@ -74,6 +75,10 @@ export function SuspendAccountConfirmation({
   return (
     <GenericInfoPage
       illustration={StyledUserError}
+      remoteIllustration={{
+        url: genericInfoPageIllustrationUrls.cryingManPaintingLarge,
+        backgroundColor: 'negative01',
+      }}
       title="Souhaites-tu suspendre ton compte pass&nbsp;Culture&nbsp;?"
       buttonPrimary={{
         wording: 'Oui, suspendre mon compte',

--- a/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.web.test.tsx
+++ b/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.web.test.tsx
@@ -7,6 +7,7 @@ import { ProfileStackParamList } from 'features/navigation/navigators/ProfileSta
 import { RootStackParamList } from 'features/navigation/navigators/RootNavigator/types'
 import { SuspendAccountConfirmation } from 'features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation'
 import * as useEmailUpdateStatus from 'features/profile/queries/useEmailUpdateStatusQuery'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { checkAccessibilityFor, render } from 'tests/utils/web'
 
@@ -26,6 +27,10 @@ jest.spyOn(useEmailUpdateStatus, 'useEmailUpdateStatusQuery').mockReturnValue({
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<SuspendAccountConfirmation />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     const navigation = {
       navigate: jest.fn(),

--- a/src/libs/network/OfflinePage.native.test.tsx
+++ b/src/libs/network/OfflinePage.native.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
 import { beneficiaryUser } from 'fixtures/user'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { render, screen } from 'tests/utils'
 
 import { OfflinePage } from './OfflinePage'
@@ -15,6 +17,10 @@ jest.mock('features/auth/context/AuthContext', () => ({
 }))
 
 describe('<OfflinePage />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should match snapshot with default message', () => {
     mockUseAuthContext.mockReturnValueOnce({ isLoggedIn: false })
     render(<OfflinePage />)
@@ -27,5 +33,12 @@ describe('<OfflinePage />', () => {
     render(<OfflinePage />)
 
     expect(screen).toMatchSnapshot()
+  })
+
+  it('should display new vision ui illustration when wipNewVisionUi FF activated', () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.WIP_NEW_VISION_UI])
+    render(<OfflinePage />)
+
+    expect(screen.getByTestId('generic-info-page-remote-illustration')).toBeOnTheScreen()
   })
 })

--- a/src/libs/network/OfflinePage.tsx
+++ b/src/libs/network/OfflinePage.tsx
@@ -2,10 +2,14 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Tag } from 'ui/designSystem/Tag/Tag'
+import { GenericInfoPageIllustration } from 'ui/pages/GenericInfoPageIllustration'
 import { Page } from 'ui/pages/Page'
 import { BrokenConnection as InitialBrokenConnection } from 'ui/svg/BrokenConnection'
 import { Bookings } from 'ui/svg/icons/Bookings'
@@ -15,12 +19,20 @@ import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const OfflinePage = () => {
   const { isLoggedIn } = useAuthContext()
+  const enableNewVisionUi = useFeatureFlag(RemoteStoreFeatureFlags.WIP_NEW_VISION_UI)
 
   return (
     <Container>
       <Content>
         <Spacer.TopScreen />
-        <BrokenConnection />
+        {enableNewVisionUi ? (
+          <GenericInfoPageIllustration
+            backgroundColor="negative01"
+            url={genericInfoPageIllustrationUrls.disconnectedCableStickManLarge}
+          />
+        ) : (
+          <BrokenConnection />
+        )}
         <StyledViewGap gap={4}>
           <StyledTitle2>Oups, pas de réseau&nbsp;!</StyledTitle2>
           <StyledBody>
@@ -49,6 +61,7 @@ export const OfflinePage = () => {
 const StyledViewGap = styled(ViewGap)(({ theme }) => ({
   marginVertical: theme.designSystem.size.spacing.l,
 }))
+
 const BrokenConnection = styled(InitialBrokenConnection).attrs(({ theme }) => ({
   color: theme.designSystem.color.icon.brandPrimary,
   size: theme.illustrations.sizes.fullPage,

--- a/src/shared/illustrations/genericInfoPageIllustrations.ts
+++ b/src/shared/illustrations/genericInfoPageIllustrations.ts
@@ -15,6 +15,7 @@ const genericInfoPageIllustrationNames = [
   'stressedKnightLarge',
   'trashMosaic',
   'validStampMosaïcLarge',
+  'workedInPrgressSignSculptureLarge',
 ] as const
 
 type GenericInfoPageIllustrationName = (typeof genericInfoPageIllustrationNames)[number]
@@ -38,4 +39,7 @@ export const genericInfoPageIllustrationUrls = {
   stressedKnightLarge: buildCategoryIllustrationUrl('stressedKnightLarge.png'),
   trashMosaic: buildCategoryIllustrationUrl('trashMosaic.png'),
   validStampMosaïcLarge: buildCategoryIllustrationUrl('validStampMosaïcLarge.png'),
+  workedInPrgressSignSculptureLarge: buildCategoryIllustrationUrl(
+    'workedInPrgressSignSculptureLarge.png'
+  ),
 } as const satisfies Record<GenericInfoPageIllustrationName, string>

--- a/src/shared/illustrations/genericInfoPageIllustrations.ts
+++ b/src/shared/illustrations/genericInfoPageIllustrations.ts
@@ -1,6 +1,7 @@
 import { buildCategoryIllustrationUrl } from 'shared/illustrations/buildCategoryIllustrationUrl'
 
 const genericInfoPageIllustrationNames = [
+  'birthdayCake',
   'blockedPaintingLarge',
   'brokenDinosaurSkeletonLarge',
   'emptyDigitalWindowLarge',
@@ -17,6 +18,7 @@ const genericInfoPageIllustrationNames = [
 type GenericInfoPageIllustrationName = (typeof genericInfoPageIllustrationNames)[number]
 
 export const genericInfoPageIllustrationUrls = {
+  birthdayCake: buildCategoryIllustrationUrl('birthdayCake.png'),
   blockedPaintingLarge: buildCategoryIllustrationUrl('blockedPaintingLarge.png'),
   brokenDinosaurSkeletonLarge: buildCategoryIllustrationUrl('brokenDinosaurSkeletonLarge.png'),
   emptyDigitalWindowLarge: buildCategoryIllustrationUrl('emptyDigitalWindowLarge.png'),

--- a/src/shared/illustrations/genericInfoPageIllustrations.ts
+++ b/src/shared/illustrations/genericInfoPageIllustrations.ts
@@ -4,6 +4,7 @@ const genericInfoPageIllustrationNames = [
   'birthdayCake',
   'blockedPaintingLarge',
   'brokenDinosaurSkeletonLarge',
+  'cryingManPaintingLarge',
   'disconnectedCableStickManLarge',
   'emptyDigitalWindowLarge',
   'emptyWalletLarge',
@@ -24,6 +25,7 @@ export const genericInfoPageIllustrationUrls = {
   birthdayCake: buildCategoryIllustrationUrl('birthdayCake.png'),
   blockedPaintingLarge: buildCategoryIllustrationUrl('blockedPaintingLarge.png'),
   brokenDinosaurSkeletonLarge: buildCategoryIllustrationUrl('brokenDinosaurSkeletonLarge.png'),
+  cryingManPaintingLarge: buildCategoryIllustrationUrl('cryingManPaintingLarge.png'),
   disconnectedCableStickManLarge: buildCategoryIllustrationUrl(
     'disconnectedCableStickManLarge.png'
   ),

--- a/src/shared/illustrations/genericInfoPageIllustrations.ts
+++ b/src/shared/illustrations/genericInfoPageIllustrations.ts
@@ -8,6 +8,7 @@ const genericInfoPageIllustrationNames = [
   'emptyWalletLarge',
   'hourglass',
   'mailBoxSendingLarge',
+  'mobileDeviceAndParameters',
   'questioningKnightLarge',
   'sculptureMagnifyingGlassPaperLarge',
   'stressedKnightLarge',
@@ -25,6 +26,7 @@ export const genericInfoPageIllustrationUrls = {
   emptyWalletLarge: buildCategoryIllustrationUrl('emptyWalletLarge.png'),
   hourglass: buildCategoryIllustrationUrl('hourglass.png'),
   mailBoxSendingLarge: buildCategoryIllustrationUrl('mailBoxSendingLarge.png'),
+  mobileDeviceAndParameters: buildCategoryIllustrationUrl('mobileDeviceAndParameters.png'),
   questioningKnightLarge: buildCategoryIllustrationUrl('questioningKnightLarge.png'),
   sculptureMagnifyingGlassPaperLarge: buildCategoryIllustrationUrl(
     'sculptureMagnifyingGlassPaperLarge.png'

--- a/src/shared/illustrations/genericInfoPageIllustrations.ts
+++ b/src/shared/illustrations/genericInfoPageIllustrations.ts
@@ -13,6 +13,7 @@ const genericInfoPageIllustrationNames = [
   'mobileDeviceAndParameters',
   'questioningKnightLarge',
   'sculptureMagnifyingGlassPaperLarge',
+  'signingDocumentPaintingLarge',
   'stressedKnightLarge',
   'trashMosaic',
   'validStampMosaïcLarge',
@@ -38,6 +39,7 @@ export const genericInfoPageIllustrationUrls = {
   sculptureMagnifyingGlassPaperLarge: buildCategoryIllustrationUrl(
     'sculptureMagnifyingGlassPaperLarge.png'
   ),
+  signingDocumentPaintingLarge: buildCategoryIllustrationUrl('signingDocumentPaintingLarge.png'),
   stressedKnightLarge: buildCategoryIllustrationUrl('stressedKnightLarge.png'),
   trashMosaic: buildCategoryIllustrationUrl('trashMosaic.png'),
   validStampMosaïcLarge: buildCategoryIllustrationUrl('validStampMosaïcLarge.png'),

--- a/src/shared/illustrations/genericInfoPageIllustrations.ts
+++ b/src/shared/illustrations/genericInfoPageIllustrations.ts
@@ -4,6 +4,7 @@ const genericInfoPageIllustrationNames = [
   'birthdayCake',
   'blockedPaintingLarge',
   'brokenDinosaurSkeletonLarge',
+  'disconnectedCableStickManLarge',
   'emptyDigitalWindowLarge',
   'emptyWalletLarge',
   'hourglass',
@@ -22,6 +23,9 @@ export const genericInfoPageIllustrationUrls = {
   birthdayCake: buildCategoryIllustrationUrl('birthdayCake.png'),
   blockedPaintingLarge: buildCategoryIllustrationUrl('blockedPaintingLarge.png'),
   brokenDinosaurSkeletonLarge: buildCategoryIllustrationUrl('brokenDinosaurSkeletonLarge.png'),
+  disconnectedCableStickManLarge: buildCategoryIllustrationUrl(
+    'disconnectedCableStickManLarge.png'
+  ),
   emptyDigitalWindowLarge: buildCategoryIllustrationUrl('emptyDigitalWindowLarge.png'),
   emptyWalletLarge: buildCategoryIllustrationUrl('emptyWalletLarge.png'),
   hourglass: buildCategoryIllustrationUrl('hourglass.png'),

--- a/src/ui/pages/GenericErrorPage.native.test.tsx
+++ b/src/ui/pages/GenericErrorPage.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { genericInfoPageIllustrationUrls } from 'shared/illustrations/genericInfoPageIllustrations'
 import { render, screen } from 'tests/utils'
 import { PhonePending } from 'ui/svg/icons/PhonePending'
 import { Typo } from 'ui/theme'
@@ -33,5 +34,25 @@ describe('<GenericErrorPage />', () => {
     )
 
     expect(screen).toMatchSnapshot()
+  })
+
+  it('should display remote illustration when defined', () => {
+    render(
+      <GenericErrorPage
+        helmetTitle="HelmetTitle"
+        illustration={PhonePending}
+        remoteIllustration={{
+          url: genericInfoPageIllustrationUrls.mobileDeviceAndParameters,
+          backgroundColor: 'pending01',
+        }}
+        title="GenericErrorPage"
+        subtitle="Subtitle"
+        buttonPrimary={{ wording: 'Primary button', onPress: jest.fn() }}
+        buttonTertiary={{ wording: 'Tertiary button', onPress: jest.fn() }}>
+        <Typo.Body>Children...</Typo.Body>
+      </GenericErrorPage>
+    )
+
+    expect(screen.getByTestId('generic-info-page-remote-illustration')).toBeOnTheScreen()
   })
 })

--- a/src/ui/pages/GenericErrorPage.tsx
+++ b/src/ui/pages/GenericErrorPage.tsx
@@ -7,7 +7,9 @@ import { Helmet } from 'libs/react-helmet/Helmet'
 import { useColorScheme } from 'libs/styled/useColorScheme'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
+import { GenericInfoPageIllustration } from 'ui/pages/GenericInfoPageIllustration'
 import { Page } from 'ui/pages/Page'
+import { RemoteIllustration } from 'ui/pages/types'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { Typo } from 'ui/theme'
 import { illustrationSizes } from 'ui/theme/illustrationSizes'
@@ -31,6 +33,7 @@ type Props = PropsWithChildren<{
   buttonPrimary?: ButtonProps
   buttonTertiary?: ButtonProps
   buttonTertiaryExternalNav?: ReactNode
+  remoteIllustration?: RemoteIllustration
 }>
 
 // NEVER EVER USE NAVIGATION (OR ANYTHING FROM @react-navigation)
@@ -47,11 +50,26 @@ export const GenericErrorPage: FunctionComponent<Props> = ({
   buttonPrimary,
   buttonTertiary,
   buttonTertiaryExternalNav,
+  remoteIllustration,
   children,
 }) => {
   const { top } = useSafeAreaInsets()
   const { designSystem } = useTheme()
   const colorScheme = useColorScheme()
+
+  const renderIllustration = () => {
+    if (remoteIllustration) return <GenericInfoPageIllustration {...remoteIllustration} />
+
+    if (IllustrationComponent)
+      return (
+        <IllustrationComponent
+          size={illustrationSizes.fullPage}
+          color={designSystem.color.icon.brandPrimary}
+        />
+      )
+
+    return null
+  }
 
   return (
     <React.Fragment>
@@ -78,14 +96,7 @@ export const GenericErrorPage: FunctionComponent<Props> = ({
         <Placeholder height={top} />
         <Container>
           <View>
-            <IllustrationContainer>
-              {IllustrationComponent ? (
-                <IllustrationComponent
-                  size={illustrationSizes.fullPage}
-                  color={designSystem.color.icon.brandPrimary}
-                />
-              ) : null}
-            </IllustrationContainer>
+            <IllustrationContainer>{renderIllustration()}</IllustrationContainer>
             <TextContainer gap={4}>
               <StyledTitle {...getHeadingAttrs(1)}>{title}</StyledTitle>
               {subtitle ? (

--- a/src/ui/pages/GenericInfoPage.native.test.tsx
+++ b/src/ui/pages/GenericInfoPage.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { render, screen } from 'tests/utils'
+import BirthdayCake from 'ui/animations/onboarding_birthday_cake.json'
 import { MaintenanceCone } from 'ui/svg/icons/MaintenanceCone'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
 import { Typo } from 'ui/theme'
@@ -75,6 +76,27 @@ describe('<GenericInfoPage />', () => {
     render(
       <GenericInfoPage
         illustration={MaintenanceCone}
+        remoteIllustration={{
+          url: 'https://example.com/illustration.png',
+          backgroundColor: 'positive01',
+        }}
+        title="Title"
+        buttonPrimary={{
+          wording: 'ButtonPrimary',
+          onPress,
+        }}
+      />
+    )
+
+    expect(screen.getByTestId('generic-info-page-remote-illustration')).toBeOnTheScreen()
+  })
+
+  it('should display remote illustation when animation and remote illustration defined', () => {
+    render(
+      <GenericInfoPage
+        animation={BirthdayCake}
+        animationColoringMode="targeted"
+        animationTargetShapeNames={['Fond 1', 'Gradient Fill 1']}
         remoteIllustration={{
           url: 'https://example.com/illustration.png',
           backgroundColor: 'positive01',

--- a/src/ui/pages/GenericInfoPage.tsx
+++ b/src/ui/pages/GenericInfoPage.tsx
@@ -80,7 +80,7 @@ type AnimationProps =
   | ({
       animation: AnimationObject
       illustration?: never
-      remoteIllustration?: never
+      remoteIllustration?: RemoteIllustration
     } & AnimationColoringProps)
 
 type Props = PropsWithChildren<{
@@ -139,6 +139,16 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
     legacyColor: designSystem.color.icon.brandPrimary,
   })
 
+  const animationContent = renderAnimationContent({
+    animation,
+    remoteIllustration,
+    animationColoringMode,
+    animationTargetLayerNames,
+    animationTargetShapeNames,
+  })
+
+  const hasAnimation = !!animation && !remoteIllustration
+
   return (
     <Page>
       <Header
@@ -150,18 +160,9 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
 
         <ContainerFlex flexValue={flexWeb}>
           <ContainerWithCenteredContent marginVertical={marginVertical} flexValue={flexWeb}>
-            <IllustrationContainer animation={!!animation}>
+            <IllustrationContainer animation={hasAnimation}>
               {illustrationContent}
-              {animation ? (
-                <ThemedStyledLottieView
-                  source={animation}
-                  width="100%"
-                  height="100%"
-                  coloringMode={animationColoringMode}
-                  targetShapeNames={animationTargetShapeNames}
-                  targetLayerNames={animationTargetLayerNames}
-                />
-              ) : null}
+              {animation ? animationContent : null}
             </IllustrationContainer>
             <TextContainer gap={4} flex={flexMobile}>
               <StyledTitle2 {...getHeadingAttrs(1)}>{title}</StyledTitle2>
@@ -206,6 +207,38 @@ const renderIllustrationContent = ({
   }
 
   return <IllustrationComponent size={illustrationSizes.fullPage} color={legacyColor} />
+}
+
+type AnimationContentProps = {
+  animation?: AnimationObject
+  remoteIllustration?: RemoteIllustration
+} & AnimationColoringProps
+
+const renderAnimationContent = ({
+  animation,
+  remoteIllustration,
+  animationColoringMode,
+  animationTargetShapeNames,
+  animationTargetLayerNames,
+}: AnimationContentProps): ReactNode => {
+  if (remoteIllustration) {
+    return <GenericInfoPageIllustration {...remoteIllustration} />
+  }
+
+  if (animation) {
+    return (
+      <ThemedStyledLottieView
+        source={animation}
+        width="100%"
+        height="100%"
+        coloringMode={animationColoringMode}
+        targetShapeNames={animationTargetShapeNames}
+        targetLayerNames={animationTargetLayerNames}
+      />
+    )
+  }
+
+  return null
 }
 
 type FeatureFlaggedIllustrationProps = {

--- a/src/ui/pages/GenericInfoPage.tsx
+++ b/src/ui/pages/GenericInfoPage.tsx
@@ -18,12 +18,10 @@ import { PageHeaderWithoutPlaceholder } from 'ui/components/headers/PageHeaderWi
 import { ExternalNavigationProps, InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
-import {
-  GenericInfoPageIllustration,
-  type RemoteIllustration,
-} from 'ui/pages/GenericInfoPageIllustration'
+import { GenericInfoPageIllustration } from 'ui/pages/GenericInfoPageIllustration'
 import { getGenericInfoPageButtons } from 'ui/pages/helpers/getGenericInfoPageButtons'
 import { Page } from 'ui/pages/Page'
+import { RemoteIllustration } from 'ui/pages/types'
 import { AccessibleIcon, AccessibleRectangleIcon } from 'ui/svg/icons/types'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { illustrationSizes } from 'ui/theme/illustrationSizes'

--- a/src/ui/pages/GenericInfoPageIllustration.tsx
+++ b/src/ui/pages/GenericInfoPageIllustration.tsx
@@ -4,12 +4,8 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { IllustrationColorKey } from 'theme/types'
+import { RemoteIllustration } from 'ui/pages/types'
 import { getSpacing } from 'ui/theme'
-
-export type RemoteIllustration = {
-  url: string
-  backgroundColor: IllustrationColorKey
-}
 
 export const GenericInfoPageIllustration = ({
   url,
@@ -18,7 +14,7 @@ export const GenericInfoPageIllustration = ({
   <Container
     illustrationBackgroundColor={backgroundColor}
     testID="generic-info-page-remote-illustration">
-    <RemoteIllustration source={{ uri: url }} resizeMode="contain" />
+    <RemoteIllustrationImage source={{ uri: url }} resizeMode="contain" />
   </Container>
 )
 
@@ -37,7 +33,7 @@ const Container = styled.View<{
   marginTop: theme.designSystem.size.spacing.l,
 }))
 
-const RemoteIllustration = styled(FastImage)({
+const RemoteIllustrationImage = styled(FastImage)({
   width: '100%',
   height: '100%',
 })

--- a/src/ui/pages/types.ts
+++ b/src/ui/pages/types.ts
@@ -1,0 +1,6 @@
+import { IllustrationColorKey } from 'theme/types'
+
+export type RemoteIllustration = {
+  url: string
+  backgroundColor: IllustrationColorKey
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43114

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 14 37 34" src="https://github.com/user-attachments/assets/4f812e99-45af-4779-a37a-5e5efeea4532" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 15 03 36" src="https://github.com/user-attachments/assets/bdc58dfe-7c70-448a-b7b0-b4582b888ae0" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 15 42 45" src="https://github.com/user-attachments/assets/1bc4deb9-41ab-46f2-99e2-e9a2ac171280" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 16 18 24" src="https://github.com/user-attachments/assets/f994b5b7-703d-4955-909d-4f63376dd2c6" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 17 08 09" src="https://github.com/user-attachments/assets/41b470ba-e542-49f1-8225-5e4884390303" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 17 09 16" src="https://github.com/user-attachments/assets/aaef303b-f2fc-4322-bea2-e593c3941e23" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 17 10 18" src="https://github.com/user-attachments/assets/6bba5db3-3cf4-4f08-978b-d4f9cac29e7d" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-11 at 09 06 33" src="https://github.com/user-attachments/assets/3eb7a39c-5e0f-4fee-8ead-06b92bde1a9f" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-11 at 09 08 48" src="https://github.com/user-attachments/assets/aa07ab87-6482-4869-b14c-90fd4f55226a" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-11 at 09 26 36" src="https://github.com/user-attachments/assets/1508ac1f-ff8b-40fa-8666-bbe6e828ee7c" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 15 03 10" src="https://github.com/user-attachments/assets/e13762c1-f03a-48df-ba02-64cf35bf501e" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 15 05 56" src="https://github.com/user-attachments/assets/c9225c69-001d-48d3-a8bf-e0fb8edad432" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 15 59 43" src="https://github.com/user-attachments/assets/0eb07826-8552-4a3b-8cf5-859d9da4de5b" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 16 26 25" src="https://github.com/user-attachments/assets/7e42b297-fd15-4ff9-b88d-6619b925b99d" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 17 14 17" src="https://github.com/user-attachments/assets/03a102d1-d982-45cc-a09b-5c26c980d8d9" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 17 16 19" src="https://github.com/user-attachments/assets/b036b776-5777-46ed-947d-0b417061e44a" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 17 17 21" src="https://github.com/user-attachments/assets/9293f104-d03c-4140-b9b7-4427947b87b5" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-11 at 09 11 00" src="https://github.com/user-attachments/assets/76ac4ae0-84e3-4498-9757-52e4362e5f32" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-11 at 09 12 48" src="https://github.com/user-attachments/assets/4dd79e37-8a50-4d77-9778-ddef46dc57a3" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-11 at 09 29 27" src="https://github.com/user-attachments/assets/b79607a0-45ed-4ddb-b9a5-55c84a4b2a87" />|
| Android          |               |       |
| Phone - Chrome   |<img width="383" height="676" alt="Capture d’écran 2026-08-10 à 14 37 15" src="https://github.com/user-attachments/assets/2b9cd56a-9a01-48be-aed8-95da66c0e7ca" /> <img width="393" height="681" alt="Capture d’écran 2026-08-10 à 15 03 49" src="https://github.com/user-attachments/assets/0bcbc606-17c2-4f92-bd35-1a64d8b98694" /> <img width="401" height="691" alt="Capture d’écran 2026-08-10 à 15 42 25" src="https://github.com/user-attachments/assets/9050152d-9f10-4d80-b963-34ddb1be0962" /> <img width="395" height="684" alt="Capture d’écran 2026-08-10 à 16 18 11" src="https://github.com/user-attachments/assets/f818dc0e-3dce-4fd3-aa42-7952bd095db3" /> <img width="403" height="679" alt="Capture d’écran 2026-08-10 à 17 07 56" src="https://github.com/user-attachments/assets/79a706d3-8f27-4688-a091-f7fd3b8b97b0" /> <img width="395" height="686" alt="Capture d’écran 2026-08-10 à 17 08 59" src="https://github.com/user-attachments/assets/1ed657ed-9176-45c9-b99f-547c67c8ff88" /> <img width="393" height="679" alt="Capture d’écran 2026-08-10 à 17 10 00" src="https://github.com/user-attachments/assets/71648242-78af-439c-8eb6-583231c32bcb" /> <img width="387" height="683" alt="Capture d’écran 2026-08-11 à 09 04 17" src="https://github.com/user-attachments/assets/96f6dbc2-4e75-470c-b7a8-c183c2567f3e" /> <img width="400" height="698" alt="Capture d’écran 2026-08-11 à 09 07 43" src="https://github.com/user-attachments/assets/fab1f26c-7f7e-4148-adb7-e30a92650fdb" /> <img width="394" height="684" alt="Capture d’écran 2026-08-11 à 09 26 23" src="https://github.com/user-attachments/assets/e1d1b9f6-9dd4-4fe2-bbb6-a96005568a1a" />|<img width="392" height="691" alt="Capture d’écran 2026-08-10 à 15 03 04" src="https://github.com/user-attachments/assets/2da6659b-e1b0-4b1d-8b2d-f528ea39208a" /> <img width="394" height="684" alt="Capture d’écran 2026-08-10 à 15 05 46" src="https://github.com/user-attachments/assets/d8f60d1a-6fb2-4f43-819f-f7f5c558d8c8" /> <img width="391" height="684" alt="Capture d’écran 2026-08-10 à 15 59 15" src="https://github.com/user-attachments/assets/97a77255-6160-4f27-99bc-de6687e325ab" /> <img width="396" height="683" alt="Capture d’écran 2026-08-10 à 16 26 00" src="https://github.com/user-attachments/assets/97545607-a5aa-43ca-a1a5-c915d22baa96" /> <img width="387" height="680" alt="Capture d’écran 2026-08-10 à 17 13 32" src="https://github.com/user-attachments/assets/e7a30f99-fd0d-4bbe-b7bf-e204cda9b83f" /> <img width="397" height="682" alt="Capture d’écran 2026-08-10 à 17 15 39" src="https://github.com/user-attachments/assets/34ea4165-258a-49d7-a333-b3a62034b4da" /> <img width="399" height="683" alt="Capture d’écran 2026-08-10 à 17 17 03" src="https://github.com/user-attachments/assets/3c82f19d-1aaf-4de7-b61b-c042e69ce4e1" /> <img width="391" height="683" alt="Capture d’écran 2026-08-11 à 09 10 50" src="https://github.com/user-attachments/assets/ac970269-633d-4716-9aae-b904759d07fb" /> <img width="390" height="680" alt="Capture d’écran 2026-08-11 à 09 12 23" src="https://github.com/user-attachments/assets/543f44c6-d3d6-4879-af92-ced932ee571e" /> <img width="395" height="680" alt="Capture d’écran 2026-08-11 à 09 28 47" src="https://github.com/user-attachments/assets/1a588395-00e0-4cf5-bb0b-ea08ffc11f17" />|
| Desktop - Chrome |<img width="1908" height="926" alt="Capture d’écran 2026-08-10 à 14 37 06" src="https://github.com/user-attachments/assets/9fdbe574-67b9-4a37-9bff-ee52633ea45c" /> <img width="1916" height="928" alt="Capture d’écran 2026-08-10 à 15 03 56" src="https://github.com/user-attachments/assets/fea3a8b2-77cc-4af8-b6b7-808c1ad394fa" /> <img width="1915" height="930" alt="Capture d’écran 2026-08-10 à 15 42 18" src="https://github.com/user-attachments/assets/3d9b9751-5308-452e-a073-a6bc181a297e" /> <img width="1918" height="929" alt="Capture d’écran 2026-08-10 à 16 18 03" src="https://github.com/user-attachments/assets/eec78709-22b7-4348-9b04-e23e543d75fa" /> <img width="1494" height="745" alt="Capture d’écran 2026-08-10 à 17 07 47" src="https://github.com/user-attachments/assets/6ebfaf4c-f696-43b7-b368-87cb0be35cd4" /> <img width="1487" height="744" alt="Capture d’écran 2026-08-10 à 17 09 06" src="https://github.com/user-attachments/assets/731d2a61-5fec-49de-9929-636ab25ff707" /> <img width="1491" height="745" alt="Capture d’écran 2026-08-10 à 17 09 53" src="https://github.com/user-attachments/assets/799fb3c6-b908-4e39-85d3-bd52f167edf5" /> <img width="1509" height="766" alt="Capture d’écran 2026-08-11 à 09 04 10" src="https://github.com/user-attachments/assets/e2899efc-f592-46c2-83dd-9573dd91e092" /> <img width="1510" height="762" alt="Capture d’écran 2026-08-11 à 09 07 51" src="https://github.com/user-attachments/assets/4540e7b8-b2ce-4962-b052-ba1a2502fb4d" /> <img width="1509" height="765" alt="Capture d’écran 2026-08-11 à 09 26 16" src="https://github.com/user-attachments/assets/4123e017-00a0-457b-a6c1-2e724c0e1fce" />|<img width="1914" height="929" alt="Capture d’écran 2026-08-10 à 15 02 57" src="https://github.com/user-attachments/assets/015bcd3b-e71b-4a96-9b90-0f76d36d18d9" /> <img width="1918" height="930" alt="Capture d’écran 2026-08-10 à 15 05 37" src="https://github.com/user-attachments/assets/cc249209-9467-43a0-971b-aac9bcb536c4" /> <img width="1916" height="928" alt="Capture d’écran 2026-08-10 à 15 59 30" src="https://github.com/user-attachments/assets/fd3fafa0-679c-4771-98c1-601c285868d6" /> <img width="1917" height="927" alt="Capture d’écran 2026-08-10 à 16 26 14" src="https://github.com/user-attachments/assets/3aa06736-c246-44be-b435-77e5394388ac" /> <img width="1486" height="744" alt="Capture d’écran 2026-08-10 à 17 13 44" src="https://github.com/user-attachments/assets/6133e544-11dd-4288-9bfb-d7c90e92e9e7" /> <img width="1490" height="745" alt="Capture d’écran 2026-08-10 à 17 15 33" src="https://github.com/user-attachments/assets/2dfaaebe-10b9-46a1-8e60-dd01124ef838" /> <img width="1485" height="741" alt="Capture d’écran 2026-08-10 à 17 17 11" src="https://github.com/user-attachments/assets/d4f7c605-b9ff-40e7-a5c1-8392f0f9d4d9" /> <img width="1513" height="764" alt="Capture d’écran 2026-08-11 à 09 10 44" src="https://github.com/user-attachments/assets/e38a078a-9206-4aca-9b91-2c2417c537e9" /> <img width="1508" height="764" alt="Capture d’écran 2026-08-11 à 09 12 35" src="https://github.com/user-attachments/assets/b4243e46-ca8e-424e-a3da-fd29cd96c440" /> <img width="1509" height="762" alt="Capture d’écran 2026-08-11 à 09 28 59" src="https://github.com/user-attachments/assets/baf1455a-e36b-467a-bc56-e0edda546a9e" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
