### PR TITLE
(PC-43180) fix(Map): display markers on ios

### DIFF
--- a/src/features/venueMap/components/VenueMapCluster/VenueMapCluster.tsx
+++ b/src/features/venueMap/components/VenueMapCluster/VenueMapCluster.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
+import styled from 'styled-components/native'
 // eslint-disable-next-line no-restricted-imports
 
 import { ClusterImageColorName } from 'features/venueMap/components/VenueMapView/types'
+import { MARKER_SIZE } from 'features/venueMap/constant'
 import { getClusterImage } from 'features/venueMap/helpers/venueMapCluster/getClusterImage'
 import { Marker } from 'libs/maps/maps'
 /**
@@ -30,7 +32,8 @@ export type VenueMapClusterProps = {
 }
 
 export const VenueMapCluster = ({ geometry, properties, onPress, color }: VenueMapClusterProps) => {
-  const points = properties.point_count
+  const imageName = getClusterImage(properties.point_count, color)
+
   return (
     <Marker
       key={properties.cluster_id}
@@ -38,10 +41,16 @@ export const VenueMapCluster = ({ geometry, properties, onPress, color }: VenueM
         longitude: geometry.coordinates[0],
         latitude: geometry.coordinates[1],
       }}
-      image={{ uri: getClusterImage(points, color) }}
-      style={{ zIndex: points + 1 }}
+      style={{ zIndex: properties.point_count + 1 }}
       onPress={onPress}
-      testID="venue-map-cluster"
-    />
+      testID="venue-map-cluster">
+      {imageName ? <ClusterImage source={{ uri: imageName }} /> : null}
+    </Marker>
   )
 }
+
+const ClusterImage = styled.Image({
+  width: MARKER_SIZE.width,
+  height: MARKER_SIZE.height,
+  resizeMode: 'contain',
+})

--- a/src/features/venueMap/components/VenueMapView/Marker/Marker.tsx
+++ b/src/features/venueMap/components/VenueMapView/Marker/Marker.tsx
@@ -15,23 +15,29 @@ interface MarkerProps extends MapMarkerProps {
   isSelected: boolean
   showLabel: boolean
 }
+
 export const Marker = ({ venue, isSelected, showLabel, ...otherProps }: MarkerProps) => {
   return (
     <CustomMarker
-      image={{
-        uri: getActivityIconName(isSelected, venue.activity),
-      }}
       anchor={{ x: 0.5, y: showLabel ? 0.6 : 1 }}
       testID={`marker-${venue.venueId}${isSelected ? '-selected' : ''}`}
       zIndex={isSelected ? PIN_MAX_Z_INDEX : undefined}
       {...otherProps}>
+      <PinImage source={{ uri: getActivityIconName(isSelected, venue.activity) }} />
       {showLabel ? <VenueMapLabel venue={venue} /> : null}
     </CustomMarker>
   )
 }
 
 const CustomMarker = styled(MapMarker)({
+  alignItems: 'center',
   minWidth: MARKER_SIZE.width,
   height: MARKER_SIZE.height + LABEL_HEIGHT,
   width: 'auto',
+})
+
+const PinImage = styled.Image({
+  width: MARKER_SIZE.width,
+  height: MARKER_SIZE.height,
+  resizeMode: 'contain',
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43180

## Context

La props `image` de `Marker n'a pas l'air de bien fonctionner sur ios`, passer l'image en `children résoud le problème`

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="430" height="897" alt="Capture d’écran 2026-08-11 à 12 43 13" src="https://github.com/user-attachments/assets/18d874e9-9f6b-4c64-81be-b38d01d39e47" />|<img width="429" height="897" alt="Capture d’écran 2026-08-11 à 12 42 27" src="https://github.com/user-attachments/assets/9a148ff9-c2c6-4602-96ac-6c382b3b7663" />|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
