### PR TITLE
(PC-43327) fix(shared): preserve tab bar space in ModalScreenWrapper in web mobile

### DIFF
--- a/src/shared/ModalScreenWrapper/ModalScreenWrapper.web.tsx
+++ b/src/shared/ModalScreenWrapper/ModalScreenWrapper.web.tsx
@@ -87,6 +87,7 @@ const ModalContainer = styled(Animated.View)<{ fullScreen?: boolean }>(({ theme,
   borderTopLeftRadius: theme.designSystem.size.borderRadius.l,
   borderTopRightRadius: theme.designSystem.size.borderRadius.l,
   overflow: 'hidden',
+  paddingBottom: theme.isMobileViewport ? theme.tabBar.height : undefined,
   ...(theme.isDesktopViewport
     ? {
         borderBottomLeftRadius: theme.designSystem.size.borderRadius.l,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43327

## Context
Le bouton de validation de la modale de localisation était masquée par la barre de navigation car le composant n'avait pas de `paddingBottom`

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |<img width="416" height="694" alt="Capture d’écran 2026-08-20 à 10 26 13" src="https://github.com/user-attachments/assets/e6b92989-a9d5-4847-af19-9147964d9321" />|<img width="424" height="699" alt="Capture d’écran 2026-08-20 à 10 26 03" src="https://github.com/user-attachments/assets/1d841c83-9a2e-48ea-a70e-616d712e4b26" />|
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
