### PR TITLE
(PC-43244) fix(app): title and see all button take all available space for artists playlist and search results venues playlist

### DIFF
--- a/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
@@ -669,104 +669,106 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                           Les artistes
                         </Text>
                       </View>
-                      <View
-                        style={
-                          {
-                            "flexDirection": "row",
-                            "flexGrow": 1,
-                          }
-                        }
-                      >
+                      <View>
                         <View
-                          accessibilityLabel="Voir tout pour la sélection Les artistes"
-                          accessibilityRole="button"
-                          accessibilityState={
-                            {
-                              "busy": undefined,
-                              "checked": undefined,
-                              "disabled": false,
-                              "expanded": undefined,
-                              "selected": undefined,
-                            }
-                          }
-                          accessibilityValue={
-                            {
-                              "max": undefined,
-                              "min": undefined,
-                              "now": undefined,
-                              "text": undefined,
-                            }
-                          }
-                          accessible={true}
-                          focusable={true}
-                          onClick={[Function]}
-                          onResponderGrant={[Function]}
-                          onResponderMove={[Function]}
-                          onResponderRelease={[Function]}
-                          onResponderTerminate={[Function]}
-                          onResponderTerminationRequest={[Function]}
-                          onStartShouldSetResponder={[Function]}
                           style={
-                            [
-                              [
-                                {
-                                  "userSelect": "auto",
-                                },
-                                {
-                                  "alignItems": "center",
-                                  "backgroundColor": "transparent",
-                                  "borderWidth": 0,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "paddingBottom": 2,
-                                  "paddingLeft": 2,
-                                  "paddingRight": 2,
-                                  "paddingTop": 2,
-                                  "width": "auto",
-                                },
-                              ],
-                              {
-                                "opacity": 1,
-                              },
-                            ]
+                            {
+                              "flexDirection": "row",
+                              "flexGrow": 1,
+                            }
                           }
-                          testID="Voir tout pour la sélection Les artistes"
                         >
                           <View
-                            gap={8}
-                            hasIcon={false}
-                            isMultiline={false}
-                            style={
+                            accessibilityLabel="Voir tout pour la sélection Les artistes"
+                            accessibilityRole="button"
+                            accessibilityState={
                               {
-                                "alignItems": "center",
-                                "columnGap": 8,
-                                "flexDirection": "row",
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": false,
+                                "expanded": undefined,
+                                "selected": undefined,
                               }
                             }
-                          >
-                            <Text
-                              style={
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            focusable={true}
+                            onClick={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              [
                                 [
                                   {
-                                    "color": "#161617",
-                                    "fontFamily": "Montserrat-SemiBold",
-                                    "fontSize": 14,
-                                    "lineHeight": 14,
+                                    "userSelect": "auto",
                                   },
                                   {
-                                    "color": "#6123df",
-                                    "flexBasis": undefined,
-                                    "flexGrow": undefined,
-                                    "flexShrink": 1,
-                                    "maxWidth": "100%",
-                                    "minWidth": 0,
-                                    "textAlign": undefined,
+                                    "alignItems": "center",
+                                    "backgroundColor": "transparent",
+                                    "borderWidth": 0,
+                                    "flexDirection": "row",
+                                    "justifyContent": "center",
+                                    "paddingBottom": 2,
+                                    "paddingLeft": 2,
+                                    "paddingRight": 2,
+                                    "paddingTop": 2,
+                                    "width": "auto",
                                   },
-                                ]
+                                ],
+                                {
+                                  "opacity": 1,
+                                },
+                              ]
+                            }
+                            testID="Voir tout pour la sélection Les artistes"
+                          >
+                            <View
+                              gap={8}
+                              hasIcon={false}
+                              isMultiline={false}
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "columnGap": 8,
+                                  "flexDirection": "row",
+                                }
                               }
                             >
-                              Voir tout
-                            </Text>
+                              <Text
+                                style={
+                                  [
+                                    {
+                                      "color": "#161617",
+                                      "fontFamily": "Montserrat-SemiBold",
+                                      "fontSize": 14,
+                                      "lineHeight": 14,
+                                    },
+                                    {
+                                      "color": "#6123df",
+                                      "flexBasis": undefined,
+                                      "flexGrow": undefined,
+                                      "flexShrink": 1,
+                                      "maxWidth": "100%",
+                                      "minWidth": 0,
+                                      "textAlign": undefined,
+                                    },
+                                  ]
+                                }
+                              >
+                                Voir tout
+                              </Text>
+                            </View>
                           </View>
                         </View>
                       </View>

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, useState } from 'react'
+import { View } from 'react-native'
 import { styled, useTheme } from 'styled-components/native'
 
 import { CategoryIdEnum, OfferArtist, SearchGroupNameEnumv2, SubcategoryIdEnum } from 'api/gen'
