### PR TITLE
(PC-43006) fix(app): no truncated content on 320px screens.

### DIFF
--- a/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
@@ -47,333 +47,360 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
           En cochant ces 2 cases tu assures avoir lu :
         </Text>
         <View
-          accessibilityLabel="Conditions Générales d’Utilisation - Lien externe"
-          accessibilityRole="link"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": false,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
-            [
-              [
-                {
-                  "userSelect": "auto",
-                },
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "transparent",
-                  "borderWidth": 0,
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "paddingBottom": 2,
-                  "paddingLeft": 2,
-                  "paddingRight": 2,
-                  "paddingTop": 2,
-                  "width": "auto",
-                },
-              ],
-              {
-                "opacity": 1,
-              },
-            ]
+            {
+              "alignItems": "flex-start",
+            }
           }
-          testID="Conditions Générales d’Utilisation - Lien externe"
         >
           <View
-            gap={8}
-            hasIcon={true}
-            isMultiline={true}
-            style={
+            accessibilityLabel="Conditions Générales d’Utilisation - Lien externe"
+            accessibilityRole="link"
+            accessibilityState={
               {
-                "alignItems": "center",
-                "columnGap": 8,
-                "flexDirection": "row",
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
               }
             }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "paddingBottom": 2,
+                    "paddingLeft": 2,
+                    "paddingRight": 2,
+                    "paddingTop": 2,
+                    "width": "auto",
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Conditions Générales d’Utilisation - Lien externe"
           >
             <View
+              fullWidth={false}
+              gap={8}
+              hasIcon={true}
+              isMultiline={true}
               style={
                 {
-                  "flexShrink": 0,
+                  "alignItems": "center",
+                  "columnGap": 8,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                accessibilityLabel="Nouvelle fenêtre"
-                height={22}
-                width={22}
+                style={
+                  {
+                    "flexShrink": 0,
+                  }
+                }
               >
-                <Text>
-                  undefined-SVG-Mock
-                </Text>
+                <View
+                  accessibilityLabel="Nouvelle fenêtre"
+                  height={22}
+                  width={22}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
               </View>
+              <Text
+                numberOfLines={2}
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    {
+                      "color": "#161617",
+                      "flexBasis": undefined,
+                      "flexGrow": undefined,
+                      "flexShrink": 1,
+                      "maxWidth": "100%",
+                      "minWidth": 0,
+                      "textAlign": undefined,
+                    },
+                  ]
+                }
+              >
+                Conditions Générales d’Utilisation
+              </Text>
             </View>
-            <Text
-              numberOfLines={2}
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-SemiBold",
-                    "fontSize": 16,
-                    "lineHeight": 22,
-                  },
-                  {
-                    "color": "#161617",
-                    "flexBasis": undefined,
-                    "flexGrow": undefined,
-                    "flexShrink": 1,
-                    "maxWidth": "100%",
-                    "minWidth": 0,
-                    "textAlign": undefined,
-                  },
-                ]
-              }
-            >
-              Conditions Générales d’Utilisation
-            </Text>
           </View>
         </View>
         <View
-          accessibilityLabel="Charte des données personnelles - Lien externe"
-          accessibilityRole="link"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": false,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
-            [
-              [
-                {
-                  "userSelect": "auto",
-                },
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "transparent",
-                  "borderWidth": 0,
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "paddingBottom": 2,
-                  "paddingLeft": 2,
-                  "paddingRight": 2,
-                  "paddingTop": 2,
-                  "width": "auto",
-                },
-              ],
-              {
-                "opacity": 1,
-              },
-            ]
+            {
+              "alignItems": "flex-start",
+            }
           }
-          testID="Charte des données personnelles - Lien externe"
         >
           <View
