### PR TITLE
(PC-43191) fix(artist): similar artists playlist title and see all button take all available space

### DIFF
--- a/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
+++ b/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
@@ -48,26 +48,27 @@ export const ArtistSimilarArtists: FunctionComponent<Props> = ({ artistId }) => 
     <View>
       <HeaderContainer>
         <TitleRow gap={3}>
-          <TitleContainer>
-            <AccessibleTitle title={TITLE} TitleComponent={TitleLevel2} withMargin={false} />
-          </TitleContainer>
+          <AccessibleTitle title={TITLE} TitleComponent={TitleLevel2} withMargin={false} />
+
           {artists.length > 1 ? (
-            <SeeAllButton
-              playlistTitle={TITLE}
-              data={{
-                onBeforeNavigate,
-                navigateToVerticalPlaylist: {
-                  screen: 'VerticalPlaylistArtists',
-                  params: {
-                    title: TITLE,
-                    subtitle: undefined,
-                    similarToArtistId: artistId,
-                    originDetails: 'similarArtistsPlaylist',
+            <View>
+              <SeeAllButton
+                playlistTitle={TITLE}
+                data={{
+                  onBeforeNavigate,
+                  navigateToVerticalPlaylist: {
+                    screen: 'VerticalPlaylistArtists',
+                    params: {
+                      title: TITLE,
+                      subtitle: undefined,
+                      similarToArtistId: artistId,
+                      originDetails: 'similarArtistsPlaylist',
+                    },
                   },
-                },
-                hideSearchSeeAll: true,
-              }}
-            />
+                  hideSearchSeeAll: true,
+                }}
+              />
+            </View>
           ) : null}
         </TitleRow>
       </HeaderContainer>
@@ -88,10 +89,6 @@ const HeaderContainer = styled.View(({ theme }) => ({
   marginHorizontal: theme.contentPage.marginHorizontal,
   marginBottom: theme.designSystem.size.spacing.m,
 }))
-
-const TitleContainer = styled.View({
-  flex: 1,
-})
 
 const TitleRow = styled(ViewGap)({
   flexDirection: 'row',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43191

## Context
L'objectif de cette PR est que le titre de la playlist des artistes similaires sur la page artiste et le bouton Voir tout prennent toute la place disponible en natif (en web c'était déjà ok).

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-12 at 16 07 25" src="https://github.com/user-attachments/assets/84d9a1b7-a7a7-48b3-9d5e-ade4482be7f0" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-12 at 16 48 40" src="https://github.com/user-attachments/assets/bf596ca3-0035-440b-bd52-ca208b333f36" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-12 at 15 53 15" src="https://github.com/user-attachments/assets/08ea7149-5777-4974-a3c0-bec23b1a3bd3" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-12 at 15 52 37" src="https://github.com/user-attachments/assets/1f99f6ae-a4b7-4228-a2b5-3f9231ff3684" />|
| Android          |<img width="1080" height="2400" alt="Screenshot_1786543534" src="https://github.com/user-attachments/assets/2fbe2b59-a857-4932-a561-b1de451fe139" />|<img width="1080" height="2400" alt="Screenshot_1786543522" src="https://github.com/user-attachments/assets/2a898875-608a-4c30-a80f-8be659615553" />|
| Phone - Chrome   |<img width="393" height="682" alt="Capture d’écran 2026-08-12 à 16 06 26" src="https://github.com/user-attachments/assets/8243899c-cb0b-4380-8e29-e10d4001a720" />|<img width="400" height="690" alt="Capture d’écran 2026-08-12 à 15 53 22" src="https://github.com/user-attachments/assets/f8efd0cd-9672-454d-aae4-9a2777d7e409" />|
| Desktop - Chrome |<img width="1505" height="761" alt="Capture d’écran 2026-08-12 à 16 06 18" src="https://github.com/user-attachments/assets/d328f4e6-143d-43ac-a57c-0b0b6439b72e" />|<img width="1509" height="761" alt="Capture d’écran 2026-08-12 à 15 53 29" src="https://github.com/user-attachments/assets/0addf5c0-7846-44e2-9fbb-4953f703b7e3" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