@@ -125,14 +126,16 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
           <Typo.Title4 {...getTextSemanticAttrs(2)}>{title}</Typo.Title4>
         </TitleContainer>
         {artists.length > 1 ? (
-          <SeeAllButton
-            playlistTitle={title}
-            data={{
-              onBeforeNavigate: onSeeAllBeforeNavigate,
-              navigateToVerticalPlaylist,
-              hideSearchSeeAll: true,
-            }}
-          />
+          <View>
+            <SeeAllButton
+              playlistTitle={title}
+              data={{
+                onBeforeNavigate: onSeeAllBeforeNavigate,
+                navigateToVerticalPlaylist,
+                hideSearchSeeAll: true,
+              }}
+            />
+          </View>
         ) : null}
       </SeeAllButtonContainer>
 

--- a/src/features/search/components/SearchListHeader/ArtistSection.tsx
+++ b/src/features/search/components/SearchListHeader/ArtistSection.tsx
@@ -47,14 +47,16 @@ export const ArtistSection = ({
             <Typo.Title3>{playlistTitle}</Typo.Title3>
           </TitleContainer>
           {artists.length > 1 ? (
-            <SeeAllButton
-              playlistTitle={playlistTitle}
-              data={{
-                onBeforeNavigate,
-                navigateToVerticalPlaylist,
-                hideSearchSeeAll: true,
-              }}
-            />
+            <View>
+              <SeeAllButton
+                playlistTitle={playlistTitle}
+                data={{
+                  onBeforeNavigate,
+                  navigateToVerticalPlaylist,
+                  hideSearchSeeAll: true,
+                }}
+              />
+            </View>
           ) : null}
         </SeeAllButtonContainer>
         <NumberOfItems nbItems={artists.length} />

--- a/src/features/search/components/VenuePlaylist/VenuePlaylist.tsx
+++ b/src/features/search/components/VenuePlaylist/VenuePlaylist.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native'
 import React, { Ref, useEffect } from 'react'
-import { Platform, StyleProp, ViewStyle, ViewToken } from 'react-native'
+import { Platform, StyleProp, View, ViewStyle, ViewToken } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 import { useTheme } from 'styled-components'
 import styled from 'styled-components/native'
@@ -160,14 +160,16 @@ export const VenuePlaylist: React.FC<Props> = ({
               <Typo.Title3 numberOfLines={isWeb ? 1 : undefined}>{venuePlaylistTitle}</Typo.Title3>
             </TitleContainer>
             {venues.length > 1 ? (
-              <SeeAllButton
-                playlistTitle={venuePlaylistTitle}
-                data={{
-                  onBeforeNavigate,
-                  navigateToVerticalPlaylist,
-                  hideSearchSeeAll: true,
-                }}
-              />
+              <View>
+                <SeeAllButton
+                  playlistTitle={venuePlaylistTitle}
+                  data={{
+                    onBeforeNavigate,
+                    navigateToVerticalPlaylist,
+                    hideSearchSeeAll: true,
+                  }}
+                />
+              </View>
             ) : null}
           </SeeAllButtonContainer>
           {shouldDisplaySeeOnMapButton ? (

--- a/src/features/search/pages/SearchResults/v2/components/SearchPlaylists/ArtistsPlaylist.tsx
+++ b/src/features/search/pages/SearchResults/v2/components/SearchPlaylists/ArtistsPlaylist.tsx
@@ -56,14 +56,16 @@ export const ArtistsPlaylist = ({
           <TitleContainer>
             <Typo.Title3>{playlistTitle}</Typo.Title3>
           </TitleContainer>
-          <SeeAllButton
-            playlistTitle={playlistTitle}
-            data={{
-              onBeforeNavigate,
-              navigateToVerticalPlaylist,
-              hideSearchSeeAll: true,
-            }}
-          />
+          <View>
+            <SeeAllButton
+              playlistTitle={playlistTitle}
+              data={{
+                onBeforeNavigate,
+                navigateToVerticalPlaylist,
+                hideSearchSeeAll: true,
+              }}
+            />
+          </View>
         </SeeAllButtonContainer>
         <NumberOfItems nbItems={artistsResponse.length} />
       </HeaderContainer>

--- a/src/features/search/pages/SearchResults/v2/components/SearchPlaylists/VenuesPlaylist.tsx
+++ b/src/features/search/pages/SearchResults/v2/components/SearchPlaylists/VenuesPlaylist.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native'
 import React, { Ref, useEffect } from 'react'
-import { Platform, StyleProp, ViewStyle, ViewToken } from 'react-native'
+import { Platform, StyleProp, View, ViewStyle, ViewToken } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 import { useTheme } from 'styled-components'
 import styled from 'styled-components/native'
@@ -159,14 +159,16 @@ export const VenuePlaylist: React.FC<Props> = ({
             <TitleContainer>
               <Typo.Title3 numberOfLines={isWeb ? 1 : undefined}>{venuePlaylistTitle}</Typo.Title3>
             </TitleContainer>
-            <SeeAllButton
-              playlistTitle={venuePlaylistTitle}
-              data={{
-                onBeforeNavigate,
-                navigateToVerticalPlaylist,
-                hideSearchSeeAll: true,
-              }}
-            />
+            <View>
+              <SeeAllButton
+                playlistTitle={venuePlaylistTitle}
+                data={{
+                  onBeforeNavigate,
+                  navigateToVerticalPlaylist,
+                  hideSearchSeeAll: true,
+                }}
+              />
+            </View>
           </SeeAllButtonContainer>
           {shouldDisplaySeeOnMapButton ? (
             <ButtonContainer>

--- a/src/features/venue/components/VenueOffers/VenueOffersList.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffersList.tsx
@@ -1,6 +1,6 @@
 import { useIsFocused, useRoute } from '@react-navigation/native'
 import React, { FunctionComponent, useCallback } from 'react'
-import { Platform, ViewToken } from 'react-native'
+import { Platform, View, ViewToken } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -221,14 +221,16 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
               <Typo.Title3 {...getTextSemanticAttrs(2)}>{playlistTitle}</Typo.Title3>
             </TitleContainer>
             {artists.length > 1 ? (
-              <SeeAllButton
-                playlistTitle={playlistTitle}
-                data={{
-                  onBeforeNavigate: onSeeAllBeforeNavigate,
-                  navigateToVerticalPlaylist,
-                  hideSearchSeeAll: true,
-                }}
-              />
+              <View>
+                <SeeAllButton
+                  playlistTitle={playlistTitle}
+                  data={{
+                    onBeforeNavigate: onSeeAllBeforeNavigate,
+                    navigateToVerticalPlaylist,
+                    hideSearchSeeAll: true,
+                  }}
+                />
+              </View>
             ) : null}
           </SeeAllButtonContainer>
           <ObservedPlaylist onViewableItemsChanged={handleArtistsViewableItemsChanged}>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43191

## Context

L'objectif de cette PR est que le titre de toutes les playlist artistes de l'app et le bouton Voir tout prennent tout l'espace disponible en natif ainsi que la playlist de lieux dans les résultats de recherche.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-17 at 15 43 22" src="https://github.com/user-attachments/assets/f5a725c1-3d04-485d-906a-94765ac46951" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-17 at 15 48 20" src="https://github.com/user-attachments/assets/2c6502fa-523e-467c-a6ab-50516e88595d" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-18 at 09 04 26" src="https://github.com/user-attachments/assets/5447b1df-990c-4e80-a886-faaaa8a9d7a4" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-18 at 09 15 15" src="https://github.com/user-attachments/assets/848c8206-00e7-4a42-9bbe-502a56ae1934" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-17 at 15 47 28" src="https://github.com/user-attachments/assets/562d3ae7-3e9c-4f04-a485-81dae528e32d" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-17 at 15 48 36" src="https://github.com/user-attachments/assets/aca03490-33b0-464d-8e9e-5acc72f953fd" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-18 at 09 12 47" src="https://github.com/user-attachments/assets/fe5dd51b-048c-4018-b195-96e6e7eb2478" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-18 at 09 15 53" src="https://github.com/user-attachments/assets/0afe5a0d-78bc-4cc7-9075-4138dacfcae2" />|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
