### PR TITLE
(PC-43274) refactor(app): remove volunteering feedback + wipEnableVolunteerFeedback FF

### DIFF
--- a/src/features/home/components/modules/venues/VenuesModule.native.test.tsx
+++ b/src/features/home/components/modules/venues/VenuesModule.native.test.tsx
@@ -1,4 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import React from 'react'
 
 import { VenuesModule } from 'features/home/components/modules/venues/VenuesModule'
@@ -7,7 +6,6 @@ import { venuesSearchFixture } from 'libs/algolia/fixtures/venuesSearchFixture'
 import { analytics } from 'libs/analytics/provider'
 import { DisplayParametersFields } from 'libs/contentful/types'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
-import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent } from 'tests/utils'
 
@@ -55,118 +53,43 @@ describe('VenuesModule component', () => {
     expect(screen.queryByText('Nouveau')).not.toBeOnTheScreen()
   })
 
-  describe('When playlist has exclusively volunteering venues', () => {
-    describe('When wipEnableVolunteerFeedback FF activated', () => {
-      beforeEach(() => {
-        setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_VOLUNTEER_FEEDBACK])
-      })
-
-      it('should display feedback', () => {
-        renderVenuesModule({
-          displayParameters: { ...props.displayParameters, isExclusiveVolunteering: true },
-        })
-
-        expect(screen.getByText('Le bénévolat sur le pass t’intéresse t-il ?')).toBeOnTheScreen()
-      })
-
-      it('should trigger FeatureFeedbackClicked log with yes answer when answering yes to feedback quiz', async () => {
-        await AsyncStorage.removeItem('volunteering_feedback')
-        renderVenuesModule({
-          displayParameters: { ...props.displayParameters, isExclusiveVolunteering: true },
-        })
-
-        await user.press(screen.getByText('Oui'))
-
-        expect(analytics.logFeatureFeedbackClicked).toHaveBeenCalledWith({
-          featureName: 'volunteer',
-          feedbackResponse: 'Oui',
-          from: 'home',
-          entryId: 'fakeEntryId',
-        })
-      })
-
-      it('should trigger FeatureFeedbackClicked log with no answer when answering no to feedback quiz', async () => {
-        await AsyncStorage.removeItem('volunteering_feedback')
-        renderVenuesModule({
-          displayParameters: { ...props.displayParameters, isExclusiveVolunteering: true },
-        })
-
-        await user.press(screen.getByText('Non'))
-
-        expect(analytics.logFeatureFeedbackClicked).toHaveBeenCalledWith({
-          featureName: 'volunteer',
-          feedbackResponse: 'Non',
-          from: 'home',
-          entryId: 'fakeEntryId',
-        })
-      })
+  it('should trigger ConsultVenue log with originDetails set to volunteeringPlaylist when pressing on a venue when playlist has exclusively volunteering venues', async () => {
+    renderVenuesModule({
+      displayParameters: { ...props.displayParameters, isExclusiveVolunteering: true },
     })
 
-    it('should not display feedback when wipEnableVolunteerFeedback FF deactivated', () => {
-      renderVenuesModule({
-        displayParameters: { ...props.displayParameters, isExclusiveVolunteering: true },
-      })
+    const venues = screen.getAllByLabelText('Le Petit Rintintin 1 - Paris - 75000 - Cinéma')
+    const firstVenue = venues[0]
 
-      expect(
-        screen.queryByText('Le bénévolat sur le pass t’intéresse t-il ?')
-      ).not.toBeOnTheScreen()
-    })
+    if (firstVenue) {
+      await user.press(firstVenue)
+    }
 
-    it('should trigger ConsultVenue log with originDetails set to volunteeringPlaylist when pressing on a venue', async () => {
-      renderVenuesModule({
-        displayParameters: { ...props.displayParameters, isExclusiveVolunteering: true },
-      })
-
-      const venues = screen.getAllByLabelText('Le Petit Rintintin 1 - Paris - 75000 - Cinéma')
-      const firstVenue = venues[0]
-
-      if (firstVenue) {
-        await user.press(firstVenue)
-      }
-
-      expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
-        venueId: props.data?.playlistItems[0].id.toString(),
-        from: 'home',
-        moduleName: props.displayParameters.title,
-        moduleId: props.moduleId,
-        homeEntryId: props.homeEntryId,
-        originDetails: 'volunteeringPlaylist',
-      })
+    expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
+      venueId: props.data?.playlistItems[0].id.toString(),
+      from: 'home',
+      moduleName: props.displayParameters.title,
+      moduleId: props.moduleId,
+      homeEntryId: props.homeEntryId,
+      originDetails: 'volunteeringPlaylist',
     })
   })
 
