### PR TITLE
(PC-43219) fix(PersonalData): add push to navigation to avoid stack issues leading to disabled CTA

### DIFF
--- a/src/features/profile/components/EditableFiled/EditableField.tsx
+++ b/src/features/profile/components/EditableFiled/EditableField.tsx
@@ -12,6 +12,7 @@ type EditableFieldProps = {
   value?: string | null
   navigateTo?: ProfileNavigateParams[0]
   navigateParams?: ProfileNavigateParams[1]
+  withPush?: boolean
   onBeforeNavigate?: () => void
   accessibilityLabel?: string
 }
@@ -21,6 +22,7 @@ export function EditableField({
   value,
   navigateTo,
   navigateParams,
+  withPush,
   onBeforeNavigate,
   accessibilityLabel,
 }: EditableFieldProps) {
@@ -44,7 +46,7 @@ export function EditableField({
         {showButton ? (
           <ButtonContainer>
             <EditButton
-              navigateTo={getProfilePropConfig(navigateTo, navigateParams)}
+              navigateTo={{ ...getProfilePropConfig(navigateTo, navigateParams), withPush }}
               onPress={onBeforeNavigate}
               wording={isCompleted ? 'Modifier' : 'Compléter'}
               accessibilityLabel={accessibilityLabel}

--- a/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { navigate, popTo } from '__mocks__/@react-navigation/native'
+import { navigate, popTo, push } from '__mocks__/@react-navigation/native'
 import { UpdateEmailTokenExpiration } from 'api/gen'
 import * as Auth from 'features/auth/context/AuthContext'
 import * as OpenUrlAPI from 'features/navigation/helpers/openUrl'
@@ -94,7 +94,7 @@ describe('PersonalData', () => {
     expect(screen.queryByText('Prénom et nom')).not.toBeOnTheScreen()
   })
 
-  it('should redirect to ChangeEmail when clicking on modify email button', async () => {
+  it('should push to ChangeEmail when clicking on modify email button', async () => {
     mockedUseAuthContext.mockReturnValueOnce({
       ...initialAuthContext,
       user: beneficiaryUserV2,
@@ -104,13 +104,13 @@ describe('PersonalData', () => {
 
     await user.press(screen.getByTestId('Modifier l’e-mail'))
 
-    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+    expect(push).toHaveBeenCalledWith('ProfileStackNavigator', {
       params: undefined,
       screen: 'ChangeEmail',
     })
   })
 
-  it('should redirect to ChangePassword when clicking on modify password button', async () => {
+  it('should push to ChangePassword when clicking on modify password button', async () => {
     mockedUseAuthContext.mockReturnValueOnce({
       ...initialAuthContext,
       user: nonBeneficiaryUserV2,
@@ -120,36 +120,43 @@ describe('PersonalData', () => {
 
     await user.press(screen.getByTestId('Modifier le mot de passe'))
 
-    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+    expect(push).toHaveBeenCalledWith('ProfileStackNavigator', {
       params: undefined,
       screen: 'ChangePassword',
     })
   })
 
-  it('should redirect to ChangeStatus when clicking on modify status button', async () => {
+  it('should push to ChangeStatus when clicking on modify status button', async () => {
     mockedUseAuthContext.mockReturnValueOnce({
       ...initialAuthContext,
       user: nonBeneficiaryUserV2,
     })
 
+    push.mockClear()
+    navigate.mockClear()
+
     render(reactQueryProviderHOC(<PersonalData />))
 
     await user.press(screen.getByTestId('Modifier le statut'))
 
-    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+    expect(push).toHaveBeenCalledWith('ProfileStackNavigator', {
+      params: undefined,
+      screen: 'ChangeStatus',
+    })
+    expect(navigate).not.toHaveBeenCalledWith('ProfileStackNavigator', {
       params: undefined,
       screen: 'ChangeStatus',
     })
   })
 
-  it('should redirect to ChangeCity when clicking on modify city button for beneficiaries', async () => {
+  it('should push to ChangeCity when clicking on modify city button for beneficiaries', async () => {
     mockedUseAuthContext.mockReturnValueOnce(initialAuthContext)
 
     render(reactQueryProviderHOC(<PersonalData />))
 
     await user.press(screen.getByTestId('Modifier l’adresse de résidence'))
 
-    expect(navigate).toHaveBeenCalledWith('ProfileStackNavigator', {
+    expect(push).toHaveBeenCalledWith('ProfileStackNavigator', {
       params: { type: PersonalDataTypes.PROFIL_PERSONAL_DATA },
       screen: 'ChangeCity',
     })
@@ -226,7 +233,7 @@ describe('PersonalData', () => {
     })
   })
 
-  it('should  not display phone number section when user has none', async () => {
+  it('should not display phone number section when user has none', async () => {
     mockedUseAuthContext.mockReturnValueOnce({
       ...initialAuthContext,
       user: { ...mockedUser, phoneNumber: undefined },

--- a/src/features/profile/pages/PersonalData/PersonalData.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.tsx
@@ -59,6 +59,7 @@ export function PersonalData() {
             navigateTo={updateEmailRoute}
             onBeforeNavigate={onEmailChangeClick}
             accessibilityLabel="Modifier l’e-mail"
+            withPush
           />
           {user?.phoneNumber ? (
             <EditableField
@@ -66,6 +67,7 @@ export function PersonalData() {
               value={user?.phoneNumber}
               navigateTo="ChangePhoneNumber"
               accessibilityLabel="Modifier le numéro de téléphone"
+              withPush
             />
           ) : null}
           {user?.hasPassword ? (
@@ -74,6 +76,7 @@ export function PersonalData() {
               value={'*'.repeat(12)}
               navigateTo="ChangePassword"
               accessibilityLabel="Modifier le mot de passe"
+              withPush
             />
           ) : null}
           <EditableField
@@ -81,6 +84,7 @@ export function PersonalData() {
             value={getActivityLabel(user?.activityId)}
             navigateTo="ChangeStatus"
             accessibilityLabel="Modifier le statut"
+            withPush
           />
           <EditableField
             label="Adresse de résidence"
@@ -88,6 +92,7 @@ export function PersonalData() {
             navigateTo="ChangeCity"
             navigateParams={{ type: PersonalDataTypes.PROFIL_PERSONAL_DATA }}
             accessibilityLabel="Modifier l’adresse de résidence"
+            withPush
           />
           <ViewGap gap={8}>
             <Banner


### PR DESCRIPTION

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43219

## Context

**Problème :**
Dans PersonalData.tsx, le bouton modifier le Statut(pareil pour les autres champs) ouvre un écran enfant du navigator Profil -> après un retour arrière, dans certains états internes de navigation imbriquée, un nouveau clic vers le même parent + même écran enfant peut être interprété comme “déjà au bon endroit” ->  aucune transition visible, donc impression de bouton inactif.

**Solution proposée :**
Push = ajoute toujours une nouvelle entrée dans la stack, donc après un goBack, un nouveau clic crée explicitement une nouvelle navigation.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

https://github.com/user-attachments/assets/dc82f6ca-d9fd-4861-8ee4-7b18d1b3ce5d

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
