### PR TITLE
(PC-43189) fix(Offer): remove bottom text banner for offer cta

### DIFF
--- a/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
@@ -206,7 +206,7 @@ exports[`ThematicHome should render correctly 1`] = `
       <View
         style={
           {
-            "bottom": 88,
+            "bottom": 24,
             "position": "absolute",
             "right": 24,
             "zIndex": 1,

--- a/src/features/bookings/components/BookingDetailsContent.tsx
+++ b/src/features/bookings/components/BookingDetailsContent.tsx
@@ -26,6 +26,7 @@ import { HeaderWithImage } from 'ui/components/headers/HeaderWithImage'
 import { useModal } from 'ui/components/modals/useModal'
 import { Banner } from 'ui/designSystem/Banner/Banner'
 import { BannerType } from 'ui/designSystem/Banner/enums'
+import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 const scrollIndicatorInsets = { right: 1 }
 
@@ -42,6 +43,7 @@ export const BookingDetailsContent = ({
 }) => {
   const { isDesktopViewport, designSystem } = useTheme()
   const { height: windowHeight } = useWindowDimensions()
+  const { bottom: contentBottomPadding } = useCustomSafeInsets()
   const [topBlockHeight, setTopBlockHeight] = React.useState<number>(0)
   const display = properties.isEvent === true ? 'punched' : 'full'
   const EXTRA_ANDROID_MARGIN = designSystem.size.spacing.xxl
@@ -158,6 +160,7 @@ export const BookingDetailsContent = ({
             cancelBooking={cancelBooking}
             showArchiveModal={showArchiveModal}
             hasTicket={hasTicket}
+            bottom={contentBottomPadding}
           />
         )}
         <CancelBookingModal

--- a/src/features/bookings/components/BookingDetailsContentMobile.tsx
+++ b/src/features/bookings/components/BookingDetailsContentMobile.tsx
@@ -18,6 +18,7 @@ export const BookingDetailsContentMobile = ({
   cancelBooking,
   showArchiveModal,
   hasTicket,
+  bottom,
 }: {
   topBlock: React.JSX.Element
   booking: BookingResponse
@@ -26,6 +27,7 @@ export const BookingDetailsContentMobile = ({
   cancelBooking: () => void
   showArchiveModal: () => void
   hasTicket: boolean
+  bottom: number
 }) => {
   return (
     <View testID="booking_details_mobile">
@@ -56,7 +58,7 @@ export const BookingDetailsContentMobile = ({
 
       <StyledSeparator />
       <SectionContainer>
-        <BookingDetailsCancelButtonContainer>
+        <BookingDetailsCancelButtonContainer paddingBottom={bottom}>
           <BookingDetailsCancelButton
             booking={booking}
             onCancel={cancelBooking}
@@ -93,9 +95,11 @@ const TicketCutoutContainer = styled.View({
   alignSelf: 'center',
 })
 
-const BookingDetailsCancelButtonContainer = styled(Container)(({ theme }) => ({
-  marginBottom: theme.designSystem.size.spacing.xxxl,
-}))
+const BookingDetailsCancelButtonContainer = styled(Container)<{ paddingBottom: number }>(
+  ({ paddingBottom, theme }) => ({
+    paddingBottom: paddingBottom + theme.designSystem.size.spacing.xl,
+  })
+)
 
 const ErrorBannerContainer = styled(Container)(({ theme }) => ({
   marginTop: theme.designSystem.size.spacing.xxl,

--- a/src/features/home/pages/GenericHome.tsx
+++ b/src/features/home/pages/GenericHome.tsx
@@ -372,7 +372,7 @@ const FooterContainer = styled.View(({ theme }) => ({
 const ScrollToTopContainer = styled.View(({ theme }) => ({
   position: 'absolute',
   right: theme.designSystem.size.spacing.xl,
-  bottom: theme.tabBar.height + theme.designSystem.size.spacing.xl,
+  bottom: theme.designSystem.size.spacing.xl,
   zIndex: theme.zIndex.floatingButton,
 }))
 

--- a/src/features/offer/components/StickyBookingButton/StickyBookingButton.tsx
+++ b/src/features/offer/components/StickyBookingButton/StickyBookingButton.tsx
@@ -6,7 +6,6 @@ import { CTAButton } from 'features/offer/components/CTAButton/CTAButton'
 import { ICTAWordingAndAction } from 'features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction'
 import { StickyBottomWrapper } from 'ui/components/StickyBottomWrapper/StickyBottomWrapper'
 import { Spacer } from 'ui/theme'
-import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 type Props = {
   ctaWordingAndAction: ICTAWordingAndAction
@@ -21,7 +20,6 @@ export const StickyBookingButton: FunctionComponent<Props> = ({
   isLoggedIn,
   displayGradient,
 }) => {
-  const { bottom } = useCustomSafeInsets()
   const { wording, onPress, navigateTo, externalNav, isDisabled, bottomBannerText } =
     ctaWordingAndAction
 
@@ -30,7 +28,7 @@ export const StickyBookingButton: FunctionComponent<Props> = ({
   }
 
   return (
-    <StyledStickyBottomWrapper bottom={-bottom} displayGradient={displayGradient}>
+    <StyledStickyBottomWrapper displayGradient={displayGradient}>
       {wording ? (
         <CallToActionContainer testID="sticky-booking-button" accessible>
           <ButtonWrapper>
@@ -52,9 +50,9 @@ export const StickyBookingButton: FunctionComponent<Props> = ({
   )
 }
 
-const StyledStickyBottomWrapper = styled(StickyBottomWrapper)<{ bottom: number }>(({ bottom }) => ({
-  bottom,
-}))
+const StyledStickyBottomWrapper = styled(StickyBottomWrapper)({
+  bottom: 0,
+})
 
 const CallToActionContainer = styled.View(({ theme }) => ({
   paddingHorizontal: theme.designSystem.size.spacing.l,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43189

## Context

Suite à [ce commit](https://github.com/pass-culture/pass-culture-app-native/commit/3542c8625d709e6965a28910d14457e23a67d82d), le `bottom` renvoyé par `useCustomSafeInsets` est plus grand.
- Dans le bouton de réservation d'offre, il était utilisé en négatif, il a donc été poussé plus bas, sous la barre de navigation système (uniquement sur Android). Pour compenser, on enlève ce bottom pour que le CTA soit de nouveau entièrement visible. Si l'espacement à la barre de navigation n'est pas bon, il pourra être ajuster avec le `marginBottom` du composant interne (`CallToActionContainer`).
- Dans `ThematicHome`, la hauteur de la tabBar était prise en compte alors qu'elle n'est pas présente sur cet écran.
- Dans la page `BookingDetails`, le bottom de la safe inset area n'était pas pris en compte

Le commit mentionné sur le edge-to-edge a pu avoir un impact plus large que ce qui est corrigé ici, auquel cas ce sera traité dans une autre PR.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Before |  After&nbsp;&nbsp;&nbsp; |
| :---------------: | :-----------: | :-----------:  |
| iOS                  |               |               |
| Android          | <img width="946" height="2049" alt="scroll-top-master" src="https://github.com/user-attachments/assets/c28a9861-4640-459d-8864-dada9a39ba4a" /><img width="946" height="2049" alt="offer-cta-master" src="https://github.com/user-attachments/assets/b9613608-f585-49bf-b677-df12afc7257b" /> <img width="946" height="2049" alt="booking-cta-master" src="https://github.com/user-attachments/assets/d41a48a6-7558-4d64-9b1f-ce5dd5524cee" /> | <img width="946" height="2049" alt="scroll-top-pr" src="https://github.com/user-attachments/assets/8b433b1e-3d06-4e39-8a76-218f40b56036" /> <img width="946" height="2049" alt="offer-cta-pr" src="https://github.com/user-attachments/assets/54ba306c-a0e5-49ba-90f4-050018b90964" /> <img width="946" height="2049" alt="booking-cta-pr" src="https://github.com/user-attachments/assets/9ffeed19-7663-4065-9c7c-6eaca17121aa" /> |
| Phone - Chrome   |               |               |
| Desktop - Chrome |               |               |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