-            gap={8}
-            hasIcon={true}
-            isMultiline={true}
-            style={
+            accessibilityLabel="Charte des données personnelles - Lien externe"
+            accessibilityRole="link"
+            accessibilityState={
               {
-                "alignItems": "center",
-                "columnGap": 8,
-                "flexDirection": "row",
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
               }
             }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "paddingBottom": 2,
+                    "paddingLeft": 2,
+                    "paddingRight": 2,
+                    "paddingTop": 2,
+                    "width": "auto",
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Charte des données personnelles - Lien externe"
           >
             <View
+              fullWidth={false}
+              gap={8}
+              hasIcon={true}
+              isMultiline={true}
               style={
                 {
-                  "flexShrink": 0,
+                  "alignItems": "center",
+                  "columnGap": 8,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                accessibilityLabel="Nouvelle fenêtre"
-                height={22}
-                width={22}
+                style={
+                  {
+                    "flexShrink": 0,
+                  }
+                }
               >
-                <Text>
-                  undefined-SVG-Mock
-                </Text>
+                <View
+                  accessibilityLabel="Nouvelle fenêtre"
+                  height={22}
+                  width={22}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
               </View>
+              <Text
+                numberOfLines={2}
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    {
+                      "color": "#161617",
+                      "flexBasis": undefined,
+                      "flexGrow": undefined,
+                      "flexShrink": 1,
+                      "maxWidth": "100%",
+                      "minWidth": 0,
+                      "textAlign": undefined,
+                    },
+                  ]
+                }
+              >
+                Charte des données personnelles
+              </Text>
             </View>
-            <Text
-              numberOfLines={2}
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-SemiBold",
-                    "fontSize": 16,
-                    "lineHeight": 22,
-                  },
-                  {
-                    "color": "#161617",
-                    "flexBasis": undefined,
-                    "flexGrow": undefined,
-                    "flexShrink": 1,
-                    "maxWidth": "100%",
-                    "minWidth": 0,
-                    "textAlign": undefined,
-                  },
-                ]
-              }
-            >
-              Charte des données personnelles
-            </Text>
           </View>
         </View>
         <View
-          accessibilityLabel="Charte d’utilisation et de bonne conduite - Lien externe"
-          accessibilityRole="link"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": false,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
-            [
-              [
-                {
-                  "userSelect": "auto",
-                },
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "transparent",
-                  "borderWidth": 0,
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "paddingBottom": 2,
-                  "paddingLeft": 2,
-                  "paddingRight": 2,
-                  "paddingTop": 2,
-                  "width": "auto",
-                },
-              ],
-              {
-                "opacity": 1,
-              },
-            ]
+            {
+              "alignItems": "flex-start",
+            }
           }
-          testID="Charte d’utilisation et de bonne conduite - Lien externe"
         >
           <View
-            gap={8}
-            hasIcon={true}
-            isMultiline={true}
-            style={
+            accessibilityLabel="Charte d’utilisation et de bonne conduite - Lien externe"
+            accessibilityRole="link"
+            accessibilityState={
               {
-                "alignItems": "center",
-                "columnGap": 8,
-                "flexDirection": "row",
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
               }
             }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "paddingBottom": 2,
+                    "paddingLeft": 2,
+                    "paddingRight": 2,
+                    "paddingTop": 2,
+                    "width": "auto",
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Charte d’utilisation et de bonne conduite - Lien externe"
           >
             <View
+              fullWidth={false}
+              gap={8}
+              hasIcon={true}
+              isMultiline={true}
               style={
                 {
-                  "flexShrink": 0,
+                  "alignItems": "center",
+                  "columnGap": 8,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                accessibilityLabel="Nouvelle fenêtre"
-                height={22}
-                width={22}
+                style={
+                  {
+                    "flexShrink": 0,
+                  }
+                }
               >
-                <Text>
-                  undefined-SVG-Mock
-                </Text>
+                <View
+                  accessibilityLabel="Nouvelle fenêtre"
+                  height={22}
+                  width={22}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
               </View>
+              <Text
+                numberOfLines={2}
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    {
+                      "color": "#161617",
+                      "flexBasis": undefined,
+                      "flexGrow": undefined,
+                      "flexShrink": 1,
+                      "maxWidth": "100%",
+                      "minWidth": 0,
+                      "textAlign": undefined,
+                    },
+                  ]
+                }
+              >
+                Charte d’utilisation et de bonne conduite
+              </Text>
             </View>
-            <Text
-              numberOfLines={2}
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-SemiBold",
-                    "fontSize": 16,
-                    "lineHeight": 22,
-                  },
-                  {
-                    "color": "#161617",
-                    "flexBasis": undefined,
-                    "flexGrow": undefined,
-                    "flexShrink": 1,
-                    "maxWidth": "100%",
-                    "minWidth": 0,
-                    "textAlign": undefined,
-                  },
-                ]
-              }
-            >
-              Charte d’utilisation et de bonne conduite
-            </Text>
           </View>
         </View>
       </View>
@@ -870,333 +897,360 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
           En cochant ces 2 cases tu assures avoir lu :
         </Text>
         <View
-          accessibilityLabel="Conditions Générales d’Utilisation - Lien externe"
-          accessibilityRole="link"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": false,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
-            [
-              [
-                {
-                  "userSelect": "auto",
-                },
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "transparent",
-                  "borderWidth": 0,
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "paddingBottom": 2,
-                  "paddingLeft": 2,
-                  "paddingRight": 2,
-                  "paddingTop": 2,
-                  "width": "auto",
-                },
-              ],
-              {
-                "opacity": 1,
-              },
-            ]
+            {
+              "alignItems": "flex-start",
+            }
           }
