### PR TITLE
(PC-43208) fix(Search): use tab bar height to compute map CTA bottom

### DIFF
--- a/src/features/search/pages/SearchResults/v2/components/SearchLists/OffersList.tsx
+++ b/src/features/search/pages/SearchResults/v2/components/SearchLists/OffersList.tsx
@@ -35,6 +35,7 @@ import { useGetHeaderHeight } from 'shared/header/useGetHeaderHeight'
 import { Offer } from 'shared/offer/types'
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
 import { ScrollToTopButton } from 'ui/components/ScrollToTopButton'
+import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 const searchIdGenerated = v4()
 const isWeb = Platform.OS === 'web'
@@ -51,6 +52,7 @@ export const OffersList: FC<PropsWithChildren<Props>> = ({
   hasBeenClicked,
   setHasBeenClicked,
 }) => {
+  const { tabBarHeight } = useCustomSafeInsets()
   const transformHits = useTransformOfferHits()
 
   const {
@@ -174,6 +176,7 @@ export const OffersList: FC<PropsWithChildren<Props>> = ({
           />
 
           <FloatingButtonsWrapper
+            tabBarHeight={tabBarHeight}
             layout={LinearTransition.springify().damping(15).stiffness(20).duration(1000)}>
             {shouldRenderScrollToTopButton ? (
               <ScrollToTopButton
@@ -205,13 +208,15 @@ const LineSeparator = styled.View(({ theme }) => ({
   marginVertical: theme.designSystem.size.spacing.l,
 }))
 
-const FloatingButtonsWrapper = styled(Animated.View)(({ theme }) => ({
-  position: 'absolute',
-  flexDirection: 'row',
-  alignItems: 'center',
-  justifyContent: 'flex-end',
-  gap: theme.designSystem.size.spacing.s,
-  right: theme.designSystem.size.spacing.xl,
-  bottom: theme.tabBar.height + theme.designSystem.size.spacing.xl,
-  zIndex: theme.zIndex.floatingButton,
-}))
+const FloatingButtonsWrapper = styled(Animated.View)<{ tabBarHeight: number }>(
+  ({ theme, tabBarHeight }) => ({
+    position: 'absolute',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: theme.designSystem.size.spacing.s,
+    right: theme.designSystem.size.spacing.xl,
+    bottom: tabBarHeight + theme.designSystem.size.spacing.xl,
+    zIndex: theme.zIndex.floatingButton,
+  })
+)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43208

## Context

[Ce commit](https://github.com/pass-culture/pass-culture-app-native/commit/3542c8625d709e6965a28910d14457e23a67d82d) réhausse le bottom de l'inset d'une page sur Android, et donc fait que la Tabbar passe au-dessus du CTA "Voir la carte" sur la page des résultats de recherche.
Cette PR positionne ce CTA en tenant compte de la nouvelle hauteur de la Tabbar de l'app.

Le problème est commun à d'autres écrans de l'app, pour lesquels on fera d'autres PR.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Android          | <img width="1440" height="3120" alt="image" src="https://github.com/user-attachments/assets/6189b798-e6ec-44a6-8322-416d635bc843" /> | <img width="1440" height="3120" alt="image" src="https://github.com/user-attachments/assets/5b092fe6-cc8a-4ce2-85a1-9b46e05d4ff8" /> |