-  describe('When playlist has not exclusively volunteering venues', () => {
-    it('should not display new tag', () => {
-      renderVenuesModule()
+  it('should trigger ConsultVenue log without originDetails set to volunteeringPlaylist when pressing on a venue when playlist has not exclusively volunteering venues', async () => {
+    renderVenuesModule()
+    const venues = screen.getAllByLabelText('Le Petit Rintintin 1 - Paris - 75000 - Cinéma')
+    const firstVenue = venues[0]
 
-      expect(screen.queryByText('Nouveau')).not.toBeOnTheScreen()
-    })
+    if (firstVenue) {
+      await user.press(firstVenue)
+    }
 
-    it('should not display feedback when wipEnableVolunteerFeedback FF activated', () => {
-      setFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_VOLUNTEER_FEEDBACK])
-      renderVenuesModule()
-
-      expect(
-        screen.queryByText('Le bénévolat sur le pass t’intéresse t-il ?')
-      ).not.toBeOnTheScreen()
-    })
-
-    it('should trigger ConsultVenue log without originDetails set to volunteeringPlaylist when pressing on a venue', async () => {
-      renderVenuesModule()
-      const venues = screen.getAllByLabelText('Le Petit Rintintin 1 - Paris - 75000 - Cinéma')
-      const firstVenue = venues[0]
-
-      if (firstVenue) {
-        await user.press(firstVenue)
-      }
-
-      expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
-        venueId: props.data?.playlistItems[0].id.toString(),
-        from: 'home',
-        moduleName: props.displayParameters.title,
-        moduleId: props.moduleId,
-        homeEntryId: props.homeEntryId,
-      })
+    expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
+      venueId: props.data?.playlistItems[0].id.toString(),
+      from: 'home',
+      moduleName: props.displayParameters.title,
+      moduleId: props.moduleId,
+      homeEntryId: props.homeEntryId,
     })
   })
 })

--- a/src/features/home/components/modules/venues/VenuesModule.tsx
+++ b/src/features/home/components/modules/venues/VenuesModule.tsx
@@ -3,15 +3,11 @@ import { ViewToken } from 'react-native'
 import { useTheme } from 'styled-components'
 import { styled } from 'styled-components/native'
 
-import { ReactionTypeEnum } from 'api/gen'
 import { VenueTile } from 'features/home/components/modules/venues/VenueTile'
 import { HomepageModuleType, ModuleData, VenuesModuleParameters } from 'features/home/types'
-import { FeedBack } from 'features/reactions/components/FeedBack'
 import { VenueHit } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics/provider'
 import { ContentTypes, DisplayParametersFields } from 'libs/contentful/types'
-import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
-import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { ObservedPlaylist } from 'shared/ObservedPlaylist/ObservedPlaylist'
 import { VerticalPlaylist } from 'shared/verticalPlaylist/enums'
 import { PassPlaylist } from 'ui/components/PassPlaylist'