-          testID="Conditions Générales d’Utilisation - Lien externe"
         >
           <View
-            gap={8}
-            hasIcon={true}
-            isMultiline={true}
-            style={
+            accessibilityLabel="Conditions Générales d’Utilisation - Lien externe"
+            accessibilityRole="link"
+            accessibilityState={
               {
-                "alignItems": "center",
-                "columnGap": 8,
-                "flexDirection": "row",
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
               }
             }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "paddingBottom": 2,
+                    "paddingLeft": 2,
+                    "paddingRight": 2,
+                    "paddingTop": 2,
+                    "width": "auto",
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Conditions Générales d’Utilisation - Lien externe"
           >
             <View
+              fullWidth={false}
+              gap={8}
+              hasIcon={true}
+              isMultiline={true}
               style={
                 {
-                  "flexShrink": 0,
+                  "alignItems": "center",
+                  "columnGap": 8,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                accessibilityLabel="Nouvelle fenêtre"
-                height={22}
-                width={22}
+                style={
+                  {
+                    "flexShrink": 0,
+                  }
+                }
               >
-                <Text>
-                  undefined-SVG-Mock
-                </Text>
+                <View
+                  accessibilityLabel="Nouvelle fenêtre"
+                  height={22}
+                  width={22}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
               </View>
+              <Text
+                numberOfLines={2}
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    {
+                      "color": "#161617",
+                      "flexBasis": undefined,
+                      "flexGrow": undefined,
+                      "flexShrink": 1,
+                      "maxWidth": "100%",
+                      "minWidth": 0,
+                      "textAlign": undefined,
+                    },
+                  ]
+                }
+              >
+                Conditions Générales d’Utilisation
+              </Text>
             </View>
-            <Text
-              numberOfLines={2}
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-SemiBold",
-                    "fontSize": 16,
-                    "lineHeight": 22,
-                  },
-                  {
-                    "color": "#161617",
-                    "flexBasis": undefined,
-                    "flexGrow": undefined,
-                    "flexShrink": 1,
-                    "maxWidth": "100%",
-                    "minWidth": 0,
-                    "textAlign": undefined,
-                  },
-                ]
-              }
-            >
-              Conditions Générales d’Utilisation
-            </Text>
           </View>
         </View>
         <View
-          accessibilityLabel="Charte des données personnelles - Lien externe"
-          accessibilityRole="link"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": false,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
-            [
-              [
-                {
-                  "userSelect": "auto",
-                },
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "transparent",
-                  "borderWidth": 0,
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "paddingBottom": 2,
-                  "paddingLeft": 2,
-                  "paddingRight": 2,
-                  "paddingTop": 2,
-                  "width": "auto",
-                },
-              ],
-              {
-                "opacity": 1,
-              },
-            ]
+            {
+              "alignItems": "flex-start",
+            }
           }
-          testID="Charte des données personnelles - Lien externe"
         >
           <View
-            gap={8}
-            hasIcon={true}
-            isMultiline={true}
-            style={
+            accessibilityLabel="Charte des données personnelles - Lien externe"
+            accessibilityRole="link"
+            accessibilityState={
               {
-                "alignItems": "center",
-                "columnGap": 8,
-                "flexDirection": "row",
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
               }
             }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "paddingBottom": 2,
+                    "paddingLeft": 2,
+                    "paddingRight": 2,
+                    "paddingTop": 2,
+                    "width": "auto",
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Charte des données personnelles - Lien externe"
           >
             <View
+              fullWidth={false}
+              gap={8}
+              hasIcon={true}
+              isMultiline={true}
               style={
                 {
-                  "flexShrink": 0,
+                  "alignItems": "center",
+                  "columnGap": 8,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                accessibilityLabel="Nouvelle fenêtre"
-                height={22}
-                width={22}
+                style={
+                  {
+                    "flexShrink": 0,
+                  }
+                }
               >
-                <Text>
-                  undefined-SVG-Mock
-                </Text>
+                <View
+                  accessibilityLabel="Nouvelle fenêtre"
+                  height={22}
+                  width={22}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
               </View>
+              <Text
+                numberOfLines={2}
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    {
+                      "color": "#161617",
+                      "flexBasis": undefined,
+                      "flexGrow": undefined,
+                      "flexShrink": 1,
+                      "maxWidth": "100%",
+                      "minWidth": 0,
+                      "textAlign": undefined,
+                    },
+                  ]
+                }
+              >
+                Charte des données personnelles
+              </Text>
             </View>
-            <Text
-              numberOfLines={2}
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-SemiBold",
-                    "fontSize": 16,
-                    "lineHeight": 22,
-                  },
-                  {
-                    "color": "#161617",
-                    "flexBasis": undefined,
-                    "flexGrow": undefined,
-                    "flexShrink": 1,
-                    "maxWidth": "100%",
-                    "minWidth": 0,
-                    "textAlign": undefined,
-                  },
-                ]
-              }
-            >
-              Charte des données personnelles
-            </Text>
           </View>
         </View>
         <View
