### PR TITLE
(PC-43276) fix(offer): make active carousel dot visible in dark mode …

### DIFF
--- a/src/ui/components/CarouselDot/CarouselDot.tsx
+++ b/src/ui/components/CarouselDot/CarouselDot.tsx
@@ -11,22 +11,28 @@ import styled, { useTheme } from 'styled-components/native'
 type Props = {
   index: number
   animValue: SharedValue<number>
+  activeColor?: string
+  inactiveColor?: string
 }
 
 const SMALL_DOT_SIZE = 4
 const BIG_DOT_SIZE = SMALL_DOT_SIZE + 4
 
-export const CarouselDot: React.FunctionComponent<Props> = ({ animValue, index }) => {
+export const CarouselDot: React.FunctionComponent<Props> = ({
+  animValue,
+  index,
+  activeColor,
+  inactiveColor,
+}) => {
   const { designSystem } = useTheme()
+
+  const dotActiveColor = activeColor ?? designSystem.color.icon.locked
+  const dotInactiveColor = inactiveColor ?? designSystem.color.icon.subtle
 
   const animStyle = useAnimatedStyle(() => {
     const inputRange = [index - 1, index, index + 1]
     const marginOutputRange = [2, 0, 2]
-    const colorOutputRange = [
-      designSystem.color.icon.subtle,
-      designSystem.color.icon.locked,
-      designSystem.color.icon.subtle,
-    ]
+    const colorOutputRange = [dotInactiveColor, dotActiveColor, dotInactiveColor]
     const widthOutputRange = [SMALL_DOT_SIZE, BIG_DOT_SIZE, SMALL_DOT_SIZE]
 
     return {
@@ -35,7 +41,7 @@ export const CarouselDot: React.FunctionComponent<Props> = ({ animValue, index }
       height: interpolate(animValue?.value, inputRange, widthOutputRange, Extrapolation.CLAMP),
       margin: interpolate(animValue?.value, inputRange, marginOutputRange, Extrapolation.CLAMP),
     }
-  }, [animValue, index])
+  }, [animValue, index, dotActiveColor, dotInactiveColor])
 
   return <Dot testID="carousel-dot" style={animStyle} />
 }

--- a/src/ui/components/ImagesCarousel/ImagesCarousel.tsx
+++ b/src/ui/components/ImagesCarousel/ImagesCarousel.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react'
 import { useWindowDimensions } from 'react-native'
 import { useSharedValue } from 'react-native-reanimated'
 import Carousel from 'react-native-reanimated-carousel'
-import styled from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
 import { PinchableBox } from 'features/offer/components/PinchableBox/PinchableBox'
@@ -28,6 +28,7 @@ export const ImagesCarousel: FunctionComponent<Props> = ({
   goBack,
   onSnapToItem,
 }: Props) => {
+  const { designSystem } = useTheme()
   const footerHeight = useGetFooterHeight(FOOTER_HEIGHT)
 
   const progressValue = useSharedValue<number>(defaultIndex)
@@ -68,6 +69,7 @@ export const ImagesCarousel: FunctionComponent<Props> = ({
                   <CarouselDot
                     animValue={progressValue}
                     index={index}
+                    activeColor={designSystem.color.icon.default}
                     key={index + carouselDotId}
                   />
                 ))}


### PR DESCRIPTION
…on preview screens

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43276

## Context

En dark mode, sur l'écran plein écran des illustrations d'une offre (`OfferPreview`), le dot de pagination **actif** était invisible : on ne voyait plus qu'un seul point au lieu de deux, ce qui donnait l'impression d'un rendu cassé.

**Cause**

`CarouselDot` codait en dur ses couleurs pour un usage sur pastille blanche :

| Rôle | Token | Light | Dark |
|------|-------|-------|------|
| Dot actif | `icon.locked` | `#161617` | `#161617` |
| Dot inactif | `icon.subtle` | `#696a6f` | `#cbcdd2` |

Sur la page offre, `OfferImageCarousel` passe par `CarouselPaginationBase`, dont le conteneur est en `background.locked` (`#ffffff` dans les deux thèmes) : le contraste reste correct, d'où l'absence de bug sur le carrousel inline.

En revanche `ImagesCarousel` pose les dots directement sur un footer en `background.default` (`#161617` en dark) → le dot actif était **noir sur noir**. Seul le dot inactif (`#cbcdd2`) restait visible.

**Correction**

- `CarouselDot` accepte désormais deux props optionnelles `activeColor` / `inactiveColor`, avec pour valeurs par défaut les couleurs actuelles — aucun impact sur les appelants existants.
- `ImagesCarousel` passe `activeColor={designSystem.color.icon.default}`, token qui s'inverse avec le thème (`#161617` en light, `#ffffff` en dark).

Le rendu en light mode est donc **strictement inchangé** (`icon.default === icon.locked` en light). `VenuePreviewCarousel`, second consommateur de `ImagesCarousel`, bénéficie de la même correction.

## Screenshots

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-08-19 at 15 08 26" src="https://github.com/user-attachments/assets/aa6e64c8-3a47-4a24-bd77-75be802d0480" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-08-19 at 15 08 49" src="https://github.com/user-attachments/assets/1da8db32-db07-4a7f-af4c-3bde1380fb75" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-08-19 at 15 08 46" src="https://github.com/user-attachments/assets/35e47189-2ceb-4a77-8185-df6e778543d2" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-08-19 at 15 08 29" src="https://github.com/user-attachments/assets/ee7cca01-12a3-45ca-900c-f50e65c45462" />

