### PR TITLE
(PC-43218) fix(offer): add offerId param to ConsultArtist log triggered on offer page from artists section

### DIFF
--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -540,6 +540,7 @@ describe('<OfferBody />', () => {
         artistId: '1',
         artistName: 'Stephen King',
         from: 'offer',
+        offerId: offer.id.toString(),
       })
     })
 
@@ -561,6 +562,7 @@ describe('<OfferBody />', () => {
         artistId: '1',
         artistName: 'Stephen King',
         from: 'offer',
+        offerId: offer.id.toString(),
       })
     })
 

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -125,7 +125,12 @@ export const OfferBody: FunctionComponent<Props> = ({
   }
 
   const handleOnArtistPlaylistItemPress = (artistId: string, artistName: string) => {
-    void analytics.logConsultArtist({ artistId, artistName, from: 'offer' })
+    void analytics.logConsultArtist({
+      artistId,
+      artistName,
+      from: 'offer',
+      offerId: offer.id.toString(),
+    })
   }
 
   const fullAddressOffer = formatFullAddress(


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43218

## Context

Il manque le paramètre offerId lorsque l'on déclenche le log ConsultArtist depuis un bouton artiste de la page offre.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
