### PR TITLE
(PC-43156) feat(analytics): log OfferImagesScroll on offer images nav…

### DIFF
--- a/__mocks__/react-native-reanimated-carousel.tsx
+++ b/__mocks__/react-native-reanimated-carousel.tsx
@@ -9,7 +9,7 @@ export default forwardRef<
     onProgressChange: (offsetProgress: number, absoluteProgress: number) => void
   }
 >(function Carousel(
-  { renderItem, data, testID, width, height, onProgressChange, defaultIndex = 0 },
+  { renderItem, data, testID, width, height, onProgressChange, onSnapToItem, defaultIndex = 0 },
   ref
 ) {
   useImperativeHandle(ref, () => ({
@@ -17,6 +17,7 @@ export default forwardRef<
     prev: jest.fn(),
     scrollTo: ({ index }: { index: number }) => {
       onProgressChange(0, index)
+      onSnapToItem?.(index)
     },
     getCurrentIndex: jest.fn(),
   }))

--- a/src/features/offer/components/OfferContent/OfferContent.web.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.tsx
@@ -1,9 +1,10 @@
-import React, { FunctionComponent, useMemo, useState } from 'react'
+import React, { FunctionComponent, useCallback, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components/native'
 
 import { OfferContentBase } from 'features/offer/components/OfferContent/OfferContentBase'
 import { OfferCTAProvider } from 'features/offer/components/OfferContent/OfferCTAProvider'
 import { OfferContentProps } from 'features/offer/types'
+import { analytics } from 'libs/analytics/provider'
 import { getImagesUrlsWithCredit } from 'shared/getImagesUrlsWithCredit/getImagesUrlsWithCredit'
 import { useGetHeaderHeight } from 'shared/header/useGetHeaderHeight'
 import { ImageWithCredit } from 'shared/types'
@@ -39,11 +40,28 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
 
   const offerImagesUrl = useMemo(() => offerImages.map((image) => image.url), [offerImages])
 
+  const lastLoggedImageIndex = useRef(0)
+
   const handlePreviewPress = (defaultIndex = 0) => {
     if (!offer.images) return
     setCarouselDefaultIndex(defaultIndex)
+    lastLoggedImageIndex.current = defaultIndex
     showModal()
   }
+
+  const handleCarouselSnapToItem = useCallback(
+    (imageIndex: number) => {
+      if (imageIndex === lastLoggedImageIndex.current) return
+      lastLoggedImageIndex.current = imageIndex
+      analytics.logOfferImagesScroll({
+        offerId: offer.id,
+        nbImages: offerImagesUrl.length,
+        imageIndex,
+        from: 'offerPreview',
+      })
+    },
+    [offer.id, offerImagesUrl.length]
+  )
 
   const BodyWrapper = useMemo(
     () =>
@@ -64,6 +82,7 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
           isVisible={visible}
           imagesURL={offerImagesUrl}
           defaultIndex={carouselDefaultIndex}
+          onSnapToItem={offerImagesUrl.length > 1 ? handleCarouselSnapToItem : undefined}
         />
         <StyledOfferContentBase
           offer={offer}

--- a/src/features/offer/components/OfferContent/OfferContent.web.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.tsx
@@ -1,10 +1,10 @@
-import React, { FunctionComponent, useCallback, useMemo, useRef, useState } from 'react'
+import React, { FunctionComponent, useMemo, useState } from 'react'
 import styled from 'styled-components/native'
 
 import { OfferContentBase } from 'features/offer/components/OfferContent/OfferContentBase'
 import { OfferCTAProvider } from 'features/offer/components/OfferContent/OfferCTAProvider'
+import { useLogOfferImagesScroll } from 'features/offer/helpers/useLogOfferImagesScroll/useLogOfferImagesScroll'
 import { OfferContentProps } from 'features/offer/types'
-import { analytics } from 'libs/analytics/provider'
 import { getImagesUrlsWithCredit } from 'shared/getImagesUrlsWithCredit/getImagesUrlsWithCredit'
 import { useGetHeaderHeight } from 'shared/header/useGetHeaderHeight'
 import { ImageWithCredit } from 'shared/types'
@@ -40,28 +40,18 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
 
   const offerImagesUrl = useMemo(() => offerImages.map((image) => image.url), [offerImages])
 
-  const lastLoggedImageIndex = useRef(0)
-
   const handlePreviewPress = (defaultIndex = 0) => {
     if (!offer.images) return
     setCarouselDefaultIndex(defaultIndex)
-    lastLoggedImageIndex.current = defaultIndex
     showModal()
   }
 
-  const handleCarouselSnapToItem = useCallback(
-    (imageIndex: number) => {
-      if (imageIndex === lastLoggedImageIndex.current) return
-      lastLoggedImageIndex.current = imageIndex
-      analytics.logOfferImagesScroll({
-        offerId: offer.id,
-        nbImages: offerImagesUrl.length,
-        imageIndex,
-        from: 'offerPreview',
-      })
-    },
-    [offer.id, offerImagesUrl.length]
-  )
+  const logImagesScroll = useLogOfferImagesScroll({
+    offerId: offer.id,
+    nbImages: offerImagesUrl.length,
+    from: 'offerPreview',
+    defaultIndex: carouselDefaultIndex,
+  })
 
   const BodyWrapper = useMemo(
     () =>
@@ -82,7 +72,7 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
           isVisible={visible}
           imagesURL={offerImagesUrl}
           defaultIndex={carouselDefaultIndex}
-          onSnapToItem={offerImagesUrl.length > 1 ? handleCarouselSnapToItem : undefined}
+          onSnapToItem={logImagesScroll}
         />
         <StyledOfferContentBase
           offer={offer}

--- a/src/features/offer/components/OfferImageCarousel/OfferImageCarousel.tsx
+++ b/src/features/offer/components/OfferImageCarousel/OfferImageCarousel.tsx
@@ -17,6 +17,7 @@ type OfferImageCarouselProps = {
   imageDimensions: OfferImageContainerDimensions
   onItemPress?: (index: number) => void
   onLoad?: () => void
+  onSnapToItem?: (index: number) => void
   style?: StyleProp<ViewStyle>
 }
 
@@ -26,6 +27,7 @@ export const OfferImageCarousel: React.FunctionComponent<OfferImageCarouselProps
   imageDimensions,
   onItemPress,
   onLoad,
+  onSnapToItem,
   style,
 }) => {
   const { designSystem } = useTheme()
@@ -82,6 +84,7 @@ export const OfferImageCarousel: React.FunctionComponent<OfferImageCarouselProps
           progressValue.value = absoluteProgress
           setCurrentIndex(absoluteProgress)
         }}
+        onSnapToItem={onSnapToItem}
         data={offerImages}
         renderItem={renderItem}
         style={carouselStyle}

--- a/src/features/offer/components/OfferImageContainer/OfferImageContainer.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageContainer.tsx
@@ -62,6 +62,7 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
       imageUrl={placeholderImage}
       paddingTop={designSystem.size.spacing.xxl * 4}>
       <OfferImageRenderer
+        offerId={offer.id}
         offerImages={images}
         placeholderImage={placeholderImage}
         progressValue={progressValue}

--- a/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.test.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.test.tsx
@@ -9,7 +9,7 @@ import { mockOfferImageDimensions } from 'features/offer/fixtures/offerImageDime
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { analytics } from 'libs/analytics/provider'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen, waitFor } from 'tests/utils/web'
+import { render, screen, userEvent, waitFor } from 'tests/utils/web'
 
 const mockOnPress = jest.fn()
 
@@ -111,6 +111,8 @@ describe('<OfferImageContainer />', () => {
   })
 
   describe('analytics', () => {
+    const user = userEvent.setup()
+
     it('should log OfferImagesScroll when navigating with the arrows', async () => {
       render(
         reactQueryProviderHOC(
@@ -125,7 +127,7 @@ describe('<OfferImageContainer />', () => {
         { theme: { isDesktopViewport: true } }
       )
 
-      fireEvent.click(await screen.findByTestId('Image suivante'))
+      await user.click(await screen.findByTestId('Image suivante'))
 
       await waitFor(() => {
         expect(analytics.logOfferImagesScroll).toHaveBeenCalledWith({
@@ -154,6 +156,95 @@ describe('<OfferImageContainer />', () => {
       await screen.findByTestId('offerImageContainerCarousel')
 
       expect(analytics.logOfferImagesScroll).not.toHaveBeenCalled()
+    })
+
+    it('should not log OfferImagesScroll when the offer has no image', async () => {
+      render(
+        reactQueryProviderHOC(
+          <OfferImageContainer
+            images={[]}
+            categoryId={CategoryIdEnum.CINEMA}
+            onPress={mockOnPress}
+            imageDimensions={mockOfferImageDimensions}
+            offer={offerResponseSnap}
+          />
+        ),
+        { theme: { isDesktopViewport: true } }
+      )
+
+      await screen.findByTestId('offerImageContainerCarousel')
+
+      expect(analytics.logOfferImagesScroll).not.toHaveBeenCalled()
+    })
+
+    it('should log OfferImagesScroll for each image change', async () => {
+      render(
+        reactQueryProviderHOC(
+          <OfferImageContainer
+            images={[
+              { url: 'some_url_to_some_resource' },
+              { url: 'some_url2_to_some_resource' },
+              { url: 'some_url3_to_some_resource' },
+            ]}
+            categoryId={CategoryIdEnum.CINEMA}
+            onPress={mockOnPress}
+            imageDimensions={mockOfferImageDimensions}
+            offer={offerResponseSnap}
+          />
+        ),
+        { theme: { isDesktopViewport: true } }
+      )
+
+      const nextButton = await screen.findByTestId('Image suivante')
+      await user.click(nextButton)
+      await user.click(nextButton)
+      await user.click(await screen.findByTestId('Image précédente'))
+
+      await waitFor(() => {
+        expect(analytics.logOfferImagesScroll).toHaveBeenCalledTimes(3)
+      })
+
+      expect(analytics.logOfferImagesScroll).toHaveBeenNthCalledWith(1, {
+        offerId: offerResponseSnap.id,
+        nbImages: 3,
+        imageIndex: 1,
+        from: 'offer',
+      })
+      expect(analytics.logOfferImagesScroll).toHaveBeenNthCalledWith(2, {
+        offerId: offerResponseSnap.id,
+        nbImages: 3,
+        imageIndex: 2,
+        from: 'offer',
+      })
+      expect(analytics.logOfferImagesScroll).toHaveBeenNthCalledWith(3, {
+        offerId: offerResponseSnap.id,
+        nbImages: 3,
+        imageIndex: 1,
+        from: 'offer',
+      })
+    })
+
+    it('should not log OfferImagesScroll when already on the last image', async () => {
+      render(
+        reactQueryProviderHOC(
+          <OfferImageContainer
+            images={[{ url: 'some_url_to_some_resource' }, { url: 'some_url2_to_some_resource' }]}
+            categoryId={CategoryIdEnum.CINEMA}
+            onPress={mockOnPress}
+            imageDimensions={mockOfferImageDimensions}
+            offer={offerResponseSnap}
+          />
+        ),
+        { theme: { isDesktopViewport: true } }
+      )
+
+      const nextButton = await screen.findByTestId('Image suivante')
+      await user.click(nextButton)
+      await user.click(nextButton)
+
+      await waitFor(() => {
+        expect(analytics.logOfferImagesScroll).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })

--- a/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.test.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.test.tsx
@@ -7,8 +7,9 @@ import { ConsentStatus } from 'features/cookies/types'
 import { OfferImageContainer } from 'features/offer/components/OfferImageContainer/OfferImageContainer'
 import { mockOfferImageDimensions } from 'features/offer/fixtures/offerImageDimensions'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
+import { analytics } from 'libs/analytics/provider'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render, screen } from 'tests/utils/web'
+import { fireEvent, render, screen, waitFor } from 'tests/utils/web'
 
 const mockOnPress = jest.fn()
 
@@ -106,6 +107,53 @@ describe('<OfferImageContainer />', () => {
 
     expect(container).not.toHaveStyle({
       position: 'sticky',
+    })
+  })
+
+  describe('analytics', () => {
+    it('should log OfferImagesScroll when navigating with the arrows', async () => {
+      render(
+        reactQueryProviderHOC(
+          <OfferImageContainer
+            images={[{ url: 'some_url_to_some_resource' }, { url: 'some_url2_to_some_resource' }]}
+            categoryId={CategoryIdEnum.CINEMA}
+            onPress={mockOnPress}
+            imageDimensions={mockOfferImageDimensions}
+            offer={offerResponseSnap}
+          />
+        ),
+        { theme: { isDesktopViewport: true } }
+      )
+
+      fireEvent.click(await screen.findByTestId('Image suivante'))
+
+      await waitFor(() => {
+        expect(analytics.logOfferImagesScroll).toHaveBeenCalledWith({
+          offerId: offerResponseSnap.id,
+          nbImages: 2,
+          imageIndex: 1,
+          from: 'offer',
+        })
+      })
+    })
+
+    it('should not log OfferImagesScroll when the offer has only one image', async () => {
+      render(
+        reactQueryProviderHOC(
+          <OfferImageContainer
+            images={[{ url: 'some_url_to_some_resource' }]}
+            categoryId={CategoryIdEnum.CINEMA}
+            onPress={mockOnPress}
+            imageDimensions={mockOfferImageDimensions}
+            offer={offerResponseSnap}
+          />
+        ),
+        { theme: { isDesktopViewport: true } }
+      )
+
+      await screen.findByTestId('offerImageContainerCarousel')
+
+      expect(analytics.logOfferImagesScroll).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.tsx
@@ -76,6 +76,7 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
   return (
     <Wrapper>
       <StyledOfferImageRenderer
+        offerId={offer.id}
         offerImages={images}
         headerHeight={headerHeight}
         placeholderImage={placeholderImage}

--- a/src/features/offer/components/OfferImageContainer/OfferImageRenderer.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useRef, useState } from 'react'
+import React, { FunctionComponent, useCallback, useState } from 'react'
 import { StyleProp, ViewStyle } from 'react-native'
 import Animated, { FadeIn, FadeOut, SharedValue } from 'react-native-reanimated'
 import styled from 'styled-components/native'
@@ -7,8 +7,8 @@ import { CategoryIdEnum } from 'api/gen'
 import { OfferBodyImagePlaceholder } from 'features/offer/components/OfferBodyImagePlaceholder'
 import { OfferImageCarousel } from 'features/offer/components/OfferImageCarousel/OfferImageCarousel'
 import { OfferImageCarouselItem } from 'features/offer/components/OfferImageCarousel/OfferImageCarouselItem'
+import { useLogOfferImagesScroll } from 'features/offer/helpers/useLogOfferImagesScroll/useLogOfferImagesScroll'
 import { OfferImageContainerDimensions } from 'features/offer/types'
-import { analytics } from 'libs/analytics/provider'
 import { ImageWithCredit } from 'shared/types'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Play } from 'ui/svg/icons/Play'
@@ -42,17 +42,11 @@ export const OfferImageRenderer: FunctionComponent<Props> = ({
     setCarouselReady(true)
   }, [setCarouselReady])
 
-  const nbImages = offerImages.length
-  const lastLoggedImageIndex = useRef(0)
-
-  const handleSnapToItem = useCallback(
-    (imageIndex: number) => {
-      if (imageIndex === lastLoggedImageIndex.current) return
-      lastLoggedImageIndex.current = imageIndex
-      analytics.logOfferImagesScroll({ offerId, nbImages, imageIndex, from: 'offer' })
-    },
-    [offerId, nbImages]
-  )
+  const logImagesScroll = useLogOfferImagesScroll({
+    offerId,
+    nbImages: offerImages.length,
+    from: 'offer',
+  })
 
   return (
     <Animated.View entering={FadeIn} style={style} testID="imageRenderer">
@@ -62,7 +56,7 @@ export const OfferImageRenderer: FunctionComponent<Props> = ({
         imageDimensions={imageDimensions}
         onItemPress={onPress}
         onLoad={handleCarouselLoad}
-        onSnapToItem={nbImages > 1 ? handleSnapToItem : undefined}
+        onSnapToItem={logImagesScroll}
         isReady={carouselReady}
       />
       {carouselReady ? null : (

--- a/src/features/offer/components/OfferImageContainer/OfferImageRenderer.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useState } from 'react'
+import React, { FunctionComponent, useCallback, useRef, useState } from 'react'
 import { StyleProp, ViewStyle } from 'react-native'
 import Animated, { FadeIn, FadeOut, SharedValue } from 'react-native-reanimated'
 import styled from 'styled-components/native'
@@ -8,6 +8,7 @@ import { OfferBodyImagePlaceholder } from 'features/offer/components/OfferBodyIm
 import { OfferImageCarousel } from 'features/offer/components/OfferImageCarousel/OfferImageCarousel'
 import { OfferImageCarouselItem } from 'features/offer/components/OfferImageCarousel/OfferImageCarouselItem'
 import { OfferImageContainerDimensions } from 'features/offer/types'
+import { analytics } from 'libs/analytics/provider'
 import { ImageWithCredit } from 'shared/types'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Play } from 'ui/svg/icons/Play'
@@ -15,6 +16,7 @@ import { Play } from 'ui/svg/icons/Play'
 type Props = {
   categoryId: CategoryIdEnum | null
   imageDimensions: OfferImageContainerDimensions
+  offerId: number
   onSeeVideoPress?: VoidFunction
   offerImages?: ImageWithCredit[]
   placeholderImage?: string
@@ -24,6 +26,7 @@ type Props = {
 }
 
 export const OfferImageRenderer: FunctionComponent<Props> = ({
+  offerId,
   offerImages = [],
   imageDimensions,
   progressValue,
@@ -39,6 +42,18 @@ export const OfferImageRenderer: FunctionComponent<Props> = ({
     setCarouselReady(true)
   }, [setCarouselReady])
 
+  const nbImages = offerImages.length
+  const lastLoggedImageIndex = useRef(0)
+
+  const handleSnapToItem = useCallback(
+    (imageIndex: number) => {
+      if (imageIndex === lastLoggedImageIndex.current) return
+      lastLoggedImageIndex.current = imageIndex
+      analytics.logOfferImagesScroll({ offerId, nbImages, imageIndex, from: 'offer' })
+    },
+    [offerId, nbImages]
+  )
+
   return (
     <Animated.View entering={FadeIn} style={style} testID="imageRenderer">
       <StyledOfferImageCarousel
@@ -47,6 +62,7 @@ export const OfferImageRenderer: FunctionComponent<Props> = ({
         imageDimensions={imageDimensions}
         onItemPress={onPress}
         onLoad={handleCarouselLoad}
+        onSnapToItem={nbImages > 1 ? handleSnapToItem : undefined}
         isReady={carouselReady}
       />
       {carouselReady ? null : (

--- a/src/features/offer/helpers/useLogOfferImagesScroll/useLogOfferImagesScroll.test.ts
+++ b/src/features/offer/helpers/useLogOfferImagesScroll/useLogOfferImagesScroll.test.ts
@@ -1,0 +1,88 @@
+import { useLogOfferImagesScroll } from 'features/offer/helpers/useLogOfferImagesScroll/useLogOfferImagesScroll'
+import { analytics } from 'libs/analytics/provider'
+import { renderHook } from 'tests/utils'
+
+describe('useLogOfferImagesScroll', () => {
+  it('should not return a logger when the offer has no image', () => {
+    const { result } = renderHook(() =>
+      useLogOfferImagesScroll({ offerId: 1, nbImages: 0, from: 'offer' })
+    )
+
+    expect(result.current).toBeUndefined()
+  })
+
+  it('should not return a logger when the offer has a single image', () => {
+    const { result } = renderHook(() =>
+      useLogOfferImagesScroll({ offerId: 1, nbImages: 1, from: 'offer' })
+    )
+
+    expect(result.current).toBeUndefined()
+  })
+
+  it('should log the event with the new image index', () => {
+    const { result } = renderHook(() =>
+      useLogOfferImagesScroll({ offerId: 1, nbImages: 3, from: 'offer' })
+    )
+
+    result.current?.(1)
+
+    expect(analytics.logOfferImagesScroll).toHaveBeenNthCalledWith(1, {
+      offerId: 1,
+      nbImages: 3,
+      imageIndex: 1,
+      from: 'offer',
+    })
+  })
+
+  it('should log every image change of a rapid succession', () => {
+    const { result } = renderHook(() =>
+      useLogOfferImagesScroll({ offerId: 1, nbImages: 3, from: 'offerPreview' })
+    )
+
+    result.current?.(1)
+    result.current?.(2)
+    result.current?.(1)
+
+    expect(analytics.logOfferImagesScroll).toHaveBeenCalledTimes(3)
+    expect(analytics.logOfferImagesScroll).toHaveBeenNthCalledWith(3, {
+      offerId: 1,
+      nbImages: 3,
+      imageIndex: 1,
+      from: 'offerPreview',
+    })
+  })
+
+  it('should not log twice the same image index', () => {
+    const { result } = renderHook(() =>
+      useLogOfferImagesScroll({ offerId: 1, nbImages: 3, from: 'offer' })
+    )
+
+    result.current?.(2)
+    result.current?.(2)
+
+    expect(analytics.logOfferImagesScroll).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not log the image the carousel is opened on', () => {
+    const { result } = renderHook(() =>
+      useLogOfferImagesScroll({ offerId: 1, nbImages: 3, from: 'offerPreview', defaultIndex: 2 })
+    )
+
+    result.current?.(2)
+
+    expect(analytics.logOfferImagesScroll).not.toHaveBeenCalled()
+  })
+
+  it('should not log the image the carousel is reopened on when the default index changes', () => {
+    const { result, rerender } = renderHook(
+      ({ defaultIndex }: { defaultIndex: number }) =>
+        useLogOfferImagesScroll({ offerId: 1, nbImages: 3, from: 'offerPreview', defaultIndex }),
+      { initialProps: { defaultIndex: 0 } }
+    )
+
+    rerender({ defaultIndex: 1 })
+    result.current?.(1)
+
+    expect(analytics.logOfferImagesScroll).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/offer/helpers/useLogOfferImagesScroll/useLogOfferImagesScroll.ts
+++ b/src/features/offer/helpers/useLogOfferImagesScroll/useLogOfferImagesScroll.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+import { analytics } from 'libs/analytics/provider'
+import { OfferImagesScrollFrom } from 'libs/analytics/types'
+
+type Props = {
+  offerId: number
+  nbImages: number
+  from: OfferImagesScrollFrom
+  defaultIndex?: number
+}
+
+type LogOfferImagesScroll = (imageIndex: number) => void
+
+export const useLogOfferImagesScroll = ({
+  offerId,
+  nbImages,
+  from,
+  defaultIndex = 0,
+}: Props): LogOfferImagesScroll | undefined => {
+  const lastLoggedImageIndex = useRef(defaultIndex)
+
+  useEffect(() => {
+    lastLoggedImageIndex.current = defaultIndex
+  }, [defaultIndex])
+
+  const logOfferImagesScroll = useCallback(
+    (imageIndex: number) => {
+      if (imageIndex === lastLoggedImageIndex.current) return
+
+      lastLoggedImageIndex.current = imageIndex
+      analytics.logOfferImagesScroll({ offerId, nbImages, imageIndex, from })
+    },
+    [offerId, nbImages, from]
+  )
+
+  return nbImages > 1 ? logOfferImagesScroll : undefined
+}

--- a/src/features/offer/pages/OfferPreview/OfferPreview.native.test.tsx
+++ b/src/features/offer/pages/OfferPreview/OfferPreview.native.test.tsx
@@ -37,10 +37,12 @@ jest.mock('ui/components/ImagesCarousel/ImagesCarousel', () => {
         MockedReact.Fragment,
         null,
         MockedReact.createElement(ActualImagesCarousel, props),
-        MockedReact.createElement(
-          Text,
-          { onPress: () => props.onSnapToItem?.(1) },
-          'Aller à l’illustration 2'
+        ...props.images.map((_, index) =>
+          MockedReact.createElement(
+            Text,
+            { key: index, onPress: () => props.onSnapToItem?.(index) },
+            `Aller à l’illustration ${index + 1}`
+          )
         )
       ),
   }
@@ -75,5 +77,43 @@ describe('<OfferPreview />', () => {
       imageIndex: 1,
       from: 'offerPreview',
     })
+  })
+
+  it('should log OfferImagesScroll for each image change', async () => {
+    const user = userEvent.setup()
+    useRoute.mockReturnValueOnce({ params: { id: 42 } })
+    await renderAsync(<OfferPreview />)
+
+    await user.press(screen.getByText('Aller à l’illustration 2'))
+    await user.press(screen.getByText('Aller à l’illustration 1'))
+
+    expect(analytics.logOfferImagesScroll).toHaveBeenCalledTimes(2)
+    expect(analytics.logOfferImagesScroll).toHaveBeenNthCalledWith(2, {
+      offerId: 42,
+      nbImages: 2,
+      imageIndex: 0,
+      from: 'offerPreview',
+    })
+  })
+
+  it('should log OfferImagesScroll once when the same image is snapped twice', async () => {
+    const user = userEvent.setup()
+    useRoute.mockReturnValueOnce({ params: { id: 42 } })
+    await renderAsync(<OfferPreview />)
+
+    await user.press(screen.getByText('Aller à l’illustration 2'))
+    await user.press(screen.getByText('Aller à l’illustration 2'))
+
+    expect(analytics.logOfferImagesScroll).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not log OfferImagesScroll for the image the carousel is opened on', async () => {
+    const user = userEvent.setup()
+    useRoute.mockReturnValueOnce({ params: { id: 42, defaultIndex: 1 } })
+    await renderAsync(<OfferPreview />)
+
+    await user.press(screen.getByText('Aller à l’illustration 2'))
+
+    expect(analytics.logOfferImagesScroll).not.toHaveBeenCalled()
   })
 })

--- a/src/features/offer/pages/OfferPreview/OfferPreview.native.test.tsx
+++ b/src/features/offer/pages/OfferPreview/OfferPreview.native.test.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { ComponentProps } from 'react'
 
 import { useRoute } from '__mocks__/@react-navigation/native'
 import { OfferResponse } from 'api/gen'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { OfferPreview } from 'features/offer/pages/OfferPreview/OfferPreview'
-import { renderAsync, screen } from 'tests/utils'
+import { analytics } from 'libs/analytics/provider'
+import { renderAsync, screen, userEvent } from 'tests/utils'
 
 const mockOffer = jest.fn((): { data: OfferResponse } => ({
   data: {
@@ -23,6 +24,28 @@ jest.mock('queries/offer/useOfferQuery', () => ({
   useOfferQuery: () => mockOffer(),
 }))
 
+jest.mock('ui/components/ImagesCarousel/ImagesCarousel', () => {
+  const MockedReact = jest.requireActual<typeof import('react')>('react')
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native')
+  const { ImagesCarousel: ActualImagesCarousel } = jest.requireActual<
+    typeof import('ui/components/ImagesCarousel/ImagesCarousel')
+  >('ui/components/ImagesCarousel/ImagesCarousel')
+
+  return {
+    ImagesCarousel: (props: ComponentProps<typeof ActualImagesCarousel>) =>
+      MockedReact.createElement(
+        MockedReact.Fragment,
+        null,
+        MockedReact.createElement(ActualImagesCarousel, props),
+        MockedReact.createElement(
+          Text,
+          { onPress: () => props.onSnapToItem?.(1) },
+          'Aller à l’illustration 2'
+        )
+      ),
+  }
+})
+
 jest.useFakeTimers()
 
 describe('<OfferPreview />', () => {
@@ -37,5 +60,20 @@ describe('<OfferPreview />', () => {
     await renderAsync(<OfferPreview />)
 
     expect(await screen.findByText('Illustration 2 sur 2')).toBeOnTheScreen()
+  })
+
+  it('should log OfferImagesScroll when changing image', async () => {
+    const user = userEvent.setup()
+    useRoute.mockReturnValueOnce({ params: { id: 42 } })
+    await renderAsync(<OfferPreview />)
+
+    await user.press(screen.getByText('Aller à l’illustration 2'))
+
+    expect(analytics.logOfferImagesScroll).toHaveBeenCalledWith({
+      offerId: 42,
+      nbImages: 2,
+      imageIndex: 1,
+      from: 'offerPreview',
+    })
   })
 })

--- a/src/features/offer/pages/OfferPreview/OfferPreview.tsx
+++ b/src/features/offer/pages/OfferPreview/OfferPreview.tsx
@@ -1,9 +1,9 @@
 import { useRoute } from '@react-navigation/native'
-import React, { FunctionComponent, useRef } from 'react'
+import React, { FunctionComponent } from 'react'
 
 import { UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
 import { useGoBack } from 'features/navigation/useGoBack'
-import { analytics } from 'libs/analytics/provider'
+import { useLogOfferImagesScroll } from 'features/offer/helpers/useLogOfferImagesScroll/useLogOfferImagesScroll'
 import { useOfferQuery } from 'queries/offer/useOfferQuery'
 import { getImagesUrlsWithCredit } from 'shared/getImagesUrlsWithCredit/getImagesUrlsWithCredit'
 import { ImageWithCredit } from 'shared/types'
@@ -15,29 +15,23 @@ export const OfferPreview: FunctionComponent = () => {
   const { data: offer } = useOfferQuery({ offerId: params.id })
 
   const defaultIndex = params.defaultIndex ?? 0
-  const lastLoggedImageIndex = useRef(defaultIndex)
+  const images = offer?.images ? getImagesUrlsWithCredit<ImageWithCredit>(offer.images) : []
+
+  const logImagesScroll = useLogOfferImagesScroll({
+    offerId: params.id,
+    nbImages: images.length,
+    from: 'offerPreview',
+    defaultIndex,
+  })
 
   if (!offer?.images) return null
-
-  const images = getImagesUrlsWithCredit<ImageWithCredit>(offer.images)
-
-  const handleSnapToItem = (imageIndex: number) => {
-    if (imageIndex === lastLoggedImageIndex.current) return
-    lastLoggedImageIndex.current = imageIndex
-    analytics.logOfferImagesScroll({
-      offerId: params.id,
-      nbImages: images.length,
-      imageIndex,
-      from: 'offerPreview',
-    })
-  }
 
   return (
     <ImagesCarousel
       images={images.map((image) => image.url)}
       goBack={goBack}
       defaultIndex={defaultIndex}
-      onSnapToItem={images.length > 1 ? handleSnapToItem : undefined}
+      onSnapToItem={logImagesScroll}
     />
   )
 }

--- a/src/features/offer/pages/OfferPreview/OfferPreview.tsx
+++ b/src/features/offer/pages/OfferPreview/OfferPreview.tsx
@@ -1,8 +1,9 @@
 import { useRoute } from '@react-navigation/native'
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useRef } from 'react'
 
 import { UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
 import { useGoBack } from 'features/navigation/useGoBack'
+import { analytics } from 'libs/analytics/provider'
 import { useOfferQuery } from 'queries/offer/useOfferQuery'
 import { getImagesUrlsWithCredit } from 'shared/getImagesUrlsWithCredit/getImagesUrlsWithCredit'
 import { ImageWithCredit } from 'shared/types'
@@ -14,16 +15,29 @@ export const OfferPreview: FunctionComponent = () => {
   const { data: offer } = useOfferQuery({ offerId: params.id })
 
   const defaultIndex = params.defaultIndex ?? 0
+  const lastLoggedImageIndex = useRef(defaultIndex)
 
   if (!offer?.images) return null
 
   const images = getImagesUrlsWithCredit<ImageWithCredit>(offer.images)
+
+  const handleSnapToItem = (imageIndex: number) => {
+    if (imageIndex === lastLoggedImageIndex.current) return
+    lastLoggedImageIndex.current = imageIndex
+    analytics.logOfferImagesScroll({
+      offerId: params.id,
+      nbImages: images.length,
+      imageIndex,
+      from: 'offerPreview',
+    })
+  }
 
   return (
     <ImagesCarousel
       images={images.map((image) => image.url)}
       goBack={goBack}
       defaultIndex={defaultIndex}
+      onSnapToItem={images.length > 1 ? handleSnapToItem : undefined}
     />
   )
 }

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -117,6 +117,7 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logMultivenueOptionDisplayed: jest.fn(),
   logNoSearchResult: jest.fn(),
   logNotificationToggle: jest.fn(),
+  logOfferImagesScroll: jest.fn(),
   logOnboardingStarted: jest.fn(),
   logOpenDMSForeignCitizenURL: jest.fn(),
   logOpenDMSFrenchCitizenURL: jest.fn(),

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -37,7 +37,7 @@ import { ShareAppModalType } from 'features/share/types'
 import { SubscriptionAnalyticsParams } from 'features/subscription/types'
 import { buildPerformSearchState, urlWithValueMaxLength } from 'libs/analytics'
 import { analytics } from 'libs/analytics/provider'
-import { AdviceType, ConsultOfferLogParams } from 'libs/analytics/types'
+import { AdviceType, ConsultOfferLogParams, OfferImagesScrollFrom } from 'libs/analytics/types'
 import { buildAccessibilityFilterParam, buildModuleDisplayedOnHomepage } from 'libs/analytics/utils'
 import { ContentTypes } from 'libs/contentful/types'
 import { AnalyticsEvent } from 'libs/firebase/analytics/events'
@@ -543,6 +543,12 @@ export const logEventAnalytics = {
       { firebase: AnalyticsEvent.NOTIFICATION_TOGGLE },
       { enableEmail, enablePush: Platform.OS === 'android' ? true : enablePush }
     ),
+  logOfferImagesScroll: (params: {
+    offerId: number
+    nbImages: number
+    imageIndex: number
+    from: OfferImagesScrollFrom
+  }) => analytics.logEvent({ firebase: AnalyticsEvent.OFFER_IMAGES_SCROLL }, params),
   logOnboardingStarted: (params: { type: 'login' | 'start' }) =>
     analytics.logEvent({ firebase: AnalyticsEvent.ONBOARDING_STARTED }, params),
   logOpenDMSForeignCitizenURL: () =>

--- a/src/libs/analytics/types.ts
+++ b/src/libs/analytics/types.ts
@@ -18,6 +18,8 @@ export type ClubAdviceType = 'book_club' | 'cine_club' | 'scene_club'
 
 export type AdviceType = ClubAdviceType | 'pro'
 
+export type OfferImagesScrollFrom = 'offer' | 'offerPreview'
+
 export type OfferAnalyticsParams = {
   from: Referrals
   query?: string

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -114,6 +114,7 @@ export enum AnalyticsEvent {
   MULTI_VENUE_OPTION_DISPLAYED = 'MultivenueOptionDisplayed',
   NO_SEARCH_RESULT = 'NoSearchResult',
   NOTIFICATION_TOGGLE = 'NotificationToggle',
+  OFFER_IMAGES_SCROLL = 'OfferImagesScroll',
   ONBOARDING_STARTED = 'OnboardingStarted',
   OPEN_DMS_FOREIGN_CITIZEN_URL = 'OpenDMSForeignCitizenURL',
   OPEN_DMS_FRENCH_CITIZEN_URL = 'OpenDMSFrenchCitizenURL',

--- a/src/ui/components/ImagesCarousel/ImagesCarousel.tsx
+++ b/src/ui/components/ImagesCarousel/ImagesCarousel.tsx
@@ -19,12 +19,14 @@ type Props = {
   images: string[]
   defaultIndex: number
   goBack: VoidFunction
+  onSnapToItem?: (index: number) => void
 }
 
 export const ImagesCarousel: FunctionComponent<Props> = ({
   images,
   defaultIndex,
   goBack,
+  onSnapToItem,
 }: Props) => {
   const footerHeight = useGetFooterHeight(FOOTER_HEIGHT)
 
@@ -51,6 +53,7 @@ export const ImagesCarousel: FunctionComponent<Props> = ({
           progressValue.value = absoluteProgress
           setIndex(Math.round(absoluteProgress))
         }}
+        onSnapToItem={onSnapToItem}
         defaultIndex={defaultIndex}
         data={images}
         renderItem={({ item: image }) => <PinchableBox imageUrl={image} />}

--- a/src/ui/components/ImagesCarouselModal/ImagesCarouselModal.tsx
+++ b/src/ui/components/ImagesCarouselModal/ImagesCarouselModal.tsx
@@ -4,6 +4,7 @@ type ImagesCarouselModalProps = {
   hideModal: () => void
   onClose?: () => void
   defaultIndex?: number
+  onSnapToItem?: (index: number) => void
 }
 
 export const ImagesCarouselModal = (_props: ImagesCarouselModalProps) => null

--- a/src/ui/components/ImagesCarouselModal/ImagesCarouselModal.web.test.tsx
+++ b/src/ui/components/ImagesCarouselModal/ImagesCarouselModal.web.test.tsx
@@ -131,6 +131,30 @@ describe('<ImagesCarouselModal />', () => {
     expect(await screen.findByText('2/3')).toBeInTheDocument()
   })
 
+  it('should call onSnapToItem with the new index when navigating with the arrows', async () => {
+    jest.useFakeTimers()
+    const mockOnSnapToItem = jest.fn()
+    render(
+      <ImagesCarouselModal
+        isVisible
+        imagesURL={['image1', 'image2', 'image3']}
+        hideModal={jest.fn()}
+        onSnapToItem={mockOnSnapToItem}
+      />
+    )
+
+    await forceOnLayout()
+    await screen.findByTestId('imagesCarouselContainer')
+
+    fireEvent.click(await screen.findByTestId('Image suivante'))
+
+    await act(async () => {
+      jest.advanceTimersByTime(500)
+    })
+
+    expect(mockOnSnapToItem).toHaveBeenCalledWith(1)
+  })
+
   it('should close modal on click on close button', async () => {
     jest.useFakeTimers()
     const mockOnClose = jest.fn()

--- a/src/ui/components/ImagesCarouselModal/ImagesCarouselModal.web.tsx
+++ b/src/ui/components/ImagesCarouselModal/ImagesCarouselModal.web.tsx
@@ -24,6 +24,7 @@ type ImagesCarouselModalProps = {
   hideModal: () => void
   onClose?: () => void
   defaultIndex?: number
+  onSnapToItem?: (index: number) => void
 }
 
 const renderCarouselItem = ({ item: image, index }: { item: string; index: number }) => (
@@ -36,6 +37,7 @@ export const ImagesCarouselModal = ({
   defaultIndex = 0,
   onClose,
   isVisible = false,
+  onSnapToItem,
 }: ImagesCarouselModalProps) => {
   const [carouselSize, setCarouselSize] = useState<CarouselSize>()
   const carouselRef = useRef<ICarouselInstance>(null)
@@ -105,6 +107,7 @@ export const ImagesCarouselModal = ({
               enabled={false}
               scrollAnimationDuration={500}
               onProgressChange={handleProgressChange}
+              onSnapToItem={onSnapToItem}
               data={imagesURL}
               renderItem={renderCarouselItem}
             />
@@ -119,7 +122,7 @@ export const ImagesCarouselModal = ({
     }
 
     return <CarouselImage source={{ uri: String(imagesURL[0]) }} accessibilityLabel="Image 1" />
-  }, [carouselSize, imagesURL, defaultIndex, handlePressButton, handleProgressChange])
+  }, [carouselSize, imagesURL, defaultIndex, handlePressButton, handleProgressChange, onSnapToItem])
 
   const MODAL_PADDING = {
     x: designSystem.size.spacing.xxxl,


### PR DESCRIPTION
…igation

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43156

## Context

Le carrousel d'images de la page offre n'émettait aucun event lors d'un changement d'image, ni en inline ni en plein écran. On ne pouvait donc pas savoir si les visuels multiples sont réellement consultés — et donc pas arbitrer l'effort de collecte auprès des acteurs culturels, ni la pertinence de l'emplacement du carrousel.

Cette PR ajoute l'event **`OfferImagesScroll`**, émis à chaque changement d'image effectif, avec les paramètres `offerId`, `nbImages`, `imageIndex` et `from`.

| Écran | `from` | Interaction |
| :--- | :--- | :--- |
| Page offre (carrousel inline) | `offer` | Swipe (natif) / flèches préc.-suiv. (web) |
| Plein écran (`OfferPreview` natif / modale web) | `offerPreview` | Swipe (natif) / flèches préc.-suiv. (web) |

Comme prévu par la spec, swipe et flèches produisent le même event avec les mêmes paramètres — la distinction se fait en analyse via `agentType`.

### Choix techniques

- **`onSnapToItem` plutôt que `onProgressChange`** : `onProgressChange` émet des valeurs fractionnaires en continu pendant le geste et déclencherait des events fantômes sur un swipe annulé. `onSnapToItem` n'est appelé qu'en fin de scroll, une fois l'image calée, et couvre aussi les `scrollTo()` programmatiques des flèches web. Un seul point de branchement pour les deux plateformes.
- **Pas d'analytics dans `ui/`** : `ImagesCarousel` et `ImagesCarouselModal` sont partagés avec les écrans venue. Ils exposent un prop optionnel `onSnapToItem` et c'est la feature `offer` qui logue. Aucun impact côté venue.
- **Log centralisé dans `OfferImageRenderer`** pour le carrousel inline, ce composant étant partagé par `OfferImageContainer.tsx` et `OfferImageContainer.web.tsx`.
- **Aucun event parasite** : pas de log quand l'offre n'a qu'une image, ni à l'ouverture du plein écran sur un `defaultIndex`.
- **`imageIndex` est 0-based**, cohérent avec les autres paramètres d'index du repo (`index`, `offer_display_index`). À valider côté Data avant la recette.

### Note sur les tests

Le mock partagé `__mocks__/react-native-reanimated-carousel.tsx` ne gérait que `onProgressChange`, ce qui rendait impossible tout test de la navigation par flèches. Il propage désormais aussi `onSnapToItem` sur `scrollTo`, comme le fait la librairie réelle. Le swipe natif n'étant pas simulable avec cette librairie, le test de `OfferPreview` passe par un shim exposant le callback.