-          accessibilityLabel="Charte d’utilisation et de bonne conduite - Lien externe"
-          accessibilityRole="link"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": false,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
-            [
-              [
-                {
-                  "userSelect": "auto",
-                },
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "transparent",
-                  "borderWidth": 0,
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "paddingBottom": 2,
-                  "paddingLeft": 2,
-                  "paddingRight": 2,
-                  "paddingTop": 2,
-                  "width": "auto",
-                },
-              ],
-              {
-                "opacity": 1,
-              },
-            ]
+            {
+              "alignItems": "flex-start",
+            }
           }
-          testID="Charte d’utilisation et de bonne conduite - Lien externe"
         >
           <View
-            gap={8}
-            hasIcon={true}
-            isMultiline={true}
-            style={
+            accessibilityLabel="Charte d’utilisation et de bonne conduite - Lien externe"
+            accessibilityRole="link"
+            accessibilityState={
               {
-                "alignItems": "center",
-                "columnGap": 8,
-                "flexDirection": "row",
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
               }
             }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "paddingBottom": 2,
+                    "paddingLeft": 2,
+                    "paddingRight": 2,
+                    "paddingTop": 2,
+                    "width": "auto",
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="Charte d’utilisation et de bonne conduite - Lien externe"
           >
             <View
+              fullWidth={false}
+              gap={8}
+              hasIcon={true}
+              isMultiline={true}
               style={
                 {
-                  "flexShrink": 0,
+                  "alignItems": "center",
+                  "columnGap": 8,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                accessibilityLabel="Nouvelle fenêtre"
-                height={22}
-                width={22}
+                style={
+                  {
+                    "flexShrink": 0,
+                  }
+                }
               >
-                <Text>
-                  undefined-SVG-Mock
-                </Text>
+                <View
+                  accessibilityLabel="Nouvelle fenêtre"
+                  height={22}
+                  width={22}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
               </View>
+              <Text
+                numberOfLines={2}
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    {
+                      "color": "#161617",
+                      "flexBasis": undefined,
+                      "flexGrow": undefined,
+                      "flexShrink": 1,
+                      "maxWidth": "100%",
+                      "minWidth": 0,
+                      "textAlign": undefined,
+                    },
+                  ]
+                }
+              >
+                Charte d’utilisation et de bonne conduite
+              </Text>
             </View>
-            <Text
-              numberOfLines={2}
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-SemiBold",
-                    "fontSize": 16,
-                    "lineHeight": 22,
-                  },
-                  {
-                    "color": "#161617",
-                    "flexBasis": undefined,
-                    "flexGrow": undefined,
-                    "flexShrink": 1,
-                    "maxWidth": "100%",
-                    "minWidth": 0,
-                    "textAlign": undefined,
-                  },
-                ]
-              }
-            >
-              Charte d’utilisation et de bonne conduite
-            </Text>
           </View>
         </View>
       </View>

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -3017,333 +3017,360 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
                 En cochant ces 2 cases tu assures avoir lu :
               </Text>
               <View
-                accessibilityLabel="Conditions Générales d’Utilisation - Lien externe"
-                accessibilityRole="link"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderWidth": 0,
-                        "flexDirection": "row",
-                        "justifyContent": "center",
-                        "paddingBottom": 2,
-                        "paddingLeft": 2,
-                        "paddingRight": 2,
-                        "paddingTop": 2,
-                        "width": "auto",
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
+                  {
+                    "alignItems": "flex-start",
+                  }
                 }
-                testID="Conditions Générales d’Utilisation - Lien externe"
               >
                 <View
