### PR TITLE
(PC-41652) feat(auth): Add last login info in login

### DIFF
--- a/src/cheatcodes/pages/CheatcodesMenu.tsx
+++ b/src/cheatcodes/pages/CheatcodesMenu.tsx
@@ -140,6 +140,12 @@ export function CheatcodesMenu(): React.JSX.Element {
     },
     {
       id: uuidv4(),
+      title: 'Last login info 📱',
+      navigationTarget: { screen: 'CheatcodesScreenLastLoginInfo' },
+      subscreens: [],
+    },
+    {
+      id: uuidv4(),
       title: 'Debug informations 🪲',
       navigationTarget: { screen: 'CheatcodesScreenDebugInformations' },
       subscreens: [],

--- a/src/cheatcodes/pages/others/CheatcodesScreenLastLoginInfo.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenLastLoginInfo.tsx
@@ -1,0 +1,24 @@
+import React, { useState, useEffect } from 'react'
+
+import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
+import { LastLoginInfoBanner } from 'features/auth/components/LastLoginInfoBanner'
+import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
+import { FormattedLastLoginInfo } from 'features/auth/types'
+
+export const CheatcodesScreenLastLoginInfo = () => {
+  const [lastLoginInfo, setLastLoginInfo] = useState<FormattedLastLoginInfo | null>(null)
+
+  useEffect(() => {
+    const loadLastLoginInfo = async () => {
+      const info = await getLastLoginInfo()
+      setLastLoginInfo(info)
+    }
+    void loadLastLoginInfo()
+  }, [])
+
+  return (
+    <CheatcodesTemplateScreen title="Last login info 📱" flexDirection="column">
+      <LastLoginInfoBanner lastLoginInfo={lastLoginInfo} />
+    </CheatcodesTemplateScreen>
+  )
+}

--- a/src/features/auth/components/AuthenticationButton/AuthenticationButton.native.test.tsx
+++ b/src/features/auth/components/AuthenticationButton/AuthenticationButton.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { AuthenticationButton } from 'features/auth/components/AuthenticationButton/AuthenticationButton'
 import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
+import { Provider } from 'features/auth/types'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { render, screen, userEvent } from 'tests/utils'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
@@ -33,7 +34,7 @@ describe('<AuthenticationButton />', () => {
   it('should navigate to the LoginMethodsWithLastLoginInfo page when last login info exists', async () => {
     jest.mocked(getLastLoginInfo).mockResolvedValueOnce({
       maskedEmail: 'rog*************@passculture.gen',
-      provider: { label: 'E-mail', icon: EmailFilled },
+      provider: { label: 'E-mail', icon: EmailFilled, type: Provider.EMAIL },
       lastLoginAt: '18/08/2026',
     })
 
@@ -69,7 +70,7 @@ describe('<AuthenticationButton />', () => {
   it('should navigate to the LoginMethodsWithLastLoginInfo page with additional params when last login info exists', async () => {
     jest.mocked(getLastLoginInfo).mockResolvedValueOnce({
       maskedEmail: 'rog*************@passculture.gen',
-      provider: { label: 'E-mail', icon: EmailFilled },
+      provider: { label: 'E-mail', icon: EmailFilled, type: Provider.EMAIL },
       lastLoginAt: '18/08/2026',
     })
 

--- a/src/features/auth/components/AuthenticationButton/AuthenticationButton.native.test.tsx
+++ b/src/features/auth/components/AuthenticationButton/AuthenticationButton.native.test.tsx
@@ -36,7 +36,7 @@ describe('<AuthenticationButton />', () => {
 
   it('should navigate to the LoginMethodsWithLastLoginInfo page when last login info exists', async () => {
     jest.mocked(getLastLoginInfo).mockResolvedValueOnce({
-      maskedEmail: 'rog*************@passculture.gen',
+      maskedEmail: 'rog*************@gmail.com',
       provider: { label: 'E-mail', icon: EmailFilled, type: Provider.EMAIL },
       lastLoginAt: '18/08/2026',
     })
@@ -72,7 +72,7 @@ describe('<AuthenticationButton />', () => {
 
   it('should navigate to the LoginMethodsWithLastLoginInfo page with additional params when last login info exists', async () => {
     jest.mocked(getLastLoginInfo).mockResolvedValueOnce({
-      maskedEmail: 'rog*************@passculture.gen',
+      maskedEmail: 'rog*************@gmail.com',
       provider: { label: 'E-mail', icon: EmailFilled, type: Provider.EMAIL },
       lastLoginAt: '18/08/2026',
     })

--- a/src/features/auth/components/AuthenticationButton/AuthenticationButton.native.test.tsx
+++ b/src/features/auth/components/AuthenticationButton/AuthenticationButton.native.test.tsx
@@ -5,6 +5,9 @@ import { AuthenticationButton } from 'features/auth/components/AuthenticationBut
 import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
 import { Provider } from 'features/auth/types'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent } from 'tests/utils'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 
@@ -18,12 +21,12 @@ jest.mock('features/navigation/helpers/openUrl')
 jest.mock('features/auth/helpers/getLastLoginInfo')
 
 describe('<AuthenticationButton />', () => {
-  beforeEach(() => jest.clearAllMocks())
+  beforeEach(() => setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_SAVE_LAST_LOGIN_INFO]))
 
   it('should navigate to the LoginMethods page when there is no last login info', async () => {
     jest.mocked(getLastLoginInfo).mockResolvedValueOnce(null)
 
-    render(<AuthenticationButton type="login" />)
+    render(reactQueryProviderHOC(<AuthenticationButton type="login" />))
 
     const connectButton = await screen.findByText('Se connecter')
     await user.press(connectButton)
@@ -38,7 +41,7 @@ describe('<AuthenticationButton />', () => {
       lastLoginAt: '18/08/2026',
     })
 
-    render(<AuthenticationButton type="login" />)
+    render(reactQueryProviderHOC(<AuthenticationButton type="login" />))
 
     const connectButton = await screen.findByText('Se connecter')
     await user.press(connectButton)
@@ -47,7 +50,7 @@ describe('<AuthenticationButton />', () => {
   })
 
   it('should navigate to the SignupMethods page when is type signup', async () => {
-    render(<AuthenticationButton type="signup" />)
+    render(reactQueryProviderHOC(<AuthenticationButton type="signup" />))
 
     const connectButton = screen.getByText('Créer un compte')
     await user.press(connectButton)
@@ -59,7 +62,7 @@ describe('<AuthenticationButton />', () => {
   it('should navigate to the LoginMethods page with additional params when there is no last login info', async () => {
     jest.mocked(getLastLoginInfo).mockResolvedValueOnce(null)
 
-    render(<AuthenticationButton type="login" params={NAV_PARAMS_LOGIN} />)
+    render(reactQueryProviderHOC(<AuthenticationButton type="login" params={NAV_PARAMS_LOGIN} />))
 
     const connectButton = await screen.findByText('Se connecter')
     await user.press(connectButton)
@@ -74,7 +77,7 @@ describe('<AuthenticationButton />', () => {
       lastLoginAt: '18/08/2026',
     })
 
-    render(<AuthenticationButton type="login" params={NAV_PARAMS_LOGIN} />)
+    render(reactQueryProviderHOC(<AuthenticationButton type="login" params={NAV_PARAMS_LOGIN} />))
 
     const connectButton = await screen.findByText('Se connecter')
     await user.press(connectButton)
@@ -83,7 +86,7 @@ describe('<AuthenticationButton />', () => {
   })
 
   it('should navigate to the SignupMethods page with additional params when is type signup', async () => {
-    render(<AuthenticationButton type="signup" params={NAV_PARAMS_SIGNUP} />)
+    render(reactQueryProviderHOC(<AuthenticationButton type="signup" params={NAV_PARAMS_SIGNUP} />))
 
     const connectButton = screen.getByText('Créer un compte')
     await user.press(connectButton)

--- a/src/features/auth/components/AuthenticationButton/AuthenticationButton.native.test.tsx
+++ b/src/features/auth/components/AuthenticationButton/AuthenticationButton.native.test.tsx
@@ -2,8 +2,10 @@ import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { AuthenticationButton } from 'features/auth/components/AuthenticationButton/AuthenticationButton'
+import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { render, screen, userEvent } from 'tests/utils'
+import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 
 const NAV_PARAMS_LOGIN = { offerId: 1 }
 const NAV_PARAMS_SIGNUP = { offerId: 1, from: StepperOrigin.HOME }
@@ -12,15 +14,35 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 jest.mock('features/navigation/helpers/openUrl')
+jest.mock('features/auth/helpers/getLastLoginInfo')
 
 describe('<AuthenticationButton />', () => {
-  it('should navigate to the LoginMethods page when is type login', async () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('should navigate to the LoginMethods page when there is no last login info', async () => {
+    jest.mocked(getLastLoginInfo).mockResolvedValueOnce(null)
+
     render(<AuthenticationButton type="login" />)
 
-    const connectButton = screen.getByText('Se connecter')
+    const connectButton = await screen.findByText('Se connecter')
     await user.press(connectButton)
 
     expect(navigate).toHaveBeenCalledWith('LoginMethods', {})
+  })
+
+  it('should navigate to the LoginMethodsWithLastLoginInfo page when last login info exists', async () => {
+    jest.mocked(getLastLoginInfo).mockResolvedValueOnce({
+      maskedEmail: 'rog*************@passculture.gen',
+      provider: { label: 'E-mail', icon: EmailFilled },
+      lastLoginAt: '18/08/2026',
+    })
+
+    render(<AuthenticationButton type="login" />)
+
+    const connectButton = await screen.findByText('Se connecter')
+    await user.press(connectButton)
+
+    expect(navigate).toHaveBeenCalledWith('LoginMethodsWithLastLoginInfo', {})
   })
 
   it('should navigate to the SignupMethods page when is type signup', async () => {
@@ -30,23 +52,42 @@ describe('<AuthenticationButton />', () => {
     await user.press(connectButton)
 
     expect(navigate).toHaveBeenCalledWith('SignupMethods', {})
+    expect(getLastLoginInfo).not.toHaveBeenCalled()
   })
 
-  it('should navigate to the LoginMethods page with additional params when defined for login', async () => {
+  it('should navigate to the LoginMethods page with additional params when there is no last login info', async () => {
+    jest.mocked(getLastLoginInfo).mockResolvedValueOnce(null)
+
     render(<AuthenticationButton type="login" params={NAV_PARAMS_LOGIN} />)
 
-    const connectButton = screen.getByText('Se connecter')
+    const connectButton = await screen.findByText('Se connecter')
     await user.press(connectButton)
 
     expect(navigate).toHaveBeenCalledWith('LoginMethods', NAV_PARAMS_LOGIN)
   })
 
-  it('should navigate to the SignupMethods page with additional params when defined for signup', async () => {
+  it('should navigate to the LoginMethodsWithLastLoginInfo page with additional params when last login info exists', async () => {
+    jest.mocked(getLastLoginInfo).mockResolvedValueOnce({
+      maskedEmail: 'rog*************@passculture.gen',
+      provider: { label: 'E-mail', icon: EmailFilled },
+      lastLoginAt: '18/08/2026',
+    })
+
+    render(<AuthenticationButton type="login" params={NAV_PARAMS_LOGIN} />)
+
+    const connectButton = await screen.findByText('Se connecter')
+    await user.press(connectButton)
+
+    expect(navigate).toHaveBeenCalledWith('LoginMethodsWithLastLoginInfo', NAV_PARAMS_LOGIN)
+  })
+
+  it('should navigate to the SignupMethods page with additional params when is type signup', async () => {
     render(<AuthenticationButton type="signup" params={NAV_PARAMS_SIGNUP} />)
 
     const connectButton = screen.getByText('Créer un compte')
     await user.press(connectButton)
 
     expect(navigate).toHaveBeenCalledWith('SignupMethods', NAV_PARAMS_SIGNUP)
+    expect(getLastLoginInfo).not.toHaveBeenCalled()
   })
 })

--- a/src/features/auth/components/AuthenticationButton/AuthenticationButton.tsx
+++ b/src/features/auth/components/AuthenticationButton/AuthenticationButton.tsx
@@ -1,6 +1,7 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useEffect, useState } from 'react'
 import styled from 'styled-components/native'
 
+import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
 import {
   RootNavigateParams,
   RootStackParamList,
@@ -33,11 +34,34 @@ export const AuthenticationButton: FunctionComponent<Props> = ({
   params = {},
   onAdditionalPress: onPress,
 }) => {
+  const [hasLastLoginInfo, setHasLastLoginInfo] = useState(false)
+
   const isLogin = type === 'login'
+
+  useEffect(() => {
+    if (isLogin === false) return
+
+    const loadLastLoginInfo = async () => {
+      const lastLoginInfo = await getLastLoginInfo()
+      setHasLastLoginInfo(lastLoginInfo !== null)
+    }
+
+    void loadLastLoginInfo()
+  }, [isLogin])
+
+  const loginScreen: RootNavigateParams[0] =
+    hasLastLoginInfo === true ? 'LoginMethodsWithLastLoginInfo' : 'LoginMethods'
+
   const nextNavigation: {
     screen: RootNavigateParams[0]
-    params: RootStackParamList['SignupMethods'] | RootStackParamList['LoginMethods']
-  } = { screen: isLogin ? 'LoginMethods' : 'SignupMethods', params }
+    params:
+      | RootStackParamList['SignupMethods']
+      | RootStackParamList['LoginMethods']
+      | RootStackParamList['LoginMethodsWithLastLoginInfo']
+  } = {
+    screen: isLogin ? loginScreen : 'SignupMethods',
+    params,
+  }
 
   const text = isLogin ? 'Déjà un compte\u00a0?' : 'Pas de compte\u00a0?'
   const wording = isLogin ? 'Se connecter' : 'Créer un compte'

--- a/src/features/auth/components/AuthenticationButton/AuthenticationButton.tsx
+++ b/src/features/auth/components/AuthenticationButton/AuthenticationButton.tsx
@@ -7,6 +7,8 @@ import {
   RootStackParamList,
 } from 'features/navigation/navigators/RootNavigator/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { ColorsType } from 'theme/types'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Link } from 'ui/designSystem/Link/Link'
@@ -34,23 +36,25 @@ export const AuthenticationButton: FunctionComponent<Props> = ({
   params = {},
   onAdditionalPress: onPress,
 }) => {
+  const enabledSaveLastLoginInfo = useFeatureFlag(
+    RemoteStoreFeatureFlags.ENABLE_SAVE_LAST_LOGIN_INFO
+  )
   const [hasLastLoginInfo, setHasLastLoginInfo] = useState(false)
 
   const isLogin = type === 'login'
 
   useEffect(() => {
-    if (isLogin === false) return
-
+    if (!isLogin || !enabledSaveLastLoginInfo) return
     const loadLastLoginInfo = async () => {
       const lastLoginInfo = await getLastLoginInfo()
       setHasLastLoginInfo(lastLoginInfo !== null)
     }
-
     void loadLastLoginInfo()
-  }, [isLogin])
+  }, [isLogin, enabledSaveLastLoginInfo])
 
-  const loginScreen: RootNavigateParams[0] =
-    hasLastLoginInfo === true ? 'LoginMethodsWithLastLoginInfo' : 'LoginMethods'
+  const loginScreen: RootNavigateParams[0] = hasLastLoginInfo
+    ? 'LoginMethodsWithLastLoginInfo'
+    : 'LoginMethods'
 
   const nextNavigation: {
     screen: RootNavigateParams[0]

--- a/src/features/auth/components/LastLoginInfoBanner.tsx
+++ b/src/features/auth/components/LastLoginInfoBanner.tsx
@@ -1,0 +1,28 @@
+import React, { FunctionComponent } from 'react'
+import styled from 'styled-components/native'
+
+import { FormattedLastLoginInfo } from 'features/auth/types'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { Tag } from 'ui/designSystem/Tag/Tag'
+import { Typo } from 'ui/theme'
+import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
+
+type Props = { lastLoginInfo: FormattedLastLoginInfo | null }
+
+export const LastLoginInfoBanner: FunctionComponent<Props> = ({ lastLoginInfo }) => {
+  if (!lastLoginInfo) return null
+
+  return (
+    <Container gap={4}>
+      <Tag label={lastLoginInfo.provider.label} Icon={lastLoginInfo.provider.icon} />
+      <Typo.Title4 {...getNoHeadingAttrs()}>{lastLoginInfo.maskedEmail}</Typo.Title4>
+      <Typo.BodyXs>Connecté pour la dernière fois le {lastLoginInfo.lastLoginAt}</Typo.BodyXs>
+    </Container>
+  )
+}
+
+const Container = styled(ViewGap)(({ theme }) => ({
+  padding: theme.designSystem.size.spacing.l,
+  border: `1px solid ${theme.designSystem.color.border.subtle}`,
+  borderRadius: theme.designSystem.size.borderRadius.m,
+}))

--- a/src/features/auth/components/ProviderButton.tsx
+++ b/src/features/auth/components/ProviderButton.tsx
@@ -1,0 +1,57 @@
+import React, { FunctionComponent } from 'react'
+
+import { SSOButtonAppleBase } from 'features/auth/components/SSOButton/SSOButtonAppleBase'
+import { SSOButtonGoogleBase } from 'features/auth/components/SSOButton/SSOButtonGoogleBase'
+import { Provider, FormattedLastLoginInfo } from 'features/auth/types'
+import { RootStackParamList } from 'features/navigation/navigators/RootNavigator/types'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
+import { Button } from 'ui/designSystem/Button/Button'
+import { EmailFilled } from 'ui/svg/icons/EmailFilled'
+
+type Props = {
+  lastLoginInfo: FormattedLastLoginInfo | null
+  params: RootStackParamList['LoginMethodsWithLastLoginInfo']
+  enableAppleSSO: boolean
+  onGoogleSuccess: (params: {
+    authorizationCode: string
+    oauthStateToken: string
+    provider: Provider.GOOGLE
+  }) => void
+  onAppleSuccess: (params: {
+    authorizationCode: string
+    oauthStateToken: string
+    provider: Provider.APPLE
+  }) => void
+}
+
+export const ProviderButton: FunctionComponent<Props> = ({
+  lastLoginInfo,
+  params,
+  enableAppleSSO,
+  onGoogleSuccess,
+  onAppleSuccess,
+}) => {
+  switch (lastLoginInfo?.provider.type) {
+    case Provider.GOOGLE:
+      return <SSOButtonGoogleBase type="login" onSuccess={onGoogleSuccess} />
+
+    case Provider.APPLE:
+      if (!enableAppleSSO) return null
+      return <SSOButtonAppleBase type="login" onSuccess={onAppleSuccess} />
+
+    case Provider.EMAIL:
+      return (
+        <InternalTouchableLink
+          as={Button}
+          variant="secondary"
+          color="neutral"
+          icon={EmailFilled}
+          wording="Continuer avec mon e-mail"
+          navigateTo={{ screen: 'Login', params }}
+        />
+      )
+
+    default:
+      return null
+  }
+}

--- a/src/features/auth/components/SSOButton/SSOButtonApple.native.test.tsx
+++ b/src/features/auth/components/SSOButton/SSOButtonApple.native.test.tsx
@@ -82,7 +82,7 @@ describe('<SSOButtonApple />', () => {
           source: 'iPhone 13',
         },
       },
-      'apple',
+      Provider.APPLE,
       { credentials: 'omit' }
     )
   })

--- a/src/features/auth/components/SSOButton/SSOButtonApple.native.test.tsx
+++ b/src/features/auth/components/SSOButton/SSOButtonApple.native.test.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import * as API from 'api/api'
 import { AccountState, OauthStateResponseV2, SigninResponseV2, UserProfileResponse } from 'api/gen'
 import { SSOButtonApple } from 'features/auth/components/SSOButton/SSOButtonApple'
+import { Provider } from 'features/auth/types'
 import { beneficiaryUserFromAPI } from 'fixtures/user'
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
@@ -97,7 +98,7 @@ describe('<SSOButtonApple />', () => {
     expect(onSignInFailureSpy).toHaveBeenCalledWith({
       isSuccess: false,
       content: { code: 'NETWORK_REQUEST_FAILED', general: [] },
-      provider: 'apple',
+      provider: Provider.APPLE,
     })
   })
 

--- a/src/features/auth/components/SSOButton/SSOButtonAppleBase.tsx
+++ b/src/features/auth/components/SSOButton/SSOButtonAppleBase.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react'
 import { Platform } from 'react-native'
 
+import { Provider } from 'features/auth/types'
 import { RootStackParamList } from 'features/navigation/navigators/RootNavigator/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { useLogTypeFromRemoteConfig } from 'libs/hooks/useLogTypeFromRemoteConfig'
@@ -23,7 +24,7 @@ type Props = {
   }: {
     authorizationCode: string
     oauthStateToken: string
-    provider: 'apple'
+    provider: Provider.APPLE
   }) => void
   // Used on web - saved to sessionStorage before redirect to Apple
   params?: RootStackParamList['LoginMethods' | 'SignupMethods']
@@ -49,7 +50,11 @@ export const SSOButtonAppleBase: FC<Props> = ({ type, onSuccess, params }) => {
     saveAppleSSOContext({ type, params, oauthStateToken: '' })
     return loginToApple({
       onSuccess: ({ code, state }) =>
-        onSuccess({ authorizationCode: code, oauthStateToken: state, provider: 'apple' }),
+        onSuccess({
+          authorizationCode: code,
+          oauthStateToken: state,
+          provider: Provider.APPLE,
+        }),
       onError,
     })
   }

--- a/src/features/auth/components/SSOButton/SSOButtonGoogle.native.test.tsx
+++ b/src/features/auth/components/SSOButton/SSOButtonGoogle.native.test.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import * as API from 'api/api'
 import { AccountState, OauthStateResponseV2, SigninResponseV2 } from 'api/gen'
 import { SSOButtonGoogle } from 'features/auth/components/SSOButton/SSOButtonGoogle'
+import { Provider } from 'features/auth/types'
 import { UserProfile } from 'features/share/types'
 import { beneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics/provider'
@@ -95,7 +96,7 @@ describe('<SSOButtonGoogle />', () => {
     expect(onSignInFailureSpy).toHaveBeenCalledWith({
       isSuccess: false,
       content: { code: 'NETWORK_REQUEST_FAILED', general: [] },
-      provider: 'google',
+      provider: Provider.GOOGLE,
     })
   })
 

--- a/src/features/auth/components/SSOButton/SSOButtonGoogle.native.test.tsx
+++ b/src/features/auth/components/SSOButton/SSOButtonGoogle.native.test.tsx
@@ -9,6 +9,7 @@ import { Provider } from 'features/auth/types'
 import { UserProfile } from 'features/share/types'
 import { beneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { remoteConfigResponseFixture } from 'libs/firebase/remoteConfig/fixtures/remoteConfigResponse.fixture'
 import * as useRemoteConfigQuery from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
@@ -48,6 +49,7 @@ const useRemoteConfigSpy = jest.spyOn(useRemoteConfigQuery, 'useRemoteConfigQuer
 
 describe('<SSOButtonGoogle />', () => {
   beforeEach(() => {
+    setFeatureFlags([])
     mockServer.getApi<OauthStateResponseV2>('/v2/oauth/state', {
       oauthStateToken: 'oauth_state_token',
     })
@@ -80,7 +82,7 @@ describe('<SSOButtonGoogle />', () => {
           source: 'iPhone 13',
         },
       },
-      'google',
+      Provider.GOOGLE,
       { credentials: 'omit' }
     )
   })

--- a/src/features/auth/components/SSOButton/SSOButtonGoogleBase.tsx
+++ b/src/features/auth/components/SSOButton/SSOButtonGoogleBase.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
 
+import { Provider } from 'features/auth/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { useLogTypeFromRemoteConfig } from 'libs/hooks/useLogTypeFromRemoteConfig'
 import { LogTypeEnum } from 'libs/monitoring/errors'
@@ -19,7 +20,7 @@ type Props = {
   }: {
     authorizationCode: string
     oauthStateToken: string
-    provider: 'google'
+    provider: Provider.GOOGLE
   }) => void
 }
 
@@ -40,7 +41,11 @@ export const SSOButtonGoogleBase: FC<Props> = ({ type, onSuccess }) => {
   const handleLogin = async () =>
     loginToGoogle({
       onSuccess: ({ code, state = '' }) =>
-        onSuccess({ authorizationCode: code, oauthStateToken: state, provider: 'google' }),
+        onSuccess({
+          authorizationCode: code,
+          oauthStateToken: state,
+          provider: Provider.GOOGLE,
+        }),
       onError,
     })
 

--- a/src/features/auth/helpers/getLastLoginInfo.native.test.ts
+++ b/src/features/auth/helpers/getLastLoginInfo.native.test.ts
@@ -21,13 +21,13 @@ describe('getLastLoginInfo', () => {
   describe('when the provider is Google', () => {
     it('should return the Google provider label and icon', async () => {
       jest.mocked(storage.readObject).mockResolvedValueOnce({
-        maskedEmail: 'rog*************@passculture.gen',
+        maskedEmail: 'rog*************@gmail.com',
         provider: Provider.GOOGLE,
         lastLoginAt: '2026-08-17T14:11:41.595Z',
       })
 
       await expect(getLastLoginInfo()).resolves.toEqual({
-        maskedEmail: 'rog*************@passculture.gen',
+        maskedEmail: 'rog*************@gmail.com',
         provider: { label: 'Google', icon: Google, type: Provider.GOOGLE },
         lastLoginAt: '17/08/2026',
       })
@@ -37,13 +37,13 @@ describe('getLastLoginInfo', () => {
   describe('when the provider is Apple', () => {
     it('should return the Apple provider label and icon', async () => {
       jest.mocked(storage.readObject).mockResolvedValueOnce({
-        maskedEmail: 'rog*************@passculture.gen',
+        maskedEmail: 'rog*************@apple.com',
         provider: Provider.APPLE,
         lastLoginAt: '2026-08-17T14:11:41.595Z',
       })
 
       await expect(getLastLoginInfo()).resolves.toEqual({
-        maskedEmail: 'rog*************@passculture.gen',
+        maskedEmail: 'rog*************@apple.com',
         provider: { label: 'Apple', icon: Apple, type: Provider.APPLE },
         lastLoginAt: '17/08/2026',
       })
@@ -53,13 +53,13 @@ describe('getLastLoginInfo', () => {
   describe('when the provider is email', () => {
     it('should return the email provider label and icon', async () => {
       jest.mocked(storage.readObject).mockResolvedValueOnce({
-        maskedEmail: 'rog*************@passculture.gen',
+        maskedEmail: 'rog*************@gmail.com',
         provider: Provider.EMAIL,
         lastLoginAt: '2026-08-17T14:11:41.595Z',
       })
 
       await expect(getLastLoginInfo()).resolves.toEqual({
-        maskedEmail: 'rog*************@passculture.gen',
+        maskedEmail: 'rog*************@gmail.com',
         provider: { label: 'E-mail', icon: EmailFilled, type: Provider.EMAIL },
         lastLoginAt: '17/08/2026',
       })
@@ -69,13 +69,13 @@ describe('getLastLoginInfo', () => {
   describe('when the last login date is invalid', () => {
     it('should return an empty lastLoginAt', async () => {
       jest.mocked(storage.readObject).mockResolvedValueOnce({
-        maskedEmail: 'rog*************@passculture.gen',
+        maskedEmail: 'rog*************@gmail.com',
         provider: Provider.EMAIL,
         lastLoginAt: 'invalid-date',
       })
 
       await expect(getLastLoginInfo()).resolves.toEqual({
-        maskedEmail: 'rog*************@passculture.gen',
+        maskedEmail: 'rog*************@gmail.com',
         provider: { label: 'E-mail', icon: EmailFilled, type: Provider.EMAIL },
         lastLoginAt: '',
       })
@@ -85,7 +85,7 @@ describe('getLastLoginInfo', () => {
   describe('when the provider is invalid', () => {
     it('should return null', async () => {
       jest.mocked(storage.readObject).mockResolvedValueOnce({
-        maskedEmail: 'rog*************@passculture.gen',
+        maskedEmail: 'rog*************@gmail.com',
         provider: 'invalid-provider' as Provider,
         lastLoginAt: '2026-08-17T14:11:41.595Z',
       })

--- a/src/features/auth/helpers/getLastLoginInfo.native.test.ts
+++ b/src/features/auth/helpers/getLastLoginInfo.native.test.ts
@@ -1,4 +1,5 @@
 import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
+import { Provider } from 'features/auth/types'
 import { storage } from 'libs/storage'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { Apple } from 'ui/svg/icons/socialNetwork/Apple'
@@ -21,13 +22,13 @@ describe('getLastLoginInfo', () => {
     it('should return the Google provider label and icon', async () => {
       jest.mocked(storage.readObject).mockResolvedValueOnce({
         maskedEmail: 'rog*************@passculture.gen',
-        provider: 'google',
+        provider: Provider.GOOGLE,
         lastLoginAt: '2026-08-17T14:11:41.595Z',
       })
 
       await expect(getLastLoginInfo()).resolves.toEqual({
         maskedEmail: 'rog*************@passculture.gen',
-        provider: { label: 'Google', icon: Google },
+        provider: { label: 'Google', icon: Google, type: Provider.GOOGLE },
         lastLoginAt: '17/08/2026',
       })
     })
@@ -37,13 +38,13 @@ describe('getLastLoginInfo', () => {
     it('should return the Apple provider label and icon', async () => {
       jest.mocked(storage.readObject).mockResolvedValueOnce({
         maskedEmail: 'rog*************@passculture.gen',
-        provider: 'apple',
+        provider: Provider.APPLE,
         lastLoginAt: '2026-08-17T14:11:41.595Z',
       })
 
       await expect(getLastLoginInfo()).resolves.toEqual({
         maskedEmail: 'rog*************@passculture.gen',
-        provider: { label: 'Apple', icon: Apple },
+        provider: { label: 'Apple', icon: Apple, type: Provider.APPLE },
         lastLoginAt: '17/08/2026',
       })
     })
@@ -53,13 +54,13 @@ describe('getLastLoginInfo', () => {
     it('should return the email provider label and icon', async () => {
       jest.mocked(storage.readObject).mockResolvedValueOnce({
         maskedEmail: 'rog*************@passculture.gen',
-        provider: 'email',
+        provider: Provider.EMAIL,
         lastLoginAt: '2026-08-17T14:11:41.595Z',
       })
 
       await expect(getLastLoginInfo()).resolves.toEqual({
         maskedEmail: 'rog*************@passculture.gen',
-        provider: { label: 'E-mail', icon: EmailFilled },
+        provider: { label: 'E-mail', icon: EmailFilled, type: Provider.EMAIL },
         lastLoginAt: '17/08/2026',
       })
     })
@@ -69,13 +70,13 @@ describe('getLastLoginInfo', () => {
     it('should return an empty lastLoginAt', async () => {
       jest.mocked(storage.readObject).mockResolvedValueOnce({
         maskedEmail: 'rog*************@passculture.gen',
-        provider: 'email',
+        provider: Provider.EMAIL,
         lastLoginAt: 'invalid-date',
       })
 
       await expect(getLastLoginInfo()).resolves.toEqual({
         maskedEmail: 'rog*************@passculture.gen',
-        provider: { label: 'E-mail', icon: EmailFilled },
+        provider: { label: 'E-mail', icon: EmailFilled, type: Provider.EMAIL },
         lastLoginAt: '',
       })
     })
@@ -85,7 +86,7 @@ describe('getLastLoginInfo', () => {
     it('should return null', async () => {
       jest.mocked(storage.readObject).mockResolvedValueOnce({
         maskedEmail: 'rog*************@passculture.gen',
-        provider: 'invalid-provider',
+        provider: 'invalid-provider' as Provider,
         lastLoginAt: '2026-08-17T14:11:41.595Z',
       })
 

--- a/src/features/auth/helpers/getLastLoginInfo.native.test.ts
+++ b/src/features/auth/helpers/getLastLoginInfo.native.test.ts
@@ -80,4 +80,16 @@ describe('getLastLoginInfo', () => {
       })
     })
   })
+
+  describe('when the provider is invalid', () => {
+    it('should return null', async () => {
+      jest.mocked(storage.readObject).mockResolvedValueOnce({
+        maskedEmail: 'rog*************@passculture.gen',
+        provider: 'invalid-provider',
+        lastLoginAt: '2026-08-17T14:11:41.595Z',
+      })
+
+      await expect(getLastLoginInfo()).resolves.toBeNull()
+    })
+  })
 })

--- a/src/features/auth/helpers/getLastLoginInfo.native.test.ts
+++ b/src/features/auth/helpers/getLastLoginInfo.native.test.ts
@@ -1,0 +1,83 @@
+import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
+import { storage } from 'libs/storage'
+import { EmailFilled } from 'ui/svg/icons/EmailFilled'
+import { Apple } from 'ui/svg/icons/socialNetwork/Apple'
+import { Google } from 'ui/svg/icons/socialNetwork/Google'
+
+jest.mock('libs/storage', () => ({ storage: { readObject: jest.fn() } }))
+
+describe('getLastLoginInfo', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('should return null when no login information is stored', async () => {
+    jest.mocked(storage.readObject).mockResolvedValueOnce(null)
+
+    await expect(getLastLoginInfo()).resolves.toBeNull()
+
+    expect(storage.readObject).toHaveBeenCalledWith('last_login_info')
+  })
+
+  describe('when the provider is Google', () => {
+    it('should return the Google provider label and icon', async () => {
+      jest.mocked(storage.readObject).mockResolvedValueOnce({
+        maskedEmail: 'rog*************@passculture.gen',
+        provider: 'google',
+        lastLoginAt: '2026-08-17T14:11:41.595Z',
+      })
+
+      await expect(getLastLoginInfo()).resolves.toEqual({
+        maskedEmail: 'rog*************@passculture.gen',
+        provider: { label: 'Google', icon: Google },
+        lastLoginAt: '17/08/2026',
+      })
+    })
+  })
+
+  describe('when the provider is Apple', () => {
+    it('should return the Apple provider label and icon', async () => {
+      jest.mocked(storage.readObject).mockResolvedValueOnce({
+        maskedEmail: 'rog*************@passculture.gen',
+        provider: 'apple',
+        lastLoginAt: '2026-08-17T14:11:41.595Z',
+      })
+
+      await expect(getLastLoginInfo()).resolves.toEqual({
+        maskedEmail: 'rog*************@passculture.gen',
+        provider: { label: 'Apple', icon: Apple },
+        lastLoginAt: '17/08/2026',
+      })
+    })
+  })
+
+  describe('when the provider is email', () => {
+    it('should return the email provider label and icon', async () => {
+      jest.mocked(storage.readObject).mockResolvedValueOnce({
+        maskedEmail: 'rog*************@passculture.gen',
+        provider: 'email',
+        lastLoginAt: '2026-08-17T14:11:41.595Z',
+      })
+
+      await expect(getLastLoginInfo()).resolves.toEqual({
+        maskedEmail: 'rog*************@passculture.gen',
+        provider: { label: 'E-mail', icon: EmailFilled },
+        lastLoginAt: '17/08/2026',
+      })
+    })
+  })
+
+  describe('when the last login date is invalid', () => {
+    it('should return an empty lastLoginAt', async () => {
+      jest.mocked(storage.readObject).mockResolvedValueOnce({
+        maskedEmail: 'rog*************@passculture.gen',
+        provider: 'email',
+        lastLoginAt: 'invalid-date',
+      })
+
+      await expect(getLastLoginInfo()).resolves.toEqual({
+        maskedEmail: 'rog*************@passculture.gen',
+        provider: { label: 'E-mail', icon: EmailFilled },
+        lastLoginAt: '',
+      })
+    })
+  })
+})

--- a/src/features/auth/helpers/getLastLoginInfo.ts
+++ b/src/features/auth/helpers/getLastLoginInfo.ts
@@ -1,4 +1,4 @@
-import { FormattedLastLoginInfo, LastLoginInfo } from 'features/auth/types'
+import { FormattedLastLoginInfo, LastLoginInfo, Provider } from 'features/auth/types'
 import { storage } from 'libs/storage'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { Apple } from 'ui/svg/icons/socialNetwork/Apple'
@@ -8,12 +8,12 @@ const getProvider = (
   provider: LastLoginInfo['provider']
 ): FormattedLastLoginInfo['provider'] | null => {
   switch (provider) {
-    case 'google':
-      return { label: 'Google', icon: Google }
-    case 'apple':
-      return { label: 'Apple', icon: Apple }
-    case 'email':
-      return { label: 'E-mail', icon: EmailFilled }
+    case Provider.GOOGLE:
+      return { type: Provider.GOOGLE, label: 'Google', icon: Google }
+    case Provider.APPLE:
+      return { type: Provider.APPLE, label: 'Apple', icon: Apple }
+    case Provider.EMAIL:
+      return { type: Provider.EMAIL, label: 'E-mail', icon: EmailFilled }
     default:
       return null
   }

--- a/src/features/auth/helpers/getLastLoginInfo.ts
+++ b/src/features/auth/helpers/getLastLoginInfo.ts
@@ -1,0 +1,32 @@
+import { FormattedLastLoginInfo, LastLoginInfo } from 'features/auth/types'
+import { storage } from 'libs/storage'
+import { EmailFilled } from 'ui/svg/icons/EmailFilled'
+import { Apple } from 'ui/svg/icons/socialNetwork/Apple'
+import { Google } from 'ui/svg/icons/socialNetwork/Google'
+
+const getProvider = (provider: LastLoginInfo['provider']): FormattedLastLoginInfo['provider'] => {
+  switch (provider) {
+    case 'google':
+      return { label: 'Google', icon: Google }
+    case 'apple':
+      return { label: 'Apple', icon: Apple }
+    case 'email':
+      return { label: 'E-mail', icon: EmailFilled }
+  }
+}
+
+const formatLastLoginDate = (date: string): string => {
+  const parsedDate = new Date(date)
+  if (Number.isNaN(parsedDate.getTime())) return ''
+  return new Intl.DateTimeFormat('fr-FR').format(parsedDate)
+}
+
+export const getLastLoginInfo = async (): Promise<FormattedLastLoginInfo | null> => {
+  const lastLoginInfo = await storage.readObject<LastLoginInfo>('last_login_info')
+  if (!lastLoginInfo) return null
+  return {
+    maskedEmail: lastLoginInfo.maskedEmail,
+    provider: getProvider(lastLoginInfo.provider),
+    lastLoginAt: formatLastLoginDate(lastLoginInfo.lastLoginAt),
+  }
+}

--- a/src/features/auth/helpers/getLastLoginInfo.ts
+++ b/src/features/auth/helpers/getLastLoginInfo.ts
@@ -4,7 +4,9 @@ import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { Apple } from 'ui/svg/icons/socialNetwork/Apple'
 import { Google } from 'ui/svg/icons/socialNetwork/Google'
 
-const getProvider = (provider: LastLoginInfo['provider']): FormattedLastLoginInfo['provider'] => {
+const getProvider = (
+  provider: LastLoginInfo['provider']
+): FormattedLastLoginInfo['provider'] | null => {
   switch (provider) {
     case 'google':
       return { label: 'Google', icon: Google }
@@ -12,6 +14,8 @@ const getProvider = (provider: LastLoginInfo['provider']): FormattedLastLoginInf
       return { label: 'Apple', icon: Apple }
     case 'email':
       return { label: 'E-mail', icon: EmailFilled }
+    default:
+      return null
   }
 }
 
@@ -24,9 +28,13 @@ const formatLastLoginDate = (date: string): string => {
 export const getLastLoginInfo = async (): Promise<FormattedLastLoginInfo | null> => {
   const lastLoginInfo = await storage.readObject<LastLoginInfo>('last_login_info')
   if (!lastLoginInfo) return null
+
+  const provider = getProvider(lastLoginInfo.provider)
+  if (!provider) return null
+
   return {
     maskedEmail: lastLoginInfo.maskedEmail,
-    provider: getProvider(lastLoginInfo.provider),
+    provider,
     lastLoginAt: formatLastLoginDate(lastLoginInfo.lastLoginAt),
   }
 }

--- a/src/features/auth/helpers/getSSOErrorMessage.ts
+++ b/src/features/auth/helpers/getSSOErrorMessage.ts
@@ -1,14 +1,14 @@
-import { SignInResponseFailure } from 'features/auth/types'
+import { SignInResponseFailure, Provider } from 'features/auth/types'
 
 type SSOErrorContext = 'signup' | 'login'
 
 type GetSSOErrorMessageParams = {
-  provider: 'google' | 'apple' | undefined
+  provider: Provider.APPLE | Provider.GOOGLE | undefined
   context: SSOErrorContext
 }
 
 export const getSSOErrorMessage = ({ provider, context }: GetSSOErrorMessageParams): string => {
-  const providerName = provider === 'apple' ? 'Apple' : 'Google'
+  const providerName = provider === Provider.APPLE ? 'Apple' : 'Google'
   const action = context === 'signup' ? 'L’inscription avec ce' : 'La connexion avec ton'
   return `${action} compte ${providerName} est refusée. Contacte le support pour plus d\u2019informations depuis le Profil.`
 }

--- a/src/features/auth/helpers/maskEmail.native.test.ts
+++ b/src/features/auth/helpers/maskEmail.native.test.ts
@@ -1,0 +1,39 @@
+import { maskEmail } from './maskEmail'
+
+describe('maskEmail', () => {
+  describe('when the local part contains between 1 and 4 characters', () => {
+    it.each([
+      ['a@me.com', 'a***@me.com'],
+      ['am@me.com', 'a***@me.com'],
+      ['amy@me.com', 'a***@me.com'],
+      ['anne@me.com', 'a***@me.com'],
+    ])('should mask %s as %s', (email: string, expected: string) => {
+      expect(maskEmail(email)).toBe(expected)
+    })
+  })
+
+  describe('when the local part contains exactly 5 characters', () => {
+    it.each([
+      ['annie@me.com', 'an***@me.com'],
+      ['marie@test.com', 'ma***@test.com'],
+    ])('should mask %s as %s', (email: string, expected: string) => {
+      expect(maskEmail(email)).toBe(expected)
+    })
+  })
+
+  describe('when the local part contains 6 or more characters', () => {
+    it.each([
+      ['abcdef@me.com', 'abc***@me.com'],
+      ['anne-onime@me.com', 'ann*******@me.com'],
+      ['alexandre@test.com', 'ale******@test.com'],
+    ])('should mask %s as %s', (email: string, expected: string) => {
+      expect(maskEmail(email)).toBe(expected)
+    })
+  })
+
+  describe('when the email address is invalid', () => {
+    it('should throw an error when the @ symbol is missing', () => {
+      expect(() => maskEmail('invalid-email')).toThrow('Adresse email invalide')
+    })
+  })
+})

--- a/src/features/auth/helpers/maskEmail.ts
+++ b/src/features/auth/helpers/maskEmail.ts
@@ -1,0 +1,11 @@
+export const maskEmail = (email: string): string => {
+  const [localPart, domain] = email.split('@')
+
+  if (!localPart || !domain) throw new Error('Adresse email invalide')
+
+  const length = localPart.length
+
+  if (length <= 4) return `${localPart.slice(0, 1)}***@${domain}`
+  if (length === 5) return `${localPart.slice(0, 2)}***@${domain}`
+  return `${localPart.slice(0, 3)}${'*'.repeat(length - 3)}@${domain}`
+}

--- a/src/features/auth/helpers/saveLastLoginInfo.native.test.ts
+++ b/src/features/auth/helpers/saveLastLoginInfo.native.test.ts
@@ -1,0 +1,29 @@
+import { maskEmail } from 'features/auth/helpers/maskEmail'
+import { storage } from 'libs/storage'
+
+import { saveLastLoginInfo } from './saveLastLoginInfo'
+
+jest.mock('libs/storage', () => ({ storage: { saveObject: jest.fn() } }))
+
+jest.mock('features/auth/helpers/maskEmail', () => ({ maskEmail: jest.fn() }))
+
+const date = new Date('2026-08-17T13:09:00.000Z')
+jest.spyOn(global, 'Date').mockImplementation(() => date as unknown as Date)
+;(maskEmail as jest.Mock).mockReturnValue('ann*******@me.com')
+
+describe('saveLastLoginInfo', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('should save the masked email, provider and login date', async () => {
+    await saveLastLoginInfo({
+      email: 'anne-onime@me.com',
+      provider: 'google',
+    })
+
+    expect(storage.saveObject).toHaveBeenCalledWith('last_login_info', {
+      maskedEmail: 'ann*******@me.com',
+      provider: 'google',
+      lastLoginAt: date.toISOString(),
+    })
+  })
+})

--- a/src/features/auth/helpers/saveLastLoginInfo.native.test.ts
+++ b/src/features/auth/helpers/saveLastLoginInfo.native.test.ts
@@ -1,4 +1,5 @@
 import { maskEmail } from 'features/auth/helpers/maskEmail'
+import { Provider } from 'features/auth/types'
 import { storage } from 'libs/storage'
 
 import { saveLastLoginInfo } from './saveLastLoginInfo'
@@ -17,12 +18,12 @@ describe('saveLastLoginInfo', () => {
   it('should save the masked email, provider and login date', async () => {
     await saveLastLoginInfo({
       email: 'anne-onime@me.com',
-      provider: 'google',
+      provider: Provider.GOOGLE,
     })
 
     expect(storage.saveObject).toHaveBeenCalledWith('last_login_info', {
       maskedEmail: 'ann*******@me.com',
-      provider: 'google',
+      provider: Provider.GOOGLE,
       lastLoginAt: date.toISOString(),
     })
   })

--- a/src/features/auth/helpers/saveLastLoginInfo.native.test.ts
+++ b/src/features/auth/helpers/saveLastLoginInfo.native.test.ts
@@ -10,19 +10,19 @@ jest.mock('features/auth/helpers/maskEmail', () => ({ maskEmail: jest.fn() }))
 
 const date = new Date('2026-08-17T13:09:00.000Z')
 jest.spyOn(global, 'Date').mockImplementation(() => date as unknown as Date)
-;(maskEmail as jest.Mock).mockReturnValue('ann*******@me.com')
+;(maskEmail as jest.Mock).mockReturnValue('ann*******@gmail.com')
 
 describe('saveLastLoginInfo', () => {
   beforeEach(() => jest.clearAllMocks())
 
   it('should save the masked email, provider and login date', async () => {
     await saveLastLoginInfo({
-      email: 'anne-onime@me.com',
+      email: 'anne-onime@gmail.com',
       provider: Provider.GOOGLE,
     })
 
     expect(storage.saveObject).toHaveBeenCalledWith('last_login_info', {
-      maskedEmail: 'ann*******@me.com',
+      maskedEmail: 'ann*******@gmail.com',
       provider: Provider.GOOGLE,
       lastLoginAt: date.toISOString(),
     })

--- a/src/features/auth/helpers/saveLastLoginInfo.ts
+++ b/src/features/auth/helpers/saveLastLoginInfo.ts
@@ -1,0 +1,19 @@
+import { maskEmail } from 'features/auth/helpers/maskEmail'
+import { LastLoginInfo } from 'features/auth/types'
+import { storage } from 'libs/storage'
+
+export const saveLastLoginInfo = async ({
+  email,
+  provider,
+}: {
+  email: string
+  provider: LastLoginInfo['provider']
+}) => {
+  const lastLoginInfo: LastLoginInfo = {
+    maskedEmail: maskEmail(email),
+    provider,
+    lastLoginAt: new Date().toISOString(),
+  }
+
+  await storage.saveObject('last_login_info', lastLoginInfo)
+}

--- a/src/features/auth/helpers/useLoginRoutine.ts
+++ b/src/features/auth/helpers/useLoginRoutine.ts
@@ -24,7 +24,7 @@ export function useLoginRoutine(): LoginRoutine {
     await saveRefreshToken(response.refreshToken)
     await storage.saveString('access_token', response.accessToken)
     scheduleAccessTokenRemoval(response.accessToken)
-    analytics.logLogin({ method, type: analyticsType })
+    void analytics.logLogin({ method, type: analyticsType })
     setIsLoggedIn(true)
     resetContexts()
   }

--- a/src/features/auth/pages/AppleSSOCallback.web.test.tsx
+++ b/src/features/auth/pages/AppleSSOCallback.web.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import { AccountState } from 'api/gen'
 import { useSignInMutation } from 'features/auth/queries/useSignInMutation'
-import { SignInResponseFailure } from 'features/auth/types'
+import { Provider, SignInResponseFailure } from 'features/auth/types'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import * as appleSSOContextModule from 'libs/react-native-apple-sso/appleSSOContext'
 import { render } from 'tests/utils/web'
@@ -64,7 +64,7 @@ describe('AppleSSOCallback (web)', () => {
       expect(mockSignInAsync).toHaveBeenCalledWith({
         authorizationCode: 'apple-code',
         oauthStateToken: VALID_STATE,
-        provider: 'apple',
+        provider: Provider.APPLE,
       })
     })
   })
@@ -199,7 +199,7 @@ describe('AppleSSOCallback (web)', () => {
       const onFailure = getOnFailure()
       onFailure({
         isSuccess: false,
-        provider: 'apple',
+        provider: Provider.APPLE,
         content: {
           code: 'SSO_EMAIL_NOT_FOUND',
           accountCreationToken: 'token-123',
@@ -212,7 +212,7 @@ describe('AppleSSOCallback (web)', () => {
         accountCreationToken: 'token-123',
         email: 'user@apple.com',
         from: StepperOrigin.LOGIN,
-        ssoProvider: 'apple',
+        ssoProvider: Provider.APPLE,
       })
     })
 
@@ -225,7 +225,7 @@ describe('AppleSSOCallback (web)', () => {
       const onFailure = getOnFailure()
       onFailure({
         isSuccess: false,
-        provider: 'apple',
+        provider: Provider.APPLE,
         content: {
           code: 'SSO_EMAIL_NOT_FOUND',
           accountCreationToken: 'token-456',
@@ -238,7 +238,7 @@ describe('AppleSSOCallback (web)', () => {
         accountCreationToken: 'token-456',
         email: 'user@apple.com',
         from: StepperOrigin.SIGNUP,
-        ssoProvider: 'apple',
+        ssoProvider: Provider.APPLE,
       })
     })
   })

--- a/src/features/auth/pages/AppleSSOCallback.web.tsx
+++ b/src/features/auth/pages/AppleSSOCallback.web.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 import { AccountState } from 'api/gen'
 import { getSnackbarSSOErrorMessage } from 'features/auth/helpers/getSSOErrorMessage'
 import { useSignInMutation } from 'features/auth/queries/useSignInMutation'
-import { SignInResponseFailure } from 'features/auth/types'
+import { Provider, SignInResponseFailure } from 'features/auth/types'
 import { resetFromRef } from 'features/navigation/navigationRef'
 import {
   RootStackParamList,
@@ -62,7 +62,7 @@ export const AppleSSOCallback = () => {
           accountCreationToken: response.content?.accountCreationToken,
           email: response.content?.email,
           from: context?.type === 'signup' ? StepperOrigin.SIGNUP : StepperOrigin.LOGIN,
-          ssoProvider: 'apple',
+          ssoProvider: Provider.APPLE,
         })
       } else {
         showErrorSnackBar(
@@ -121,7 +121,7 @@ export const AppleSSOCallback = () => {
         const response = await signInAsync({
           authorizationCode: code,
           oauthStateToken: context.oauthStateToken,
-          provider: 'apple' as const,
+          provider: Provider.APPLE,
         })
 
         if (response.accountState === AccountState.ACTIVE) {

--- a/src/features/auth/pages/login/LoginMethods.native.test.tsx
+++ b/src/features/auth/pages/login/LoginMethods.native.test.tsx
@@ -4,7 +4,7 @@ import { navigate, useRoute } from '__mocks__/@react-navigation/native'
 import * as API from 'api/api'
 import { AccountState, FavoriteResponse, OauthStateResponseV2, SigninResponseV2 } from 'api/gen'
 import { AuthContext } from 'features/auth/context/AuthContext'
-import { SignInResponseFailure } from 'features/auth/types'
+import { Provider, SignInResponseFailure } from 'features/auth/types'
 import { favoriteResponseSnap } from 'features/favorites/fixtures/favoriteResponseSnap'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { UserProfile } from 'features/share/types'
@@ -219,7 +219,7 @@ describe('<LoginMethods/>', () => {
         accountCreationToken: 'accountCreationToken',
         email: 'user@icloud.com',
         from: StepperOrigin.LOGIN_METHODS,
-        ssoProvider: 'apple',
+        ssoProvider: Provider.APPLE,
       })
     })
   })
@@ -288,7 +288,7 @@ describe('<LoginMethods/>', () => {
         accountCreationToken: 'accountCreationToken',
         email: 'user@gmail.com',
         from: StepperOrigin.LOGIN_METHODS,
-        ssoProvider: 'google',
+        ssoProvider: Provider.GOOGLE,
       })
     })
 

--- a/src/features/auth/pages/login/LoginMethods.native.test.tsx
+++ b/src/features/auth/pages/login/LoginMethods.native.test.tsx
@@ -246,7 +246,7 @@ describe('<LoginMethods/>', () => {
             source: 'iPhone 13',
           },
         },
-        'google',
+        Provider.GOOGLE,
         { credentials: 'omit' }
       )
     })

--- a/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.native.test.tsx
+++ b/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.native.test.tsx
@@ -5,7 +5,7 @@ import * as API from 'api/api'
 import { AccountState, OauthStateResponseV2, SigninResponseV2 } from 'api/gen'
 import { AuthContext } from 'features/auth/context/AuthContext'
 import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
-import { FormattedLastLoginInfo, SignInResponseFailure } from 'features/auth/types'
+import { FormattedLastLoginInfo, Provider, SignInResponseFailure } from 'features/auth/types'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { UserProfile } from 'features/share/types'
 import { analytics } from 'libs/analytics/provider'
@@ -47,19 +47,19 @@ const user = userEvent.setup()
 
 const LAST_LOGIN_INFO_EMAIL: FormattedLastLoginInfo = {
   maskedEmail: 'rog*************@passculture.gen',
-  provider: { label: 'E-mail', icon: EmailFilled },
+  provider: { label: 'E-mail', icon: EmailFilled, type: Provider.EMAIL },
   lastLoginAt: '17/08/2026',
 }
 
 const LAST_LOGIN_INFO_GOOGLE: FormattedLastLoginInfo = {
   maskedEmail: 'rog*************@passculture.gen',
-  provider: { label: 'Google', icon: Google },
+  provider: { label: 'Google', icon: Google, type: Provider.GOOGLE },
   lastLoginAt: '17/08/2026',
 }
 
 const LAST_LOGIN_INFO_APPLE: FormattedLastLoginInfo = {
   maskedEmail: 'rog*************@passculture.gen',
-  provider: { label: 'Apple', icon: Apple },
+  provider: { label: 'Apple', icon: Apple, type: Provider.APPLE },
   lastLoginAt: '17/08/2026',
 }
 
@@ -260,7 +260,7 @@ describe('<LoginMethodsWithLastLoginInfo />', () => {
         accountCreationToken: 'accountCreationToken',
         email: 'user@gmail.com',
         from: StepperOrigin.LOGIN_METHODS,
-        ssoProvider: 'google',
+        ssoProvider: Provider.GOOGLE,
       })
     })
   })

--- a/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.native.test.tsx
+++ b/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.native.test.tsx
@@ -1,0 +1,330 @@
+import React from 'react'
+
+import { navigate, useRoute } from '__mocks__/@react-navigation/native'
+import * as API from 'api/api'
+import { AccountState, OauthStateResponseV2, SigninResponseV2 } from 'api/gen'
+import { AuthContext } from 'features/auth/context/AuthContext'
+import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
+import { FormattedLastLoginInfo, SignInResponseFailure } from 'features/auth/types'
+import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
+import { UserProfile } from 'features/share/types'
+import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { mockServer } from 'tests/mswServer'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { render, screen, userEvent } from 'tests/utils'
+import { EmailFilled } from 'ui/svg/icons/EmailFilled'
+import { Apple } from 'ui/svg/icons/socialNetwork/Apple'
+import { Google } from 'ui/svg/icons/socialNetwork/Google'
+
+import { LoginMethodsWithLastLoginInfo } from './LoginMethodsWithLastLoginInfo'
+
+jest.mock('libs/firebase/analytics/analytics')
+jest.mock('libs/network/NetInfoWrapper')
+jest.mock('libs/monitoring/services')
+jest.mock('features/navigation/helpers/navigateToHome')
+jest.mock('features/navigation/helpers/usePreviousRouteName')
+jest.mock('features/auth/helpers/getLastLoginInfo')
+
+const mockResetSearch = jest.fn()
+
+jest.mock('features/search/context/SearchWrapper', () => ({
+  useSearch: jest.fn(() => ({ resetSearch: mockResetSearch })),
+}))
+
+const mockIdentityCheckDispatch = jest.fn()
+
+jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({
+  useSubscriptionContext: jest.fn(() => ({ dispatch: mockIdentityCheckDispatch })),
+}))
+
+const apiPostOAuthAuthorize = jest.spyOn(API.api, 'postNativeV2OauthssoProviderAuthorize')
+
+jest.useFakeTimers()
+
+const user = userEvent.setup()
+
+const LAST_LOGIN_INFO_EMAIL: FormattedLastLoginInfo = {
+  maskedEmail: 'rog*************@passculture.gen',
+  provider: { label: 'E-mail', icon: EmailFilled },
+  lastLoginAt: '17/08/2026',
+}
+
+const LAST_LOGIN_INFO_GOOGLE: FormattedLastLoginInfo = {
+  maskedEmail: 'rog*************@passculture.gen',
+  provider: { label: 'Google', icon: Google },
+  lastLoginAt: '17/08/2026',
+}
+
+const LAST_LOGIN_INFO_APPLE: FormattedLastLoginInfo = {
+  maskedEmail: 'rog*************@passculture.gen',
+  provider: { label: 'Apple', icon: Apple },
+  lastLoginAt: '17/08/2026',
+}
+
+describe('<LoginMethodsWithLastLoginInfo />', () => {
+  beforeEach(() => {
+    setFeatureFlags([])
+    jest.mocked(getLastLoginInfo).mockResolvedValue(LAST_LOGIN_INFO_EMAIL)
+    useRoute.mockReturnValue({ params: {} })
+
+    mockServer.getApi<OauthStateResponseV2>('/v2/oauth/state', {
+      oauthStateToken: 'oauth_state_token',
+    })
+
+    mockServer.postApi<SigninResponseV2>('/v2/signin', {
+      accessToken: 'accessToken',
+      refreshToken: 'refreshToken',
+      accountState: AccountState.ACTIVE,
+    })
+
+    mockMeApiCall({ showEligibleCard: false } as UserProfile)
+  })
+
+  afterEach(() => jest.clearAllMocks())
+
+  it('should display the last login information', async () => {
+    renderLoginMethodsWithLastLoginInfo()
+
+    expect(await screen.findByText('rog*************@passculture.gen')).toBeOnTheScreen()
+    expect(screen.getByText('E-mail')).toBeOnTheScreen()
+    expect(screen.getByText('Connecté pour la dernière fois le 17/08/2026')).toBeOnTheScreen()
+  })
+
+  describe('when the last login provider is Google', () => {
+    beforeEach(() => jest.mocked(getLastLoginInfo).mockResolvedValue(LAST_LOGIN_INFO_GOOGLE))
+
+    it('should display the Google sign in button', async () => {
+      renderLoginMethodsWithLastLoginInfo()
+
+      expect(await screen.findByText('Se connecter avec Google')).toBeOnTheScreen()
+    })
+
+    it('should not display the Apple sign in button', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_APPLE_SSO])
+
+      renderLoginMethodsWithLastLoginInfo()
+
+      expect(await screen.findByText('Se connecter avec Google')).toBeOnTheScreen()
+      expect(screen.queryByText('Se connecter avec Apple')).not.toBeOnTheScreen()
+    })
+
+    it('should not display the email sign in button', async () => {
+      renderLoginMethodsWithLastLoginInfo()
+
+      expect(await screen.findByText('Se connecter avec Google')).toBeOnTheScreen()
+      expect(screen.queryByText('Continuer avec mon e-mail')).not.toBeOnTheScreen()
+    })
+  })
+
+  describe('when the last login provider is Apple', () => {
+    beforeEach(() => jest.mocked(getLastLoginInfo).mockResolvedValue(LAST_LOGIN_INFO_APPLE))
+
+    it('should display the Apple sign in button when Apple SSO is enabled', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_APPLE_SSO])
+
+      renderLoginMethodsWithLastLoginInfo()
+
+      expect(await screen.findByText('Se connecter avec Apple')).toBeOnTheScreen()
+    })
+
+    it('should not display the Apple sign in button when Apple SSO is disabled', async () => {
+      renderLoginMethodsWithLastLoginInfo()
+
+      await screen.findByText('Connecte-toi')
+
+      expect(screen.queryByText('Se connecter avec Apple')).not.toBeOnTheScreen()
+    })
+  })
+
+  describe('when the last login provider is email', () => {
+    it('should display the email sign in button', async () => {
+      renderLoginMethodsWithLastLoginInfo()
+
+      expect(await screen.findByText('Continuer avec mon e-mail')).toBeOnTheScreen()
+    })
+
+    it('should navigate to Login when the email sign in button is clicked', async () => {
+      renderLoginMethodsWithLastLoginInfo()
+
+      const emailButton = await screen.findByText('Continuer avec mon e-mail')
+      await user.press(emailButton)
+
+      expect(navigate).toHaveBeenCalledWith('Login', {})
+    })
+
+    it('should not display the Google sign in button', async () => {
+      renderLoginMethodsWithLastLoginInfo()
+
+      await screen.findByText('Continuer avec mon e-mail')
+
+      expect(screen.queryByText('Se connecter avec Google')).not.toBeOnTheScreen()
+    })
+  })
+
+  describe('other login methods', () => {
+    it('should navigate to LoginMethods when the other login methods button is clicked', async () => {
+      renderLoginMethodsWithLastLoginInfo()
+
+      const otherMethodsButton = await screen.findByText('Autres moyens de connexion')
+      await user.press(otherMethodsButton)
+
+      expect(navigate).toHaveBeenCalledWith('LoginMethods', {})
+    })
+  })
+
+  describe('signup CTA', () => {
+    it('should navigate to SignupMethods when the signup button is clicked', async () => {
+      renderLoginMethodsWithLastLoginInfo()
+
+      const signupButton = await screen.findByText('Créer un compte')
+      await user.press(signupButton)
+
+      expect(navigate).toHaveBeenCalledWith('SignupMethods', {})
+    })
+
+    it('should log analytics when the signup button is clicked', async () => {
+      renderLoginMethodsWithLastLoginInfo()
+
+      const signupButton = await screen.findByText('Créer un compte')
+      await user.press(signupButton)
+
+      expect(analytics.logSignUpClicked).toHaveBeenCalledWith({
+        from: 'loginMethods',
+      })
+    })
+  })
+
+  describe('generic SSO errors', () => {
+    it('should display rate limit snackbar when too many attempts error occurs with Google', async () => {
+      jest.mocked(getLastLoginInfo).mockResolvedValueOnce(LAST_LOGIN_INFO_GOOGLE)
+
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
+        responseOptions: {
+          statusCode: 429,
+          data: { code: 'TOO_MANY_ATTEMPTS', general: [] },
+        },
+      })
+
+      renderLoginMethodsWithLastLoginInfo()
+
+      await user.press(await screen.findByTestId('Se connecter avec Google'))
+
+      expect(screen.getByTestId('snackbar-error')).toBeOnTheScreen()
+      expect(
+        screen.getByText('Nombre de tentatives dépassé. Réessaye dans 1 minute.')
+      ).toBeOnTheScreen()
+    })
+
+    it('should display network error snackbar when network request failed with Google', async () => {
+      jest.mocked(getLastLoginInfo).mockResolvedValueOnce(LAST_LOGIN_INFO_GOOGLE)
+
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
+        responseOptions: {
+          statusCode: 500,
+          data: { code: 'NETWORK_REQUEST_FAILED', general: [] },
+        },
+      })
+
+      renderLoginMethodsWithLastLoginInfo()
+
+      await user.press(await screen.findByTestId('Se connecter avec Google'))
+
+      expect(screen.getByTestId('snackbar-error')).toBeOnTheScreen()
+      expect(
+        screen.getByText('Erreur réseau. Tu peux réessayer une fois la connexion réétablie.')
+      ).toBeOnTheScreen()
+    })
+
+    it('should redirect to signup form when SSO email is not found', async () => {
+      jest.mocked(getLastLoginInfo).mockResolvedValueOnce(LAST_LOGIN_INFO_GOOGLE)
+
+      mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
+        responseOptions: {
+          statusCode: 401,
+          data: {
+            code: 'SSO_EMAIL_NOT_FOUND',
+            general: [],
+            accountCreationToken: 'accountCreationToken',
+            email: 'user@gmail.com',
+          },
+        },
+      })
+
+      renderLoginMethodsWithLastLoginInfo()
+
+      await user.press(await screen.findByTestId('Se connecter avec Google'))
+
+      expect(navigate).toHaveBeenCalledWith('SignupForm', {
+        accountCreationToken: 'accountCreationToken',
+        email: 'user@gmail.com',
+        from: StepperOrigin.LOGIN_METHODS,
+        ssoProvider: 'google',
+      })
+    })
+  })
+
+  describe('Apple SSO', () => {
+    beforeEach(() => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_APPLE_SSO])
+      jest.mocked(getLastLoginInfo).mockResolvedValue(LAST_LOGIN_INFO_APPLE)
+    })
+
+    it('should sign in when Apple SSO button is clicked', async () => {
+      mockServer.postApi<SigninResponseV2>('/v2/oauth/apple/authorize', {
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        accountState: AccountState.ACTIVE,
+      })
+
+      mockMeApiCall({ showEligibleCard: false } as UserProfile)
+
+      renderLoginMethodsWithLastLoginInfo()
+
+      await user.press(await screen.findByText('Se connecter avec Apple'))
+
+      expect(apiPostOAuthAuthorize).toHaveBeenCalledWith(
+        {
+          authorizationCode: 'mockAppleAuthCode',
+          oauthStateToken: 'oauth_state_token',
+          deviceInfo: { deviceId: '', os: undefined, source: undefined },
+        },
+        'apple',
+        { credentials: 'omit' }
+      )
+    })
+  })
+
+  describe('with route params', () => {
+    beforeEach(() => useRoute.mockReturnValue({ params: { offerId: 1, from: StepperOrigin.HOME } }))
+
+    it('should pass the route params to the Login screen', async () => {
+      renderLoginMethodsWithLastLoginInfo()
+
+      await user.press(await screen.findByText('Continuer avec mon e-mail'))
+
+      expect(navigate).toHaveBeenCalledWith('Login', { offerId: 1, from: StepperOrigin.HOME })
+    })
+  })
+})
+
+const renderLoginMethodsWithLastLoginInfo = () => {
+  return render(
+    reactQueryProviderHOC(
+      <AuthContext.Provider
+        value={{
+          isLoggedIn: false,
+          setIsLoggedIn: jest.fn(),
+          isUserLoading: false,
+          refetchUser: jest.fn(),
+        }}>
+        <LoginMethodsWithLastLoginInfo />
+      </AuthContext.Provider>
+    )
+  )
+}
+
+const mockMeApiCall = (response: UserProfile) => {
+  mockServer.getApi<UserProfile>('/v1/me', response)
+}

--- a/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.native.test.tsx
+++ b/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.native.test.tsx
@@ -46,19 +46,19 @@ jest.useFakeTimers()
 const user = userEvent.setup()
 
 const LAST_LOGIN_INFO_EMAIL: FormattedLastLoginInfo = {
-  maskedEmail: 'rog*************@passculture.gen',
+  maskedEmail: 'rog*************@gmail.com',
   provider: { label: 'E-mail', icon: EmailFilled, type: Provider.EMAIL },
   lastLoginAt: '17/08/2026',
 }
 
 const LAST_LOGIN_INFO_GOOGLE: FormattedLastLoginInfo = {
-  maskedEmail: 'rog*************@passculture.gen',
+  maskedEmail: 'rog*************@gmail.com',
   provider: { label: 'Google', icon: Google, type: Provider.GOOGLE },
   lastLoginAt: '17/08/2026',
 }
 
 const LAST_LOGIN_INFO_APPLE: FormattedLastLoginInfo = {
-  maskedEmail: 'rog*************@passculture.gen',
+  maskedEmail: 'rog*************@apple.com',
   provider: { label: 'Apple', icon: Apple, type: Provider.APPLE },
   lastLoginAt: '17/08/2026',
 }
@@ -87,7 +87,7 @@ describe('<LoginMethodsWithLastLoginInfo />', () => {
   it('should display the last login information', async () => {
     renderLoginMethodsWithLastLoginInfo()
 
-    expect(await screen.findByText('rog*************@passculture.gen')).toBeOnTheScreen()
+    expect(await screen.findByText('rog*************@gmail.com')).toBeOnTheScreen()
     expect(screen.getByText('E-mail')).toBeOnTheScreen()
     expect(screen.getByText('Connecté pour la dernière fois le 17/08/2026')).toBeOnTheScreen()
   })
@@ -99,21 +99,7 @@ describe('<LoginMethodsWithLastLoginInfo />', () => {
       renderLoginMethodsWithLastLoginInfo()
 
       expect(await screen.findByText('Se connecter avec Google')).toBeOnTheScreen()
-    })
-
-    it('should not display the Apple sign in button', async () => {
-      setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_APPLE_SSO])
-
-      renderLoginMethodsWithLastLoginInfo()
-
-      expect(await screen.findByText('Se connecter avec Google')).toBeOnTheScreen()
       expect(screen.queryByText('Se connecter avec Apple')).not.toBeOnTheScreen()
-    })
-
-    it('should not display the email sign in button', async () => {
-      renderLoginMethodsWithLastLoginInfo()
-
-      expect(await screen.findByText('Se connecter avec Google')).toBeOnTheScreen()
       expect(screen.queryByText('Continuer avec mon e-mail')).not.toBeOnTheScreen()
     })
   })
@@ -127,6 +113,8 @@ describe('<LoginMethodsWithLastLoginInfo />', () => {
       renderLoginMethodsWithLastLoginInfo()
 
       expect(await screen.findByText('Se connecter avec Apple')).toBeOnTheScreen()
+      expect(screen.queryByText('Se connecter avec Google')).not.toBeOnTheScreen()
+      expect(screen.queryByText('Continuer avec mon e-mail')).not.toBeOnTheScreen()
     })
 
     it('should not display the Apple sign in button when Apple SSO is disabled', async () => {
@@ -143,6 +131,8 @@ describe('<LoginMethodsWithLastLoginInfo />', () => {
       renderLoginMethodsWithLastLoginInfo()
 
       expect(await screen.findByText('Continuer avec mon e-mail')).toBeOnTheScreen()
+      expect(screen.queryByText('Se connecter avec Google')).not.toBeOnTheScreen()
+      expect(screen.queryByText('Se connecter avec Apple')).not.toBeOnTheScreen()
     })
 
     it('should navigate to Login when the email sign in button is clicked', async () => {
@@ -152,14 +142,6 @@ describe('<LoginMethodsWithLastLoginInfo />', () => {
       await user.press(emailButton)
 
       expect(navigate).toHaveBeenCalledWith('Login', {})
-    })
-
-    it('should not display the Google sign in button', async () => {
-      renderLoginMethodsWithLastLoginInfo()
-
-      await screen.findByText('Continuer avec mon e-mail')
-
-      expect(screen.queryByText('Se connecter avec Google')).not.toBeOnTheScreen()
     })
   })
 
@@ -190,9 +172,7 @@ describe('<LoginMethodsWithLastLoginInfo />', () => {
       const signupButton = await screen.findByText('Créer un compte')
       await user.press(signupButton)
 
-      expect(analytics.logSignUpClicked).toHaveBeenCalledWith({
-        from: 'loginMethods',
-      })
+      expect(analytics.logSignUpClicked).toHaveBeenCalledWith({ from: 'loginMethods' })
     })
   })
 
@@ -201,10 +181,7 @@ describe('<LoginMethodsWithLastLoginInfo />', () => {
       jest.mocked(getLastLoginInfo).mockResolvedValueOnce(LAST_LOGIN_INFO_GOOGLE)
 
       mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
-        responseOptions: {
-          statusCode: 429,
-          data: { code: 'TOO_MANY_ATTEMPTS', general: [] },
-        },
+        responseOptions: { statusCode: 429, data: { code: 'TOO_MANY_ATTEMPTS', general: [] } },
       })
 
       renderLoginMethodsWithLastLoginInfo()
@@ -221,10 +198,7 @@ describe('<LoginMethodsWithLastLoginInfo />', () => {
       jest.mocked(getLastLoginInfo).mockResolvedValueOnce(LAST_LOGIN_INFO_GOOGLE)
 
       mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
-        responseOptions: {
-          statusCode: 500,
-          data: { code: 'NETWORK_REQUEST_FAILED', general: [] },
-        },
+        responseOptions: { statusCode: 500, data: { code: 'NETWORK_REQUEST_FAILED', general: [] } },
       })
 
       renderLoginMethodsWithLastLoginInfo()
@@ -325,6 +299,4 @@ const renderLoginMethodsWithLastLoginInfo = () => {
   )
 }
 
-const mockMeApiCall = (response: UserProfile) => {
-  mockServer.getApi<UserProfile>('/v1/me', response)
-}
+const mockMeApiCall = (response: UserProfile) => mockServer.getApi<UserProfile>('/v1/me', response)

--- a/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.native.test.tsx
+++ b/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.native.test.tsx
@@ -290,7 +290,7 @@ describe('<LoginMethodsWithLastLoginInfo />', () => {
           oauthStateToken: 'oauth_state_token',
           deviceInfo: { deviceId: '', os: undefined, source: undefined },
         },
-        'apple',
+        Provider.APPLE,
         { credentials: 'omit' }
       )
     })

--- a/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.tsx
+++ b/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.tsx
@@ -1,0 +1,128 @@
+import { useNavigation, useRoute } from '@react-navigation/native'
+import React, { useState, useEffect, useCallback } from 'react'
+import styled from 'styled-components/native'
+
+import { AuthenticationButton } from 'features/auth/components/AuthenticationButton/AuthenticationButton'
+import { LastLoginInfoBanner } from 'features/auth/components/LastLoginInfoBanner'
+import { SSOButtonAppleBase } from 'features/auth/components/SSOButton/SSOButtonAppleBase'
+import { SSOButtonGoogleBase } from 'features/auth/components/SSOButton/SSOButtonGoogleBase'
+import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
+import { getSnackbarSSOErrorMessage } from 'features/auth/helpers/getSSOErrorMessage'
+import { useSignInMutation } from 'features/auth/queries/useSignInMutation'
+import { FormattedLastLoginInfo, SignInResponseFailure } from 'features/auth/types'
+import {
+  StepperOrigin,
+  UseNavigationType,
+  UseRouteType,
+} from 'features/navigation/navigators/RootNavigator/types'
+import { analytics } from 'libs/analytics/provider'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { Button } from 'ui/designSystem/Button/Button'
+import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
+import { PageWithHeader } from 'ui/pages/PageWithHeader'
+import { EmailFilled } from 'ui/svg/icons/EmailFilled'
+import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
+import { Typo } from 'ui/theme'
+import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+
+export const LoginMethodsWithLastLoginInfo = () => {
+  const { navigate } = useNavigation<UseNavigationType>()
+  const { params } = useRoute<UseRouteType<'LoginMethodsWithLastLoginInfo'>>()
+  const enableAppleSSO = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ENABLE_APPLE_SSO)
+
+  const onLogSignUpAnalytics = useCallback(() => {
+    void analytics.logSignUpClicked({ from: 'loginMethods' })
+  }, [])
+
+  const [lastLoginInfo, setLastLoginInfo] = useState<FormattedLastLoginInfo | null>(null)
+
+  useEffect(() => {
+    const loadLastLoginInfo = async () => {
+      const info = await getLastLoginInfo()
+      setLastLoginInfo(info)
+    }
+    void loadLastLoginInfo()
+  }, [])
+
+  const onSSOSignInFailure = useCallback(
+    (response: SignInResponseFailure) => {
+      if (response.content?.code === 'SSO_EMAIL_NOT_FOUND') {
+        return navigate('SignupForm', {
+          accountCreationToken: response.content?.accountCreationToken,
+          email: response.content?.email,
+          from: StepperOrigin.LOGIN_METHODS,
+          ssoProvider: response.provider,
+        })
+      }
+      showErrorSnackBar(getSnackbarSSOErrorMessage({ response, context: 'login' }))
+    },
+    [navigate]
+  )
+
+  const { mutate: signInGoogle } = useSignInMutation({
+    params,
+    doNotNavigateOnSigninSuccess: false,
+    onFailure: onSSOSignInFailure,
+    analyticsType: 'SSO_login',
+    analyticsMethod: 'fromLoginGoogle',
+  })
+
+  const { mutate: signInApple } = useSignInMutation({
+    params,
+    doNotNavigateOnSigninSuccess: false,
+    onFailure: onSSOSignInFailure,
+    analyticsType: 'SSO_login',
+    analyticsMethod: 'fromLoginApple',
+  })
+
+  return (
+    <PageWithHeader
+      shouldLimitWidth
+      shouldDisplayBackButton
+      title="Connexion"
+      scrollChildren={
+        <ViewGap gap={6}>
+          <Typo.Title3 {...getTextSemanticAttrs(2)}>Connecte-toi</Typo.Title3>
+
+          <LastLoginInfoBanner lastLoginInfo={lastLoginInfo} />
+
+          {lastLoginInfo?.provider.label === 'Google' ? (
+            <SSOButtonGoogleBase type="login" onSuccess={signInGoogle} />
+          ) : null}
+
+          {lastLoginInfo?.provider.label === 'Apple' && enableAppleSSO ? (
+            <SSOButtonAppleBase type="login" onSuccess={signInApple} />
+          ) : null}
+
+          {lastLoginInfo?.provider.label === 'E-mail' ? (
+            <InternalTouchableLink
+              as={Button}
+              variant="secondary"
+              color="neutral"
+              icon={EmailFilled}
+              wording="Continuer avec mon e-mail"
+              navigateTo={{ screen: 'Login', params }}
+            />
+          ) : null}
+
+          <InternalTouchableLink
+            as={Button}
+            variant="tertiary"
+            color="neutral"
+            icon={PlainArrowNext}
+            wording="Autres moyens de connexion"
+            navigateTo={{ screen: 'LoginMethods', params }}
+          />
+        </ViewGap>
+      }
+      fixedBottomChildren={<SignUpButton type="signup" onAdditionalPress={onLogSignUpAnalytics} />}
+    />
+  )
+}
+
+const SignUpButton = styled(AuthenticationButton).attrs(({ theme }) => ({
+  linkColor: theme.designSystem.color.text.brandSecondary,
+}))``

--- a/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.tsx
+++ b/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.tsx
@@ -4,8 +4,7 @@ import styled from 'styled-components/native'
 
 import { AuthenticationButton } from 'features/auth/components/AuthenticationButton/AuthenticationButton'
 import { LastLoginInfoBanner } from 'features/auth/components/LastLoginInfoBanner'
-import { SSOButtonAppleBase } from 'features/auth/components/SSOButton/SSOButtonAppleBase'
-import { SSOButtonGoogleBase } from 'features/auth/components/SSOButton/SSOButtonGoogleBase'
+import { ProviderButton } from 'features/auth/components/ProviderButton'
 import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
 import { getSnackbarSSOErrorMessage } from 'features/auth/helpers/getSSOErrorMessage'
 import { useSignInMutation } from 'features/auth/queries/useSignInMutation'
@@ -23,7 +22,6 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
-import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
 import { Typo } from 'ui/theme'
 import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
@@ -89,24 +87,13 @@ export const LoginMethodsWithLastLoginInfo = () => {
 
           <LastLoginInfoBanner lastLoginInfo={lastLoginInfo} />
 
-          {lastLoginInfo?.provider.label === 'Google' ? (
-            <SSOButtonGoogleBase type="login" onSuccess={signInGoogle} />
-          ) : null}
-
-          {lastLoginInfo?.provider.label === 'Apple' && enableAppleSSO ? (
-            <SSOButtonAppleBase type="login" onSuccess={signInApple} />
-          ) : null}
-
-          {lastLoginInfo?.provider.label === 'E-mail' ? (
-            <InternalTouchableLink
-              as={Button}
-              variant="secondary"
-              color="neutral"
-              icon={EmailFilled}
-              wording="Continuer avec mon e-mail"
-              navigateTo={{ screen: 'Login', params }}
-            />
-          ) : null}
+          <ProviderButton
+            lastLoginInfo={lastLoginInfo}
+            params={params}
+            enableAppleSSO={enableAppleSSO}
+            onGoogleSuccess={signInGoogle}
+            onAppleSuccess={signInApple}
+          />
 
           <InternalTouchableLink
             as={Button}

--- a/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.web.test.tsx
+++ b/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.web.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+
+import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
+import { FormattedLastLoginInfo, Provider } from 'features/auth/types'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { checkAccessibilityFor, render } from 'tests/utils/web'
+import { EmailFilled } from 'ui/svg/icons/EmailFilled'
+import { Apple } from 'ui/svg/icons/socialNetwork/Apple'
+import { Google } from 'ui/svg/icons/socialNetwork/Google'
+
+import { LoginMethodsWithLastLoginInfo } from './LoginMethodsWithLastLoginInfo'
+
+jest.mock('libs/firebase/analytics/analytics')
+jest.mock('features/auth/helpers/getLastLoginInfo')
+
+const mockResetSearch = jest.fn()
+
+jest.mock('features/search/context/SearchWrapper', () => ({
+  useSearch: jest.fn(() => ({
+    resetSearch: mockResetSearch,
+  })),
+}))
+
+const mockIdentityCheckDispatch = jest.fn()
+
+jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({
+  useSubscriptionContext: jest.fn(() => ({
+    dispatch: mockIdentityCheckDispatch,
+  })),
+}))
+
+const LAST_LOGIN_INFO_EMAIL: FormattedLastLoginInfo = {
+  maskedEmail: 'rog*************@passculture.gen',
+  provider: {
+    label: 'E-mail',
+    icon: EmailFilled,
+    type: Provider.EMAIL,
+  },
+  lastLoginAt: '17/08/2026',
+}
+
+const LAST_LOGIN_INFO_GOOGLE: FormattedLastLoginInfo = {
+  maskedEmail: 'rog*************@passculture.gen',
+  provider: {
+    label: 'Google',
+    icon: Google,
+    type: Provider.GOOGLE,
+  },
+  lastLoginAt: '17/08/2026',
+}
+
+const LAST_LOGIN_INFO_APPLE: FormattedLastLoginInfo = {
+  maskedEmail: 'rog*************@passculture.gen',
+  provider: {
+    label: 'Apple',
+    icon: Apple,
+    type: Provider.APPLE,
+  },
+  lastLoginAt: '17/08/2026',
+}
+
+describe('<LoginMethodsWithLastLoginInfo />', () => {
+  beforeEach(() => {
+    setFeatureFlags([])
+    jest.mocked(getLastLoginInfo).mockResolvedValue(LAST_LOGIN_INFO_EMAIL)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Accessibility', () => {
+    it('should not have basic accessibility issues with email provider', async () => {
+      jest.mocked(getLastLoginInfo).mockResolvedValueOnce(LAST_LOGIN_INFO_EMAIL)
+
+      const { container } = render(reactQueryProviderHOC(<LoginMethodsWithLastLoginInfo />))
+
+      const results = await checkAccessibilityFor(container)
+
+      expect(results).toHaveNoViolations()
+    })
+
+    it('should not have basic accessibility issues with Google provider', async () => {
+      jest.mocked(getLastLoginInfo).mockResolvedValueOnce(LAST_LOGIN_INFO_GOOGLE)
+
+      const { container } = render(reactQueryProviderHOC(<LoginMethodsWithLastLoginInfo />))
+
+      const results = await checkAccessibilityFor(container)
+
+      expect(results).toHaveNoViolations()
+    })
+
+    it('should not have basic accessibility issues with Apple provider', async () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_APPLE_SSO])
+      jest.mocked(getLastLoginInfo).mockResolvedValueOnce(LAST_LOGIN_INFO_APPLE)
+
+      const { container } = render(reactQueryProviderHOC(<LoginMethodsWithLastLoginInfo />))
+
+      const results = await checkAccessibilityFor(container)
+
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.web.test.tsx
+++ b/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.web.test.tsx
@@ -32,32 +32,20 @@ jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({
 }))
 
 const LAST_LOGIN_INFO_EMAIL: FormattedLastLoginInfo = {
-  maskedEmail: 'rog*************@passculture.gen',
-  provider: {
-    label: 'E-mail',
-    icon: EmailFilled,
-    type: Provider.EMAIL,
-  },
+  maskedEmail: 'rog*************@gmail.com',
+  provider: { label: 'E-mail', icon: EmailFilled, type: Provider.EMAIL },
   lastLoginAt: '17/08/2026',
 }
 
 const LAST_LOGIN_INFO_GOOGLE: FormattedLastLoginInfo = {
-  maskedEmail: 'rog*************@passculture.gen',
-  provider: {
-    label: 'Google',
-    icon: Google,
-    type: Provider.GOOGLE,
-  },
+  maskedEmail: 'rog*************@gmail.com',
+  provider: { label: 'Google', icon: Google, type: Provider.GOOGLE },
   lastLoginAt: '17/08/2026',
 }
 
 const LAST_LOGIN_INFO_APPLE: FormattedLastLoginInfo = {
-  maskedEmail: 'rog*************@passculture.gen',
-  provider: {
-    label: 'Apple',
-    icon: Apple,
-    type: Provider.APPLE,
-  },
+  maskedEmail: 'rog*************@apple.com',
+  provider: { label: 'Apple', icon: Apple, type: Provider.APPLE },
   lastLoginAt: '17/08/2026',
 }
 

--- a/src/features/auth/pages/signup/SignupMethods/SignupMethods.native.test.tsx
+++ b/src/features/auth/pages/signup/SignupMethods/SignupMethods.native.test.tsx
@@ -4,7 +4,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { api } from 'api/api'
 import { AccountState, OauthStateResponseV2, SigninResponseV2 } from 'api/gen'
 import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
-import { SignInResponseFailure } from 'features/auth/types'
+import { Provider, SignInResponseFailure } from 'features/auth/types'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { UserProfile } from 'features/share/types'
 import { beneficiaryUser } from 'fixtures/user'
@@ -159,7 +159,7 @@ describe('<SignupMethods />', () => {
         accountCreationToken: 'accountCreationToken',
         email: 'user@gmail.com',
         from: StepperOrigin.SIGNUP_METHODS,
-        ssoProvider: 'google',
+        ssoProvider: Provider.GOOGLE,
       })
     })
 
@@ -234,7 +234,7 @@ describe('<SignupMethods />', () => {
         accountCreationToken: 'accountCreationToken',
         email: 'user@gmail.com',
         from: StepperOrigin.SIGNUP_METHODS,
-        ssoProvider: 'apple',
+        ssoProvider: Provider.APPLE,
       })
     })
 

--- a/src/features/auth/pages/signup/SignupMethods/SignupMethods.native.test.tsx
+++ b/src/features/auth/pages/signup/SignupMethods/SignupMethods.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { api } from 'api/api'
 import { AccountState, OauthStateResponseV2, SigninResponseV2 } from 'api/gen'
+import { getLastLoginInfo } from 'features/auth/helpers/getLastLoginInfo'
 import { SignInResponseFailure } from 'features/auth/types'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { UserProfile } from 'features/share/types'
@@ -19,6 +20,7 @@ import { SignupMethods } from './SignupMethods'
 
 jest.mock('libs/network/NetInfoWrapper')
 jest.mock('libs/firebase/analytics/analytics')
+jest.mock('features/auth/helpers/getLastLoginInfo')
 
 jest.mock('features/search/context/SearchWrapper', () => ({
   useSearch: () => ({ resetSearch: jest.fn() }),
@@ -42,11 +44,14 @@ const user = userEvent.setup()
 describe('<SignupMethods />', () => {
   beforeEach(() => {
     setFeatureFlags([])
+    jest.mocked(getLastLoginInfo).mockResolvedValue(null)
     mockServer.getApi<OauthStateResponseV2>('/v2/oauth/state', {
       responseOptions: { data: { oauthStateToken: 'oauth_state_token' } },
     })
     deviceInfoStoreActions.setDeviceInfo(deviceInfo)
   })
+
+  afterEach(() => jest.clearAllMocks())
 
   it('should render correctly', async () => {
     setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_APPLE_SSO])
@@ -58,10 +63,7 @@ describe('<SignupMethods />', () => {
   describe('generic SSO errors', () => {
     it('should display rate limit snackbar when too many attempts error occurs with Google', async () => {
       mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
-        responseOptions: {
-          statusCode: 429,
-          data: { code: 'TOO_MANY_ATTEMPTS', general: [] },
-        },
+        responseOptions: { statusCode: 429, data: { code: 'TOO_MANY_ATTEMPTS', general: [] } },
       })
 
       await renderSignupMethods()
@@ -77,10 +79,7 @@ describe('<SignupMethods />', () => {
 
     it('should display network error snackbar when network request failed', async () => {
       mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
-        responseOptions: {
-          statusCode: 500,
-          data: { code: 'NETWORK_REQUEST_FAILED', general: [] },
-        },
+        responseOptions: { statusCode: 500, data: { code: 'NETWORK_REQUEST_FAILED', general: [] } },
       })
 
       await renderSignupMethods()
@@ -116,7 +115,7 @@ describe('<SignupMethods />', () => {
   })
 
   describe('for SSO Google method', () => {
-    it('should sign in when sso button is clicked and sso account already exists', async () => {
+    it('should sign in when SSO button is clicked and SSO account already exists', async () => {
       mockServer.postApi<SigninResponseV2>('/v2/oauth/google/authorize', {
         accessToken: 'accessToken',
         refreshToken: 'refreshToken',
@@ -135,13 +134,11 @@ describe('<SignupMethods />', () => {
           deviceInfo,
         },
         'google',
-        {
-          credentials: 'omit',
-        }
+        { credentials: 'omit' }
       )
     })
 
-    it('should navigate to SignupMethods when clicking Google SSO button and account does not already exist', async () => {
+    it('should navigate to SignupForm when clicking Google SSO button and account does not already exist', async () => {
       mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/google/authorize', {
         responseOptions: {
           statusCode: 401,
@@ -216,7 +213,7 @@ describe('<SignupMethods />', () => {
       expect(screen.queryByText('S’inscrire avec Apple')).not.toBeOnTheScreen()
     })
 
-    it('should navigate to SignupMethods when clicking Apple SSO button and account does not already exist', async () => {
+    it('should navigate to SignupForm when clicking Apple SSO button and account does not already exist', async () => {
       mockServer.postApi<SignInResponseFailure['content']>('/v2/oauth/apple/authorize', {
         responseOptions: {
           statusCode: 401,
@@ -261,7 +258,7 @@ describe('<SignupMethods />', () => {
   })
 
   describe('for email method', () => {
-    it('should navigate to Login when "S’inscrire avec mon e-mail" is clicked', async () => {
+    it('should navigate to SignupForm when "S’inscrire avec mon e-mail" is clicked', async () => {
       await renderSignupMethods()
 
       await user.press(screen.getByText('S’inscrire avec mon e-mail'))

--- a/src/features/auth/pages/signup/SignupMethods/SignupMethods.native.test.tsx
+++ b/src/features/auth/pages/signup/SignupMethods/SignupMethods.native.test.tsx
@@ -133,7 +133,7 @@ describe('<SignupMethods />', () => {
           oauthStateToken: 'oauth_state_token',
           deviceInfo,
         },
-        'google',
+        Provider.GOOGLE,
         { credentials: 'omit' }
       )
     })

--- a/src/features/auth/queries/signup/useSSOSignupMutation.native.test.ts
+++ b/src/features/auth/queries/signup/useSSOSignupMutation.native.test.ts
@@ -3,6 +3,7 @@ import mockdate from 'mockdate'
 import { CURRENT_DATE } from 'features/auth/fixtures/fixtures'
 import * as logAdjustRegistrationEventsModule from 'features/auth/pages/signup/helpers/logAdjustRegistrationEvents'
 import { useSSOSignupMutation } from 'features/auth/queries/signup/useSSOSignupMutation'
+import { Provider } from 'features/auth/types'
 import { getAge } from 'shared/user/getAge'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -17,7 +18,7 @@ describe('useSSOSignupMutation', () => {
     mockServer.postApi('/v1/oauth/google/account', {})
     const birthDate = '2002-12-01T00:00:00.000Z'
 
-    const { result } = renderUseSSOSignupMutation('google')
+    const { result } = renderUseSSOSignupMutation(Provider.GOOGLE)
 
     result.current.mutate({
       accountCreationToken: 'token',
@@ -36,7 +37,7 @@ describe('useSSOSignupMutation', () => {
     mockServer.postApi('/v1/oauth/apple/account', {})
     const birthDate = '2002-12-01T00:00:00.000Z'
 
-    const { result } = renderUseSSOSignupMutation('apple')
+    const { result } = renderUseSSOSignupMutation(Provider.APPLE)
 
     result.current.mutate({
       accountCreationToken: 'token',
@@ -66,7 +67,7 @@ describe('useSSOSignupMutation', () => {
   })
 })
 
-const renderUseSSOSignupMutation = (provider: 'google' | 'apple' | undefined) =>
+const renderUseSSOSignupMutation = (provider: Provider.GOOGLE | Provider.APPLE | undefined) =>
   renderHook(() => useSSOSignupMutation(provider), {
     wrapper: ({ children }) => reactQueryProviderHOC(children),
   })

--- a/src/features/auth/queries/signup/useSSOSignupMutation.ts
+++ b/src/features/auth/queries/signup/useSSOSignupMutation.ts
@@ -3,9 +3,10 @@ import { useMutation } from '@tanstack/react-query'
 import { api } from 'api/api'
 import { SSOAccountRequest } from 'api/gen'
 import { logAdjustRegistrationEvents } from 'features/auth/pages/signup/helpers/logAdjustRegistrationEvents'
+import { Provider } from 'features/auth/types'
 import { getAge } from 'shared/user/getAge'
 
-export const useSSOSignupMutation = (ssoProvider: 'google' | 'apple' | undefined) =>
+export const useSSOSignupMutation = (ssoProvider: Provider.GOOGLE | Provider.APPLE | undefined) =>
   useMutation({
     mutationFn: (params: SSOAccountRequest) => {
       if (!ssoProvider) throw new Error('ssoProvider is required for SSO signup')

--- a/src/features/auth/queries/useSignInMutation.ts
+++ b/src/features/auth/queries/useSignInMutation.ts
@@ -9,7 +9,7 @@ import { saveLastLoginInfo } from 'features/auth/helpers/saveLastLoginInfo'
 import { useLoginRoutine } from 'features/auth/helpers/useLoginRoutine'
 import {
   isOAuthLoginRequest,
-  LoginProvider,
+  Provider,
   LoginRequest,
   SignInResponseFailure,
 } from 'features/auth/types'
@@ -65,7 +65,7 @@ export const useSignInMutation = ({
         ? getSSOLoginMethod(body.provider, ssoKind)
         : analyticsMethod
       await loginRoutine(response, resolvedMethod, analyticsType || loginAnalyticsType)
-      await onSuccess(response.accountState, isOAuth ? body.provider : 'email')
+      await onSuccess(response.accountState, isOAuth ? body.provider : Provider.EMAIL)
     },
 
     onError: (error, variables) => {
@@ -106,7 +106,7 @@ const useHandleSigninSuccess = (
   const comeFrom = params?.from
 
   const navigateForActiveState = useCallback(
-    async (provider: LoginProvider) => {
+    async (provider: Provider) => {
       const user = await api.getNativeV1Me()
 
       if (user?.email) {
@@ -151,7 +151,7 @@ const useHandleSigninSuccess = (
   )
 
   return useCallback(
-    async (accountState: AccountState, provider: LoginProvider) => {
+    async (accountState: AccountState, provider: Provider) => {
       try {
         if (doNotNavigateOnSigninSuccess) {
           return

--- a/src/features/auth/queries/useSignInMutation.ts
+++ b/src/features/auth/queries/useSignInMutation.ts
@@ -5,8 +5,14 @@ import { useCallback } from 'react'
 import { api } from 'api/api'
 import { isApiError } from 'api/apiHelpers'
 import { AccountState, FavoriteResponse, RecreditType } from 'api/gen'
+import { saveLastLoginInfo } from 'features/auth/helpers/saveLastLoginInfo'
 import { useLoginRoutine } from 'features/auth/helpers/useLoginRoutine'
-import { isOAuthLoginRequest, LoginRequest, SignInResponseFailure } from 'features/auth/types'
+import {
+  isOAuthLoginRequest,
+  LoginProvider,
+  LoginRequest,
+  SignInResponseFailure,
+} from 'features/auth/types'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import {
   RootStackParamList,
@@ -59,7 +65,7 @@ export const useSignInMutation = ({
         ? getSSOLoginMethod(body.provider, ssoKind)
         : analyticsMethod
       await loginRoutine(response, resolvedMethod, analyticsType || loginAnalyticsType)
-      onSuccess(response.accountState)
+      await onSuccess(response.accountState, isOAuth ? body.provider : 'email')
     },
 
     onError: (error, variables) => {
@@ -88,7 +94,7 @@ const useHandleSigninSuccess = (
 
   const onAddFavoriteSuccess = useCallback((data?: FavoriteResponse) => {
     if (data?.offer?.id) {
-      analytics.logHasAddedOfferToFavorites({ from: 'login', offerId: data.offer.id })
+      void analytics.logHasAddedOfferToFavorites({ from: 'login', offerId: data.offer.id })
     }
   }, [])
 
@@ -99,45 +105,53 @@ const useHandleSigninSuccess = (
   const offerId = params?.offerId
   const comeFrom = params?.from
 
-  const navigateForActiveState = useCallback(async () => {
-    const user = await api.getNativeV1Me()
-    const hasSeenEligibleCard = !!(await storage.readObject('has_seen_eligible_card'))
+  const navigateForActiveState = useCallback(
+    async (provider: LoginProvider) => {
+      const user = await api.getNativeV1Me()
 
-    if (user?.recreditAmountToShow) {
-      if (
-        user.recreditTypeToShow === RecreditType.BonusCredit &&
-        user.recreditAmountToShow === bonificationBonusAmount
-      ) {
-        navigate('BonificationGranted')
+      if (user?.email) {
+        await saveLastLoginInfo({ email: user.email, provider })
+      }
+
+      const hasSeenEligibleCard = !!(await storage.readObject('has_seen_eligible_card'))
+
+      if (user?.recreditAmountToShow) {
+        if (
+          user.recreditTypeToShow === RecreditType.BonusCredit &&
+          user.recreditAmountToShow === bonificationBonusAmount
+        ) {
+          navigate('BonificationGranted')
+        } else {
+          navigate('RecreditBirthdayNotification')
+        }
+      } else if (!hasSeenEligibleCard && user.showEligibleCard) {
+        navigate('EighteenBirthday')
+      } else if (offerId) {
+        switch (comeFrom) {
+          case StepperOrigin.BOOKING:
+            navigate('Offer', { id: offerId, openModalOnNavigation: true })
+            return
+          case StepperOrigin.FAVORITE:
+            addFavorite({ offerId })
+            navigate('Offer', { id: offerId })
+            return
+          case StepperOrigin.OFFER:
+          case StepperOrigin.NOTIFICATION:
+            navigate('Offer', { id: offerId })
+            return
+          default:
+            navigateToHome()
+            return
+        }
       } else {
-        navigate('RecreditBirthdayNotification')
+        navigateToHome()
       }
-    } else if (!hasSeenEligibleCard && user.showEligibleCard) {
-      navigate('EighteenBirthday')
-    } else if (offerId) {
-      switch (comeFrom) {
-        case StepperOrigin.BOOKING:
-          navigate('Offer', { id: offerId, openModalOnNavigation: true })
-          return
-        case StepperOrigin.FAVORITE:
-          addFavorite({ offerId })
-          navigate('Offer', { id: offerId })
-          return
-        case StepperOrigin.OFFER:
-        case StepperOrigin.NOTIFICATION:
-          navigate('Offer', { id: offerId })
-          return
-        default:
-          navigateToHome()
-          return
-      }
-    } else {
-      navigateToHome()
-    }
-  }, [addFavorite, navigate, offerId, comeFrom, bonificationBonusAmount])
+    },
+    [addFavorite, navigate, offerId, comeFrom, bonificationBonusAmount]
+  )
 
   return useCallback(
-    async (accountState: AccountState) => {
+    async (accountState: AccountState, provider: LoginProvider) => {
       try {
         if (doNotNavigateOnSigninSuccess) {
           return
@@ -153,7 +167,7 @@ const useHandleSigninSuccess = (
           case AccountState.ANONYMIZED:
             return setErrorMessage?.('Ton compte à été supprimé')
           case AccountState.ACTIVE:
-            navigateForActiveState()
+            await navigateForActiveState(provider)
             return
         }
       } catch {

--- a/src/features/auth/queries/useSignInMutation.ts
+++ b/src/features/auth/queries/useSignInMutation.ts
@@ -21,6 +21,8 @@ import {
 } from 'features/navigation/navigators/RootNavigator/types'
 import { getSSOLoginMethod, LoginRoutineMethod, LoginType } from 'libs/analytics/logEventAnalytics'
 import { analytics } from 'libs/analytics/provider'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { storage } from 'libs/storage'
 import { useAddFavoriteMutation } from 'queries/favorites/useAddFavoriteMutation'
 import { useBonificationBonusAmount } from 'queries/settings/useSettings'
@@ -34,15 +36,23 @@ export const useSignInMutation = ({
   setErrorMessage,
   onFailure,
 }: {
-  params: RootStackParamList['LoginMethods' | 'SignupMethods']
+  params: RootStackParamList['LoginMethods' | 'LoginMethodsWithLastLoginInfo' | 'SignupMethods']
   doNotNavigateOnSigninSuccess?: boolean
   analyticsMethod?: LoginRoutineMethod
   analyticsType?: LoginType
   onFailure: (error: SignInResponseFailure) => void
   setErrorMessage?: (message: string) => void
 }) => {
+  const enabledSaveLastLoginInfo = useFeatureFlag(
+    RemoteStoreFeatureFlags.ENABLE_SAVE_LAST_LOGIN_INFO
+  )
   const loginRoutine = useLoginRoutine()
-  const onSuccess = useHandleSigninSuccess(params, doNotNavigateOnSigninSuccess, setErrorMessage)
+  const onSuccess = useHandleSigninSuccess(
+    params,
+    doNotNavigateOnSigninSuccess,
+    setErrorMessage,
+    enabledSaveLastLoginInfo
+  )
 
   return useMutation({
     mutationFn: async (body: LoginRequest) => {
@@ -87,7 +97,8 @@ export const useSignInMutation = ({
 const useHandleSigninSuccess = (
   params: RootStackParamList['LoginMethods' | 'SignupMethods'],
   doNotNavigateOnSigninSuccess?: boolean,
-  setErrorMessage?: (message: string) => void
+  setErrorMessage?: (message: string) => void,
+  enabledSaveLastLoginInfo = false
 ) => {
   const { navigate } = useNavigation<UseNavigationType>()
   const { data: bonificationBonusAmount } = useBonificationBonusAmount()
@@ -109,7 +120,7 @@ const useHandleSigninSuccess = (
     async (provider: Provider) => {
       const user = await api.getNativeV1Me()
 
-      if (user?.email) {
+      if (user?.email && enabledSaveLastLoginInfo) {
         await saveLastLoginInfo({ email: user.email, provider })
       }
 
@@ -147,7 +158,7 @@ const useHandleSigninSuccess = (
         navigateToHome()
       }
     },
-    [addFavorite, navigate, offerId, comeFrom, bonificationBonusAmount]
+    [enabledSaveLastLoginInfo, offerId, bonificationBonusAmount, navigate, comeFrom, addFavorite]
   )
 
   return useCallback(

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -1,4 +1,7 @@
+import React from 'react'
+
 import { OAuthSigninRequestV2, SigninRequest } from 'api/gen'
+import { AccessibleIcon } from 'ui/svg/icons/types'
 
 export type SignInResponseFailure = {
   isSuccess: false
@@ -54,3 +57,17 @@ export type LoginRequest = SigninRequest | OAuthLoginRequest
 
 export const isOAuthLoginRequest = (req: LoginRequest): req is OAuthLoginRequest =>
   'provider' in req
+
+export type LoginProvider = 'google' | 'apple' | 'email'
+
+export type LastLoginInfo = {
+  maskedEmail: string
+  provider: LoginProvider
+  lastLoginAt: string
+}
+
+export type FormattedLastLoginInfo = {
+  maskedEmail: string
+  provider: { label: string; icon: React.FC<AccessibleIcon> }
+  lastLoginAt: string
+}

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -3,10 +3,16 @@ import React from 'react'
 import { OAuthSigninRequestV2, SigninRequest } from 'api/gen'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 
+export enum Provider {
+  GOOGLE = 'google',
+  APPLE = 'apple',
+  EMAIL = 'email',
+}
+
 export type SignInResponseFailure = {
   isSuccess: false
   statusCode?: number
-  provider?: 'google' | 'apple'
+  provider?: Provider.GOOGLE | Provider.APPLE
   content?:
     | {
         code:
@@ -31,7 +37,7 @@ export type SignupData = {
   password: string
   birthdate: string
   accountCreationToken?: string
-  ssoProvider?: 'google' | 'apple'
+  ssoProvider?: Provider.GOOGLE | Provider.APPLE
 }
 
 export type PreValidationSignupNormalStepProps = {
@@ -51,23 +57,21 @@ export type PreValidationSignupLastStepProps = {
 
 // Frontend discriminator to distinguish Apple from Google (same API shape)
 type OAuthLoginRequest = Omit<OAuthSigninRequestV2, 'deviceInfo'> & {
-  provider: 'google' | 'apple'
+  provider: Provider.GOOGLE | Provider.APPLE
 }
 export type LoginRequest = SigninRequest | OAuthLoginRequest
 
 export const isOAuthLoginRequest = (req: LoginRequest): req is OAuthLoginRequest =>
   'provider' in req
 
-export type LoginProvider = 'google' | 'apple' | 'email'
-
 export type LastLoginInfo = {
   maskedEmail: string
-  provider: LoginProvider
+  provider: Provider
   lastLoginAt: string
 }
 
 export type FormattedLastLoginInfo = {
   maskedEmail: string
-  provider: { label: string; icon: React.FC<AccessibleIcon> }
+  provider: { type: Provider; label: string; icon: React.FC<AccessibleIcon> }
   lastLoginAt: string
 }

--- a/src/features/favorites/pages/NotConnectedFavorites.native.test.tsx
+++ b/src/features/favorites/pages/NotConnectedFavorites.native.test.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent } from 'tests/utils'
 
 import { NotConnectedFavorites } from './NotConnectedFavorites'
@@ -17,14 +19,16 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('NotConnectedFavorites component', () => {
+  beforeEach(() => setFeatureFlags([]))
+
   it('should render not connected favorites', () => {
-    render(<NotConnectedFavorites />)
+    render(reactQueryProviderHOC(<NotConnectedFavorites />))
 
     expect(screen).toMatchSnapshot()
   })
 
   it('should navigate to SignupMethods  when click on "Créer un compte"', async () => {
-    render(<NotConnectedFavorites />)
+    render(reactQueryProviderHOC(<NotConnectedFavorites />))
 
     await user.press(screen.getByText(`Créer un compte`))
 
@@ -32,7 +36,7 @@ describe('NotConnectedFavorites component', () => {
   })
 
   it('should log analytic "logSignUpFromFavorite" when click on "Créer un compte"', async () => {
-    render(<NotConnectedFavorites />)
+    render(reactQueryProviderHOC(<NotConnectedFavorites />))
 
     await user.press(screen.getByText(`Créer un compte`))
 
@@ -40,7 +44,7 @@ describe('NotConnectedFavorites component', () => {
   })
 
   it('should log analytic "logSignUpClicked" when click on "Créer un compte"', async () => {
-    render(<NotConnectedFavorites />)
+    render(reactQueryProviderHOC(<NotConnectedFavorites />))
 
     await user.press(screen.getByText(`Créer un compte`))
 
@@ -48,7 +52,7 @@ describe('NotConnectedFavorites component', () => {
   })
 
   it('should navigate to LoginMethods when click on "Se connecter"', async () => {
-    render(<NotConnectedFavorites />)
+    render(reactQueryProviderHOC(<NotConnectedFavorites />))
 
     await user.press(screen.getByText(`Se connecter`))
 
@@ -56,7 +60,7 @@ describe('NotConnectedFavorites component', () => {
   })
 
   it('should log analytic "logSignInFromFavorite" when click on "Se connecter"', async () => {
-    render(<NotConnectedFavorites />)
+    render(reactQueryProviderHOC(<NotConnectedFavorites />))
 
     await user.press(screen.getByText(`Se connecter`))
 

--- a/src/features/navigation/helpers/screenParamsUtils.ts
+++ b/src/features/navigation/helpers/screenParamsUtils.ts
@@ -15,6 +15,7 @@ type ScreensRequiringParsing = Extract<
   | 'Home'
   | 'Login'
   | 'LoginMethods'
+  | 'LoginMethodsWithLastLoginInfo'
   | 'Offer'
   | 'OfferPreview'
   | 'OfferVideoPreview'
@@ -114,6 +115,11 @@ export const screenParamsParser: ParamsParsers = {
     from: identityFn,
   },
   LoginMethods: {
+    displayForcedLoginHelpMessage: parseObject,
+    offerId: identityFn,
+    from: identityFn,
+  },
+  LoginMethodsWithLastLoginInfo: {
     displayForcedLoginHelpMessage: parseObject,
     offerId: identityFn,
     from: identityFn,

--- a/src/features/navigation/navigators/CheatcodesStackNavigator/CheatcodesStackNavigator.tsx
+++ b/src/features/navigation/navigators/CheatcodesStackNavigator/CheatcodesStackNavigator.tsx
@@ -43,6 +43,7 @@ import { CheatcodesScreenGenericErrorPage } from 'cheatcodes/pages/others/Cheatc
 import { CheatcodesScreenGenericInfoPage } from 'cheatcodes/pages/others/CheatcodesScreenGenericInfoPage'
 import { CheatcodesScreenGenericInfoPageIllustrations } from 'cheatcodes/pages/others/CheatcodesScreenGenericInfoPageIllustrations'
 import { CheatcodesScreenGenericOfficialPage } from 'cheatcodes/pages/others/CheatcodesScreenGenericOfficialPage'
+import { CheatcodesScreenLastLoginInfo } from 'cheatcodes/pages/others/CheatcodesScreenLastLoginInfo'
 import { CheatcodesScreenLayoutExpiredLink } from 'cheatcodes/pages/others/CheatcodesScreenLayoutExpiredLink'
 import { CheatcodesScreenMandatoryUpdate } from 'cheatcodes/pages/others/CheatcodesScreenMandatoryUpdate'
 import { CheatcodesScreenNewCaledonia } from 'cheatcodes/pages/others/CheatcodesScreenNewCaledonia'
@@ -229,6 +230,11 @@ const cheatcodesStackNavigatorPathDefinition = {
       screen: CheatcodesScreenAccesLibre,
       linking: { path: 'cheatcodes/other/acces-libre' },
       options: { title: 'Cheatcodes - Accès libre' },
+    },
+    CheatcodesScreenLastLoginInfo: {
+      screen: CheatcodesScreenLastLoginInfo,
+      linking: { path: 'cheatcodes/other/last-login-info' },
+      options: { title: 'Cheatcodes - Informations de connexion' },
     },
     CheatcodesScreenAnalyticsDebugger: {
       screen: CheatcodesScreenAnalyticsDebugger,

--- a/src/features/navigation/navigators/CheatcodesStackNavigator/types.ts
+++ b/src/features/navigation/navigators/CheatcodesStackNavigator/types.ts
@@ -46,6 +46,7 @@ export type CheatcodesStackParamList = {
   CheatcodesScreenGenericInfoPage: undefined
   CheatcodesScreenGenericInfoPageIllustrations: undefined
   CheatcodesScreenGenericOfficialPage: undefined
+  CheatcodesScreenLastLoginInfo: undefined
   CheatcodesScreenLayoutExpiredLink: undefined
   CheatcodesScreenMandatoryUpdate: undefined
   CheatcodesScreenNewCaledonia: undefined

--- a/src/features/navigation/navigators/RootNavigator/RootStackNavigator.tsx
+++ b/src/features/navigation/navigators/RootNavigator/RootStackNavigator.tsx
@@ -17,6 +17,7 @@ import { ResetPasswordEmailSent } from 'features/auth/pages/forgottenPassword/Re
 import { ResetPasswordExpiredLink } from 'features/auth/pages/forgottenPassword/ResetPasswordExpiredLink/ResetPasswordExpiredLink'
 import { Login } from 'features/auth/pages/login/Login'
 import { LoginMethods } from 'features/auth/pages/login/LoginMethods'
+import { LoginMethodsWithLastLoginInfo } from 'features/auth/pages/login/LoginMethodsWithLastLoginInfo'
 import { AccountCreated } from 'features/auth/pages/signup/AccountCreated/AccountCreated'
 import { AfterSignupEmailValidationBuffer } from 'features/auth/pages/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer'
 import { NotYetUnderageEligibility } from 'features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility'
@@ -278,6 +279,11 @@ const rootScreens: RouteConfig[] = [
     name: 'LoginMethods',
     component: LoginMethods,
     options: { title: 'Méthodes de connexion' },
+  },
+  {
+    name: 'LoginMethodsWithLastLoginInfo',
+    component: LoginMethodsWithLastLoginInfo,
+    options: { title: 'Méthodes de connexion avec informations de la dernière connexion' },
   },
   {
     name: 'BannedCountryError',

--- a/src/features/navigation/navigators/RootNavigator/linking/rootStackNavigatorPathConfig.tsx
+++ b/src/features/navigation/navigators/RootNavigator/linking/rootStackNavigatorPathConfig.tsx
@@ -74,6 +74,10 @@ const rootStackNavigatorPathDefinition: PathConfigMap<RootStackParamList> = {
     path: 'connexion',
     parse: screenParamsParser.LoginMethods,
   },
+  LoginMethodsWithLastLoginInfo: {
+    path: 'connexion-avec-dernieres-informations-de-connexion',
+    parse: screenParamsParser.LoginMethodsWithLastLoginInfo,
+  },
   ReinitializePassword: {
     path: 'mot-de-passe-perdu',
     parse: screenParamsParser.ReinitializePassword,

--- a/src/features/navigation/navigators/RootNavigator/types.ts
+++ b/src/features/navigation/navigators/RootNavigator/types.ts
@@ -8,6 +8,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 
 import { CategoryIdEnum, CulturalSurveyQuestionEnum } from 'api/gen/api'
 import { DisabilitiesProperties } from 'features/accessibility/types'
+import { Provider } from 'features/auth/types'
 import { BookingsTab } from 'features/bookings/enum'
 import { Color, OffersModuleParameters, VenuesModule } from 'features/home/types'
 import { CheatcodesStackParamList } from 'features/navigation/navigators/CheatcodesStackNavigator/types'
@@ -180,7 +181,7 @@ type SignupParams =
       email?: string
       offerId?: number
       from: StepperOrigin
-      ssoProvider?: 'google' | 'apple'
+      ssoProvider?: Provider.GOOGLE | Provider.APPLE
       stepIndex?: number
     }
   | undefined

--- a/src/features/navigation/navigators/RootNavigator/types.ts
+++ b/src/features/navigation/navigators/RootNavigator/types.ts
@@ -120,6 +120,7 @@ export enum StepperOrigin {
   HOME = 'home',
   LOGIN = 'login',
   LOGIN_METHODS = 'LoginMethods',
+  LOGIN_METHODS_WITH_LAST_LOGIN_INFO = 'LoginMethodsWithLastLoginInfo',
   NOTIFICATION = 'notification',
   OFFER = 'offer',
   ONBOARDING_GENERAL_PUBLIC_WELCOME = 'OnboardingGeneralPublicWelcome',
@@ -289,6 +290,7 @@ export type RootStackParamList = {
   LocationPicker: undefined
   Login?: LoginParams
   LoginMethods?: LoginParams
+  LoginMethodsWithLastLoginInfo?: LoginParams
   Maintenance: undefined
   MandatoryUpdatePersonalData: undefined
   MovieCalendar: undefined

--- a/src/features/onboarding/pages/onboarding/OnboardingWelcome.native.test.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingWelcome.native.test.tsx
@@ -4,7 +4,9 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { OnboardingWelcome } from 'features/onboarding/pages/onboarding/OnboardingWelcome'
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { storage } from 'libs/storage'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { userEvent, render, screen } from 'tests/utils'
 
 jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
@@ -17,14 +19,16 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('OnboardingWelcome', () => {
+  beforeEach(() => setFeatureFlags([]))
+
   it('should render correctly', () => {
-    render(<OnboardingWelcome />)
+    render(reactQueryProviderHOC(<OnboardingWelcome />))
 
     expect(screen).toMatchSnapshot()
   })
 
   it('should redirect to OnboardingGeolocation when "C’est parti !" is clicked', async () => {
-    render(<OnboardingWelcome />)
+    render(reactQueryProviderHOC(<OnboardingWelcome />))
 
     const button = screen.getByText('C’est parti\u00a0!')
     await user.press(button)
@@ -36,7 +40,7 @@ describe('OnboardingWelcome', () => {
   })
 
   it('should redirect to login when "Se connecter" is clicked', async () => {
-    render(<OnboardingWelcome />)
+    render(reactQueryProviderHOC(<OnboardingWelcome />))
 
     const loginButton = screen.getByText('Se connecter')
     await user.press(loginButton)
@@ -47,7 +51,7 @@ describe('OnboardingWelcome', () => {
   })
 
   it('should set has_seen_tutorials to true in local storage when "C’est parti !" is clicked', async () => {
-    render(<OnboardingWelcome />)
+    render(reactQueryProviderHOC(<OnboardingWelcome />))
 
     const button = screen.getByText('C’est parti\u00a0!')
     await user.press(button)
@@ -56,7 +60,7 @@ describe('OnboardingWelcome', () => {
   })
 
   it('should set has_seen_tutorials to true in local storage when "Se connecter" is clicked', async () => {
-    render(<OnboardingWelcome />)
+    render(reactQueryProviderHOC(<OnboardingWelcome />))
 
     const loginButton = screen.getByText('Se connecter')
     await user.press(loginButton)
@@ -65,7 +69,7 @@ describe('OnboardingWelcome', () => {
   })
 
   it('should log analytics when "C’est parti !" is clicked', async () => {
-    render(<OnboardingWelcome />)
+    render(reactQueryProviderHOC(<OnboardingWelcome />))
 
     const button = screen.getByText('C’est parti\u00a0!')
     await user.press(button)
@@ -74,7 +78,7 @@ describe('OnboardingWelcome', () => {
   })
 
   it('should log analytics when "Se connecter" is clicked', async () => {
-    render(<OnboardingWelcome />)
+    render(reactQueryProviderHOC(<OnboardingWelcome />))
 
     const loginButton = screen.getByText('Se connecter')
     await user.press(loginButton)

--- a/src/features/profile/containers/ProfileLoggedOut/LoggedOutHeader/LoggedOutHeader.native.test.tsx
+++ b/src/features/profile/containers/ProfileLoggedOut/LoggedOutHeader/LoggedOutHeader.native.test.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, userEvent, screen } from 'tests/utils'
 
 import { LoggedOutHeader } from './LoggedOutHeader'
@@ -13,8 +15,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('LoggedOutHeader', () => {
+  beforeEach(() => setFeatureFlags([]))
+
   it('should navigate to the SignupForm page', async () => {
-    render(<LoggedOutHeader />)
+    render(reactQueryProviderHOC(<LoggedOutHeader />))
 
     const signupButton = screen.getByText('Créer un compte')
     await user.press(signupButton)
@@ -25,7 +29,7 @@ describe('LoggedOutHeader', () => {
   })
 
   it('should navigate to the LoginMethods page', async () => {
-    render(<LoggedOutHeader />)
+    render(reactQueryProviderHOC(<LoggedOutHeader />))
 
     const signinButton = screen.getByText('Se connecter')
     await user.press(signinButton)
@@ -36,7 +40,7 @@ describe('LoggedOutHeader', () => {
   })
 
   it('should log analytics when clicking on "Créer un compte"', async () => {
-    render(<LoggedOutHeader />)
+    render(reactQueryProviderHOC(<LoggedOutHeader />))
 
     const signupButton = screen.getByText('Créer un compte')
     await user.press(signupButton)
@@ -46,7 +50,7 @@ describe('LoggedOutHeader', () => {
   })
 
   it('should not display subtitle', () => {
-    render(<LoggedOutHeader />)
+    render(reactQueryProviderHOC(<LoggedOutHeader />))
 
     const subtitle = 'Tu as 17 ou 18 ans\u00a0?'
 

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -10,6 +10,7 @@ import {
 } from 'api/gen'
 import { DisabilitiesProperties } from 'features/accessibility/types'
 import { PreValidationSignupStep } from 'features/auth/enums'
+import { Provider } from 'features/auth/types'
 import { STEP_LABEL, Step } from 'features/bookOffer/context/reducer'
 import { CookiesChoiceByCategory } from 'features/cookies/types'
 import { FavoriteSortBy } from 'features/favorites/types'
@@ -81,13 +82,13 @@ type SSOType = 'SSO_login' | 'SSO_signup'
 type EmailType = 'email_login' | 'email_signup' | 'email_reinitialize' | 'email_change'
 export type LoginType = SSOType | EmailType
 
-type SSOProvider = 'apple' | 'google'
+type SSOProvider = Provider.APPLE | Provider.GOOGLE
 
 export function getSSOLoginMethod(
   provider: SSOProvider,
   kind: 'login' | 'signup'
 ): LoginRoutineMethod {
-  const suffix = provider === 'apple' ? 'Apple' : 'Google'
+  const suffix = provider === Provider.APPLE ? 'Apple' : 'Google'
   return `${kind === 'login' ? 'fromLogin' : 'fromSignup'}${suffix}` as LoginRoutineMethod
 }
 

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -50,6 +50,7 @@ export enum RemoteStoreFeatureFlags {
   ENABLE_HANDICAP_BONIFICATION = 'enableHandicapBonification',
   ENABLE_HIDE_TICKET = 'enableHideTicket',
   ENABLE_MANDATORY_UPDATE_PERSONAL_DATA = 'enableMandatoryUpdatePersonalData',
+  ENABLE_SAVE_LAST_LOGIN_INFO = 'enableSaveLastLoginInfo',
   ENABLE_PRO_REVIEWS_VENUE_AB_TESTING = 'enableProReviewsVenueABTesting',
   ENABLE_QUALTRICS_SURVEY = 'enableQualtricsSurvey',
   ENABLE_REPLICA_ALGOLIA_INDEX = 'enableReplicaAlgoliaIndex',

--- a/src/libs/storage.ts
+++ b/src/libs/storage.ts
@@ -19,6 +19,7 @@ export type StorageKey =
   | 'has_seen_push_notifications_modal_once'
   | 'has_seen_qualtrics_survey'
   | 'has_seen_tutorials'
+  | 'last_login_info'
   | 'logged_in_session_count'
   | 'offers_viewed_count'
   | 'PASSCULTURE_REFRESH_TOKEN'


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-41652

## Context

- Stockage des dernières données de connexion (email masqué + provider + date de dernière connexion) dans le `localStorage` via `saveLastLoginInfo` depuis `useSignInMutation`
- Récupération des informations de la dernière connexion stocké dans le `localStorage` via `getLastLoginInfo`
- Si informations de dernière connexion disponible > Redirection vers une nouvelle page de connexion avec les in
- Si pas d'informations de dernière connexion disponible > Redirection vers la page normal de méthodes ce connexion
- La mise a jour de la dernière connexion dépend de `/me`
- Création d'un `ENUM` pour avec les différents type de connexion Apple, Google ou Email
- Ajout d'une page dans les cheatcodes pour récupérer et afficher les informations de connexion stocké dans le `localStorage`
- Ajout d'un FF pour désactiver la feature si il y a un problème

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |   <img width="502" height="962" alt="Capture d’écran 2026-08-18 à 16 49 59" src="https://github.com/user-attachments/assets/2df778c7-8900-46de-96ac-9360dd55ee87" />  |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
