### PR TITLE
(PC-43225) fix(advices): use ViewGap rather View to manage correctly spacing between tag and see more button

### DIFF
--- a/src/features/advices/components/AdviceCardBody/AdviceCardBody.tsx
+++ b/src/features/advices/components/AdviceCardBody/AdviceCardBody.tsx
@@ -60,7 +60,7 @@ export const AdviceCardBody: FunctionComponent<Props> = ({
         </Typo.BodyS>
       </DescriptionContainer>
       <PublicationDate>{date}</PublicationDate>
-      <BottomCardContainer>
+      <BottomCardContainer gap={6}>
         {tag}
         {shouldDisplayButton && children}
       </BottomCardContainer>
@@ -79,7 +79,7 @@ const DescriptionContainer = styled.View<{ defaultHeight: number; shouldTruncate
     shouldTruncate ? { maxHeight: MAX_LINES * defaultHeight, overflow: 'hidden', flexGrow: 1 } : {}
 )
 
-const BottomCardContainer = styled.View({
+const BottomCardContainer = styled(ViewGap)({
   flexDirection: 'row',
   justifyContent: 'space-between',
   alignItems: 'center',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43225

## Context
L'objectif de cette PR est d'avoir un espace entre le tag et le bouton Voir plus sur un avis quand ceux-ci passent sur 2 lignes (aujourd'hui uniquement dans le cas des scènes clubs)

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-17 at 16 52 10" src="https://github.com/user-attachments/assets/839db924-225b-4133-80d2-3c4fef39f054" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-17 at 17 24 09" src="https://github.com/user-attachments/assets/d4e40a76-e7d1-4dbe-8036-65001d498313" />|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