-                  gap={8}
-                  hasIcon={true}
-                  isMultiline={true}
-                  style={
+                  accessibilityLabel="Conditions Générales d’Utilisation - Lien externe"
+                  accessibilityRole="link"
+                  accessibilityState={
                     {
-                      "alignItems": "center",
-                      "columnGap": 8,
-                      "flexDirection": "row",
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
                     }
                   }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "alignItems": "center",
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                          "flexDirection": "row",
+                          "justifyContent": "center",
+                          "paddingBottom": 2,
+                          "paddingLeft": 2,
+                          "paddingRight": 2,
+                          "paddingTop": 2,
+                          "width": "auto",
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Conditions Générales d’Utilisation - Lien externe"
                 >
                   <View
+                    fullWidth={false}
+                    gap={8}
+                    hasIcon={true}
+                    isMultiline={true}
                     style={
                       {
-                        "flexShrink": 0,
+                        "alignItems": "center",
+                        "columnGap": 8,
+                        "flexDirection": "row",
                       }
                     }
                   >
                     <View
-                      accessibilityLabel="Nouvelle fenêtre"
-                      height={22}
-                      width={22}
+                      style={
+                        {
+                          "flexShrink": 0,
+                        }
+                      }
                     >
-                      <Text>
-                        undefined-SVG-Mock
-                      </Text>
+                      <View
+                        accessibilityLabel="Nouvelle fenêtre"
+                        height={22}
+                        width={22}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
                     </View>
+                    <Text
+                      numberOfLines={2}
+                      style={
+                        [
+                          {
+                            "color": "#161617",
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 22,
+                          },
+                          {
+                            "color": "#161617",
+                            "flexBasis": undefined,
+                            "flexGrow": undefined,
+                            "flexShrink": 1,
+                            "maxWidth": "100%",
+                            "minWidth": 0,
+                            "textAlign": undefined,
+                          },
+                        ]
+                      }
+                    >
+                      Conditions Générales d’Utilisation
+                    </Text>
                   </View>
-                  <Text
-                    numberOfLines={2}
-                    style={
-                      [
-                        {
-                          "color": "#161617",
-                          "fontFamily": "Montserrat-SemiBold",
-                          "fontSize": 16,
-                          "lineHeight": 22,
-                        },
-                        {
-                          "color": "#161617",
-                          "flexBasis": undefined,
-                          "flexGrow": undefined,
-                          "flexShrink": 1,
-                          "maxWidth": "100%",
-                          "minWidth": 0,
-                          "textAlign": undefined,
-                        },
-                      ]
-                    }
-                  >
-                    Conditions Générales d’Utilisation
-                  </Text>
                 </View>
               </View>
               <View
-                accessibilityLabel="Charte des données personnelles - Lien externe"
-                accessibilityRole="link"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderWidth": 0,
-                        "flexDirection": "row",
-                        "justifyContent": "center",
-                        "paddingBottom": 2,
-                        "paddingLeft": 2,
-                        "paddingRight": 2,
-                        "paddingTop": 2,
-                        "width": "auto",
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
+                  {
+                    "alignItems": "flex-start",
+                  }
                 }
-                testID="Charte des données personnelles - Lien externe"
               >
                 <View
-                  gap={8}
-                  hasIcon={true}
-                  isMultiline={true}
-                  style={
+                  accessibilityLabel="Charte des données personnelles - Lien externe"
+                  accessibilityRole="link"
+                  accessibilityState={
                     {
-                      "alignItems": "center",
-                      "columnGap": 8,
-                      "flexDirection": "row",
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
                     }
                   }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "alignItems": "center",
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                          "flexDirection": "row",
+                          "justifyContent": "center",
+                          "paddingBottom": 2,
+                          "paddingLeft": 2,
+                          "paddingRight": 2,
+                          "paddingTop": 2,
+                          "width": "auto",
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Charte des données personnelles - Lien externe"
                 >
                   <View
+                    fullWidth={false}
+                    gap={8}
+                    hasIcon={true}
+                    isMultiline={true}
                     style={
                       {
-                        "flexShrink": 0,
+                        "alignItems": "center",
+                        "columnGap": 8,
+                        "flexDirection": "row",
                       }
                     }
                   >
                     <View
-                      accessibilityLabel="Nouvelle fenêtre"
-                      height={22}
-                      width={22}
+                      style={
+                        {
+                          "flexShrink": 0,
+                        }
+                      }
                     >
-                      <Text>
-                        undefined-SVG-Mock
-                      </Text>
+                      <View
+                        accessibilityLabel="Nouvelle fenêtre"
+                        height={22}
+                        width={22}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
                     </View>
+                    <Text
+                      numberOfLines={2}
+                      style={
+                        [
+                          {
+                            "color": "#161617",
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 22,
+                          },
+                          {
+                            "color": "#161617",
+                            "flexBasis": undefined,
+                            "flexGrow": undefined,
+                            "flexShrink": 1,
+                            "maxWidth": "100%",
+                            "minWidth": 0,
+                            "textAlign": undefined,
+                          },
+                        ]
+                      }
+                    >
+                      Charte des données personnelles
+                    </Text>
                   </View>
-                  <Text
-                    numberOfLines={2}
-                    style={
-                      [
-                        {
-                          "color": "#161617",
-                          "fontFamily": "Montserrat-SemiBold",
-                          "fontSize": 16,
-                          "lineHeight": 22,
-                        },
-                        {
-                          "color": "#161617",
-                          "flexBasis": undefined,
-                          "flexGrow": undefined,
-                          "flexShrink": 1,
-                          "maxWidth": "100%",
-                          "minWidth": 0,
-                          "textAlign": undefined,
-                        },
-                      ]
-                    }
-                  >
-                    Charte des données personnelles
-                  </Text>
                 </View>
               </View>
               <View
-                accessibilityLabel="Charte d’utilisation et de bonne conduite - Lien externe"
-                accessibilityRole="link"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
-                  [
-                    [
-                      {
-                        "userSelect": "auto",
-                      },
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderWidth": 0,
-                        "flexDirection": "row",
-                        "justifyContent": "center",
-                        "paddingBottom": 2,
-                        "paddingLeft": 2,
-                        "paddingRight": 2,
-                        "paddingTop": 2,
-                        "width": "auto",
-                      },
-                    ],
-                    {
-                      "opacity": 1,
-                    },
-                  ]
+                  {
+                    "alignItems": "flex-start",
+                  }
                 }