@@ -43,9 +39,6 @@ export const VenuesModule = ({
   data,
   onViewableItemsChanged,
 }: VenuesModuleProps) => {
-  const enableVolunteerFeedback = useFeatureFlag(
-    RemoteStoreFeatureFlags.WIP_ENABLE_VOLUNTEER_FEEDBACK
-  )
   const moduleName = displayParameters.title
   const { playlistItems = [] } = data ?? { playlistItems: [] }
   const { designSystem } = useTheme()
@@ -66,7 +59,6 @@ export const VenuesModule = ({
   )
 
   const shouldModuleBeDisplayed = playlistItems.length > displayParameters.minOffers
-  const showFeedback = enableVolunteerFeedback && isExclusiveVolunteering
 
   useEffect(() => {
     if (shouldModuleBeDisplayed) {
@@ -80,16 +72,6 @@ export const VenuesModule = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shouldModuleBeDisplayed])
-
-  const handleOnLogFeedback = (type: ReactionTypeEnum) => {
-    const feedbackResponse = type === ReactionTypeEnum.LIKE ? 'Oui' : 'Non'
-    void analytics.logFeatureFeedbackClicked({
-      featureName: 'volunteer',
-      feedbackResponse,
-      from: 'home',
-      entryId: homeEntryId,
-    })
-  }
 
   if (!shouldModuleBeDisplayed) return null
 
@@ -132,24 +114,10 @@ export const VenuesModule = ({
           />
         )}
       </ObservedPlaylist>
-      {showFeedback ? (
-        <StyledFeedBack
-          storageKey="volunteering_feedback"
-          likeQuiz="https://passculture.qualtrics.com/jfe/form/SV_3sGi4gI6EEOmfsy"
-          dislikeQuiz="https://passculture.qualtrics.com/jfe/form/SV_3sGi4gI6EEOmfsy"
-          title="Le bénévolat sur le pass t’intéresse t-il&nbsp;?"
-          onLogReaction={handleOnLogFeedback}
-        />
-      ) : null}
     </Container>
   )
 }
 
 const Container = styled(ViewGap)(({ theme }) => ({
   paddingBottom: theme.home.spaceBetweenModules,
-}))
-
-const StyledFeedBack = styled(FeedBack)(({ theme }) => ({
-  marginHorizontal: theme.designSystem.size.spacing.xl,
-  width: theme.isDesktopViewport ? '50%' : 'auto',
 }))

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponent.native.test.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponent.native.test.tsx
@@ -1,4 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import Clipboard from '@react-native-clipboard/clipboard'
 import mockdate from 'mockdate'
 import React, { ComponentProps } from 'react'
@@ -292,79 +291,12 @@ describe('<VenueTopComponent />', () => {
         venueId: venueOpenToPublic.id.toString(),
       })
     })
-
-    it('should display feedback component below volunteer card when venue has volunteering url and wipEnableVolunteerFeedback FF activated', () => {
-      renderVenueTopComponent({
-        venue: { ...venueOpenToPublic, volunteeringUrl: 'url' },
-        enableVolunteer: true,
-        enableVolunteerFeedback: true,
-      })
-
-      expect(screen.getByText('Le bénévolat sur le pass t’intéresse t-il ?')).toBeOnTheScreen()
-    })
-
-    it('should not display feedback component below volunteer card when venue has volunteering url and wipEnableVolunteerFeedback FF deactivated', () => {
-      renderVenueTopComponent({
-        venue: { ...venueOpenToPublic, volunteeringUrl: 'url' },
-        enableVolunteer: true,
-      })
-
-      expect(
-        screen.queryByText('Le bénévolat sur le pass t’intéresse t-il ?')
-      ).not.toBeOnTheScreen()
-    })
-
-    it('should trigger FeatureFeedbackClicked log with yes answer when venue has volunteering url and answering yes to feedback quiz', async () => {
-      await AsyncStorage.removeItem('volunteering_feedback')
-      renderVenueTopComponent({
-        venue: { ...venueOpenToPublic, volunteeringUrl: 'url' },
-        enableVolunteer: true,
-        enableVolunteerFeedback: true,
-      })
-
-      await user.press(screen.getByText('Oui'))
-
-      expect(analytics.logFeatureFeedbackClicked).toHaveBeenCalledWith({
-        featureName: 'volunteer',
-        feedbackResponse: 'Oui',
-        from: 'venue',
-        venueId: venueOpenToPublic.id.toString(),
-      })
-    })
-
-    it('should trigger FeatureFeedbackClicked log with no answer when venue has volunteering url and answering no to feedback quiz', async () => {
-      await AsyncStorage.removeItem('volunteering_feedback')
-      renderVenueTopComponent({
-        venue: { ...venueOpenToPublic, volunteeringUrl: 'url' },
-        enableVolunteer: true,
-        enableVolunteerFeedback: true,
-      })
-
-      await user.press(screen.getByText('Non'))
-
-      expect(analytics.logFeatureFeedbackClicked).toHaveBeenCalledWith({
-        featureName: 'volunteer',
-        feedbackResponse: 'Non',
-        from: 'venue',
-        venueId: venueOpenToPublic.id.toString(),
-      })
-    })
   })
 })
 
 type RenderVenueTopComponent = ComponentProps<typeof VenueTopComponent>
 
