### PR TITLE
(PC-43317) fix(search): suggestions in autocomplete scrollable in Android

### DIFF
--- a/src/features/search/components/SearchSuggestions/SearchSuggestions.tsx
+++ b/src/features/search/components/SearchSuggestions/SearchSuggestions.tsx
@@ -171,11 +171,15 @@ export const SearchSuggestions = ({
   )
 }
 
-const StyledScrollView = styled.ScrollView(({ theme }) => ({
-  paddingTop: theme.designSystem.size.spacing.l,
-  paddingBottom: theme.designSystem.size.spacing.m,
+const StyledScrollView = styled.ScrollView.attrs(({ theme }) => ({
+  contentContainerStyle: {
+    paddingTop: theme.designSystem.size.spacing.l,
+    paddingBottom: theme.isMobileViewport
+      ? theme.tabBar.height + theme.designSystem.size.spacing.m
+      : theme.designSystem.size.spacing.m,
+    paddingLeft: theme.designSystem.size.spacing.xl,
+    paddingRight: theme.designSystem.size.spacing.xl,
+  },
+}))({
   flex: 1,
-  paddingLeft: theme.designSystem.size.spacing.xl,
-  paddingRight: theme.designSystem.size.spacing.xl,
-  ...(theme.isMobileViewport ? { marginBottom: theme.tabBar.height } : {}),
-}))
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43317

## Context
L'objectif de cette PR est que les suggestions dans l'autocomplete soient de nouveau scrollables sur Android (sur iOS et web c'est ok).
Le fix a été proposé de cette façon car sur Android, appliquer directement du padding sur le style racine d'un `ScrollView` perturbe le calcul de la zone de défilement (scrollable area). Déplacer ces marges internes dans la propriété `contentContainerStyle` via `.attrs()` permet à React Native de bien calculer la hauteur globale de défilement indépendamment du conteneur.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

https://github.com/user-attachments/assets/95a3a156-9366-4f86-b0a5-8bdb0c3a0caf



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
