### PR TITLE
(IC-1650) ci(workflow): limit the name of the branch created by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     open-pull-requests-limit: 2
     pull-request-branch-name:
       max-length: 55
+      template: '{dependency}-{version}'
     schedule:
       interval: 'weekly'
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
     open-pull-requests-limit: 2
     pull-request-branch-name:
       max-length: 55
+      template: '{dependency}-{version}'
     schedule:
       interval: 'weekly'
     labels:
@@ -34,6 +35,7 @@ updates:
     open-pull-requests-limit: 2
     pull-request-branch-name:
       max-length: 55
+      template: '{dependency}-{version}'
     schedule:
       interval: 'weekly'
     labels:
@@ -46,6 +48,7 @@ updates:
     open-pull-requests-limit: 2
     pull-request-branch-name:
       max-length: 55
+      template: '{dependency}-{version}'
     schedule:
       interval: 'weekly'
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     open-pull-requests-limit: 2
+    pull-request-branch-name:
+      max-length: 55
     schedule:
       interval: 'weekly'
     labels:
@@ -17,6 +19,8 @@ updates:
   - package-ecosystem: 'bundler'
     directory: '/'
     open-pull-requests-limit: 2
+    pull-request-branch-name:
+      max-length: 55
     schedule:
       interval: 'weekly'
     labels:
@@ -27,6 +31,8 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '.github/workflows'
     open-pull-requests-limit: 2
+    pull-request-branch-name:
+      max-length: 55
     schedule:
       interval: 'weekly'
     labels:
@@ -37,6 +43,8 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/server'
     open-pull-requests-limit: 2
+    pull-request-branch-name:
+      max-length: 55
     schedule:
       interval: 'weekly'
     labels:


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
