### PR TITLE
(PC-43174) fix(booking): fix booking events in the modal

### DIFF
--- a/src/features/bookOffer/pages/BookingOfferModal.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.tsx
@@ -152,13 +152,6 @@ export const BookingOfferModalComponent: React.FC<BookingOfferModalComponentProp
   } as ModalLeftIconProps
 
   useEffect(() => {
-    // In case the context's state is CONFIRMATION we don't need to switch back to DUO state.
-    // Probably when the component is used through useBookOfferModal hook bookingDataMovieScreening's
-    // value is not set at first render. But when used through BookOfferModal
-    // its value is already set at first component's render
-    if (step === Step.CONFIRMATION) {
-      return
-    }
     dispatch({ type: 'SET_OFFER_ID', payload: offerId })
     if (!bookingDataMovieScreening) {
       return
@@ -169,7 +162,7 @@ export const BookingOfferModalComponent: React.FC<BookingOfferModalComponentProp
     })
     dispatch({ type: 'CHANGE_STEP', payload: Step.DUO })
     dispatch({ type: 'SELECT_STOCK', payload: bookingDataMovieScreening.stockId })
-  }, [offerId, dispatch, bookingDataMovieScreening, step])
+  }, [offerId, dispatch, bookingDataMovieScreening])
 
   const {
     visible: qualtricsSurveyModalVisible,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43174

## Context

Temporarily fix booking modal for event offers which will make booking through the new workflow for cinema screenings bogus.  

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