-                testID="Charte d’utilisation et de bonne conduite - Lien externe"
               >
                 <View
-                  gap={8}
-                  hasIcon={true}
-                  isMultiline={true}
-                  style={
+                  accessibilityLabel="Charte d’utilisation et de bonne conduite - Lien externe"
+                  accessibilityRole="link"
+                  accessibilityState={
                     {
-                      "alignItems": "center",
-                      "columnGap": 8,
-                      "flexDirection": "row",
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
                     }
                   }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "alignItems": "center",
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                          "flexDirection": "row",
+                          "justifyContent": "center",
+                          "paddingBottom": 2,
+                          "paddingLeft": 2,
+                          "paddingRight": 2,
+                          "paddingTop": 2,
+                          "width": "auto",
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Charte d’utilisation et de bonne conduite - Lien externe"
                 >
                   <View
+                    fullWidth={false}
+                    gap={8}
+                    hasIcon={true}
+                    isMultiline={true}
                     style={
                       {
-                        "flexShrink": 0,
+                        "alignItems": "center",
+                        "columnGap": 8,
+                        "flexDirection": "row",
                       }
                     }
                   >
                     <View
-                      accessibilityLabel="Nouvelle fenêtre"
-                      height={22}
-                      width={22}
+                      style={
+                        {
+                          "flexShrink": 0,
+                        }
+                      }
                     >
-                      <Text>
-                        undefined-SVG-Mock
-                      </Text>
+                      <View
+                        accessibilityLabel="Nouvelle fenêtre"
+                        height={22}
+                        width={22}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
                     </View>
+                    <Text
+                      numberOfLines={2}
+                      style={
+                        [
+                          {
+                            "color": "#161617",
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 22,
+                          },
+                          {
+                            "color": "#161617",
+                            "flexBasis": undefined,
+                            "flexGrow": undefined,
+                            "flexShrink": 1,
+                            "maxWidth": "100%",
+                            "minWidth": 0,
+                            "textAlign": undefined,
+                          },
+                        ]
+                      }
+                    >
+                      Charte d’utilisation et de bonne conduite
+                    </Text>
                   </View>
-                  <Text
-                    numberOfLines={2}
-                    style={
-                      [
-                        {
-                          "color": "#161617",
-                          "fontFamily": "Montserrat-SemiBold",
-                          "fontSize": 16,
-                          "lineHeight": 22,
-                        },
-                        {
-                          "color": "#161617",
-                          "flexBasis": undefined,
-                          "flexGrow": undefined,
-                          "flexShrink": 1,
-                          "maxWidth": "100%",
-                          "minWidth": 0,
-                          "textAlign": undefined,
-                        },
-                      ]
-                    }
-                  >
-                    Charte d’utilisation et de bonne conduite
-                  </Text>
                 </View>
               </View>
             </View>

--- a/doc/accessibility/audits/web/2026_09_26.md
+++ b/doc/accessibility/audits/web/2026_09_26.md
@@ -184,6 +184,32 @@ Texte
 
 <details>
 
+<summary> ⏳ Critère 10.11 - Pour chaque page web, les contenus peuvent-ils être présentés sans perte d’information ou de fonctionnalité et sans avoir recours soit à un défilement vertical ou un défilement horizontal ?</summary>
+
+**RGAA** : [Critère 10.11](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#10.11)  
+**Ticket** : [PC-43006](https://passculture.atlassian.net/browse/PC-43006)  
+**PR** : [#10057](https://github.com/pass-culture/pass-culture-app-native/pull/10057)
+
+**Problème** 😱
+
+- **[ P01 → Création de compte ]** : Les liens externes sont tronqués à la dernière étape d’inscription.
+- **[ P01 → Création de compte ]** : La barre de navigation n'est pas visible.
+- **[ P01 → Recherche ]** : Le titre "Rechercher" est tronqué (non reproductible).
+
+**Correction** 💡
+
+- **[ P01 → Création de compte ]** : Les liens externes sont entièrement visibles à la dernière étape d’inscription.
+- **[ P01 → Création de compte ]** : La barre de navigation est visible partout.
+
+**Retours audit** 🔥  
+Texte
+
+</details>
+
+<br>
+
+<details>
+
 <summary> ⏳ Critère 11.5 - Dans chaque formulaire, les champs de même nature sont-ils regroupés, si nécessaire ?</summary>
 
 **RGAA** : [Critère 11.5](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#11.5)  

--- a/src/features/auth/pages/signup/AcceptCgu/AcceptCgu.tsx
+++ b/src/features/auth/pages/signup/AcceptCgu/AcceptCgu.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, useState, useCallback } from 'react'
+import { Platform } from 'react-native'
 import styled from 'styled-components/native'
 
 import { useSignupRecaptcha } from 'features/auth/helpers/useSignupRecaptcha'
@@ -144,33 +145,42 @@ export const AcceptCgu: FunctionComponent<PreValidationSignupLastStepProps> = ({
             <CaptionNeutralInfo>
               En cochant ces 2 cases tu assures avoir lu&nbsp;:
             </CaptionNeutralInfo>
-            <ExternalTouchableLink
-              as={Button}
-              variant="tertiary"
-              color="neutral"
-              wording="Conditions Générales d’Utilisation"
-              externalNav={{ url: env.CGU_LINK }}
-              icon={ExternalSiteFilled}
-              numberOfLines={numberOfLines}
-            />
-            <ExternalTouchableLink
-              as={Button}
-              variant="tertiary"
-              color="neutral"
-              wording="Charte des données personnelles"
-              externalNav={{ url: env.PRIVACY_POLICY_LINK }}
-              icon={ExternalSiteFilled}
-              numberOfLines={numberOfLines}
-            />
-            <ExternalTouchableLink
-              as={Button}
-              variant="tertiary"
-              color="neutral"
-              wording="Charte d’utilisation et de bonne conduite"
-              externalNav={{ url: env.CODE_OF_CONDUCT_LINK }}
-              icon={ExternalSiteFilled}
-              numberOfLines={numberOfLines}
-            />
+            <LinkWrapper>
+              <ExternalTouchableLink
+                as={Button}
+                variant="tertiary"
+                color="neutral"
+                wording="Conditions Générales d’Utilisation"
+                externalNav={{ url: env.CGU_LINK }}
+                icon={ExternalSiteFilled}
+                numberOfLines={numberOfLines}
+                fullWidth={Platform.OS === 'web'}
+              />
+            </LinkWrapper>
+            <LinkWrapper>
+              <ExternalTouchableLink
+                as={Button}
+                variant="tertiary"
+                color="neutral"
+                wording="Charte des données personnelles"
+                externalNav={{ url: env.PRIVACY_POLICY_LINK }}
+                icon={ExternalSiteFilled}
+                numberOfLines={numberOfLines}
+                fullWidth={Platform.OS === 'web'}
+              />
+            </LinkWrapper>
+            <LinkWrapper>
+              <ExternalTouchableLink
+                as={Button}
+                variant="tertiary"
+                color="neutral"
+                wording="Charte d’utilisation et de bonne conduite"
+                externalNav={{ url: env.CODE_OF_CONDUCT_LINK }}
+                icon={ExternalSiteFilled}
+                numberOfLines={numberOfLines}
+                fullWidth={Platform.OS === 'web'}
+              />
+            </LinkWrapper>
           </Container>
 
           <CheckboxGroup<string>
@@ -229,4 +239,8 @@ const Container = styled(ViewGap)(({ theme }) => ({
 
 const ReverseOrderContainer = styled.View({
   flexDirection: 'column-reverse',
+})
+
+const LinkWrapper = styled.View({
+  alignItems: 'flex-start',
 })

--- a/src/features/navigation/navigators/RootNavigator/Header/AccessibleTabBar.tsx
+++ b/src/features/navigation/navigators/RootNavigator/Header/AccessibleTabBar.tsx
@@ -1,3 +1,1 @@
-import { Route } from '@react-navigation/native'
-
-export const AccessibleTabBar = (_: { id: string; currentRoute?: Route<string> }) => null
+export const AccessibleTabBar = (_: { id: string }) => null

--- a/src/features/navigation/navigators/RootNavigator/Header/AccessibleTabBar.web.tsx
+++ b/src/features/navigation/navigators/RootNavigator/Header/AccessibleTabBar.web.tsx
@@ -1,4 +1,3 @@
-import { Route } from '@react-navigation/native'
 import React, { FC } from 'react'
 import styled from 'styled-components'
 import nativeStyled from 'styled-components/native'
@@ -12,15 +11,10 @@ import { useSearch } from 'features/search/context/SearchWrapper'
 import { Li } from 'ui/components/Li'
 import { Ul } from 'ui/components/Ul'
 
-export const AccessibleTabBar: FC<{ id: string; currentRoute?: Route<string> }> = ({
-  id,
-  currentRoute,
-}) => {
+export const AccessibleTabBar: FC<{ id: string }> = ({ id }) => {
   const { tabRoutes } = useTabNavigationContext()
   const { searchState, hideSuggestions } = useSearch()
   const routeBadgeMap = useTabBarItemBadges()
-
-  if (currentRoute && currentRoute.name !== 'TabNavigator') return null
 
   return (
     <AccessibleTabBarContainer id={id}>

--- a/src/features/navigation/navigators/RootNavigator/RootStackNavigator.tsx
+++ b/src/features/navigation/navigators/RootNavigator/RootStackNavigator.tsx
@@ -619,7 +619,7 @@ export const RootNavigator: React.FC<{ currentRoute?: Route<string> }> = ({ curr
       <Main nativeID={mainId} accessibilityRole={mainAccessibilityRole}>
         <RootStackNavigator initialRouteName={initialScreen} />
       </Main>
-      {showTabBar ? <AccessibleTabBar id={tabBarId} currentRoute={currentRoute} /> : null}
+      {showTabBar ? <AccessibleTabBar id={tabBarId} /> : null}
       {/* The components below are those for which we do not want their rendering to happen while the splash is displayed. */}
       {isSplashScreenHidden ? <PrivacyPolicy /> : null}
       {/* AppModal relies on navigation hooks on web: this modal must stay inside the NavigationContainer */}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43006

## Context
L'objectif de cette PR est d'améliorer l'accessibilité de l'inscription en rendant visible complètement les liens externes sur un écran 320px et en affichant la barre de navigation sur tous les écrans en web mobile.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-18 at 10 58 06" src="https://github.com/user-attachments/assets/0a95548d-9233-470d-b311-e6c39faaf97b" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-18 at 11 07 40" src="https://github.com/user-attachments/assets/655359d1-f129-4117-bc54-450a2216e530" />|
| Android          |<img width="1080" height="2400" alt="Screenshot_1787044641" src="https://github.com/user-attachments/assets/4a386e1d-e283-4859-a739-8da46c1bdccc" />|<img width="1080" height="2400" alt="Screenshot_1787044703" src="https://github.com/user-attachments/assets/388bc0e2-368d-46ee-82ae-f76e60347c21" />|
| Phone - Chrome   |<img width="368" height="644" alt="Capture d’écran 2026-08-18 à 10 26 42" src="https://github.com/user-attachments/assets/8f9fa92e-1211-40c0-8330-788ce2b044b2" /> <img width="373" height="769" alt="Capture d’écran 2026-08-18 à 12 17 14" src="https://github.com/user-attachments/assets/27488127-05c3-45b5-9083-ae325af5bd92" />|<img width="369" height="781" alt="Capture d’écran 2026-08-18 à 10 47 46" src="https://github.com/user-attachments/assets/6a269af7-a6b3-47d0-8427-a1021e6e88f5" /> <img width="364" height="770" alt="Capture d’écran 2026-08-18 à 12 17 34" src="https://github.com/user-attachments/assets/99c7d8f3-1571-46be-ac98-cd4f110bff69" />|
| Desktop - Chrome |<img width="1505" height="827" alt="Capture d’écran 2026-08-18 à 10 56 27" src="https://github.com/user-attachments/assets/a9ca0f98-727e-4a86-9927-9a8d552e369e" />|<img width="1506" height="829" alt="Capture d’écran 2026-08-18 à 11 18 53" src="https://github.com/user-attachments/assets/fc1401cb-31cd-4be8-97a2-69f164ae87c4" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
