### PR TITLE
(PC-43322) feat(offer): display portrait video player for YouTube Shorts

### DIFF
--- a/src/features/home/components/helpers/getVideoPlayerDimensions.ts
+++ b/src/features/home/components/helpers/getVideoPlayerDimensions.ts
@@ -1,6 +1,7 @@
 import { PixelRatio } from 'react-native'
 
 export const RATIO169 = 9 / 16
+export const RATIO916 = 16 / 9
 
 export const getVideoPlayerDimensions = ({
   isDesktopViewport,

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -21,6 +21,7 @@ import { getOfferMetadata } from 'features/offer/helpers/getOfferMetadata/getOff
 import { getOfferPrices } from 'features/offer/helpers/getOfferPrice/getOfferPrice'
 import { getOfferTags } from 'features/offer/helpers/getOfferTags/getOfferTags'
 import { useOfferSummaryInfoList } from 'features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList'
+import { useVideoOrientation } from 'features/offer/helpers/useVideoOrientation/useVideoOrientation'
 import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog'
 import { analytics } from 'libs/analytics/provider'
 import { formatPrice, getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
@@ -102,6 +103,10 @@ export const OfferBody: FunctionComponent<Props> = ({
     offer,
     isCinemaOffer,
   })
+
+  const { isPortrait: isVideoPortrait, thumbnailUrl: videoThumbnailUrl } = useVideoOrientation(
+    offer.video?.id
+  )
 
   const metadata = getOfferMetadata(extraData, subcategory.categoryId, artists.length > 0)
   const hasMetadata = metadata.length > 0
@@ -207,8 +212,12 @@ export const OfferBody: FunctionComponent<Props> = ({
       {offer.video?.id ? (
         <VideoSection
           videoId={offer.video.id}
+          isPortrait={isVideoPortrait}
           videoThumbnail={
-            <VideoThumbnailImage url={offer.video.thumbUrl ?? ''} resizeMode="cover" />
+            <VideoThumbnailImage
+              url={videoThumbnailUrl ?? offer.video.thumbUrl ?? ''}
+              resizeMode="cover"
+            />
           }
           title={offer.video?.title ?? offer.name}
           offerId={offer.id}

--- a/src/features/offer/components/OfferContent/VideoSection/GatedVideoSection.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/GatedVideoSection.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react'
 import { styled, useTheme } from 'styled-components/native'
 
 import { PlayerPreview } from 'features/home/components/modules/video/PlayerPreview/PlayerPreview'
+import { PORTRAIT_PLAYER_STYLE } from 'features/offer/constant'
 import { Duration } from 'features/offer/types'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
@@ -16,6 +17,7 @@ type Props = {
   title?: string
   duration?: Duration
   width?: number
+  isPortrait?: boolean
 }
 
 export const GatedVideoSection = ({
@@ -24,13 +26,14 @@ export const GatedVideoSection = ({
   title,
   duration,
   width,
+  isPortrait,
   onManageCookiesPress,
   onVideoConsentPress,
 }: Props) => {
   const { isDesktopViewport } = useTheme()
 
   return (
-    <Container gap={4} width={width}>
+    <Container gap={4} width={isPortrait ? undefined : width}>
       <Typo.Title3>Vidéo</Typo.Title3>
       <PlayerPreview
         thumbnail={thumbnail}
@@ -38,6 +41,7 @@ export const GatedVideoSection = ({
         duration={duration}
         height={height}
         width={width}
+        style={isPortrait ? PORTRAIT_PLAYER_STYLE : undefined}
       />
       <Typo.BodyAccentS>
         En visionnant cette vidéo, tu t’engages à accepter les cookies liés à Youtube.

--- a/src/features/offer/components/OfferContent/VideoSection/VideoSection.native.test.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/VideoSection.native.test.tsx
@@ -2,12 +2,17 @@ import React, { ComponentProps, createRef } from 'react'
 import { ScrollView } from 'react-native'
 
 import FastImage from '__mocks__/@d11/react-native-fast-image'
+import { RATIO169, RATIO916 } from 'features/home/components/helpers/getVideoPlayerDimensions'
 import { VideoSection } from 'features/offer/components/OfferContent/VideoSection/VideoSection'
+import { MAX_HEIGHT_VIDEO_PORTRAIT, MAX_WIDTH_VIDEO } from 'features/offer/constant'
 import { analytics } from 'libs/analytics/provider'
 import { render, screen, userEvent } from 'tests/utils'
 import { AnchorProvider } from 'ui/components/anchor/AnchorContext'
+import { MARGIN_HORIZONTAL } from 'ui/theme/constants'
 
 jest.mock('libs/firebase/analytics/analytics')
+
+const VIEWPORT_WIDTH = 750
 
 const defaultProps: ComponentProps<typeof VideoSection> = {
   offerId: 123,
@@ -69,6 +74,43 @@ describe('<VideoSection />', () => {
         'En visionnant cette vidéo, tu t’engages à accepter les cookies liés à Youtube.'
       )
     ).toBeOnTheScreen()
+  })
+
+  it('should size the placeholder in 16/9 for a landscape video', () => {
+    renderVideoSection()
+
+    expect(screen.getByLabelText('Le lecteur vidéo est désactivé.')).toHaveStyle({
+      width: MAX_WIDTH_VIDEO,
+      height: MAX_WIDTH_VIDEO * RATIO169,
+    })
+  })
+
+  it('should size the placeholder in 9/16 for a portrait video', () => {
+    renderVideoSection({ isPortrait: true })
+
+    expect(screen.getByLabelText('Le lecteur vidéo est désactivé.')).toHaveStyle({
+      width: MAX_HEIGHT_VIDEO_PORTRAIT / RATIO916,
+      height: MAX_HEIGHT_VIDEO_PORTRAIT,
+    })
+  })
+
+  it('should center the placeholder for a portrait video', () => {
+    renderVideoSection({ isPortrait: true })
+
+    expect(screen.getByLabelText('Le lecteur vidéo est désactivé.')).toHaveStyle({
+      alignSelf: 'center',
+    })
+  })
+
+  it('should span the whole content width for a portrait video on mobile', () => {
+    const contentWidth = VIEWPORT_WIDTH - 2 * MARGIN_HORIZONTAL
+
+    renderVideoSection({ isPortrait: true, maxWidth: 800 }, { theme: { isDesktopViewport: false } })
+
+    expect(screen.getByLabelText('Le lecteur vidéo est désactivé.')).toHaveStyle({
+      width: contentWidth,
+      height: contentWidth * RATIO916,
+    })
   })
 })
 

--- a/src/features/offer/components/OfferContent/VideoSection/VideoSection.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/VideoSection.tsx
@@ -5,8 +5,13 @@ import styled, { useTheme } from 'styled-components/native'
 import { RATIO169 } from 'features/home/components/helpers/getVideoPlayerDimensions'
 import { YoutubePlayer } from 'features/home/components/modules/video/YoutubePlayer/YoutubePlayer'
 import { GatedVideoSection } from 'features/offer/components/OfferContent/VideoSection/GatedVideoSection'
-import { MAX_WIDTH_VIDEO } from 'features/offer/constant'
+import {
+  MAX_HEIGHT_VIDEO_PORTRAIT,
+  MAX_WIDTH_VIDEO,
+  PORTRAIT_PLAYER_STYLE,
+} from 'features/offer/constant'
 import { formatDuration } from 'features/offer/helpers/formatDuration/formatDuration'
+import { getOfferVideoPlayerSize } from 'features/offer/helpers/getOfferVideoPlayerSize/getOfferVideoPlayerSize'
 import { analytics } from 'libs/analytics/provider'
 import { Anchor } from 'ui/components/anchor/Anchor'
 import { AnchorNames } from 'ui/components/anchor/anchor-name'
@@ -27,6 +32,7 @@ type VideoSectionProps = {
   playerRatio?: number
   duration?: number | null
   hasVideoCookiesConsent?: boolean
+  isPortrait?: boolean
 }
 
 export const VideoSection = ({
@@ -40,12 +46,21 @@ export const VideoSection = ({
   offerId,
   duration,
   hasVideoCookiesConsent,
+  isPortrait,
   onManageCookiesPress,
   onVideoConsentPress,
 }: VideoSectionProps) => {
-  const { isDesktopViewport } = useTheme()
-  const { width: viewportWidth } = useWindowDimensions()
-  const videoHeight = Math.min(viewportWidth, maxWidth) * playerRatio
+  const { isDesktopViewport, contentPage } = useTheme()
+  const { width: viewportWidth, height: viewportHeight } = useWindowDimensions()
+  const { width: playerWidth, height: videoHeight } = isPortrait
+    ? getOfferVideoPlayerSize({
+        isPortrait: true,
+        viewportWidth,
+        maxWidth,
+        horizontalMargin: isDesktopViewport ? 0 : contentPage.marginHorizontal,
+        maxHeight: isDesktopViewport ? MAX_HEIGHT_VIDEO_PORTRAIT : viewportHeight,
+      })
+    : getOfferVideoPlayerSize({ viewportWidth, maxWidth, playerRatio })
   const [playVideo, setPlayVideo] = useState(false)
 
   const handleOnPlayPress = useCallback(() => {
@@ -63,7 +78,8 @@ export const VideoSection = ({
           videoId={videoId}
           thumbnail={videoThumbnail}
           height={videoHeight}
-          width={viewportWidth < maxWidth ? undefined : maxWidth}
+          width={playerWidth}
+          style={isPortrait ? PORTRAIT_PLAYER_STYLE : undefined}
           initialPlayerParams={{ autoplay: true }}
           duration={duration ? formatDuration(duration, 'sec') : undefined}
           onPlayPress={handleOnPlayPress}
@@ -74,14 +90,14 @@ export const VideoSection = ({
   }, [
     duration,
     handleOnPlayPress,
-    maxWidth,
+    isPortrait,
     playVideo,
+    playerWidth,
     subtitle,
     title,
     videoHeight,
     videoId,
     videoThumbnail,
-    viewportWidth,
   ])
 
   const handleConsentAndPlay = useCallback(() => {
@@ -96,7 +112,8 @@ export const VideoSection = ({
         title={title}
         duration={duration ? formatDuration(duration, 'sec') : undefined}
         height={videoHeight}
-        width={viewportWidth < maxWidth ? undefined : maxWidth}
+        width={playerWidth}
+        isPortrait={isPortrait}
         onManageCookiesPress={onManageCookiesPress}
         onVideoConsentPress={handleConsentAndPlay}
       />
@@ -104,12 +121,12 @@ export const VideoSection = ({
   }, [
     duration,
     handleConsentAndPlay,
-    maxWidth,
+    isPortrait,
     onManageCookiesPress,
+    playerWidth,
     title,
     videoHeight,
     videoThumbnail,
-    viewportWidth,
   ])
 
   return (

--- a/src/features/offer/components/OfferContent/VideoSection/VideoSection.web.test.tsx
+++ b/src/features/offer/components/OfferContent/VideoSection/VideoSection.web.test.tsx
@@ -1,0 +1,48 @@
+import React, { ComponentProps, createRef } from 'react'
+import { ScrollView, View } from 'react-native'
+
+import { VideoSection } from 'features/offer/components/OfferContent/VideoSection/VideoSection'
+import { render, screen } from 'tests/utils/web'
+import { AnchorProvider } from 'ui/components/anchor/AnchorContext'
+
+jest.mock('libs/firebase/analytics/analytics')
+
+const defaultProps: ComponentProps<typeof VideoSection> = {
+  offerId: 123,
+  videoId: 'abc123',
+  title: 'Peppa Pig',
+  subtitle: 'le cochon rose',
+  videoThumbnail: <View />,
+  onManageCookiesPress: jest.fn(),
+  hasVideoCookiesConsent: false,
+  onVideoConsentPress: jest.fn(),
+}
+
+describe('<VideoSection />', () => {
+  it('should align the portrait player to the left instead of centering it', () => {
+    renderVideoSection({ isPortrait: true })
+
+    expect(screen.getByLabelText('Le lecteur vidéo est désactivé.')).toHaveStyle({
+      alignSelf: 'flex-start',
+    })
+  })
+
+  it('should not constrain the alignment of a landscape player', () => {
+    renderVideoSection()
+
+    expect(screen.getByLabelText('Le lecteur vidéo est désactivé.')).not.toHaveStyle({
+      alignSelf: 'flex-start',
+    })
+  })
+})
+
+const renderVideoSection = (props?: Partial<ComponentProps<typeof VideoSection>>) => {
+  const scrollRef = createRef<ScrollView>()
+
+  return render(
+    <AnchorProvider scrollViewRef={scrollRef} handleCheckScrollY={() => 0}>
+      <VideoSection {...defaultProps} {...props} />
+    </AnchorProvider>,
+    { theme: { isDesktopViewport: true } }
+  )
+}

--- a/src/features/offer/constant.tsx
+++ b/src/features/offer/constant.tsx
@@ -1,6 +1,13 @@
+import { Platform, ViewStyle } from 'react-native'
+
 import { PlaylistType } from 'features/offer/enums'
 
 export const MAX_WIDTH_VIDEO = 540
+export const MAX_HEIGHT_VIDEO_PORTRAIT = 540
+
+export const PORTRAIT_PLAYER_STYLE: ViewStyle = {
+  alignSelf: Platform.OS === 'web' ? 'flex-start' : 'center',
+}
 
 export const OFFER_SIMILAR_PLAYLIST_TITLES: Partial<Record<PlaylistType, string>> = {
   [PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS]: 'Les fans aiment aussi',

--- a/src/features/offer/helpers/getOfferVideoPlayerSize/getOfferVideoPlayerSize.native.test.ts
+++ b/src/features/offer/helpers/getOfferVideoPlayerSize/getOfferVideoPlayerSize.native.test.ts
@@ -1,0 +1,147 @@
+import { RATIO169, RATIO916 } from 'features/home/components/helpers/getVideoPlayerDimensions'
+import { MAX_HEIGHT_VIDEO_PORTRAIT, MAX_WIDTH_VIDEO } from 'features/offer/constant'
+import { getOfferVideoPlayerSize } from 'features/offer/helpers/getOfferVideoPlayerSize/getOfferVideoPlayerSize'
+
+describe('getOfferVideoPlayerSize', () => {
+  describe('landscape', () => {
+    it('should let the player take the full width when the viewport is narrower than maxWidth', () => {
+      const { width, height } = getOfferVideoPlayerSize({
+        viewportWidth: 375,
+        maxWidth: MAX_WIDTH_VIDEO,
+      })
+
+      expect(width).toBeUndefined()
+      expect(height).toBe(375 * RATIO169)
+    })
+
+    it('should limit the player to maxWidth when the viewport is wider', () => {
+      const { width, height } = getOfferVideoPlayerSize({
+        viewportWidth: 1200,
+        maxWidth: MAX_WIDTH_VIDEO,
+      })
+
+      expect(width).toBe(MAX_WIDTH_VIDEO)
+      expect(height).toBe(MAX_WIDTH_VIDEO * RATIO169)
+    })
+
+    it('should use the given playerRatio', () => {
+      const { height } = getOfferVideoPlayerSize({
+        viewportWidth: 375,
+        maxWidth: MAX_WIDTH_VIDEO,
+        playerRatio: 1,
+      })
+
+      expect(height).toBe(375)
+    })
+  })
+
+  describe('portrait', () => {
+    const MOBILE_VIEWPORT_WIDTH = 375
+    const MOBILE_HORIZONTAL_MARGIN = 24
+    const CONTENT_WIDTH = MOBILE_VIEWPORT_WIDTH - 2 * MOBILE_HORIZONTAL_MARGIN
+
+    it('should span the whole content width when no height limit is given', () => {
+      const { width, height } = getOfferVideoPlayerSize({
+        viewportWidth: MOBILE_VIEWPORT_WIDTH,
+        maxWidth: MAX_WIDTH_VIDEO,
+        isPortrait: true,
+        horizontalMargin: MOBILE_HORIZONTAL_MARGIN,
+      })
+
+      expect(width).toBe(CONTENT_WIDTH)
+      expect(height).toBe(CONTENT_WIDTH * RATIO916)
+    })
+
+    it('should keep the same horizontal margins when the height limit is not reached', () => {
+      const { width } = getOfferVideoPlayerSize({
+        viewportWidth: MOBILE_VIEWPORT_WIDTH,
+        maxWidth: MAX_WIDTH_VIDEO,
+        isPortrait: true,
+        horizontalMargin: MOBILE_HORIZONTAL_MARGIN,
+        maxHeight: 2000,
+      })
+
+      expect(width).toBe(CONTENT_WIDTH)
+    })
+
+    it('should shrink the player so it never exceeds maxHeight', () => {
+      const { width, height } = getOfferVideoPlayerSize({
+        viewportWidth: MOBILE_VIEWPORT_WIDTH,
+        maxWidth: MAX_WIDTH_VIDEO,
+        isPortrait: true,
+        horizontalMargin: MOBILE_HORIZONTAL_MARGIN,
+        maxHeight: 400,
+      })
+
+      expect(height).toBe(400)
+      expect(width).toBe(400 / RATIO916)
+    })
+
+    it('should limit the height to MAX_HEIGHT_VIDEO_PORTRAIT on desktop', () => {
+      const { width, height } = getOfferVideoPlayerSize({
+        viewportWidth: 1200,
+        maxWidth: MAX_WIDTH_VIDEO,
+        isPortrait: true,
+        maxHeight: MAX_HEIGHT_VIDEO_PORTRAIT,
+      })
+
+      expect(width).toBe(MAX_HEIGHT_VIDEO_PORTRAIT / RATIO916)
+      expect(height).toBe(MAX_HEIGHT_VIDEO_PORTRAIT)
+    })
+
+    it('should never exceed maxWidth', () => {
+      const { width } = getOfferVideoPlayerSize({
+        viewportWidth: 2000,
+        maxWidth: 100,
+        isPortrait: true,
+      })
+
+      expect(width).toBe(100)
+    })
+
+    it('should not overflow a narrow viewport', () => {
+      const { width, height } = getOfferVideoPlayerSize({
+        viewportWidth: 200,
+        maxWidth: MAX_WIDTH_VIDEO,
+        isPortrait: true,
+      })
+
+      expect(width).toBe(200)
+      expect(height).toBe(200 * RATIO916)
+    })
+
+    it('should always return an explicit width so the player can be aligned', () => {
+      const { width } = getOfferVideoPlayerSize({
+        viewportWidth: MOBILE_VIEWPORT_WIDTH,
+        maxWidth: MAX_WIDTH_VIDEO,
+        isPortrait: true,
+      })
+
+      expect(width).toBeDefined()
+    })
+
+    it('should never return a negative size when maxHeight is zero', () => {
+      const { width, height } = getOfferVideoPlayerSize({
+        viewportWidth: MOBILE_VIEWPORT_WIDTH,
+        maxWidth: MAX_WIDTH_VIDEO,
+        isPortrait: true,
+        maxHeight: 0,
+      })
+
+      expect(width).toBe(0)
+      expect(height).toBe(0)
+    })
+
+    it('should never return a negative size when the viewport is smaller than its margins', () => {
+      const { width, height } = getOfferVideoPlayerSize({
+        viewportWidth: 20,
+        maxWidth: MAX_WIDTH_VIDEO,
+        isPortrait: true,
+        horizontalMargin: MOBILE_HORIZONTAL_MARGIN,
+      })
+
+      expect(width).toBe(0)
+      expect(height).toBe(0)
+    })
+  })
+})

--- a/src/features/offer/helpers/getOfferVideoPlayerSize/getOfferVideoPlayerSize.ts
+++ b/src/features/offer/helpers/getOfferVideoPlayerSize/getOfferVideoPlayerSize.ts
@@ -1,0 +1,38 @@
+import { RATIO169, RATIO916 } from 'features/home/components/helpers/getVideoPlayerDimensions'
+
+type PortraitParams = {
+  isPortrait: true
+  viewportWidth: number
+  maxWidth: number
+  horizontalMargin?: number
+  maxHeight?: number
+}
+
+type LandscapeParams = {
+  isPortrait?: false
+  viewportWidth: number
+  maxWidth: number
+  playerRatio?: number
+}
+
+type Params = PortraitParams | LandscapeParams
+
+export const getOfferVideoPlayerSize = (params: Params) => {
+  const { viewportWidth, maxWidth } = params
+
+  if (params.isPortrait) {
+    const { horizontalMargin = 0, maxHeight } = params
+    const availableWidth = Math.min(viewportWidth - 2 * horizontalMargin, maxWidth)
+    const heightConstrainedWidth = maxHeight === undefined ? availableWidth : maxHeight / RATIO916
+    const width = Math.max(0, Math.min(availableWidth, heightConstrainedWidth))
+
+    return { width, height: width * RATIO916 }
+  }
+
+  const { playerRatio = RATIO169 } = params
+
+  return {
+    width: viewportWidth < maxWidth ? undefined : maxWidth,
+    height: Math.min(viewportWidth, maxWidth) * playerRatio,
+  }
+}

--- a/src/features/offer/helpers/useVideoOrientation/useVideoOrientation.native.test.ts
+++ b/src/features/offer/helpers/useVideoOrientation/useVideoOrientation.native.test.ts
@@ -1,0 +1,131 @@
+// eslint-disable-next-line no-restricted-imports
+import { Image } from 'react-native'
+
+import {
+  useVideoOrientation,
+  videoOrientationCache,
+} from 'features/offer/helpers/useVideoOrientation/useVideoOrientation'
+import { renderHook, waitFor } from 'tests/utils'
+
+const VIDEO_ID = 'cmtxphwLDZ0'
+const ORIGINAL_RATIO_THUMBNAIL_URL = `https://i.ytimg.com/vi/${VIDEO_ID}/oar2.jpg`
+
+const mockGetSize = (width: number, height: number) =>
+  jest
+    .spyOn(Image, 'getSize')
+    .mockImplementation((_uri, onSuccess) => Promise.resolve(onSuccess?.(width, height)))
+
+const mockGetSizeFailure = () =>
+  jest
+    .spyOn(Image, 'getSize')
+    .mockImplementation((_uri, _onSuccess, onError) =>
+      Promise.resolve(onError?.(new Error('not found')))
+    )
+
+describe('useVideoOrientation', () => {
+  beforeEach(() => {
+    videoOrientationCache.clear()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should detect a portrait video from the original ratio thumbnail', async () => {
+    mockGetSize(720, 1280)
+
+    const { result } = renderHook(() => useVideoOrientation(VIDEO_ID))
+
+    await waitFor(() => {
+      expect(result.current.isPortrait).toBe(true)
+    })
+  })
+
+  it('should expose the original ratio thumbnail url for a portrait video', async () => {
+    mockGetSize(720, 1280)
+
+    const { result } = renderHook(() => useVideoOrientation(VIDEO_ID))
+
+    await waitFor(() => {
+      expect(result.current.thumbnailUrl).toBe(ORIGINAL_RATIO_THUMBNAIL_URL)
+    })
+  })
+
+  it('should probe the original ratio thumbnail url', () => {
+    const getSize = mockGetSize(1920, 1080)
+
+    renderHook(() => useVideoOrientation(VIDEO_ID))
+
+    expect(getSize).toHaveBeenCalledWith(
+      ORIGINAL_RATIO_THUMBNAIL_URL,
+      expect.any(Function),
+      expect.any(Function)
+    )
+  })
+
+  it('should not detect a portrait video for a landscape video', async () => {
+    mockGetSize(1920, 1080)
+
+    const { result } = renderHook(() => useVideoOrientation(VIDEO_ID))
+
+    await waitFor(() => {
+      expect(result.current.isPortrait).toBe(false)
+    })
+
+    expect(result.current.thumbnailUrl).toBeUndefined()
+  })
+
+  it('should fall back to landscape when the thumbnail cannot be loaded', async () => {
+    mockGetSizeFailure()
+
+    const { result } = renderHook(() => useVideoOrientation(VIDEO_ID))
+
+    await waitFor(() => {
+      expect(result.current.isPortrait).toBe(false)
+    })
+
+    expect(result.current.thumbnailUrl).toBeUndefined()
+  })
+
+  it('should fall back to landscape when the video changes and the new one cannot be probed', async () => {
+    mockGetSize(720, 1280)
+    const { result, rerender } = renderHook(({ id }: { id: string }) => useVideoOrientation(id), {
+      initialProps: { id: VIDEO_ID },
+    })
+
+    await waitFor(() => {
+      expect(result.current.isPortrait).toBe(true)
+    })
+
+    mockGetSizeFailure()
+    rerender({ id: 'anotherVideoId' })
+
+    expect(result.current.isPortrait).toBe(false)
+    expect(result.current.thumbnailUrl).toBeUndefined()
+  })
+
+  it('should not probe twice the same video', async () => {
+    const getSize = mockGetSize(720, 1280)
+    const { result, unmount } = renderHook(() => useVideoOrientation(VIDEO_ID))
+
+    await waitFor(() => {
+      expect(result.current.isPortrait).toBe(true)
+    })
+    unmount()
+
+    const { result: secondResult } = renderHook(() => useVideoOrientation(VIDEO_ID))
+
+    expect(getSize).toHaveBeenCalledTimes(1)
+    expect(secondResult.current.isPortrait).toBe(true)
+  })
+
+  it('should not probe anything without a video id', () => {
+    const getSize = mockGetSize(720, 1280)
+
+    const { result } = renderHook(() => useVideoOrientation(undefined))
+
+    expect(getSize).not.toHaveBeenCalled()
+    expect(result.current.isPortrait).toBe(false)
+    expect(result.current.thumbnailUrl).toBeUndefined()
+  })
+})

--- a/src/features/offer/helpers/useVideoOrientation/useVideoOrientation.ts
+++ b/src/features/offer/helpers/useVideoOrientation/useVideoOrientation.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+// eslint-disable-next-line no-restricted-imports
+import { Image } from 'react-native'
+
+// YouTube exposes the thumbnail at the original aspect ratio of the video, unlike
+// hqdefault/maxresdefault which are always letterboxed to 16/9.
+const getOriginalRatioThumbnailUrl = (videoId: string) =>
+  `https://i.ytimg.com/vi/${encodeURIComponent(videoId)}/oar2.jpg`
+
+export const videoOrientationCache = new Map<string, boolean>()
+
+type MeasuredOrientation = {
+  videoId: string
+  isPortrait: boolean
+}
+
+const getOrientation = (videoId?: string, measured?: MeasuredOrientation) => {
+  if (!videoId) return false
+  if (measured?.videoId === videoId) return measured.isPortrait
+
+  return videoOrientationCache.get(videoId) ?? false
+}
+
+export const useVideoOrientation = (videoId?: string) => {
+  const [measured, setMeasured] = useState<MeasuredOrientation>()
+
+  useEffect(() => {
+    if (!videoId || videoOrientationCache.has(videoId)) return
+
+    let isSubscribed = true
+    Image.getSize(
+      getOriginalRatioThumbnailUrl(videoId),
+      (width, height) => {
+        const isPortrait = height > width
+        videoOrientationCache.set(videoId, isPortrait)
+        if (isSubscribed) setMeasured({ videoId, isPortrait })
+      },
+      () => {
+        if (isSubscribed) setMeasured({ videoId, isPortrait: false })
+      }
+    )
+
+    return () => {
+      isSubscribed = false
+    }
+  }, [videoId])
+
+  const isPortrait = getOrientation(videoId, measured)
+
+  return {
+    isPortrait,
+    thumbnailUrl: videoId && isPortrait ? getOriginalRatioThumbnailUrl(videoId) : undefined,
+  }
+}

--- a/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.native.test.tsx
+++ b/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.native.test.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
+// eslint-disable-next-line no-restricted-imports
+import { Image } from 'react-native'
 
 import { OfferResponse } from 'api/gen'
 import * as useGoBack from 'features/navigation/useGoBack'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
+import { videoOrientationCache } from 'features/offer/helpers/useVideoOrientation/useVideoOrientation'
 import { OfferVideoPreview } from 'features/offer/pages/OfferVideoPreview/OfferVideoPreview'
 import { analytics } from 'libs/analytics/provider'
-import { render, screen, userEvent } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 
 const mockOffer = jest.fn((): { data: OfferResponse } => ({
   data: offerResponseSnap,
@@ -21,10 +24,29 @@ jest.spyOn(useGoBack, 'useGoBack').mockReturnValue({
   canGoBack: jest.fn(() => true),
 })
 
+let getSizeSpy: jest.SpyInstance | undefined
+
+const mockGetSize = (width: number, height: number) => {
+  getSizeSpy = jest
+    .spyOn(Image, 'getSize')
+    .mockImplementation((_uri, onSuccess) => Promise.resolve(onSuccess?.(width, height)))
+
+  return getSizeSpy
+}
+
 const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('<OfferPreview />', () => {
+  beforeEach(() => {
+    videoOrientationCache.clear()
+  })
+
+  afterEach(() => {
+    getSizeSpy?.mockRestore()
+    getSizeSpy = undefined
+  })
+
   it('should display offer video preview page', () => {
     render(<OfferVideoPreview />)
 
@@ -49,6 +71,28 @@ describe('<OfferPreview />', () => {
     expect(analytics.logConsultVideo).toHaveBeenCalledWith({
       from: 'offer',
       offerId: '116656',
+    })
+  })
+
+  it('should keep the offer thumbnail for a landscape video', () => {
+    mockGetSize(1920, 1080)
+
+    render(<OfferVideoPreview />)
+
+    expect(screen.getByTestId('video-thumbnail')).toHaveProp('source', {
+      uri: offerResponseSnap.video?.thumbUrl,
+    })
+  })
+
+  it('should use the original ratio thumbnail for a portrait video', async () => {
+    mockGetSize(720, 1280)
+
+    render(<OfferVideoPreview />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('video-thumbnail')).toHaveProp('source', {
+        uri: `https://i.ytimg.com/vi/${offerResponseSnap.video?.id}/oar2.jpg`,
+      })
     })
   })
 })

--- a/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.tsx
+++ b/src/features/offer/pages/OfferVideoPreview/OfferVideoPreview.tsx
@@ -1,13 +1,16 @@
 import { useRoute } from '@react-navigation/native'
 import React, { FunctionComponent, useCallback, useState } from 'react'
 import { Animated, useWindowDimensions } from 'react-native'
-import styled from 'styled-components/native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import styled, { useTheme } from 'styled-components/native'
 
-import { RATIO169 } from 'features/home/components/helpers/getVideoPlayerDimensions'
 import { YoutubePlayer } from 'features/home/components/modules/video/YoutubePlayer/YoutubePlayer'
 import { UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
 import { useGoBack } from 'features/navigation/useGoBack'
+import { MAX_HEIGHT_VIDEO_PORTRAIT } from 'features/offer/constant'
 import { formatDuration } from 'features/offer/helpers/formatDuration/formatDuration'
+import { getOfferVideoPlayerSize } from 'features/offer/helpers/getOfferVideoPlayerSize/getOfferVideoPlayerSize'
+import { useVideoOrientation } from 'features/offer/helpers/useVideoOrientation/useVideoOrientation'
 import { analytics } from 'libs/analytics/provider'
 import { FastImage } from 'libs/resizing-image-on-demand/FastImage'
 import { useOfferQuery } from 'queries/offer/useOfferQuery'
@@ -24,9 +27,22 @@ const interpolated = animatedValue.interpolate({
 export const OfferVideoPreview: FunctionComponent = () => {
   const { params } = useRoute<UseRouteType<'OfferVideoPreview'>>()
   const { goBack } = useGoBack('Offer', { id: params.id })
-  const { width: viewportWidth } = useWindowDimensions()
-  const videoHeight = Math.min(viewportWidth, MAX_WIDTH) * RATIO169
+  const { isDesktopViewport, appBarHeight, contentPage } = useTheme()
+  const { top } = useSafeAreaInsets()
+  const { width: viewportWidth, height: viewportHeight } = useWindowDimensions()
   const { data: offer } = useOfferQuery({ offerId: params.id })
+  const { isPortrait, thumbnailUrl } = useVideoOrientation(offer?.video?.id)
+  const headerHeight = appBarHeight + top
+  const availableHeight = Math.max(0, viewportHeight - 2 * headerHeight)
+  const { width: playerWidth, height: videoHeight } = isPortrait
+    ? getOfferVideoPlayerSize({
+        isPortrait: true,
+        viewportWidth,
+        maxWidth: MAX_WIDTH,
+        horizontalMargin: isDesktopViewport ? 0 : contentPage.marginHorizontal,
+        maxHeight: isDesktopViewport ? MAX_HEIGHT_VIDEO_PORTRAIT : availableHeight,
+      })
+    : getOfferVideoPlayerSize({ viewportWidth, maxWidth: MAX_WIDTH })
   const [playVideo, setPlayVideo] = useState(false)
 
   const handleOnPlayPress = useCallback(() => {
@@ -50,9 +66,15 @@ export const OfferVideoPreview: FunctionComponent = () => {
           title={offer.video.title ?? offer.name}
           videoId={offer.video.id}
           height={videoHeight}
-          width={viewportWidth < MAX_WIDTH ? undefined : MAX_WIDTH}
+          width={playerWidth}
           initialPlayerParams={{ autoplay: true }}
-          thumbnail={<VideoThumbnailImage url={offer?.video.thumbUrl ?? ''} resizeMode="cover" />}
+          thumbnail={
+            <VideoThumbnailImage
+              testID="video-thumbnail"
+              url={thumbnailUrl ?? offer?.video.thumbUrl ?? ''}
+              resizeMode="cover"
+            />
+          }
           duration={
             offer.video.durationSeconds
               ? formatDuration(offer.video.durationSeconds, 'sec')


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43322

## Context

Le ticket rend possible la saisie d'une URL YouTube Shorts dans le champ vidéo d'une offre. Cette partie-là (regex partagée `getUrlYoutubeError.ts` / `YOUTUBE_REGEX`, message d'erreur, accessibilité du champ de saisie) est traitée dans **pass-culture-main** — elle ne concerne ni `pro/` ni `api/` ici.

Cette PR couvre le seul point du ticket qui relève de l'app native : le **point de vigilance sur le rendu vertical**. Le player d'offre est aujourd'hui figé en 16/9 (`RATIO169`) ; un Shorts s'y afficherait pillarboxé, minuscule entre deux larges bandes noires.

### Détecter qu'une vidéo est verticale

`OfferVideo` n'expose que `id`, `title`, `thumbUrl` et `durationSeconds` : **l'API ne dit pas si la vidéo est verticale**. Les miniatures standard ne sont d'aucune aide, elles sont letterboxées en 16/9 quel que soit le format d'origine. En revanche `oar2.jpg` (*original aspect ratio*) restitue bien le ratio natif :

| URL | Short `cmtxphwLDZ0` | Paysage `dQw4w9WgXcQ` |
|-----|---------------------|------------------------|
| `hqdefault.jpg` | 480 × 360 | 480 × 360 |
| `maxresdefault.jpg` | 1280 × 720 | 1280 × 720 |
| **`oar2.jpg`** | **720 × 1280** | **1920 × 1080** |

Le hook `useVideoOrientation` sonde donc cette URL via `Image.getSize`. **Tout échec (404, réseau, disparition de l'endpoint) retombe silencieusement sur le paysage**, donc sur le comportement actuel — aucune régression possible sur les vidéos existantes.

> ⚠️ `oar2.jpg` est un endpoint YouTube non documenté. L'alternative propre à moyen terme est de faire exposer le ratio par le back dans `OfferVideo` ; c'est le seul signal disponible depuis l'app native en attendant.

### Mise en œuvre

- `getOfferVideoPlayerSize` — fonction pure : la branche paysage **reproduit à l'identique** le calcul existant, la branche portrait plafonne la hauteur à `MAX_HEIGHT_VIDEO_PORTRAIT = 540` (soit un player 304 × 540). Sans ce plafond, un 9/16 pleine largeur ferait 667 px de haut sur un écran 375 px.
- `VideoSection` reste **présentationnel** : il reçoit une prop `isPortrait`, il n'appelle pas le hook.
- Le centrage passe par `alignSelf: 'center'` sur le player et sur le `PlayerPreview`, **pas** par `alignItems` sur le conteneur — sinon le titre « Vidéo », le sous-titre et les boutons de consentement se seraient centrés eux aussi. En portrait, le bloc gated garde sa pleine largeur pour ne pas comprimer ses boutons.
- En portrait, la miniature bascule sur `oar2.jpg` : la miniature 16/9 letterboxée aurait été recadrée en `cover` dans un cadre 9/16.
- Aucun appel réseau nouveau vers un domaine tiers : `i.ytimg.com` est déjà sollicité pour `thumbUrl`, y compris avant consentement dans l'état gated.


### Screenshots

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-08-19 at 17 05 12" src="https://github.com/user-attachments/assets/07ab4214-4d83-470e-a2b5-1b4bde2bb165" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-08-19 at 17 05 07" src="https://github.com/user-attachments/assets/1acd143d-2993-4ea0-a9e8-65912b4f1dc3" />
<img width="3456" height="1990" alt="image (4)" src="https://github.com/user-attachments/assets/a6a02eec-5598-4d76-9aa3-da529f61cf44" />

