### PR TITLE
(PC-43304) fix(app): reserve tab bar space for page not in tab bar navigator

### DIFF
--- a/src/features/navigation/navigators/RootNavigator/RootStackNavigator.tsx
+++ b/src/features/navigation/navigators/RootNavigator/RootStackNavigator.tsx
@@ -580,7 +580,7 @@ const RootStackNavigator = withWebWrapper(
 export const RootNavigator: React.FC<{ currentRoute?: Route<string> }> = ({ currentRoute }) => {
   const mainId = uuidv4()
   const tabBarId = uuidv4()
-  const { showTabBar } = useTheme()
+  const { showTabBar, isMobileViewport } = useTheme()
   const { isLoggedIn } = useAuthContext()
   const { isSplashScreenHidden } = useSplashScreenContext()
 
@@ -613,10 +613,19 @@ export const RootNavigator: React.FC<{ currentRoute?: Route<string> }> = ({ curr
     currentRoute ?? null
   )
 
+  const shouldReserveTabBarSpace = !!(
+    Platform.OS === 'web' &&
+    isMobileViewport &&
+    currentRoute?.name !== 'TabNavigator'
+  )
+
   return (
     <TabNavigationStateProvider>
       {showTabBar ? headerWithQuickAccess : <Header mainId={mainId} />}
-      <Main nativeID={mainId} accessibilityRole={mainAccessibilityRole}>
+      <Main
+        nativeID={mainId}
+        accessibilityRole={mainAccessibilityRole}
+        shouldReserveTabBarSpace={shouldReserveTabBarSpace}>
         <RootStackNavigator initialRouteName={initialScreen} />
       </Main>
       {showTabBar ? <AccessibleTabBar id={tabBarId} /> : null}
@@ -628,8 +637,11 @@ export const RootNavigator: React.FC<{ currentRoute?: Route<string> }> = ({ curr
   )
 }
 
-const Main = styled.View({
-  display: 'flex',
-  flexDirection: 'column',
-  flexGrow: 1,
-})
+const Main = styled.View<{ shouldReserveTabBarSpace: boolean }>(
+  ({ theme, shouldReserveTabBarSpace }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    flexGrow: 1,
+    paddingBottom: shouldReserveTabBarSpace ? theme.tabBar.height : undefined,
+  })
+)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43304

## Context
L'objectif de cette PR est que les nouvelles pages utilisant la barre de navigation en web mobile soient entièrement lisibles, rien ne doit être masqué par la barre de navigation. L'utilisation du `paddingBottom` permet de décaler le contenu par rapport à la taille de la barre de navigation.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |<img width="397" height="680" alt="Capture d’écran 2026-08-19 à 12 06 25" src="https://github.com/user-attachments/assets/9c9c716a-5b8a-4567-9c44-5723e0e86b78" /> <img width="391" height="683" alt="Capture d’écran 2026-08-19 à 12 06 31" src="https://github.com/user-attachments/assets/e74fa4d1-e3a8-4292-b01f-b30d90305be7" /> <img width="409" height="694" alt="Capture d’écran 2026-08-19 à 12 06 46" src="https://github.com/user-attachments/assets/1a6fa366-143c-4042-b5d0-c6b535dcb7f1" /> <img width="412" height="700" alt="Capture d’écran 2026-08-19 à 12 06 55" src="https://github.com/user-attachments/assets/8da217cf-6b48-4d3b-ab3e-b8ba087fbfb8" /> <img width="424" height="701" alt="Capture d’écran 2026-08-19 à 12 07 06" src="https://github.com/user-attachments/assets/f825761e-c660-47db-9a79-35acb5bf2686" /> <img width="412" height="702" alt="Capture d’écran 2026-08-19 à 12 07 19" src="https://github.com/user-attachments/assets/09776839-cf48-46c1-b724-c8babc3dc22a" />|<img width="410" height="686" alt="Capture d’écran 2026-08-19 à 12 07 34" src="https://github.com/user-attachments/assets/7ef2bb03-615e-4c67-81f1-ee1613cf70ad" /> <img width="416" height="703" alt="Capture d’écran 2026-08-19 à 12 07 54" src="https://github.com/user-attachments/assets/4dd0ad84-3d50-47db-afe6-57eee982574f" /> <img width="401" height="700" alt="Capture d’écran 2026-08-19 à 12 08 18" src="https://github.com/user-attachments/assets/359fd467-dd77-45ec-9ad8-41d29c96d9b2" /> <img width="396" height="683" alt="Capture d’écran 2026-08-19 à 16 04 36" src="https://github.com/user-attachments/assets/7fdd18ac-fc36-4fbc-ae74-37bd172d3d67" /> <img width="392" height="689" alt="Capture d’écran 2026-08-19 à 12 08 32" src="https://github.com/user-attachments/assets/683b8232-c1ac-46b9-ae13-dd097f5e71dd" />|
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