-const renderVenueTopComponent = ({
-  venue,
-  enableVolunteer,
-  enableVolunteerFeedback,
-}: RenderVenueTopComponent) =>
+const renderVenueTopComponent = ({ venue, enableVolunteer }: RenderVenueTopComponent) =>
   render(
-    reactQueryProviderHOC(
-      <VenueTopComponent
-        venue={venue}
-        enableVolunteer={enableVolunteer}
-        enableVolunteerFeedback={enableVolunteerFeedback}
-      />
-    )
+    reactQueryProviderHOC(<VenueTopComponent venue={venue} enableVolunteer={enableVolunteer} />)
   )

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponent.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponent.tsx
@@ -8,7 +8,6 @@ import { VenueTopComponentBase } from 'features/venue/components/VenueTopCompone
 type Props = {
   venue: VenueResponse
   enableVolunteer?: boolean
-  enableVolunteerFeedback?: boolean
   enableVenueFakeDoor?: boolean
   onPressFollowButton?: () => void
 }
@@ -16,7 +15,6 @@ type Props = {
 export const VenueTopComponent: React.FunctionComponent<Props> = ({
   venue,
   enableVolunteer,
-  enableVolunteerFeedback,
   enableVenueFakeDoor,
   onPressFollowButton,
 }) => {
@@ -31,7 +29,6 @@ export const VenueTopComponent: React.FunctionComponent<Props> = ({
       venue={venue}
       onPressBannerImage={handleImagePress}
       enableVolunteer={enableVolunteer}
-      enableVolunteerFeedback={enableVolunteerFeedback}
       enableVenueFakeDoor={enableVenueFakeDoor}
       onPressFollowButton={onPressFollowButton}
     />

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponent.web.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponent.web.tsx
@@ -9,7 +9,6 @@ import { useModal } from 'ui/components/modals/useModal'
 type Props = {
   venue: VenueResponse
   enableVolunteer?: boolean
-  enableVolunteerFeedback?: boolean
   enableVenueFakeDoor?: boolean
   onPressFollowButton?: () => void
 }
@@ -17,7 +16,6 @@ type Props = {
 export const VenueTopComponent: React.FunctionComponent<Props> = ({
   venue,
   enableVolunteer,
-  enableVolunteerFeedback,
   enableVenueFakeDoor,
   onPressFollowButton,
 }) => {
@@ -35,7 +33,6 @@ export const VenueTopComponent: React.FunctionComponent<Props> = ({
         venue={venue}
         onPressBannerImage={isDesktopViewport ? showModal : undefined}
         enableVolunteer={enableVolunteer}
-        enableVolunteerFeedback={enableVolunteerFeedback}
         enableVenueFakeDoor={enableVenueFakeDoor}
         onPressFollowButton={onPressFollowButton}
       />

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
@@ -2,11 +2,10 @@ import React from 'react'
 import { View, useWindowDimensions } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
-import { ReactionTypeEnum, VenueResponse } from 'api/gen'
+import { VenueResponse } from 'api/gen'
 import { openUrl } from 'features/navigation/helpers/openUrl'
 import { getVenueBlock } from 'features/offer/components/OfferVenueBlock/getVenueBlock'
 import { VenueBlockVenue } from 'features/offer/components/OfferVenueBlock/type'
-import { FeedBack } from 'features/reactions/components/FeedBack'
 import { OpeningHoursStatus } from 'features/venue/components/OpeningHoursStatus/OpeningHoursStatus'
 import { VenueBanner } from 'features/venue/components/VenueBody/VenueBanner'
 import { VolunteerCard } from 'features/venue/components/VenueTopComponent/VolunteerCard'
@@ -27,7 +26,6 @@ type Props = {
   venue: VenueResponse
   onPressBannerImage?: () => void
   enableVolunteer?: boolean
-  enableVolunteerFeedback?: boolean
   enableVenueFakeDoor?: boolean
   onPressFollowButton?: () => void
 }
@@ -39,7 +37,6 @@ export const VenueTopComponentBase: React.FunctionComponent<Props> = ({
   venue,
   onPressBannerImage,
   enableVolunteer,
-  enableVolunteerFeedback,
   enableVenueFakeDoor,
   onPressFollowButton,
 }) => {
@@ -74,16 +71,6 @@ export const VenueTopComponentBase: React.FunctionComponent<Props> = ({
         `${venue.volunteeringUrl}?utm_source=pass-culture&utm_medium=app&utm_campaign=orga_non_inscrite`
       )
     }
-  }
-
-  const handleOnLogFeedback = (type: ReactionTypeEnum) => {
-    const feedbackResponse = type === ReactionTypeEnum.LIKE ? 'Oui' : 'Non'
-    void analytics.logFeatureFeedbackClicked({
-      featureName: 'volunteer',
-      feedbackResponse,
-      from: 'venue',
-      venueId: venue.id.toString(),
-    })
   }
 
   return (
@@ -156,15 +143,6 @@ export const VenueTopComponentBase: React.FunctionComponent<Props> = ({
             onBlur={focusProps.onBlur}
             onPress={onPressVolunteeringCard}
           />
-          {enableVolunteerFeedback ? (
-            <StyledFeedBack
-              storageKey="volunteering_feedback"
-              likeQuiz="https://passculture.qualtrics.com/jfe/form/SV_3sGi4gI6EEOmfsy"
-              dislikeQuiz="https://passculture.qualtrics.com/jfe/form/SV_3sGi4gI6EEOmfsy"
-              title="Le bénévolat sur le pass t’intéresse t-il&nbsp;?"
-              onLogReaction={handleOnLogFeedback}
-            />
-          ) : null}
         </VolunteeringContainer>
       ) : null}
     </React.Fragment>
@@ -204,9 +182,4 @@ const getVenue = (venue: VenueResponse): VenueBlockVenue => {
 
 const VolunteeringContainer = styled(ViewGap)(({ theme }) => ({
   marginBottom: theme.designSystem.size.spacing.xl,
-}))
-
-const StyledFeedBack = styled(FeedBack)(({ theme }) => ({
-  marginHorizontal: theme.designSystem.size.spacing.xl,
-  width: theme.isDesktopViewport ? '50%' : undefined,
 }))

--- a/src/features/venue/pages/Venue/Venue.tsx
+++ b/src/features/venue/pages/Venue/Venue.tsx
@@ -90,9 +90,6 @@ export const Venue: FunctionComponent = () => {
   const enableSearchWithQuery = useFeatureFlag(RemoteStoreFeatureFlags.WIP_SEARCH_IN_VENUE_PAGE)
   const enableProAdvices = useFeatureFlag(RemoteStoreFeatureFlags.WIP_PRO_REVIEWS_VENUE)
   const enableVolunteer = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ENABLE_VOLUNTEER)
-  const enableVolunteerFeedback = useFeatureFlag(
-    RemoteStoreFeatureFlags.WIP_ENABLE_VOLUNTEER_FEEDBACK
-  )
   const enableVenueFakeDoor = useFeatureFlag(RemoteStoreFeatureFlags.WIP_VENUE_FAKE_DOOR)
   const {
     visible: searchInVenueModalVisible,
@@ -210,7 +207,6 @@ export const Venue: FunctionComponent = () => {
       <VenueTopComponent
         venue={venue}
         enableVolunteer={enableVolunteer}
-        enableVolunteerFeedback={enableVolunteerFeedback}
         enableVenueFakeDoor={enableVenueFakeDoor}
         onPressFollowButton={() => handleOnPressFollowButton('venueBanner')}
       />

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -68,7 +68,6 @@ export enum RemoteStoreFeatureFlags {
   WIP_ENABLE_SIMILAR_ARTISTS = 'wipEnableSimilarArtists',
   WIP_ENABLE_VENUE_CALENDAR = 'wipEnableVenueCalendar',
   WIP_ENABLE_VOLUNTEER = 'wipEnableVolunteer',
-  WIP_ENABLE_VOLUNTEER_FEEDBACK = 'wipEnableVolunteerFeedback',
   WIP_NEW_BOOKINGS_ENDED_ONGOING = 'wipNewBookingsEndedOngoing',
   WIP_NEW_CATEGORY_BLOCKS = 'wipNewCategoryBlocks',
   WIP_NEW_CATEGORY_BLOCKS_HOME = 'wipNewCategoryBlocksHome',

--- a/src/ui/components/PassPlaylist.tsx
+++ b/src/ui/components/PassPlaylist.tsx
@@ -152,7 +152,8 @@ const StyledSubtitle = styled(Typo.BodyAccentXs).attrs<{
 }>({
   numberOfLines: 2,
 })(({ withMargin, theme }) => ({
-  marginHorizontal: withMargin ? theme.contentPage.marginHorizontal : undefined,
+  marginLeft: withMargin ? theme.contentPage.marginHorizontal : undefined,
+  marginRight: withMargin ? theme.contentPage.marginHorizontal : undefined,
   color: theme.designSystem.color.text.subtle,
 }))
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43274

## Context
L'objectif de cette PR est de :
- Fix un bug visuel constaté sur le sous-titre de la playlist de bénévolat (plus de margin left en web)
- Supprimer la partie feedback du bénévolat et le FF associé (`wipEnableVolunteerFeedback`)

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-18 at 15 50 56" src="https://github.com/user-attachments/assets/92384795-74cd-4a05-b448-6180f6ad03c6" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-18 at 16 20 14" src="https://github.com/user-attachments/assets/5f14f584-ba49-4d9e-a65c-a3a57b953404" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-18 at 16 01 07" src="https://github.com/user-attachments/assets/58534c6e-4fde-4719-9361-c22f706c28bb" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-18 at 16 20 58" src="https://github.com/user-attachments/assets/a3dd6c56-e160-4a8a-a549-452a72833d69" />|
| Android          |               |       |
| Phone - Chrome   |<img width="405" height="700" alt="Capture d’écran 2026-08-18 à 16 19 46" src="https://github.com/user-attachments/assets/f6414c5c-b677-4071-bcd4-1617519bb04a" />|<img width="412" height="689" alt="Capture d’écran 2026-08-18 à 16 20 31" src="https://github.com/user-attachments/assets/9b546542-3195-4506-b39b-968b27b7d61e" />|
| Desktop - Chrome |<img width="1508" height="830" alt="Capture d’écran 2026-08-18 à 15 41 49" src="https://github.com/user-attachments/assets/2c33973d-d12a-4639-865f-6ed22befe318" /> <img width="1505" height="763" alt="Capture d’écran 2026-08-18 à 16 19 32" src="https://github.com/user-attachments/assets/51a83588-779d-436d-9520-2f733a73150d" />|<img width="1917" height="862" alt="Capture d’écran 2026-08-18 à 16 00 45" src="https://github.com/user-attachments/assets/94c5cf1f-0849-4098-8a34-7681c8fe5735" /> <img width="1508" height="760" alt="Capture d’écran 2026-08-18 à 16 20 41" src="https://github.com/user-attachments/assets/d9aea02f-759e-49dd-b82b-312d23dac6b4" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
