### PR TITLE
(PC-43328) feat(a11y): use string instead number in getTextSemanticAttrs

### DIFF
--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -244,7 +244,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                 testID="back-button-container"
               />
               <Text
-                accessibilityLevel={1}
+                accessibilityLevel="h1"
                 accessibilityRole="header"
                 nativeID="testUuidV4"
                 numberOfLines={1}

--- a/__snapshots__/features/achievements/pages/Achievements.native.test.tsx.native-snap
+++ b/__snapshots__/features/achievements/pages/Achievements.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<Achievements/> should match snapshot 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -277,7 +277,7 @@ exports[`<Achievements/> should match snapshot 1`] = `
                 >
                   <View>
                     <Text
-                      accessibilityLevel={2}
+                      accessibilityLevel="h2"
                       accessibilityRole="header"
                       style={
                         {

--- a/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -259,7 +259,7 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
         >
           <View>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -323,7 +323,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
         >
           <View>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -76,7 +76,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -262,7 +262,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                 </View>
               </View>
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -266,7 +266,7 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/auth/pages/login/LoginMethods.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/login/LoginMethods.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<LoginMethods/> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -259,7 +259,7 @@ exports[`<LoginMethods/> should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
@@ -427,7 +427,7 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={2}
+            accessibilityLevel="h2"
             accessibilityRole="header"
             id="testUuidV4"
             style={
@@ -1315,7 +1315,7 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
           }
         >
           <Text
-            accessibilityLevel={2}
+            accessibilityLevel="h2"
             accessibilityRole="header"
             id="testUuidV4"
             style={

--- a/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
@@ -151,7 +151,7 @@ exports[`<AccountCreated /> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -170,7 +170,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
               C’est pour bientôt !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
@@ -265,7 +265,7 @@ exports[`QuitSignupModal should render correctly 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={1}
+                    accessibilityLevel="h1"
                     accessibilityRole="header"
                     style={
                       {
@@ -280,7 +280,7 @@ exports[`QuitSignupModal should render correctly 1`] = `
                     Veux-tu abandonner l’inscription ?
                   </Text>
                   <Text
-                    accessibilityLevel={2}
+                    accessibilityLevel="h2"
                     accessibilityRole="header"
                     style={
                       {

--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -18,7 +18,7 @@ exports[`<SetBirthday /> should render correctly 1`] = `
     }
   >
     <Text
-      accessibilityLevel={2}
+      accessibilityLevel="h2"
       accessibilityRole="header"
       id="testUuidV4"
       style={
@@ -979,7 +979,7 @@ exports[`<SetBirthday /> should render correctly when account creation token and
     }
   >
     <Text
-      accessibilityLevel={2}
+      accessibilityLevel="h2"
       accessibilityRole="header"
       id="testUuidV4"
       style={

--- a/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
@@ -18,7 +18,7 @@ exports[`SetPassword Page should render correctly 1`] = `
     }
   >
     <Text
-      accessibilityLevel={2}
+      accessibilityLevel="h2"
       accessibilityRole="header"
       style={
         {

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`<EmailResendModal /> should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -292,7 +292,7 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
                   </View>
                 </View>
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -161,7 +161,7 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -251,7 +251,7 @@ exports[`Signup Form For each step should render correctly for step 1/5 1`] = `
         }
       >
         <Text
-          accessibilityLevel={2}
+          accessibilityLevel="h2"
           accessibilityRole="header"
           style={
             {
@@ -785,7 +785,7 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -947,7 +947,7 @@ exports[`Signup Form For each step should render correctly for step 2/5 1`] = `
           }
         >
           <Text
-            accessibilityLevel={2}
+            accessibilityLevel="h2"
             accessibilityRole="header"
             style={
               {
@@ -1594,7 +1594,7 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -1756,7 +1756,7 @@ exports[`Signup Form For each step should render correctly for step 3/5 1`] = `
           }
         >
           <Text
-            accessibilityLevel={2}
+            accessibilityLevel="h2"
             accessibilityRole="header"
             id="testUuidV4"
             style={
@@ -2863,7 +2863,7 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -3434,7 +3434,7 @@ exports[`Signup Form For each step should render correctly for step 4/5 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   id="testUuidV4"
                   style={

--- a/__snapshots__/features/auth/pages/signup/SignupMethods/SignupMethods.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupMethods/SignupMethods.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<SignupMethods /> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -259,7 +259,7 @@ exports[`<SignupMethods /> should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
@@ -134,7 +134,7 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
@@ -151,7 +151,7 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -166,7 +166,7 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
               Ton compte a été réactivé
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -170,7 +170,7 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
               Ton compte est désactivé
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -151,7 +151,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -166,7 +166,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
               Tu as 18 ans !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -170,7 +170,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
               Réservation confirmée !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -170,7 +170,7 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
               Réservation introuvable !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
@@ -41,7 +41,7 @@ exports[`Bookings should render correctly 1`] = `
       }
     >
       <Text
-        accessibilityLevel={1}
+        accessibilityLevel="h1"
         accessibilityRole="header"
         numberOfLines={1}
         style={

--- a/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
@@ -192,7 +192,7 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={1}
+                accessibilityLevel="h1"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
@@ -94,7 +94,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={3}
+            accessibilityLevel="h3"
             accessibilityRole="header"
             style={
               {
@@ -212,7 +212,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
     }
   >
     <Text
-      accessibilityLevel={2}
+      accessibilityLevel="h2"
       accessibilityRole="header"
       style={
         {
@@ -570,7 +570,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={3}
+            accessibilityLevel="h3"
             accessibilityRole="header"
             style={
               {
@@ -923,7 +923,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={3}
+            accessibilityLevel="h3"
             accessibilityRole="header"
             style={
               {
@@ -1276,7 +1276,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={3}
+            accessibilityLevel="h3"
             accessibilityRole="header"
             style={
               {
@@ -1632,7 +1632,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={3}
+              accessibilityLevel="h3"
               accessibilityRole="header"
               style={
                 {
@@ -1951,7 +1951,7 @@ Ils permettent à YouTube d’assurer le bon fonctionnement de la lecture, de co
           }
         >
           <Text
-            accessibilityLevel={3}
+            accessibilityLevel="h3"
             accessibilityRole="header"
             style={
               {
@@ -2125,7 +2125,7 @@ Ils permettent à YouTube d’assurer le bon fonctionnement de la lecture, de co
     }
   >
     <Text
-      accessibilityLevel={2}
+      accessibilityLevel="h2"
       accessibilityRole="header"
       style={
         {

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
@@ -156,7 +156,7 @@ exports[`CulturalSurveyIntro should render the page with correct layout and cont
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -171,7 +171,7 @@ exports[`CulturalSurveyIntro should render the page with correct layout and cont
               Tu y es presque !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx.native-snap
@@ -219,7 +219,7 @@ exports[`CulturalSurveyQuestions should render the page with correct layout 1`] 
         </View>
       </View>
       <Text
-        accessibilityLevel={1}
+        accessibilityLevel="h1"
         accessibilityRole="header"
         numberOfLines={1}
         style={
@@ -275,7 +275,7 @@ exports[`CulturalSurveyQuestions should render the page with correct layout 1`] 
           }
         >
           <Text
-            accessibilityLevel={2}
+            accessibilityLevel="h2"
             accessibilityRole="header"
             id="testUuidV4"
             style={

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
@@ -151,7 +151,7 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -166,7 +166,7 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
               Un grand merci pour tes réponses !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/culturalSurvey/pages/FAQWebview.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/FAQWebview.native.test.tsx.native-snap
@@ -149,7 +149,7 @@ exports[`FAQVebview page should render the page with correct layout 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/errors/pages/AsyncErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/AsyncErrorBoundary.native.test.tsx.native-snap
@@ -123,7 +123,7 @@ exports[`AsyncErrorBoundary component should render 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           style={
             {
@@ -138,7 +138,7 @@ exports[`AsyncErrorBoundary component should render 1`] = `
           Oups !
         </Text>
         <Text
-          accessibilityLevel={2}
+          accessibilityLevel="h2"
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/errors/pages/BannedCountryError.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/BannedCountryError.native.test.tsx.native-snap
@@ -65,7 +65,7 @@ exports[`BannedCountryError should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           style={
             {
@@ -80,7 +80,7 @@ exports[`BannedCountryError should render correctly 1`] = `
           Tu n’es pas en France ?
         </Text>
         <Text
-          accessibilityLevel={2}
+          accessibilityLevel="h2"
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/favorites/pages/Favorites.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/Favorites.native.test.tsx.native-snap
@@ -43,7 +43,7 @@ exports[`<Favorites/> should render correctly 1`] = `
       }
     >
       <Text
-        accessibilityLevel={1}
+        accessibilityLevel="h1"
         accessibilityRole="header"
         numberOfLines={1}
         style={

--- a/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -275,7 +275,7 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/favorites/pages/NotConnectedFavorites.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/NotConnectedFavorites.native.test.tsx.native-snap
@@ -71,7 +71,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             style={
               {
@@ -86,7 +86,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
             Identifie-toi pour retrouver tes favoris
           </Text>
           <Text
-            accessibilityLevel={2}
+            accessibilityLevel="h2"
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/forceUpdate/pages/ForceUpdateWithResetErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/forceUpdate/pages/ForceUpdateWithResetErrorBoundary.native.test.tsx.native-snap
@@ -65,7 +65,7 @@ exports[`<ForceUpdateWithResetErrorBoundary/> should match snapshot 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           style={
             {
@@ -80,7 +80,7 @@ exports[`<ForceUpdateWithResetErrorBoundary/> should match snapshot 1`] = `
           Mise à jour requise !
         </Text>
         <Text
-          accessibilityLevel={2}
+          accessibilityLevel="h2"
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/home/pages/GenericHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/GenericHome.native.test.tsx.native-snap
@@ -136,7 +136,7 @@ exports[`GenericHome With not displayed skeleton by default should display real 
             testID="listHeader"
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -219,7 +219,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
   >
     <View>
       <Text
-        accessibilityLevel={1}
+        accessibilityLevel="h1"
         accessibilityRole="header"
         style={
           {
@@ -4481,7 +4481,7 @@ exports[`GenericHome With not displayed skeleton by default should display skele
             testID="listHeader"
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
@@ -176,7 +176,7 @@ exports[`Home page should render correctly 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={1}
+                    accessibilityLevel="h1"
                     accessibilityRole="header"
                     numberOfLines={2}
                     style={

--- a/__snapshots__/features/home/pages/NoContentError.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/NoContentError.native.test.tsx.native-snap
@@ -65,7 +65,7 @@ exports[`NoContentError should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           style={
             {
@@ -80,7 +80,7 @@ exports[`NoContentError should render correctly 1`] = `
           Oups !
         </Text>
         <Text
-          accessibilityLevel={2}
+          accessibilityLevel="h2"
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
@@ -484,7 +484,7 @@ exports[`ThematicHome should render correctly 1`] = `
       >
         <Text
           accessibilityHidden={true}
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}
@@ -632,7 +632,7 @@ exports[`ThematicHome should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={4}
+              accessibilityLevel="h4"
               accessibilityRole="header"
               numberOfLines={1}
               style={
@@ -671,7 +671,7 @@ exports[`ThematicHome should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 numberOfLines={1}
                 style={

--- a/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`<DMSModal/> should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
@@ -266,7 +266,7 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={1}
+                    accessibilityLevel="h1"
                     accessibilityRole="header"
                     style={
                       {
@@ -281,7 +281,7 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
                     Veux-tu abandonner la vérification d’identité ?
                   </Text>
                   <Text
-                    accessibilityLevel={2}
+                    accessibilityLevel="h2"
                     accessibilityRole="header"
                     style={
                       {

--- a/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/DisableActivation.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<DisableActivation/> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -565,7 +565,7 @@ exports[`<DisableActivation/> with RemoteActivationBanner informations should re
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
@@ -53,7 +53,7 @@ exports[`Stepper navigation should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -151,7 +151,7 @@ exports[`BeneficiaryAccountCreated should render correctly for 18 year-old benef
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -166,7 +166,7 @@ exports[`BeneficiaryAccountCreated should render correctly for 18 year-old benef
               Bonne nouvelle !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {
@@ -597,7 +597,7 @@ exports[`BeneficiaryAccountCreated should render correctly for underage benefici
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -612,7 +612,7 @@ exports[`BeneficiaryAccountCreated should render correctly for underage benefici
               Bonne nouvelle !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -170,7 +170,7 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
               Demande envoyée !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/confirmation/FreeBeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/FreeBeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -151,7 +151,7 @@ exports[`FreeBeneficiaryAccountCreated should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/confirmation/IdentityCheckHonor.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/IdentityCheckHonor.native.test.tsx.native-snap
@@ -36,7 +36,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
         }
       />
       <Text
-        accessibilityLevel={1}
+        accessibilityLevel="h1"
         accessibilityRole="header"
         style={
           {
@@ -58,7 +58,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={2}
+          accessibilityLevel="h2"
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -276,7 +276,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
@@ -243,7 +243,7 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -906,7 +906,7 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -294,7 +294,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={2}
+                    accessibilityLevel="h2"
                     accessibilityRole="header"
                     style={
                       {

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.native.test.tsx.native-snap
@@ -146,7 +146,7 @@ exports[`NotEligibleEduConnect should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
@@ -242,7 +242,7 @@ exports[`ComeBackLater should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
@@ -242,7 +242,7 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.native.test.tsx.native-snap
@@ -54,7 +54,7 @@ exports[`<IdentityCheckEnd/> should render correctly 1`] = `
       }
     >
       <Text
-        accessibilityLevel={1}
+        accessibilityLevel="h1"
         accessibilityRole="header"
         style={
           {

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
@@ -156,7 +156,7 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`SelectIDOrigin should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -294,7 +294,7 @@ exports[`SelectIDOrigin should render correctly 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -274,7 +274,7 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
@@ -260,7 +260,7 @@ exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -268,7 +268,7 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/identityCheck/pages/profile/ActivationProfileRecap.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/ActivationProfileRecap.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<ActivationProfileRecap /> ff WIP_PHONE_NUMBER_IN_PROFILE_STEPPER is en
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -942,7 +942,7 @@ exports[`<ActivationProfileRecap /> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/identityCheck/pages/profile/ProfileInformationValidationCreate.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/ProfileInformationValidationCreate.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`ProfileInformationValidationCreate should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -267,7 +267,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -779,7 +779,7 @@ exports[`<SetAddress/> when ff phoneNumberInProfileStepper is enabled should ren
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -884,7 +884,7 @@ exports[`<SetAddress/> when ff phoneNumberInProfileStepper is enabled should ren
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<SetCity/> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -267,7 +267,7 @@ exports[`<SetCity/> should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<SetName/> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -267,7 +267,7 @@ exports[`<SetName/> should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/identityCheck/pages/profile/SetPhoneNumber.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetPhoneNumber.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<SetPhoneNumber/> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -275,7 +275,7 @@ exports[`<SetPhoneNumber/> should render correctly 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetProfileBookingError.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<SetProfileBookingError/> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
@@ -149,7 +149,7 @@ exports[`<SetStatus/> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -210,7 +210,7 @@ exports[`<SetStatus/> should render correctly 1`] = `
             />
             <Styled(View)>
               <Styled(Text)
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
               >
                 Sélectionne ton statut
@@ -335,7 +335,7 @@ exports[`<SetStatus/> should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
@@ -161,7 +161,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -236,7 +236,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
         >
           <View>
             <Text
-              accessibilityLevel={4}
+              accessibilityLevel="h4"
               accessibilityRole="header"
               style={
                 {
@@ -320,7 +320,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={3}
+                    accessibilityLevel="h3"
                     accessibilityRole="header"
                     style={
                       {
@@ -2323,7 +2323,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={3}
+                    accessibilityLevel="h3"
                     accessibilityRole="header"
                     style={
                       {
@@ -2614,7 +2614,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={3}
+                    accessibilityLevel="h3"
                     accessibilityRole="header"
                     style={
                       {
@@ -3597,7 +3597,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
         >
           <View>
             <Text
-              accessibilityLevel={4}
+              accessibilityLevel="h4"
               accessibilityRole="header"
               style={
                 {
@@ -3690,7 +3690,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
           }
         >
           <Text
-            accessibilityLevel={4}
+            accessibilityLevel="h4"
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/internal/pages/UTMParameters.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/UTMParameters.native.test.tsx.native-snap
@@ -161,7 +161,7 @@ exports[`<UTMParameters /> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
@@ -140,7 +140,7 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               nativeID="testUuidV4"
               style={
@@ -494,7 +494,7 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
@@ -133,7 +133,7 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               nativeID="testUuidV4"
               style={
@@ -473,7 +473,7 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
@@ -140,7 +140,7 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               nativeID="testUuidV4"
               style={
@@ -494,7 +494,7 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/maintenance/pages/Maintenance.native.test.tsx.native-snap
+++ b/__snapshots__/features/maintenance/pages/Maintenance.native.test.tsx.native-snap
@@ -65,7 +65,7 @@ exports[`<Maintenance /> should match snapshot with custom message 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           style={
             {
@@ -80,7 +80,7 @@ exports[`<Maintenance /> should match snapshot with custom message 1`] = `
           Maintenance en cours
         </Text>
         <Text
-          accessibilityLevel={2}
+          accessibilityLevel="h2"
           accessibilityRole="header"
           style={
             {
@@ -165,7 +165,7 @@ exports[`<Maintenance /> should match snapshot with default message 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           style={
             {
@@ -180,7 +180,7 @@ exports[`<Maintenance /> should match snapshot with default message 1`] = `
           Maintenance en cours
         </Text>
         <Text
-          accessibilityLevel={2}
+          accessibilityLevel="h2"
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
@@ -168,7 +168,7 @@ exports[`<PageNotFound/> should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={1}
+                accessibilityLevel="h1"
                 accessibilityRole="header"
                 style={
                   {
@@ -183,7 +183,7 @@ exports[`<PageNotFound/> should render correctly 1`] = `
                 Page introuvable !
               </Text>
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
@@ -127,7 +127,7 @@ exports[`PushNotificationsModal should render properly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             style={

--- a/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`FavoriteAuthModal should match previous snapshot 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/offer/components/NotificationAuthModal/NotificationAuthModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/NotificationAuthModal/NotificationAuthModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`NotificationAuthModal should match previous snapshot 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -170,7 +170,7 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
               Offre introuvable !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
@@ -219,7 +219,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             numberOfLines={3}
             style={
@@ -250,7 +250,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
             }
           >
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {
@@ -1225,7 +1225,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             numberOfLines={3}
             style={
@@ -1256,7 +1256,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
             }
           >
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.native.test.tsx.native-snap
@@ -160,7 +160,7 @@ exports[`OnboardingAgeSelectionFork should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             numberOfLines={3}
             style={

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
@@ -239,7 +239,7 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -254,7 +254,7 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
               Explore, découvre, profite
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
@@ -151,7 +151,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -166,7 +166,7 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
               Découvre les offres près de chez toi
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
@@ -239,7 +239,7 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -254,7 +254,7 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
               Encore un peu de patience !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/onboarding/pages/onboarding/OnboardingWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/onboarding/pages/onboarding/OnboardingWelcome.native.test.tsx.native-snap
@@ -106,7 +106,7 @@ exports[`OnboardingWelcome should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/features/profile/components/Modals/ExpiredCreditModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/Modals/ExpiredCreditModal.native.test.tsx.native-snap
@@ -127,7 +127,7 @@ exports[`<ExpiredCreditModal/> should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/profile/containers/ProfileLoggedIn/ProfileLoggedIn.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/containers/ProfileLoggedIn/ProfileLoggedIn.native.test.tsx.native-snap
@@ -50,7 +50,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               numberOfLines={3}
               style={
@@ -140,7 +140,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
             testID="credit-info"
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -412,7 +412,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
   >
     <View>
       <Text
-        accessibilityLevel={2}
+        accessibilityLevel="h2"
         accessibilityRole="header"
         style={
           {
@@ -697,7 +697,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
-        accessibilityLevel={2}
+        accessibilityLevel="h2"
         accessibilityRole="header"
         style={
           {
@@ -983,7 +983,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
-        accessibilityLevel={2}
+        accessibilityLevel="h2"
         accessibilityRole="header"
         style={
           {
@@ -1255,7 +1255,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
-        accessibilityLevel={2}
+        accessibilityLevel="h2"
         accessibilityRole="header"
         style={
           {
@@ -1782,7 +1782,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
-        accessibilityLevel={2}
+        accessibilityLevel="h2"
         accessibilityRole="header"
         style={
           {
@@ -2007,7 +2007,7 @@ exports[`<ProfileLoggedIn /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
-        accessibilityLevel={2}
+        accessibilityLevel="h2"
         accessibilityRole="header"
         style={
           {

--- a/__snapshots__/features/profile/containers/ProfileLoggedOut/ProfileLoggedOut.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/containers/ProfileLoggedOut/ProfileLoggedOut.native.test.tsx.native-snap
@@ -24,7 +24,7 @@ exports[`<ProfileLoggedOut /> should match snapshot 1`] = `
       }
     >
       <Text
-        accessibilityLevel={1}
+        accessibilityLevel="h1"
         accessibilityRole="header"
         numberOfLines={2}
         style={
@@ -309,7 +309,7 @@ exports[`<ProfileLoggedOut /> should match snapshot 1`] = `
   >
     <View>
       <Text
-        accessibilityLevel={2}
+        accessibilityLevel="h2"
         accessibilityRole="header"
         style={
           {
@@ -595,7 +595,7 @@ exports[`<ProfileLoggedOut /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
-        accessibilityLevel={2}
+        accessibilityLevel="h2"
         accessibilityRole="header"
         style={
           {
@@ -972,7 +972,7 @@ exports[`<ProfileLoggedOut /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
-        accessibilityLevel={2}
+        accessibilityLevel="h2"
         accessibilityRole="header"
         style={
           {
@@ -1378,7 +1378,7 @@ exports[`<ProfileLoggedOut /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
-        accessibilityLevel={2}
+        accessibilityLevel="h2"
         accessibilityRole="header"
         style={
           {
@@ -1603,7 +1603,7 @@ exports[`<ProfileLoggedOut /> should match snapshot 1`] = `
     </View>
     <View>
       <Text
-        accessibilityLevel={2}
+        accessibilityLevel="h2"
         accessibilityRole="header"
         style={
           {

--- a/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/Accessibility.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`Accessibility should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileAndroid.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -324,7 +324,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -378,7 +378,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -476,7 +476,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -504,7 +504,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 Les contenus listés ci-dessous ne sont pas accessibles pour les raisons suivantes.
               </Text>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -758,7 +758,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 </View>
               </View>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -786,7 +786,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 Aucune
               </Text>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -1006,7 +1006,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -1189,7 +1189,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -1219,7 +1219,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 Cette déclaration a été établie le lundi 8 décembre 2025.
               </Text>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -1416,7 +1416,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 </View>
               </View>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -1639,7 +1639,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -1738,7 +1738,7 @@ exports[`AccessibilityDeclarationMobileAndroid should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationMobileIOS.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -324,7 +324,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -378,7 +378,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -476,7 +476,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -504,7 +504,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 Les contenus listés ci-dessous ne sont pas accessibles pour les raisons suivantes.
               </Text>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -758,7 +758,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 </View>
               </View>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -786,7 +786,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 Aucune
               </Text>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -1006,7 +1006,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -1189,7 +1189,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -1219,7 +1219,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 Cette déclaration a été établie le lundi 8 décembre 2025.
               </Text>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -1416,7 +1416,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 </View>
               </View>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -1696,7 +1696,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -1795,7 +1795,7 @@ exports[`AccessibilityDeclarationMobileIOS should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -322,7 +322,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -454,7 +454,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 , en raison des non-conformités énumérées dans la section « Résultats des tests ».
               </Text>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -509,7 +509,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -537,7 +537,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 Les contenus listés ci-dessous ne sont pas accessibles pour les raisons suivantes.
               </Text>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -1703,7 +1703,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 </View>
               </View>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -1731,7 +1731,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 Pas de dérogation identifiée
               </Text>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -1768,7 +1768,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -1951,7 +1951,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -1983,7 +1983,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 .
               </Text>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -2180,7 +2180,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 </View>
               </View>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -2519,7 +2519,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 La vérification de l’accessibilité est le résultat de tests manuels, assistés par des outils (feuilles CSS dédiés, extensions HeadingsMaps et WebDeveloper Toolbar, Color Contrast Analyser).
               </Text>
               <Text
-                accessibilityLevel={3}
+                accessibilityLevel="h3"
                 accessibilityRole="header"
                 style={
                   {
@@ -3295,7 +3295,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -3397,7 +3397,7 @@ exports[`AccessibilityDeclarationWeb should render correctly 1`] = `
                 }
               />
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/SiteMapScreen.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`SiteMapScreen should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/Appearance/Appearance.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Appearance/Appearance.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`Appearance should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -279,7 +279,7 @@ exports[`Appearance should render correctly 1`] = `
                 >
                   <View
                     accessibilityLabel="Permettre l’orientation - L’affichage en mode paysage peut être moins optimal"
-                    accessibilityLevel={2}
+                    accessibilityLevel="h2"
                     accessibilityRole="header"
                     accessible={true}
                   >
@@ -460,7 +460,7 @@ exports[`Appearance should render correctly 1`] = `
                     }
                   >
                     <Text
-                      accessibilityLevel={2}
+                      accessibilityLevel="h2"
                       accessibilityRole="header"
                       style={
                         {

--- a/__snapshots__/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeAddress/ChangeAddress.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<SetAddress/> from mandatory udpate personal data screen should render 
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -267,7 +267,7 @@ exports[`<SetAddress/> from mandatory udpate personal data screen should render 
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -831,7 +831,7 @@ exports[`<SetAddress/> without previous screen should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -936,7 +936,7 @@ exports[`<SetAddress/> without previous screen should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`ChangeCity from mandatory udpate personal data screen should render cor
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -266,7 +266,7 @@ exports[`ChangeCity from mandatory udpate personal data screen should render cor
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -888,7 +888,7 @@ exports[`ChangeCity from profil personal data screen should render correctly 1`]
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -992,7 +992,7 @@ exports[`ChangeCity from profil personal data screen should render correctly 1`]
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -1614,7 +1614,7 @@ exports[`ChangeCity without previous screen should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -1718,7 +1718,7 @@ exports[`ChangeCity without previous screen should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -170,7 +170,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
               Oups !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {
@@ -594,7 +594,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -609,7 +609,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
               Oups !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -275,7 +275,7 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`ChangePassword should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
@@ -149,7 +149,7 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -210,7 +210,7 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
             />
             <Styled(View)>
               <Styled(Text)
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
               >
                 Sélectionne ton statut
@@ -335,7 +335,7 @@ exports[`<ChangeStatus/> from mandatory udpate personal data screen should rende
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -2236,7 +2236,7 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -2297,7 +2297,7 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
             />
             <Styled(View)>
               <Styled(Text)
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
               >
                 Sélectionne ton statut
@@ -2422,7 +2422,7 @@ exports[`<ChangeStatus/> without previous screen should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -4323,7 +4323,7 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -4384,7 +4384,7 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
             />
             <Styled(View)>
               <Styled(Text)
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
               >
                 Sélectionne ton statut
@@ -4509,7 +4509,7 @@ exports[`<ChangeStatus/> without previous screen should show loading component 1
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/Chatbot/components/ChatbotContainer.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Chatbot/components/ChatbotContainer.native.test.tsx.native-snap
@@ -142,7 +142,7 @@ exports[`ChatbotContainer should render webview correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
@@ -156,7 +156,7 @@ exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -286,7 +286,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
               Tu peux choisir d’accepter ou non l’activation de leur suivi.
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {
@@ -644,7 +644,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={3}
+                    accessibilityLevel="h3"
                     accessibilityRole="header"
                     style={
                       {
@@ -997,7 +997,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={3}
+                    accessibilityLevel="h3"
                     accessibilityRole="header"
                     style={
                       {
@@ -1350,7 +1350,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={3}
+                    accessibilityLevel="h3"
                     accessibilityRole="header"
                     style={
                       {
@@ -1706,7 +1706,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                     }
                   >
                     <Text
-                      accessibilityLevel={3}
+                      accessibilityLevel="h3"
                       accessibilityRole="header"
                       style={
                         {
@@ -2025,7 +2025,7 @@ Ils permettent à YouTube d’assurer le bon fonctionnement de la lecture, de co
                   }
                 >
                   <Text
-                    accessibilityLevel={3}
+                    accessibilityLevel="h3"
                     accessibilityRole="header"
                     style={
                       {
@@ -2190,7 +2190,7 @@ Ils permettent à YouTube d’assurer le bon fonctionnement de la lecture, de co
               }
             />
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DebugScreen/DebugScreen.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DebugScreen/DebugScreen.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`DebugScreen should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -259,7 +259,7 @@ exports[`DebugScreen should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
@@ -241,7 +241,7 @@ exports[`ConfirmDeleteProfile should render confirm delete profile 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`DeactivateProfileSuccess should render deactivate profile success 1`] =
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
@@ -241,7 +241,7 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
@@ -241,7 +241,7 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
@@ -241,7 +241,7 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
@@ -241,7 +241,7 @@ exports[`DeleteProfileContactSupport should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
@@ -241,7 +241,7 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`DeleteProfileSuccess should render delete profile success 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
@@ -234,7 +234,7 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfileReason/DeleteProfileReason.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -265,7 +265,7 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
                   <Styled(Styled(SadFaceSvg)) />
                   <Styled(View)>
                     <Styled(Text)
-                      accessibilityLevel={1}
+                      accessibilityLevel="h1"
                       accessibilityRole="header"
                     >
                       Pourquoi souhaites-tu supprimer ton compte ?
@@ -410,7 +410,7 @@ exports[`<DeleteProfileReason /> should match snapshot 1`] = `
                       }
                     >
                       <Text
-                        accessibilityLevel={1}
+                        accessibilityLevel="h1"
                         accessibilityRole="header"
                         style={
                           {

--- a/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -275,7 +275,7 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={1}
+                  accessibilityLevel="h1"
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`LegalNotices should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -268,7 +268,7 @@ exports[`LegalNotices should render correctly 1`] = `
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/MandatoryUpdatePersonalData.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<MandatoryUpdatePersonalData /> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -170,7 +170,7 @@ exports[`<MandatoryUpdatePersonalData /> should render correctly 1`] = `
               Mets à jour ton profil
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/ProfileInformationValidationUpdate.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/ProfileInformationValidationUpdate.native.test.tsx.native-snap
@@ -76,7 +76,7 @@ exports[`ProfileInformationValidationUpdate should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/MandatoryUpdatePersonalData/UpdatePersonalDataConfirmation.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<UpdatePersonalDataConfirmation /> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -170,7 +170,7 @@ exports[`<UpdatePersonalDataConfirmation /> should render correctly 1`] = `
               C’est noté !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<NewEmailSelection /> should match snapshot 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -267,7 +267,7 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
               }
             >
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -678,7 +678,7 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
                   }
                 />
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {
@@ -2306,7 +2306,7 @@ exports[`NotificationsSettings should render correctly when user is not logged i
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -2475,7 +2475,7 @@ exports[`NotificationsSettings should render correctly when user is not logged i
                 </View>
               </View>
               <Text
-                accessibilityLevel={2}
+                accessibilityLevel="h2"
                 accessibilityRole="header"
                 style={
                   {
@@ -2890,7 +2890,7 @@ exports[`NotificationsSettings should render correctly when user is not logged i
                   }
                 />
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {

--- a/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`PersonalData should render personal data success 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`TrackEmailChange account with password should render correctly when cho
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -259,7 +259,7 @@ exports[`TrackEmailChange account with password should render correctly when cho
         >
           <View>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {
@@ -1187,7 +1187,7 @@ exports[`TrackEmailChange account with password should render correctly when con
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -1284,7 +1284,7 @@ exports[`TrackEmailChange account with password should render correctly when con
         >
           <View>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {
@@ -2223,7 +2223,7 @@ exports[`TrackEmailChange account with password should render correctly when val
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -2320,7 +2320,7 @@ exports[`TrackEmailChange account with password should render correctly when val
         >
           <View>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {
@@ -3237,7 +3237,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -3334,7 +3334,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         >
           <View>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {
@@ -4486,7 +4486,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -4583,7 +4583,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         >
           <View>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {
@@ -5757,7 +5757,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -5854,7 +5854,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         >
           <View>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {
@@ -7017,7 +7017,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -7114,7 +7114,7 @@ exports[`TrackEmailChange account without password (sso) should render correctly
         >
           <View>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/profile/pages/Tutorial/TutorialPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Tutorial/TutorialPage.native.test.tsx.native-snap
@@ -175,7 +175,7 @@ exports[`TutorialPage should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             numberOfLines={3}
             style={

--- a/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.native.test.tsx.native-snap
@@ -46,7 +46,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification disabled shou
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           style={
             {
@@ -60,7 +60,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification disabled shou
           Comment ça marche ?
         </Text>
         <Text
-          accessibilityLevel={2}
+          accessibilityLevel="h2"
           accessibilityRole="header"
           style={
             {
@@ -207,7 +207,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification disabled shou
                     à 17 ans
                   </Text>
                   <Text
-                    accessibilityLevel={3}
+                    accessibilityLevel="h3"
                     accessibilityRole="header"
                     style={
                       {
@@ -486,7 +486,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification disabled shou
                     à 18 ans
                   </Text>
                   <Text
-                    accessibilityLevel={3}
+                    accessibilityLevel="h3"
                     accessibilityRole="header"
                     style={
                       {
@@ -1204,7 +1204,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification disabled shou
       >
         <Text
           accessibilityHidden={true}
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}
@@ -1284,7 +1284,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           style={
             {
@@ -1298,7 +1298,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
           Comment ça marche ?
         </Text>
         <Text
-          accessibilityLevel={2}
+          accessibilityLevel="h2"
           accessibilityRole="header"
           style={
             {
@@ -1445,7 +1445,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
                     à 17 ans
                   </Text>
                   <Text
-                    accessibilityLevel={3}
+                    accessibilityLevel="h3"
                     accessibilityRole="header"
                     style={
                       {
@@ -1724,7 +1724,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
                     à 18 ans
                   </Text>
                   <Text
-                    accessibilityLevel={3}
+                    accessibilityLevel="h3"
                     accessibilityRole="header"
                     style={
                       {
@@ -2181,7 +2181,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
                   }
                 >
                   <Text
-                    accessibilityLevel={3}
+                    accessibilityLevel="h3"
                     accessibilityRole="header"
                     style={
                       {
@@ -3417,7 +3417,7 @@ exports[`<ProfileTutorialAgeInformationCredit /> with bonification enabled shoul
       >
         <Text
           accessibilityHidden={true}
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<SearchFilter/> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
@@ -102,7 +102,7 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={1}
+                    accessibilityLevel="h1"
                     accessibilityRole="header"
                     small={false}
                     style={
@@ -452,7 +452,7 @@ exports[`<SearchLanding /> should render SearchLanding 1`] = `
       >
         <View>
           <Text
-            accessibilityLevel={2}
+            accessibilityLevel="h2"
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
@@ -200,7 +200,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={1}
+                    accessibilityLevel="h1"
                     accessibilityRole="header"
                     small={false}
                     style={
@@ -659,7 +659,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                         }
                       >
                         <Text
-                          accessibilityLevel={3}
+                          accessibilityLevel="h3"
                           accessibilityRole="header"
                           style={
                             {
@@ -1642,7 +1642,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                     }
                   >
                     <Text
-                      accessibilityLevel={3}
+                      accessibilityLevel="h3"
                       accessibilityRole="header"
                       style={
                         {

--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -191,7 +191,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                 }
               >
                 <Text
-                  accessibilityLevel={1}
+                  accessibilityLevel="h1"
                   accessibilityRole="header"
                   small={true}
                   style={
@@ -536,7 +536,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
           }
         >
           <Text
-            accessibilityLevel={2}
+            accessibilityLevel="h2"
             accessibilityRole="header"
             style={
               {
@@ -1813,7 +1813,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     >
                       <Text
                         accessibilityLabel="GTL playlist"
-                        accessibilityLevel={2}
+                        accessibilityLevel="h2"
                         accessibilityRole="header"
                         numberOfLines={2}
                         style={
@@ -1827,7 +1827,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                       >
                         <Text
                           accessibilityElementsHidden={true}
-                          accessibilityLevel={2}
+                          accessibilityLevel="h2"
                           accessibilityRole="header"
                           accessible={false}
                           importantForAccessibility="no"
@@ -2815,7 +2815,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                       }
                     >
                       <View
-                        accessibilityLevel={3}
+                        accessibilityLevel="h3"
                         accessibilityRole="header"
                         renderToHardwareTextureAndroid={true}
                         shouldRasterizeIOS={true}
@@ -3110,7 +3110,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                       }
                     >
                       <View
-                        accessibilityLevel={3}
+                        accessibilityLevel="h3"
                         accessibilityRole="header"
                         renderToHardwareTextureAndroid={true}
                         shouldRasterizeIOS={true}
@@ -3405,7 +3405,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                       }
                     >
                       <View
-                        accessibilityLevel={3}
+                        accessibilityLevel="h3"
                         accessibilityRole="header"
                         renderToHardwareTextureAndroid={true}
                         shouldRasterizeIOS={true}
@@ -3700,7 +3700,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                       }
                     >
                       <View
-                        accessibilityLevel={3}
+                        accessibilityLevel="h3"
                         accessibilityRole="header"
                         renderToHardwareTextureAndroid={true}
                         shouldRasterizeIOS={true}

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -183,7 +183,7 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
               testID="back-button-container"
             />
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               nativeID="testUuidV4"
               numberOfLines={1}

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -183,7 +183,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
               testID="back-button-container"
             />
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               nativeID="testUuidV4"
               numberOfLines={1}
@@ -333,7 +333,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
               >
                 <View
                   accessibilityLabel="Uniquement les offres duo - Seules les sorties seront affichées"
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   accessible={true}
                 >

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -183,7 +183,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
               testID="back-button-container"
             />
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               nativeID="testUuidV4"
               numberOfLines={1}
@@ -404,7 +404,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                 >
                   <View
                     accessibilityLabel="Uniquement les offres gratuites"
-                    accessibilityLevel={2}
+                    accessibilityLevel="h2"
                     accessibilityRole="header"
                     accessible={true}
                   >
@@ -570,7 +570,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                 >
                   <View
                     accessibilityLabel="Limiter la recherche à mon crédit"
-                    accessibilityLevel={2}
+                    accessibilityLevel="h2"
                     accessibilityRole="header"
                     accessible={true}
                   >

--- a/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
@@ -269,7 +269,7 @@ exports[`VenueModal should render correctly 1`] = `
               </View>
             </View>
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               nativeID="testUuidV4"
               numberOfLines={1}

--- a/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
@@ -190,7 +190,7 @@ exports[`ShareAppModal should match snapshot 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               nativeID="testUuidV4"
               style={

--- a/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
@@ -172,7 +172,7 @@ exports[`ShareAppModalVersionA should match snapshot 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
@@ -172,7 +172,7 @@ exports[`ShareAppModalVersionB should match snapshot 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`<NotificationsLoggedOutModal /> should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`<NotificationsSettingsModal /> should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`<OnboardingSubscriptionModal /> should display correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for activites_crea
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -786,7 +786,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for cinema 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -1398,7 +1398,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for lecture 1`] = 
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -2010,7 +2010,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for musique 1`] = 
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -2622,7 +2622,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for spectacles 1`]
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -3234,7 +3234,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for visites 1`] = 
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`<UnsubscribingConfirmationModal /> should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/features/subscription/page/OnboardingSubscription.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/page/OnboardingSubscription.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`OnboardingSubscription should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -282,7 +282,7 @@ exports[`OnboardingSubscription should render correctly 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={2}
+                    accessibilityLevel="h2"
                     accessibilityRole="header"
                     id="testUuidV4"
                     style={

--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -850,7 +850,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -1441,7 +1441,7 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -241,7 +241,7 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -170,7 +170,7 @@ exports[`<SuspensionChoiceExpiredLink/> should match snapshot 1`] = `
               Oups !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -166,7 +166,7 @@ exports[`<Venue /> should match snapshot 1`] = `
             >
               <Text
                 accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
-                accessibilityLevel={1}
+                accessibilityLevel="h1"
                 accessibilityRole="header"
                 adjustsFontSizeToFit={true}
                 style={
@@ -748,7 +748,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={2}
+                    accessibilityLevel="h2"
                     accessibilityRole="header"
                     style={
                       {
@@ -1135,7 +1135,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                             >
                               <Text
                                 accessibilityLabel="Toutes les offres"
-                                accessibilityLevel={2}
+                                accessibilityLevel="h2"
                                 accessibilityRole="header"
                                 numberOfLines={2}
                                 style={
@@ -1149,7 +1149,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                               >
                                 <Text
                                   accessibilityElementsHidden={true}
-                                  accessibilityLevel={2}
+                                  accessibilityLevel="h2"
                                   accessibilityRole="header"
                                   accessible={false}
                                   importantForAccessibility="no"
@@ -1516,7 +1516,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                               }
                             >
                               <View
-                                accessibilityLevel={3}
+                                accessibilityLevel="h3"
                                 accessibilityRole="header"
                                 renderToHardwareTextureAndroid={true}
                                 shouldRasterizeIOS={true}
@@ -1733,7 +1733,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                               }
                             >
                               <View
-                                accessibilityLevel={3}
+                                accessibilityLevel="h3"
                                 accessibilityRole="header"
                                 renderToHardwareTextureAndroid={true}
                                 shouldRasterizeIOS={true}
@@ -1950,7 +1950,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                               }
                             >
                               <View
-                                accessibilityLevel={3}
+                                accessibilityLevel="h3"
                                 accessibilityRole="header"
                                 renderToHardwareTextureAndroid={true}
                                 shouldRasterizeIOS={true}
@@ -2220,7 +2220,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {
@@ -2415,7 +2415,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {
@@ -3117,7 +3117,7 @@ d’options
       >
         <Text
           accessibilityHidden={true}
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}
@@ -3596,7 +3596,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
             >
               <Text
                 accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
-                accessibilityLevel={1}
+                accessibilityLevel="h1"
                 accessibilityRole="header"
                 adjustsFontSizeToFit={true}
                 style={
@@ -4178,7 +4178,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                   }
                 >
                   <Text
-                    accessibilityLevel={2}
+                    accessibilityLevel="h2"
                     accessibilityRole="header"
                     style={
                       {
@@ -4565,7 +4565,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                             >
                               <Text
                                 accessibilityLabel="Toutes les offres"
-                                accessibilityLevel={2}
+                                accessibilityLevel="h2"
                                 accessibilityRole="header"
                                 numberOfLines={2}
                                 style={
@@ -4579,7 +4579,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                               >
                                 <Text
                                   accessibilityElementsHidden={true}
-                                  accessibilityLevel={2}
+                                  accessibilityLevel="h2"
                                   accessibilityRole="header"
                                   accessible={false}
                                   importantForAccessibility="no"
@@ -4946,7 +4946,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                               }
                             >
                               <View
-                                accessibilityLevel={3}
+                                accessibilityLevel="h3"
                                 accessibilityRole="header"
                                 renderToHardwareTextureAndroid={true}
                                 shouldRasterizeIOS={true}
@@ -5163,7 +5163,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                               }
                             >
                               <View
-                                accessibilityLevel={3}
+                                accessibilityLevel="h3"
                                 accessibilityRole="header"
                                 renderToHardwareTextureAndroid={true}
                                 shouldRasterizeIOS={true}
@@ -5380,7 +5380,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                               }
                             >
                               <View
-                                accessibilityLevel={3}
+                                accessibilityLevel="h3"
                                 accessibilityRole="header"
                                 renderToHardwareTextureAndroid={true}
                                 shouldRasterizeIOS={true}
@@ -5650,7 +5650,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {
@@ -5845,7 +5845,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {
@@ -6547,7 +6547,7 @@ d’options
       >
         <Text
           accessibilityHidden={true}
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}
@@ -7026,7 +7026,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
             >
               <Text
                 accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
-                accessibilityLevel={1}
+                accessibilityLevel="h1"
                 accessibilityRole="header"
                 adjustsFontSizeToFit={true}
                 style={
@@ -7616,7 +7616,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                     }
                   >
                     <Text
-                      accessibilityLevel={2}
+                      accessibilityLevel="h2"
                       accessibilityRole="header"
                       style={
                         {
@@ -7662,7 +7662,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                     }
                   >
                     <Text
-                      accessibilityLevel={2}
+                      accessibilityLevel="h2"
                       accessibilityRole="header"
                       style={
                         {
@@ -7708,7 +7708,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                     }
                   >
                     <Text
-                      accessibilityLevel={2}
+                      accessibilityLevel="h2"
                       accessibilityRole="header"
                       style={
                         {
@@ -8060,7 +8060,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                     }
                   >
                     <Text
-                      accessibilityLevel={2}
+                      accessibilityLevel="h2"
                       accessibilityRole="header"
                       style={
                         {
@@ -8211,7 +8211,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                               }
                             >
                               <Text
-                                accessibilityLevel={3}
+                                accessibilityLevel="h3"
                                 accessibilityRole="header"
                                 style={
                                   {
@@ -8494,7 +8494,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                               }
                             >
                               <Text
-                                accessibilityLevel={3}
+                                accessibilityLevel="h3"
                                 accessibilityRole="header"
                                 style={
                                   {
@@ -8762,7 +8762,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                               }
                             >
                               <Text
-                                accessibilityLevel={3}
+                                accessibilityLevel="h3"
                                 accessibilityRole="header"
                                 style={
                                   {
@@ -9156,7 +9156,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                               }
                             >
                               <Text
-                                accessibilityLevel={3}
+                                accessibilityLevel="h3"
                                 accessibilityRole="header"
                                 style={
                                   {
@@ -9496,7 +9496,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                     }
                   >
                     <Text
-                      accessibilityLevel={2}
+                      accessibilityLevel="h2"
                       accessibilityRole="header"
                       style={
                         {
@@ -9921,7 +9921,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {
@@ -10116,7 +10116,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                 }
               >
                 <Text
-                  accessibilityLevel={2}
+                  accessibilityLevel="h2"
                   accessibilityRole="header"
                   style={
                     {
@@ -10818,7 +10818,7 @@ d’options
       >
         <Text
           accessibilityHidden={true}
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}

--- a/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -170,7 +170,7 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
               Lieu introuvable !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/libs/location/components/GeolocationActivationModal.native.test.tsx.native-snap
+++ b/__snapshots__/libs/location/components/GeolocationActivationModal.native.test.tsx.native-snap
@@ -127,7 +127,7 @@ exports[`GeolocationActivationModal should render properly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             style={

--- a/__snapshots__/libs/network/OfflinePage.native.test.tsx.native-snap
+++ b/__snapshots__/libs/network/OfflinePage.native.test.tsx.native-snap
@@ -58,7 +58,7 @@ exports[`<OfflinePage /> should match snapshot with button 1`] = `
       }
     >
       <Text
-        accessibilityLevel={1}
+        accessibilityLevel="h1"
         accessibilityRole="header"
         style={
           {
@@ -73,7 +73,7 @@ exports[`<OfflinePage /> should match snapshot with button 1`] = `
         Oups, pas de réseau !
       </Text>
       <Text
-        accessibilityLevel={2}
+        accessibilityLevel="h2"
         accessibilityRole="header"
         style={
           {
@@ -345,7 +345,7 @@ exports[`<OfflinePage /> should match snapshot with default message 1`] = `
       }
     >
       <Text
-        accessibilityLevel={1}
+        accessibilityLevel="h1"
         accessibilityRole="header"
         style={
           {
@@ -360,7 +360,7 @@ exports[`<OfflinePage /> should match snapshot with default message 1`] = `
         Oups, pas de réseau !
       </Text>
       <Text
-        accessibilityLevel={2}
+        accessibilityLevel="h2"
         accessibilityRole="header"
         style={
           {

--- a/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`<ApplicationProcessingModal /> should match previous snapshot 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`<AuthenticationModal /> should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`<ErrorApplicationModal /> should match previous snapshot 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`<FinishSubscriptionModal /> should display correct body when user needs
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -683,7 +683,7 @@ exports[`<FinishSubscriptionModal /> should render correctly with eighteen years
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -1192,7 +1192,7 @@ exports[`<FinishSubscriptionModal /> should render correctly with undefined depo
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/shared/verticalPlaylist/components/VerticalPlaylistOffersView.native.test.tsx.native-snap
+++ b/__snapshots__/shared/verticalPlaylist/components/VerticalPlaylistOffersView.native.test.tsx.native-snap
@@ -37,7 +37,7 @@ exports[`<VerticalPlaylistOffersView /> should render correctly 1`] = `
           height={65}
         />
         <Styled(Text)
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
         >
           My title
@@ -209,7 +209,7 @@ exports[`<VerticalPlaylistOffersView /> should render correctly 1`] = `
           }
         />
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           style={
             {
@@ -1443,7 +1443,7 @@ exports[`<VerticalPlaylistOffersView /> should render correctly 1`] = `
       >
         <Text
           accessibilityHidden={true}
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           collapsable={false}
           numberOfLines={2}

--- a/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
@@ -155,7 +155,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -170,7 +170,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
               Oups !
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/ui/components/modals/AppModal.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/modals/AppModal.native.test.tsx.native-snap
@@ -179,7 +179,7 @@ exports[`<AppModal /> on big screen 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -434,7 +434,7 @@ exports[`<AppModal /> on small screen 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -655,7 +655,7 @@ exports[`<AppModal /> with backdrop disabled 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -910,7 +910,7 @@ exports[`<AppModal /> with backdrop enabled by default 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -1165,7 +1165,7 @@ exports[`<AppModal /> with backdrop explicitly enabled 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -1506,7 +1506,7 @@ exports[`<AppModal /> with left icon render 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -1761,7 +1761,7 @@ exports[`<AppModal /> with minimal props 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -2016,7 +2016,7 @@ exports[`<AppModal /> with right icon render 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}
@@ -2358,7 +2358,7 @@ exports[`<AppModal /> without children 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             nativeID="testUuidV4"
             numberOfLines={2}

--- a/__snapshots__/ui/components/modals/MarketingModal.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/modals/MarketingModal.native.test.tsx.native-snap
@@ -190,7 +190,7 @@ exports[`MarketingModal should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               nativeID="testUuidV4"
               style={

--- a/__snapshots__/ui/pages/GenericErrorPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericErrorPage.native.test.tsx.native-snap
@@ -66,7 +66,7 @@ exports[`<GenericErrorPage /> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           style={
             {
@@ -81,7 +81,7 @@ exports[`<GenericErrorPage /> should render correctly 1`] = `
           GenericErrorPage
         </Text>
         <Text
-          accessibilityLevel={2}
+          accessibilityLevel="h2"
           accessibilityRole="header"
           style={
             {

--- a/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericInfoPage.native.test.tsx.native-snap
@@ -322,7 +322,7 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
             }
           >
             <Text
-              accessibilityLevel={1}
+              accessibilityLevel="h1"
               accessibilityRole="header"
               style={
                 {
@@ -337,7 +337,7 @@ exports[`<GenericInfoPage /> should render correctly 1`] = `
               Title
             </Text>
             <Text
-              accessibilityLevel={2}
+              accessibilityLevel="h2"
               accessibilityRole="header"
               style={
                 {

--- a/__snapshots__/ui/pages/GenericOfficialPage.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/GenericOfficialPage.native.test.tsx.native-snap
@@ -134,7 +134,7 @@ exports[`<GenericOfficialPage /> should render correctly 1`] = `
           }
         >
           <Text
-            accessibilityLevel={1}
+            accessibilityLevel="h1"
             accessibilityRole="header"
             style={
               {

--- a/__snapshots__/ui/pages/PageWithHeader.native.test.tsx.native-snap
+++ b/__snapshots__/ui/pages/PageWithHeader.native.test.tsx.native-snap
@@ -162,7 +162,7 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={
@@ -505,7 +505,7 @@ exports[`<PageWithHeader/> should render correctly on Android, with white header
         }
       >
         <Text
-          accessibilityLevel={1}
+          accessibilityLevel="h1"
           accessibilityRole="header"
           numberOfLines={2}
           style={

--- a/src/features/achievements/pages/Achievements.tsx
+++ b/src/features/achievements/pages/Achievements.tsx
@@ -18,7 +18,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { getSpacing, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const emptyAchievement = {
   name: 'empty' as AchievementEnum,
@@ -57,7 +57,7 @@ const Achievements = () => {
               <ViewGap gap={4} key={category.name}>
                 <AchievementsGroupeHeader>
                   <View>
-                    <Typo.Title4 {...getTextSemanticAttrs('h2')}>
+                    <Typo.Title4 {...setTextSemantic('h2')}>
                       {achievementCategoryDisplayTitles[category.name]}
                     </Typo.Title4>
                     <StyledBody>{category.remainingAchievementsText}</StyledBody>

--- a/src/features/achievements/pages/Achievements.tsx
+++ b/src/features/achievements/pages/Achievements.tsx
@@ -57,7 +57,7 @@ const Achievements = () => {
               <ViewGap gap={4} key={category.name}>
                 <AchievementsGroupeHeader>
                   <View>
-                    <Typo.Title4 {...getTextSemanticAttrs(2)}>
+                    <Typo.Title4 {...getTextSemanticAttrs('h2')}>
                       {achievementCategoryDisplayTitles[category.name]}
                     </Typo.Title4>
                     <StyledBody>{category.remainingAchievementsText}</StyledBody>

--- a/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
+++ b/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
@@ -83,7 +83,7 @@ export const ArtistSimilarArtists: FunctionComponent<Props> = ({ artistId }) => 
   )
 }
 
-const TitleLevel2 = styled(Typo.Title3).attrs(getTextSemanticAttrs(2))``
+const TitleLevel2 = styled(Typo.Title3).attrs(getTextSemanticAttrs('h2'))``
 
 const HeaderContainer = styled.View(({ theme }) => ({
   marginHorizontal: theme.contentPage.marginHorizontal,

--- a/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
+++ b/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
@@ -13,7 +13,7 @@ import { SeeAllButton } from 'ui/components/SeeAllButton/SeeAllButton'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
 import { AVATAR_MEDIUM } from 'ui/theme/constants'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   artistId: string
@@ -83,7 +83,7 @@ export const ArtistSimilarArtists: FunctionComponent<Props> = ({ artistId }) => 
   )
 }
 
-const TitleLevel2 = styled(Typo.Title3).attrs(getTextSemanticAttrs('h2'))``
+const TitleLevel2 = styled(Typo.Title3).attrs(setTextSemantic('h2'))``
 
 const HeaderContainer = styled.View(({ theme }) => ({
   marginHorizontal: theme.contentPage.marginHorizontal,

--- a/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtistsSkeleton.tsx
+++ b/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtistsSkeleton.tsx
@@ -48,7 +48,7 @@ export const ArtistSimilarArtistsSkeleton: FunctionComponent<Props> = ({ title }
   )
 }
 
-const TitleLevel2 = styled(Typo.Title3).attrs(getTextSemanticAttrs(2))``
+const TitleLevel2 = styled(Typo.Title3).attrs(getTextSemanticAttrs('h2'))``
 
 const HeaderContainer = styled.View(({ theme }) => ({
   marginHorizontal: theme.contentPage.marginHorizontal,

--- a/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtistsSkeleton.tsx
+++ b/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtistsSkeleton.tsx
@@ -6,7 +6,7 @@ import { AccessibleTitle } from 'features/home/components/AccessibleTitle'
 import { SkeletonTile } from 'ui/components/placeholders/SkeletonTile'
 import { Typo } from 'ui/theme'
 import { AVATAR_MEDIUM } from 'ui/theme/constants'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const NUMBER_OF_AVATARS = 10
 const AVATAR_SKELETON_KEYS = Array.from(
@@ -48,7 +48,7 @@ export const ArtistSimilarArtistsSkeleton: FunctionComponent<Props> = ({ title }
   )
 }
 
-const TitleLevel2 = styled(Typo.Title3).attrs(getTextSemanticAttrs('h2'))``
+const TitleLevel2 = styled(Typo.Title3).attrs(setTextSemantic('h2'))``
 
 const HeaderContainer = styled.View(({ theme }) => ({
   marginHorizontal: theme.contentPage.marginHorizontal,

--- a/src/features/auth/components/EmailSentGeneric.tsx
+++ b/src/features/auth/components/EmailSentGeneric.tsx
@@ -13,7 +13,7 @@ import { ButtonContainerFlexStart } from 'ui/designSystem/Button/ButtonContainer
 import { EmailSent } from 'ui/svg/icons/EmailSent'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   title: string
@@ -39,7 +39,7 @@ export const EmailSentGeneric: FunctionComponent<Props> = ({
       <IllustrationContainer>
         <StyledEmailSent />
       </IllustrationContainer>
-      <Typo.Title3 {...getTextSemanticAttrs('h2')}>{title}</Typo.Title3>
+      <Typo.Title3 {...setTextSemantic('h2')}>{title}</Typo.Title3>
       <Typo.Body>Tu as reçu un lien à l’adresse&nbsp;:</Typo.Body>
       <Typo.Body>{email}</Typo.Body>
       <Typo.Body>L’e-mail peut prendre quelques minutes pour arriver.</Typo.Body>

--- a/src/features/auth/components/EmailSentGeneric.tsx
+++ b/src/features/auth/components/EmailSentGeneric.tsx
@@ -39,7 +39,7 @@ export const EmailSentGeneric: FunctionComponent<Props> = ({
       <IllustrationContainer>
         <StyledEmailSent />
       </IllustrationContainer>
-      <Typo.Title3 {...getTextSemanticAttrs(2)}>{title}</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs('h2')}>{title}</Typo.Title3>
       <Typo.Body>Tu as reçu un lien à l’adresse&nbsp;:</Typo.Body>
       <Typo.Body>{email}</Typo.Body>
       <Typo.Body>L’e-mail peut prendre quelques minutes pour arriver.</Typo.Body>

--- a/src/features/auth/components/LastLoginInfoBanner.tsx
+++ b/src/features/auth/components/LastLoginInfoBanner.tsx
@@ -5,7 +5,7 @@ import { FormattedLastLoginInfo } from 'features/auth/types'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Tag } from 'ui/designSystem/Tag/Tag'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = { lastLoginInfo: FormattedLastLoginInfo | null }
 
@@ -15,7 +15,7 @@ export const LastLoginInfoBanner: FunctionComponent<Props> = ({ lastLoginInfo })
   return (
     <Container gap={4}>
       <Tag label={lastLoginInfo.provider.label} Icon={lastLoginInfo.provider.icon} />
-      <Typo.Title4 {...getTextSemanticAttrs('p')}>{lastLoginInfo.maskedEmail}</Typo.Title4>
+      <Typo.Title4 {...setTextSemantic('p')}>{lastLoginInfo.maskedEmail}</Typo.Title4>
       <Typo.BodyXs>Connecté pour la dernière fois le {lastLoginInfo.lastLoginAt}</Typo.BodyXs>
     </Container>
   )

--- a/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
+++ b/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
@@ -43,7 +43,7 @@ export const ForgottenPassword = () => {
               isVisible={isDoingReCaptchaChallenge}
             />
           ) : null}
-          <Typo.Title3 {...getTextSemanticAttrs(2)}>Mot de passe oublié&nbsp;?</Typo.Title3>
+          <Typo.Title3 {...getTextSemanticAttrs('h2')}>Mot de passe oublié&nbsp;?</Typo.Title3>
           <Container>
             <Typo.Body>
               Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton

--- a/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
+++ b/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
@@ -9,7 +9,7 @@ import { Form } from 'ui/components/Form'
 import { Button } from 'ui/designSystem/Button/Button'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const ForgottenPassword = () => {
   const { data: isRecaptchaEnabled, isLoading: areSettingsLoading } = useIsRecaptchaEnabled()
@@ -43,7 +43,7 @@ export const ForgottenPassword = () => {
               isVisible={isDoingReCaptchaChallenge}
             />
           ) : null}
-          <Typo.Title3 {...getTextSemanticAttrs('h2')}>Mot de passe oublié&nbsp;?</Typo.Title3>
+          <Typo.Title3 {...setTextSemantic('h2')}>Mot de passe oublié&nbsp;?</Typo.Title3>
           <Container>
             <Typo.Body>
               Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton

--- a/src/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
+++ b/src/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
@@ -21,7 +21,7 @@ import { showErrorSnackBar, showSuccessSnackBar } from 'ui/designSystem/Snackbar
 import { LoadingPage } from 'ui/pages/LoadingPage'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type ReinitializePasswordFormData = {
   newPassword: string
@@ -111,7 +111,7 @@ export const ReinitializePassword = () => {
       RightButton={<RightButtonText onClose={navigateToHome} wording="Quitter" />}
       scrollChildren={
         <React.Fragment>
-          <Typo.Title3 {...getTextSemanticAttrs('h2')}>Choisis un nouveau mot de passe</Typo.Title3>
+          <Typo.Title3 {...setTextSemantic('h2')}>Choisis un nouveau mot de passe</Typo.Title3>
           <Form.MaxWidth>
             <Container>
               <PasswordInputController

--- a/src/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
+++ b/src/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
@@ -111,7 +111,7 @@ export const ReinitializePassword = () => {
       RightButton={<RightButtonText onClose={navigateToHome} wording="Quitter" />}
       scrollChildren={
         <React.Fragment>
-          <Typo.Title3 {...getTextSemanticAttrs(2)}>Choisis un nouveau mot de passe</Typo.Title3>
+          <Typo.Title3 {...getTextSemanticAttrs('h2')}>Choisis un nouveau mot de passe</Typo.Title3>
           <Form.MaxWidth>
             <Container>
               <PasswordInputController

--- a/src/features/auth/pages/login/Login.tsx
+++ b/src/features/auth/pages/login/Login.tsx
@@ -189,7 +189,7 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
         scrollChildren={
           <React.Fragment>
             <TitleContainer>
-              <Typo.Title3 {...getTextSemanticAttrs(2)}>Connecte-toi</Typo.Title3>
+              <Typo.Title3 {...getTextSemanticAttrs('h2')}>Connecte-toi</Typo.Title3>
             </TitleContainer>
             <Form.MaxWidth>
               <InputError

--- a/src/features/auth/pages/login/Login.tsx
+++ b/src/features/auth/pages/login/Login.tsx
@@ -34,7 +34,7 @@ import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Key } from 'ui/svg/icons/Key'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type LoginFormData = { email: string; password: string }
 type Props = { doNotNavigateOnSigninSuccess?: boolean }
@@ -189,7 +189,7 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
         scrollChildren={
           <React.Fragment>
             <TitleContainer>
-              <Typo.Title3 {...getTextSemanticAttrs('h2')}>Connecte-toi</Typo.Title3>
+              <Typo.Title3 {...setTextSemantic('h2')}>Connecte-toi</Typo.Title3>
             </TitleContainer>
             <Form.MaxWidth>
               <InputError

--- a/src/features/auth/pages/login/LoginMethods.tsx
+++ b/src/features/auth/pages/login/LoginMethods.tsx
@@ -93,7 +93,7 @@ export const LoginMethods = () => {
       scrollChildren={
         <React.Fragment>
           <TitleContainer>
-            <Typo.Title3 {...getTextSemanticAttrs(2)}>Connecte-toi</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Connecte-toi</Typo.Title3>
           </TitleContainer>
           <SeparatorWithText label="Méthode recommandée" icon={StepperValidate} color="primary" />
           <Form.MaxWidth>

--- a/src/features/auth/pages/login/LoginMethods.tsx
+++ b/src/features/auth/pages/login/LoginMethods.tsx
@@ -28,7 +28,7 @@ import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { StepperValidate } from 'ui/svg/icons/StepperValidate'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const LoginMethods = () => {
   const { navigate } = useNavigation<UseNavigationType>()
@@ -93,7 +93,7 @@ export const LoginMethods = () => {
       scrollChildren={
         <React.Fragment>
           <TitleContainer>
-            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Connecte-toi</Typo.Title3>
+            <Typo.Title3 {...setTextSemantic('h2')}>Connecte-toi</Typo.Title3>
           </TitleContainer>
           <SeparatorWithText label="Méthode recommandée" icon={StepperValidate} color="primary" />
           <Form.MaxWidth>

--- a/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.tsx
+++ b/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.tsx
@@ -83,7 +83,7 @@ export const LoginMethodsWithLastLoginInfo = () => {
       title="Connexion"
       scrollChildren={
         <ViewGap gap={6}>
-          <Typo.Title3 {...getTextSemanticAttrs(2)}>Connecte-toi</Typo.Title3>
+          <Typo.Title3 {...getTextSemanticAttrs('h2')}>Connecte-toi</Typo.Title3>
 
           <LastLoginInfoBanner lastLoginInfo={lastLoginInfo} />
 

--- a/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.tsx
+++ b/src/features/auth/pages/login/LoginMethodsWithLastLoginInfo.tsx
@@ -24,7 +24,7 @@ import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const LoginMethodsWithLastLoginInfo = () => {
   const { navigate } = useNavigation<UseNavigationType>()
@@ -83,7 +83,7 @@ export const LoginMethodsWithLastLoginInfo = () => {
       title="Connexion"
       scrollChildren={
         <ViewGap gap={6}>
-          <Typo.Title3 {...getTextSemanticAttrs('h2')}>Connecte-toi</Typo.Title3>
+          <Typo.Title3 {...setTextSemantic('h2')}>Connecte-toi</Typo.Title3>
 
           <LastLoginInfoBanner lastLoginInfo={lastLoginInfo} />
 

--- a/src/features/auth/pages/signup/AcceptCgu/AcceptCgu.tsx
+++ b/src/features/auth/pages/signup/AcceptCgu/AcceptCgu.tsx
@@ -186,7 +186,7 @@ export const AcceptCgu: FunctionComponent<PreValidationSignupLastStepProps> = ({
           <CheckboxGroup<string>
             label="Conditions et confidentialité"
             labelTag="h3"
-            labelTagOverrideForAccessibility={2}
+            labelTagOverrideForAccessibility="h2"
             options={checkboxOptions}
             value={selectedValues}
             onChange={setSelectedValues}

--- a/src/features/auth/pages/signup/SetBirthday/SetBirthday.tsx
+++ b/src/features/auth/pages/signup/SetBirthday/SetBirthday.tsx
@@ -105,7 +105,7 @@ export const SetBirthday: FunctionComponent<PreValidationSignupNormalStepProps> 
   return (
     <SetContainer>
       <Form.MaxWidth>
-        <Typo.Title3 id={titleId} {...getTextSemanticAttrs(2)}>
+        <Typo.Title3 id={titleId} {...getTextSemanticAttrs('h2')}>
           {pageTitle}
         </Typo.Title3>
         {isSSOSubscriptionFromLogin ? (

--- a/src/features/auth/pages/signup/SetBirthday/SetBirthday.tsx
+++ b/src/features/auth/pages/signup/SetBirthday/SetBirthday.tsx
@@ -20,7 +20,7 @@ import { Banner } from 'ui/designSystem/Banner/Banner'
 import { Button } from 'ui/designSystem/Button/Button'
 import { IdCard } from 'ui/svg/icons/IdCard'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type BirthdayForm = {
   birthdate: Date
@@ -105,7 +105,7 @@ export const SetBirthday: FunctionComponent<PreValidationSignupNormalStepProps> 
   return (
     <SetContainer>
       <Form.MaxWidth>
-        <Typo.Title3 id={titleId} {...getTextSemanticAttrs('h2')}>
+        <Typo.Title3 id={titleId} {...setTextSemantic('h2')}>
           {pageTitle}
         </Typo.Title3>
         {isSSOSubscriptionFromLogin ? (

--- a/src/features/auth/pages/signup/SetEmail/SetEmail.tsx
+++ b/src/features/auth/pages/signup/SetEmail/SetEmail.tsx
@@ -12,7 +12,7 @@ import { Form } from 'ui/components/Form'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type FormValues = { email: string; marketingEmailSubscription: boolean }
 
@@ -47,7 +47,7 @@ export const SetEmail: FunctionComponent<PreValidationSignupNormalStepProps> = (
 
   return (
     <Form.MaxWidth>
-      <Typo.Title3 {...getTextSemanticAttrs('h2')}>Crée-toi un compte</Typo.Title3>
+      <Typo.Title3 {...setTextSemantic('h2')}>Crée-toi un compte</Typo.Title3>
       <ControllersContainer gap={5}>
         <EmailInputController
           label="Adresse e-mail"

--- a/src/features/auth/pages/signup/SetEmail/SetEmail.tsx
+++ b/src/features/auth/pages/signup/SetEmail/SetEmail.tsx
@@ -47,7 +47,7 @@ export const SetEmail: FunctionComponent<PreValidationSignupNormalStepProps> = (
 
   return (
     <Form.MaxWidth>
-      <Typo.Title3 {...getTextSemanticAttrs(2)}>Crée-toi un compte</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs('h2')}>Crée-toi un compte</Typo.Title3>
       <ControllersContainer gap={5}>
         <EmailInputController
           label="Adresse e-mail"

--- a/src/features/auth/pages/signup/SetPassword/SetPassword.tsx
+++ b/src/features/auth/pages/signup/SetPassword/SetPassword.tsx
@@ -10,7 +10,7 @@ import { PasswordInputController } from 'shared/forms/controllers/PasswordInputC
 import { Form } from 'ui/components/Form'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type FormValues = {
   password: string
@@ -39,7 +39,7 @@ export const SetPassword: FunctionComponent<PreValidationSignupNormalStepProps> 
   return (
     <SetContainer>
       <Form.MaxWidth>
-        <Typo.Title3 {...getTextSemanticAttrs('h2')}>Choisis un mot de passe</Typo.Title3>
+        <Typo.Title3 {...setTextSemantic('h2')}>Choisis un mot de passe</Typo.Title3>
         <PasswordInputContainer>
           <PasswordInputController
             label="Mot de passe"

--- a/src/features/auth/pages/signup/SetPassword/SetPassword.tsx
+++ b/src/features/auth/pages/signup/SetPassword/SetPassword.tsx
@@ -39,7 +39,7 @@ export const SetPassword: FunctionComponent<PreValidationSignupNormalStepProps> 
   return (
     <SetContainer>
       <Form.MaxWidth>
-        <Typo.Title3 {...getTextSemanticAttrs(2)}>Choisis un mot de passe</Typo.Title3>
+        <Typo.Title3 {...getTextSemanticAttrs('h2')}>Choisis un mot de passe</Typo.Title3>
         <PasswordInputContainer>
           <PasswordInputController
             label="Mot de passe"

--- a/src/features/auth/pages/signup/SignupMethods/SignupMethods.tsx
+++ b/src/features/auth/pages/signup/SignupMethods/SignupMethods.tsx
@@ -24,7 +24,7 @@ import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { StepperValidate } from 'ui/svg/icons/StepperValidate'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const SignupMethods: FunctionComponent = () => {
   const { params } = useRoute<UseRouteType<'SignupMethods'>>()
@@ -58,7 +58,7 @@ export const SignupMethods: FunctionComponent = () => {
       scrollChildren={
         <React.Fragment>
           <TitleContainer>
-            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Crée-toi un compte</Typo.Title3>
+            <Typo.Title3 {...setTextSemantic('h2')}>Crée-toi un compte</Typo.Title3>
           </TitleContainer>
           <SeparatorWithText label="Méthode recommandée" icon={StepperValidate} color="primary" />
           <StyledViewGap gap={4}>

--- a/src/features/auth/pages/signup/SignupMethods/SignupMethods.tsx
+++ b/src/features/auth/pages/signup/SignupMethods/SignupMethods.tsx
@@ -58,7 +58,7 @@ export const SignupMethods: FunctionComponent = () => {
       scrollChildren={
         <React.Fragment>
           <TitleContainer>
-            <Typo.Title3 {...getTextSemanticAttrs(2)}>Crée-toi un compte</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Crée-toi un compte</Typo.Title3>
           </TitleContainer>
           <SeparatorWithText label="Méthode recommandée" icon={StepperValidate} color="primary" />
           <StyledViewGap gap={4}>

--- a/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.tsx
+++ b/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.tsx
@@ -21,7 +21,7 @@ import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { categoriesIcons } from 'ui/svg/icons/exports/categoriesIcons'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const RecreditBirthdayNotification = () => {
   const { replace } = useNavigation<UseNavigationType>()
@@ -112,7 +112,7 @@ const ProgressBarContainer = styled.View(({ theme }) => ({
   paddingHorizontal: theme.designSystem.size.spacing.xxxl,
 }))
 
-const Amount = styled(Typo.Title2).attrs(getTextSemanticAttrs('p'))(({ theme }) => ({
+const Amount = styled(Typo.Title2).attrs(setTextSemantic('p'))(({ theme }) => ({
   textAlign: 'center',
   color: theme.designSystem.color.text.brandPrimary,
 }))

--- a/src/features/bonification/pages/BonificationBirthDate.tsx
+++ b/src/features/bonification/pages/BonificationBirthDate.tsx
@@ -25,7 +25,7 @@ import { ButtonContainerFlexStart } from 'ui/designSystem/Button/ButtonContainer
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type BirthdayForm = {
   birthdate: Date
@@ -77,7 +77,7 @@ export const BonificationBirthDate = () => {
         <Form.MaxWidth>
           <StyledBodyXsSteps>Étape 3 sur 5</StyledBodyXsSteps>
           <ViewGap gap={4}>
-            <Typo.Title3 id={titleId} {...getTextSemanticAttrs('h2')}>
+            <Typo.Title3 id={titleId} {...setTextSemantic('h2')}>
               Quelle est la date de naissance de ton représentant légal&nbsp;?
             </Typo.Title3>
 

--- a/src/features/bonification/pages/BonificationBirthDate.tsx
+++ b/src/features/bonification/pages/BonificationBirthDate.tsx
@@ -77,7 +77,7 @@ export const BonificationBirthDate = () => {
         <Form.MaxWidth>
           <StyledBodyXsSteps>Étape 3 sur 5</StyledBodyXsSteps>
           <ViewGap gap={4}>
-            <Typo.Title3 id={titleId} {...getTextSemanticAttrs(2)}>
+            <Typo.Title3 id={titleId} {...getTextSemanticAttrs('h2')}>
               Quelle est la date de naissance de ton représentant légal&nbsp;?
             </Typo.Title3>
 

--- a/src/features/bonification/pages/BonificationBirthPlace.tsx
+++ b/src/features/bonification/pages/BonificationBirthPlace.tsx
@@ -108,7 +108,7 @@ export const BonificationBirthPlace = () => {
         <Form.MaxWidth>
           <StyledBodyXsSteps>{step}</StyledBodyXsSteps>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getTextSemanticAttrs(2)}>{title}</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs('h2')}>{title}</Typo.Title3>
             <Controller
               control={control}
               name="birthCountrySelection"

--- a/src/features/bonification/pages/BonificationBirthPlace.tsx
+++ b/src/features/bonification/pages/BonificationBirthPlace.tsx
@@ -29,7 +29,7 @@ import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export type FormValues = {
   birthCountrySelection: InseeCountry
@@ -108,7 +108,7 @@ export const BonificationBirthPlace = () => {
         <Form.MaxWidth>
           <StyledBodyXsSteps>{step}</StyledBodyXsSteps>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getTextSemanticAttrs('h2')}>{title}</Typo.Title3>
+            <Typo.Title3 {...setTextSemantic('h2')}>{title}</Typo.Title3>
             <Controller
               control={control}
               name="birthCountrySelection"

--- a/src/features/bonification/pages/BonificationExplanations.tsx
+++ b/src/features/bonification/pages/BonificationExplanations.tsx
@@ -28,7 +28,7 @@ import { Speaker } from 'ui/svg/icons/Speaker'
 import { WarningFilled } from 'ui/svg/icons/WarningFilled'
 import { Typo } from 'ui/theme'
 import { SPACE } from 'ui/theme/constants'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const BonificationExplanations = () => {
   const { navigate } = useNavigation<UseNavigationType>()
@@ -68,7 +68,7 @@ export const BonificationExplanations = () => {
             <Container>
               <StyledSpeaker />
             </Container>
-            <StyledTitle3 {...getTextSemanticAttrs('h2')}>
+            <StyledTitle3 {...setTextSemantic('h2')}>
               Quel est ce bonus et comment en bénéficier&nbsp;?
             </StyledTitle3>
             <Typo.Body>

--- a/src/features/bonification/pages/BonificationExplanations.tsx
+++ b/src/features/bonification/pages/BonificationExplanations.tsx
@@ -68,7 +68,7 @@ export const BonificationExplanations = () => {
             <Container>
               <StyledSpeaker />
             </Container>
-            <StyledTitle3 {...getTextSemanticAttrs(2)}>
+            <StyledTitle3 {...getTextSemanticAttrs('h2')}>
               Quel est ce bonus et comment en bénéficier&nbsp;?
             </StyledTitle3>
             <Typo.Body>

--- a/src/features/bonification/pages/BonificationGranted.tsx
+++ b/src/features/bonification/pages/BonificationGranted.tsx
@@ -13,7 +13,7 @@ import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { categoriesIcons } from 'ui/svg/icons/exports/categoriesIcons'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const BonificationGranted = () => {
   const { designSystem } = useTheme()
@@ -85,7 +85,7 @@ const ProgressBarContainer = styled.View(({ theme }) => ({
   paddingHorizontal: theme.designSystem.size.spacing.xxxl,
 }))
 
-const Amount = styled(Typo.Title2).attrs(getTextSemanticAttrs('p'))(({ theme }) => ({
+const Amount = styled(Typo.Title2).attrs(setTextSemantic('p'))(({ theme }) => ({
   textAlign: 'center',
   color: theme.designSystem.color.text.brandPrimary,
 }))

--- a/src/features/bonification/pages/BonificationNames.tsx
+++ b/src/features/bonification/pages/BonificationNames.tsx
@@ -22,7 +22,7 @@ import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type FormValues = {
   firstNames: string[]
@@ -69,7 +69,7 @@ export const BonificationNames = () => {
         <Form.MaxWidth>
           <StyledBodyXsSteps>Étape 1 sur 5</StyledBodyXsSteps>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getTextSemanticAttrs('h2')}>
+            <Typo.Title3 {...setTextSemantic('h2')}>
               Quels sont les noms et prénoms de ton représentant légal&nbsp;?
             </Typo.Title3>
             <Controller

--- a/src/features/bonification/pages/BonificationNames.tsx
+++ b/src/features/bonification/pages/BonificationNames.tsx
@@ -69,7 +69,7 @@ export const BonificationNames = () => {
         <Form.MaxWidth>
           <StyledBodyXsSteps>Étape 1 sur 5</StyledBodyXsSteps>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getTextSemanticAttrs(2)}>
+            <Typo.Title3 {...getTextSemanticAttrs('h2')}>
               Quels sont les noms et prénoms de ton représentant légal&nbsp;?
             </Typo.Title3>
             <Controller

--- a/src/features/bonification/pages/BonificationRequiredInformation.tsx
+++ b/src/features/bonification/pages/BonificationRequiredInformation.tsx
@@ -55,7 +55,7 @@ export const BonificationRequiredInformation = () => {
             <Container>
               <IdCardWithMagnifyingGlass />
             </Container>
-            <StyledTitle3 {...getTextSemanticAttrs(2)}>{title}</StyledTitle3>
+            <StyledTitle3 {...getTextSemanticAttrs('h2')}>{title}</StyledTitle3>
             <Typo.Body>Munis-toi des informations suivantes pour faire ta demande&nbsp;:</Typo.Body>
             <VerticalUl>
               {isDisabilityBonification ? (

--- a/src/features/bonification/pages/BonificationRequiredInformation.tsx
+++ b/src/features/bonification/pages/BonificationRequiredInformation.tsx
@@ -19,7 +19,7 @@ import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { IdCardWithMagnifyingGlass as InitialIdCardWithMagnifyingGlass } from 'ui/svg/icons/IdCardWithMagnifyingGlass'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const BonificationRequiredInformation = () => {
   const { params } = useRoute<UseRouteType<'BonificationRequiredInformation'>>()
@@ -55,7 +55,7 @@ export const BonificationRequiredInformation = () => {
             <Container>
               <IdCardWithMagnifyingGlass />
             </Container>
-            <StyledTitle3 {...getTextSemanticAttrs('h2')}>{title}</StyledTitle3>
+            <StyledTitle3 {...setTextSemantic('h2')}>{title}</StyledTitle3>
             <Typo.Body>Munis-toi des informations suivantes pour faire ta demande&nbsp;:</Typo.Body>
             <VerticalUl>
               {isDisabilityBonification ? (

--- a/src/features/bonification/pages/BonificationTitle.tsx
+++ b/src/features/bonification/pages/BonificationTitle.tsx
@@ -16,7 +16,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export type Title = 'Madame' | 'Monsieur'
 
@@ -47,7 +47,7 @@ export const BonificationTitle = () => {
       scrollChildren={
         <React.Fragment>
           <StyledBodyXsSteps>Étape 2 sur 5</StyledBodyXsSteps>
-          <Typo.Title3 {...getTextSemanticAttrs('h2')}>
+          <Typo.Title3 {...setTextSemantic('h2')}>
             Quelle est la civilité de ton représentant légal&nbsp;?
           </Typo.Title3>
           <SelectorContainer

--- a/src/features/bonification/pages/BonificationTitle.tsx
+++ b/src/features/bonification/pages/BonificationTitle.tsx
@@ -47,7 +47,7 @@ export const BonificationTitle = () => {
       scrollChildren={
         <React.Fragment>
           <StyledBodyXsSteps>Étape 2 sur 5</StyledBodyXsSteps>
-          <Typo.Title3 {...getTextSemanticAttrs(2)}>
+          <Typo.Title3 {...getTextSemanticAttrs('h2')}>
             Quelle est la civilité de ton représentant légal&nbsp;?
           </Typo.Title3>
           <SelectorContainer

--- a/src/features/bookOffer/components/BookDateChoice.tsx
+++ b/src/features/bookOffer/components/BookDateChoice.tsx
@@ -35,7 +35,7 @@ export const BookDateChoice = ({ stocks, userRemainingCredit }: Props) => {
     : ''
   return (
     <StyledView>
-      <Typo.Title3 {...getTextSemanticAttrs(3)} testID="DateStep">
+      <Typo.Title3 {...getTextSemanticAttrs('h3')} testID="DateStep">
         Date
       </Typo.Title3>
       {bookingState.step === Step.DATE ? (

--- a/src/features/bookOffer/components/BookDateChoice.tsx
+++ b/src/features/bookOffer/components/BookDateChoice.tsx
@@ -10,7 +10,7 @@ import { getDistinctPricesFromAllStock } from 'features/bookOffer/helpers/bookin
 import { formatToCompleteFrenchDate } from 'libs/parsers/formatDates'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   stocks: OfferStockResponse[]
@@ -35,7 +35,7 @@ export const BookDateChoice = ({ stocks, userRemainingCredit }: Props) => {
     : ''
   return (
     <StyledView>
-      <Typo.Title3 {...getTextSemanticAttrs('h3')} testID="DateStep">
+      <Typo.Title3 {...setTextSemantic('h3')} testID="DateStep">
         Date
       </Typo.Title3>
       {bookingState.step === Step.DATE ? (

--- a/src/features/bookOffer/components/BookHourChoice.tsx
+++ b/src/features/bookOffer/components/BookHourChoice.tsx
@@ -129,7 +129,7 @@ export const BookHourChoice = () => {
     </View>
   ) : (
     <ViewGap gap={4}>
-      <Typo.Title3 {...getTextSemanticAttrs(3)}>{radioGroupLabel}</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs('h3')}>{radioGroupLabel}</Typo.Title3>
       <TouchableOpacity onPress={changeHour}>
         <Typo.Button>{buttonTitle}</Typo.Button>
       </TouchableOpacity>

--- a/src/features/bookOffer/components/BookHourChoice.tsx
+++ b/src/features/bookOffer/components/BookHourChoice.tsx
@@ -24,7 +24,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { RadioButtonGroup } from 'ui/designSystem/RadioButtonGroup/RadioButtonGroup'
 import { RadioButtonGroupOption } from 'ui/designSystem/RadioButtonGroup/types'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const radioGroupLabel = 'Horaires'
 
@@ -129,7 +129,7 @@ export const BookHourChoice = () => {
     </View>
   ) : (
     <ViewGap gap={4}>
-      <Typo.Title3 {...getTextSemanticAttrs('h3')}>{radioGroupLabel}</Typo.Title3>
+      <Typo.Title3 {...setTextSemantic('h3')}>{radioGroupLabel}</Typo.Title3>
       <TouchableOpacity onPress={changeHour}>
         <Typo.Button>{buttonTitle}</Typo.Button>
       </TouchableOpacity>

--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -39,7 +39,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { Error } from 'ui/svg/icons/Error'
 import { LocationBuilding } from 'ui/svg/icons/LocationBuilding'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export interface BookingDetailsProps {
   stocks: OfferStockResponse[]
@@ -200,7 +200,7 @@ export const BookingDetails = ({ stocks, onPressBookOffer, isLoading }: BookingD
         Icon={Error}
       />
       <Container>
-        <Typo.Title4 {...getTextSemanticAttrs('h2')}>Informations</Typo.Title4>
+        <Typo.Title4 {...setTextSemantic('h2')}>Informations</Typo.Title4>
       </Container>
       <BookingInformationsContainer>
         <BookingInformations />
@@ -333,7 +333,7 @@ const VenueTitleContainer = styled.View(({ theme }) => ({
   marginBottom: theme.designSystem.size.spacing.l,
 }))
 
-const VenueTitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))({
+const VenueTitleText = styled(Typo.Title4).attrs(setTextSemantic('h2'))({
   flexShrink: 1,
 })
 

--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -200,7 +200,7 @@ export const BookingDetails = ({ stocks, onPressBookOffer, isLoading }: BookingD
         Icon={Error}
       />
       <Container>
-        <Typo.Title4 {...getTextSemanticAttrs(2)}>Informations</Typo.Title4>
+        <Typo.Title4 {...getTextSemanticAttrs('h2')}>Informations</Typo.Title4>
       </Container>
       <BookingInformationsContainer>
         <BookingInformations />
@@ -333,7 +333,7 @@ const VenueTitleContainer = styled.View(({ theme }) => ({
   marginBottom: theme.designSystem.size.spacing.l,
 }))
 
-const VenueTitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))({
+const VenueTitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))({
   flexShrink: 1,
 })
 

--- a/src/features/bookOffer/components/Calendar/MonthHeader.tsx
+++ b/src/features/bookOffer/components/Calendar/MonthHeader.tsx
@@ -6,7 +6,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { ArrowNext as DefaultArrowNext } from 'ui/svg/icons/ArrowNext'
 import { ArrowPrevious as DefaultArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   date: Date
@@ -27,7 +27,7 @@ export const MonthHeader: React.FC<Props> = ({ date, addMonth }) => {
         color="neutral"
       />
 
-      <Typo.Body {...getTextSemanticAttrs('h2')} accessibilityLiveRegion="polite">
+      <Typo.Body {...setTextSemantic('h2')} accessibilityLiveRegion="polite">
         {month}
       </Typo.Body>
 

--- a/src/features/bookOffer/components/Calendar/MonthHeader.tsx
+++ b/src/features/bookOffer/components/Calendar/MonthHeader.tsx
@@ -27,7 +27,7 @@ export const MonthHeader: React.FC<Props> = ({ date, addMonth }) => {
         color="neutral"
       />
 
-      <Typo.Body {...getTextSemanticAttrs(2)} accessibilityLiveRegion="polite">
+      <Typo.Body {...getTextSemanticAttrs('h2')} accessibilityLiveRegion="polite">
         {month}
       </Typo.Body>
 

--- a/src/features/bookOffer/components/CancellationDetails.tsx
+++ b/src/features/bookOffer/components/CancellationDetails.tsx
@@ -5,7 +5,7 @@ import { formatToCompleteFrenchDateTime } from 'libs/parsers/formatDates'
 import { useBookingOfferQuery } from 'queries/offer/useBookingOfferQuery'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const NOT_CANCELLABLE_MESSAGE =
   'En confirmant la réservation, j’accepte son exécution immédiate et renonce à mon droit de rétractation. Une confirmation de cet accord me sera envoyée par email.'
@@ -32,7 +32,7 @@ export const CancellationDetails: React.FC = () => {
 
   return (
     <ViewGap gap={2}>
-      <Typo.Title4 {...getTextSemanticAttrs('h2')}>Conditions d’annulation</Typo.Title4>
+      <Typo.Title4 {...setTextSemantic('h2')}>Conditions d’annulation</Typo.Title4>
       <Typo.BodyAccentXs>{message}</Typo.BodyAccentXs>
     </ViewGap>
   )

--- a/src/features/bookOffer/components/CancellationDetails.tsx
+++ b/src/features/bookOffer/components/CancellationDetails.tsx
@@ -32,7 +32,7 @@ export const CancellationDetails: React.FC = () => {
 
   return (
     <ViewGap gap={2}>
-      <Typo.Title4 {...getTextSemanticAttrs(2)}>Conditions d’annulation</Typo.Title4>
+      <Typo.Title4 {...getTextSemanticAttrs('h2')}>Conditions d’annulation</Typo.Title4>
       <Typo.BodyAccentXs>{message}</Typo.BodyAccentXs>
     </ViewGap>
   )

--- a/src/features/bookOffer/components/CguDetails.tsx
+++ b/src/features/bookOffer/components/CguDetails.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react'
 
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   children: ReactNode
@@ -11,7 +11,7 @@ type Props = {
 export const CguDetails: React.FC<Props> = ({ children }) => {
   return (
     <ViewGap gap={4}>
-      <Typo.Title4 {...getTextSemanticAttrs('h2')}>Conditions d’utilisation</Typo.Title4>
+      <Typo.Title4 {...setTextSemantic('h2')}>Conditions d’utilisation</Typo.Title4>
       {children}
     </ViewGap>
   )

--- a/src/features/bookOffer/components/CguDetails.tsx
+++ b/src/features/bookOffer/components/CguDetails.tsx
@@ -11,7 +11,7 @@ type Props = {
 export const CguDetails: React.FC<Props> = ({ children }) => {
   return (
     <ViewGap gap={4}>
-      <Typo.Title4 {...getTextSemanticAttrs(2)}>Conditions d’utilisation</Typo.Title4>
+      <Typo.Title4 {...getTextSemanticAttrs('h2')}>Conditions d’utilisation</Typo.Title4>
       {children}
     </ViewGap>
   )

--- a/src/features/bookings/components/Ticket/TicketBottomPart/TicketCodeTitle.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/TicketCodeTitle.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const TicketCodeTitle = ({
   accessibilityLabel,
@@ -20,7 +20,7 @@ export const TicketCodeTitle = ({
   </StyledTouchable>
 )
 
-const StyledTitle = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))(({ theme }) => ({
+const StyledTitle = styled(Typo.Title4).attrs(setTextSemantic('h2'))(({ theme }) => ({
   color: theme.designSystem.color.text.brandPrimary,
 }))
 

--- a/src/features/bookings/components/Ticket/TicketBottomPart/TicketCodeTitle.tsx
+++ b/src/features/bookings/components/Ticket/TicketBottomPart/TicketCodeTitle.tsx
@@ -20,7 +20,7 @@ export const TicketCodeTitle = ({
   </StyledTouchable>
 )
 
-const StyledTitle = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))(({ theme }) => ({
+const StyledTitle = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))(({ theme }) => ({
   color: theme.designSystem.color.text.brandPrimary,
 }))
 

--- a/src/features/bookings/components/Ticket/TicketTopPart.tsx
+++ b/src/features/bookings/components/Ticket/TicketTopPart.tsx
@@ -43,7 +43,7 @@ export const TicketTopPart = ({
 }: TicketTopPartProps) => {
   return (
     <ViewGap gap={6}>
-      <Typo.Title2 {...getTextSemanticAttrs(1)}>{title}</Typo.Title2>
+      <Typo.Title2 {...getTextSemanticAttrs('h1')}>{title}</Typo.Title2>
       <ViewGap gap={2}>
         {user.firstName && user.lastName ? (
           <Row>

--- a/src/features/bookings/components/Ticket/TicketTopPart.tsx
+++ b/src/features/bookings/components/Ticket/TicketTopPart.tsx
@@ -12,7 +12,7 @@ import { ClockFilled } from 'ui/svg/icons/ClockFilled'
 import { ProfileFilled } from 'ui/svg/icons/ProfileFilled'
 import { Stock } from 'ui/svg/icons/Stock'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type TicketTopPartProps = {
   title: string
@@ -43,7 +43,7 @@ export const TicketTopPart = ({
 }: TicketTopPartProps) => {
   return (
     <ViewGap gap={6}>
-      <Typo.Title2 {...getTextSemanticAttrs('h1')}>{title}</Typo.Title2>
+      <Typo.Title2 {...setTextSemantic('h1')}>{title}</Typo.Title2>
       <ViewGap gap={2}>
         {user.firstName && user.lastName ? (
           <Row>

--- a/src/features/cookies/components/CookiesSettings.tsx
+++ b/src/features/cookies/components/CookiesSettings.tsx
@@ -71,7 +71,7 @@ export const CookiesSettings = ({
 
   return (
     <React.Fragment>
-      <Typo.Title4 {...getTextSemanticAttrs(2)}>
+      <Typo.Title4 {...getTextSemanticAttrs('h2')}>
         À quoi servent tes cookies et tes données&nbsp;?
       </Typo.Title4>
       <ChoiceContainer>

--- a/src/features/cookies/components/CookiesSettings.tsx
+++ b/src/features/cookies/components/CookiesSettings.tsx
@@ -18,7 +18,7 @@ import { InputLabel } from 'ui/components/InputLabel/InputLabel'
 import { styledInputLabel } from 'ui/components/InputLabel/styledInputLabel'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const checkboxID = uuidv4()
 const labelID = uuidv4()
@@ -71,7 +71,7 @@ export const CookiesSettings = ({
 
   return (
     <React.Fragment>
-      <Typo.Title4 {...getTextSemanticAttrs('h2')}>
+      <Typo.Title4 {...setTextSemantic('h2')}>
         À quoi servent tes cookies et tes données&nbsp;?
       </Typo.Title4>
       <ChoiceContainer>

--- a/src/features/cookies/pages/CookiesDetails.tsx
+++ b/src/features/cookies/pages/CookiesDetails.tsx
@@ -10,7 +10,7 @@ import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouch
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Link } from 'ui/designSystem/Link/Link'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const CookiesDetails = (props: CookiesChoiceSettings) => {
   return (
@@ -28,7 +28,7 @@ export const CookiesDetails = (props: CookiesChoiceSettings) => {
         <CookiesSettings {...props} />
       </CookiesSettingsContainer>
       <ViewGap gap={4}>
-        <Typo.Title4 {...getTextSemanticAttrs('h2')}>Tu as la main dessus</Typo.Title4>
+        <Typo.Title4 {...setTextSemantic('h2')}>Tu as la main dessus</Typo.Title4>
         <Typo.Body>
           Ton choix est conservé pendant 6 mois et tu pourras le modifier dans les paramètres de
           confidentialité de ton profil à tout moment.

--- a/src/features/cookies/pages/CookiesDetails.tsx
+++ b/src/features/cookies/pages/CookiesDetails.tsx
@@ -28,7 +28,7 @@ export const CookiesDetails = (props: CookiesChoiceSettings) => {
         <CookiesSettings {...props} />
       </CookiesSettingsContainer>
       <ViewGap gap={4}>
-        <Typo.Title4 {...getTextSemanticAttrs(2)}>Tu as la main dessus</Typo.Title4>
+        <Typo.Title4 {...getTextSemanticAttrs('h2')}>Tu as la main dessus</Typo.Title4>
         <Typo.Body>
           Ton choix est conservé pendant 6 mois et tu pourras le modifier dans les paramètres de
           confidentialité de ton profil à tout moment.

--- a/src/features/culturalSurvey/components/CulturalSurveyPageHeader.tsx
+++ b/src/features/culturalSurvey/components/CulturalSurveyPageHeader.tsx
@@ -7,7 +7,7 @@ import { useGoBack } from 'features/navigation/useGoBack'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ArrowPrevious as DefaultArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   title: string
@@ -41,7 +41,7 @@ const BarAndTitle = styled.View(({ theme }) => ({
   flex: 1,
 }))
 
-const Title = styled(Typo.Title4).attrs(() => ({ ...getTextSemanticAttrs('h1'), numberOfLines: 1 }))(
+const Title = styled(Typo.Title4).attrs(() => ({ ...setTextSemantic('h1'), numberOfLines: 1 }))(
   ({ theme }) => ({
     flex: 1,
     marginRight: theme.designSystem.size.spacing.xl,

--- a/src/features/culturalSurvey/components/CulturalSurveyPageHeader.tsx
+++ b/src/features/culturalSurvey/components/CulturalSurveyPageHeader.tsx
@@ -41,7 +41,7 @@ const BarAndTitle = styled.View(({ theme }) => ({
   flex: 1,
 }))
 
-const Title = styled(Typo.Title4).attrs(() => ({ ...getTextSemanticAttrs(1), numberOfLines: 1 }))(
+const Title = styled(Typo.Title4).attrs(() => ({ ...getTextSemanticAttrs('h1'), numberOfLines: 1 }))(
   ({ theme }) => ({
     flex: 1,
     marginRight: theme.designSystem.size.spacing.xl,

--- a/src/features/favorites/components/NumberOfResults.tsx
+++ b/src/features/favorites/components/NumberOfResults.tsx
@@ -24,6 +24,6 @@ const Container = styled.View(({ theme }) => ({
   marginBottom: theme.designSystem.size.spacing.l,
 }))
 
-const Caption = styled(Typo.BodyAccentXs).attrs(() => getTextSemanticAttrs(2))(({ theme }) => ({
+const Caption = styled(Typo.BodyAccentXs).attrs(() => getTextSemanticAttrs('h2'))(({ theme }) => ({
   color: theme.designSystem.color.text.subtle,
 }))

--- a/src/features/favorites/components/NumberOfResults.tsx
+++ b/src/features/favorites/components/NumberOfResults.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { plural } from 'libs/plural'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const NumberOfResults: React.FC<{ nbFavorites: number }> = ({ nbFavorites }) => {
   if (!nbFavorites) return null
@@ -24,6 +24,6 @@ const Container = styled.View(({ theme }) => ({
   marginBottom: theme.designSystem.size.spacing.l,
 }))
 
-const Caption = styled(Typo.BodyAccentXs).attrs(() => getTextSemanticAttrs('h2'))(({ theme }) => ({
+const Caption = styled(Typo.BodyAccentXs).attrs(() => setTextSemantic('h2'))(({ theme }) => ({
   color: theme.designSystem.color.text.subtle,
 }))

--- a/src/features/favorites/pages/NotConnectedFavorites.tsx
+++ b/src/features/favorites/pages/NotConnectedFavorites.tsx
@@ -11,7 +11,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { Page } from 'ui/pages/Page'
 import { UserFavorite } from 'ui/svg/icons/UserFavorite'
 import { Spacer, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const NotConnectedFavorites = () => {
   const { bottom } = useSafeAreaInsets()
@@ -33,10 +33,10 @@ export const NotConnectedFavorites = () => {
             <Illustration />
           </IllustrationContainer>
           <TextContainer gap={4}>
-            <StyledTitle2 {...getTextSemanticAttrs('h1')}>
+            <StyledTitle2 {...setTextSemantic('h1')}>
               Identifie-toi pour retrouver tes favoris
             </StyledTitle2>
-            <StyledBody {...getTextSemanticAttrs('h2')}>
+            <StyledBody {...setTextSemantic('h2')}>
               Ton compte te permettra de retrouver tous tes bons plans en un clin d’oeil&nbsp;!
             </StyledBody>
           </TextContainer>

--- a/src/features/favorites/pages/NotConnectedFavorites.tsx
+++ b/src/features/favorites/pages/NotConnectedFavorites.tsx
@@ -33,10 +33,10 @@ export const NotConnectedFavorites = () => {
             <Illustration />
           </IllustrationContainer>
           <TextContainer gap={4}>
-            <StyledTitle2 {...getTextSemanticAttrs(1)}>
+            <StyledTitle2 {...getTextSemanticAttrs('h1')}>
               Identifie-toi pour retrouver tes favoris
             </StyledTitle2>
-            <StyledBody {...getTextSemanticAttrs(2)}>
+            <StyledBody {...getTextSemanticAttrs('h2')}>
               Ton compte te permettra de retrouver tous tes bons plans en un clin d’oeil&nbsp;!
             </StyledBody>
           </TextContainer>

--- a/src/features/home/components/modules/venues/VenueTile.tsx
+++ b/src/features/home/components/modules/venues/VenueTile.tsx
@@ -54,7 +54,7 @@ const UnmemoizedVenueTile = (props: VenueTileProps) => {
   )
 
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.VENUE, { ...venue, distance })
-  const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs(3)
+  const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs('h3')
 
   function handlePressVenue() {
     // We pre-populate the query-cache with the data from the search result for a smooth transition

--- a/src/features/home/components/modules/venues/VenueTile.tsx
+++ b/src/features/home/components/modules/venues/VenueTile.tsx
@@ -19,7 +19,7 @@ import { ImageTile } from 'ui/components/ImageTile'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Tag } from 'ui/designSystem/Tag/Tag'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export interface VenueTileProps {
   venue: VenueHit
@@ -54,7 +54,7 @@ const UnmemoizedVenueTile = (props: VenueTileProps) => {
   )
 
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.VENUE, { ...venue, distance })
-  const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs('h3')
+  const headingProps = Platform.OS === 'web' ? {} : setTextSemantic('h3')
 
   function handlePressVenue() {
     // We pre-populate the query-cache with the data from the search result for a smooth transition

--- a/src/features/home/components/modules/video/VideoModuleHeader.tsx
+++ b/src/features/home/components/modules/video/VideoModuleHeader.tsx
@@ -49,7 +49,7 @@ export const VideoModuleHeader: FunctionComponent<Props> = ({
         <Tag label={videoTag} variant={TagVariant.DEFAULT} />
       </StyledTagContainer>
 
-      <Typo.Title3 {...getTextSemanticAttrs(1)}>{moduleName}</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs('h1')}>{moduleName}</Typo.Title3>
 
       <StyledCaptionDate>{`Publiée le ${formatToFrenchDate(
         new Date(videoPublicationDate)
@@ -62,7 +62,7 @@ export const VideoModuleHeader: FunctionComponent<Props> = ({
       ) : null}
 
       <OfferTitleContainer>
-        <Typo.Title4 {...getTextSemanticAttrs(2)}>{offerTitle}</Typo.Title4>
+        <Typo.Title4 {...getTextSemanticAttrs('h2')}>{offerTitle}</Typo.Title4>
       </OfferTitleContainer>
 
       {!isMultiOffer && offers[0] && !hasThematicHomeEntry ? (

--- a/src/features/home/components/modules/video/VideoModuleHeader.tsx
+++ b/src/features/home/components/modules/video/VideoModuleHeader.tsx
@@ -14,7 +14,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { Tag } from 'ui/designSystem/Tag/Tag'
 import { TagVariant } from 'ui/designSystem/Tag/types'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   analyticsParams: OfferAnalyticsParams
@@ -49,7 +49,7 @@ export const VideoModuleHeader: FunctionComponent<Props> = ({
         <Tag label={videoTag} variant={TagVariant.DEFAULT} />
       </StyledTagContainer>
 
-      <Typo.Title3 {...getTextSemanticAttrs('h1')}>{moduleName}</Typo.Title3>
+      <Typo.Title3 {...setTextSemantic('h1')}>{moduleName}</Typo.Title3>
 
       <StyledCaptionDate>{`Publiée le ${formatToFrenchDate(
         new Date(videoPublicationDate)
@@ -62,7 +62,7 @@ export const VideoModuleHeader: FunctionComponent<Props> = ({
       ) : null}
 
       <OfferTitleContainer>
-        <Typo.Title4 {...getTextSemanticAttrs('h2')}>{offerTitle}</Typo.Title4>
+        <Typo.Title4 {...setTextSemantic('h2')}>{offerTitle}</Typo.Title4>
       </OfferTitleContainer>
 
       {!isMultiOffer && offers[0] && !hasThematicHomeEntry ? (

--- a/src/features/identityCheck/components/CenteredTitle.tsx
+++ b/src/features/identityCheck/components/CenteredTitle.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const CenteredTitle = ({ title, titleID }: { title: string; titleID?: string }) => (
   <TitleContainer>
@@ -15,6 +15,6 @@ const TitleContainer = styled.View({
   width: '100%',
 })
 
-const Title = styled(Typo.Title4).attrs(() => getTextSemanticAttrs('h2'))({
+const Title = styled(Typo.Title4).attrs(() => setTextSemantic('h2'))({
   textAlign: 'center',
 })

--- a/src/features/identityCheck/components/CenteredTitle.tsx
+++ b/src/features/identityCheck/components/CenteredTitle.tsx
@@ -15,6 +15,6 @@ const TitleContainer = styled.View({
   width: '100%',
 })
 
-const Title = styled(Typo.Title4).attrs(() => getTextSemanticAttrs(2))({
+const Title = styled(Typo.Title4).attrs(() => getTextSemanticAttrs('h2'))({
   textAlign: 'center',
 })

--- a/src/features/identityCheck/components/JustifiedLeftTitle.tsx
+++ b/src/features/identityCheck/components/JustifiedLeftTitle.tsx
@@ -16,4 +16,4 @@ const TitleContainer = styled.View(({ theme }) => ({
   marginBottom: theme.designSystem.size.spacing.xxl,
 }))
 
-const Title = styled(Typo.Title3).attrs(() => getTextSemanticAttrs(2))({})
+const Title = styled(Typo.Title3).attrs(() => getTextSemanticAttrs('h2'))({})

--- a/src/features/identityCheck/components/JustifiedLeftTitle.tsx
+++ b/src/features/identityCheck/components/JustifiedLeftTitle.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const JustifiedLeftTitle = ({ title, titleID }: { title: string; titleID?: string }) => (
   <TitleContainer>
@@ -16,4 +16,4 @@ const TitleContainer = styled.View(({ theme }) => ({
   marginBottom: theme.designSystem.size.spacing.xxl,
 }))
 
-const Title = styled(Typo.Title3).attrs(() => getTextSemanticAttrs('h2'))({})
+const Title = styled(Typo.Title3).attrs(() => setTextSemantic('h2'))({})

--- a/src/features/identityCheck/components/Summary.tsx
+++ b/src/features/identityCheck/components/Summary.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export type InfoListItemProps = {
   title: string
@@ -16,7 +16,7 @@ export const Summary: FC<{ title: string; data: InfoListItemProps[] }> = ({ data
 
   return (
     <ViewGap gap={5}>
-      <Typo.Title3 {...getTextSemanticAttrs('p')}>{title}</Typo.Title3>
+      <Typo.Title3 {...setTextSemantic('p')}>{title}</Typo.Title3>
       <BodyContainer gap={6}>
         {filteredData.map((item) => (
           <SummaryItem key={item.title} {...item} />

--- a/src/features/identityCheck/pages/Stepper.tsx
+++ b/src/features/identityCheck/pages/Stepper.tsx
@@ -30,7 +30,7 @@ import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { Page } from 'ui/pages/Page'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const Stepper = () => {
   useShowDisableActivation()
@@ -159,7 +159,7 @@ export const Stepper = () => {
   )
 }
 
-const StyledTitle1 = styled(Typo.Title1).attrs(() => getTextSemanticAttrs('h1'))``
+const StyledTitle1 = styled(Typo.Title1).attrs(() => setTextSemantic('h1'))``
 
 const TitleContainer = styled.View(({ theme }) => ({
   marginTop: theme.isDesktopViewport ? getSpacing(16) : theme.designSystem.size.spacing.l,

--- a/src/features/identityCheck/pages/Stepper.tsx
+++ b/src/features/identityCheck/pages/Stepper.tsx
@@ -159,7 +159,7 @@ export const Stepper = () => {
   )
 }
 
-const StyledTitle1 = styled(Typo.Title1).attrs(() => getTextSemanticAttrs(1))``
+const StyledTitle1 = styled(Typo.Title1).attrs(() => getTextSemanticAttrs('h1'))``
 
 const TitleContainer = styled.View(({ theme }) => ({
   marginTop: theme.isDesktopViewport ? getSpacing(16) : theme.designSystem.size.spacing.l,

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
@@ -21,7 +21,7 @@ import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { categoriesIcons } from 'ui/svg/icons/exports/categoriesIcons'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export function BeneficiaryAccountCreated() {
   const { designSystem } = useTheme()
@@ -106,7 +106,7 @@ const ProgressBarContainer = styled.View(({ theme }) => ({
   paddingHorizontal: theme.designSystem.size.spacing.xxxl,
 }))
 
-const Amount = styled(Typo.Title2).attrs(getTextSemanticAttrs('p'))(({ theme }) => ({
+const Amount = styled(Typo.Title2).attrs(setTextSemantic('p'))(({ theme }) => ({
   textAlign: 'center',
   color: theme.designSystem.color.text.brandPrimary,
 }))

--- a/src/features/identityCheck/pages/confirmation/IdentityCheckHonor.tsx
+++ b/src/features/identityCheck/pages/confirmation/IdentityCheckHonor.tsx
@@ -63,11 +63,11 @@ export const IdentityCheckHonor = () => {
     <Page>
       <StyledScrollView>
         <HeaderHeightSpacer headerHeight={headerHeight} />
-        <Typo.Title2 {...getTextSemanticAttrs(1)}>
+        <Typo.Title2 {...getTextSemanticAttrs('h1')}>
           Les informations que tu as renseignées sont-elles correctes&nbsp;?
         </Typo.Title2>
         <TextContainer>
-          <Typo.Title4 {...getTextSemanticAttrs(2)}>
+          <Typo.Title4 {...getTextSemanticAttrs('h2')}>
             &quot;Je déclare que l’ensemble des informations que j’ai renseignées durant mon
             inscription sont correctes.&quot;
           </Typo.Title4>

--- a/src/features/identityCheck/pages/confirmation/IdentityCheckHonor.tsx
+++ b/src/features/identityCheck/pages/confirmation/IdentityCheckHonor.tsx
@@ -19,7 +19,7 @@ import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { Page } from 'ui/pages/Page'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const IdentityCheckHonor = () => {
   const headerHeight = useGetHeaderHeight()
@@ -63,11 +63,11 @@ export const IdentityCheckHonor = () => {
     <Page>
       <StyledScrollView>
         <HeaderHeightSpacer headerHeight={headerHeight} />
-        <Typo.Title2 {...getTextSemanticAttrs('h1')}>
+        <Typo.Title2 {...setTextSemantic('h1')}>
           Les informations que tu as renseignées sont-elles correctes&nbsp;?
         </Typo.Title2>
         <TextContainer>
-          <Typo.Title4 {...getTextSemanticAttrs('h2')}>
+          <Typo.Title4 {...setTextSemantic('h2')}>
             &quot;Je déclare que l’ensemble des informations que j’ai renseignées durant mon
             inscription sont correctes.&quot;
           </Typo.Title4>

--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.tsx
@@ -43,7 +43,7 @@ export const IdentityCheckEnd: FC = () => {
           />
         </IllustrationContainer>
         <TextContainer>
-          <StyledTitle2 {...getTextSemanticAttrs(1)}>
+          <StyledTitle2 {...getTextSemanticAttrs('h1')}>
             Ta pièce d’identité a bien été transmise&nbsp;!
           </StyledTitle2>
         </TextContainer>

--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.tsx
@@ -10,7 +10,7 @@ import { Page } from 'ui/pages/Page'
 import { EmailSent } from 'ui/svg/icons/EmailSent'
 import { Typo } from 'ui/theme'
 import { illustrationSizes } from 'ui/theme/illustrationSizes'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const IdentityCheckEnd: FC = () => {
   const { designSystem } = useTheme()
@@ -43,7 +43,7 @@ export const IdentityCheckEnd: FC = () => {
           />
         </IllustrationContainer>
         <TextContainer>
-          <StyledTitle2 {...getTextSemanticAttrs('h1')}>
+          <StyledTitle2 {...setTextSemantic('h1')}>
             Ta pièce d’identité a bien été transmise&nbsp;!
           </StyledTitle2>
         </TextContainer>

--- a/src/features/identityCheck/pages/identification/ubble/SelectIDOrigin.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectIDOrigin.tsx
@@ -12,7 +12,7 @@ import { Earth as InitialEarth } from 'ui/svg/icons/Earth'
 import { France as FranceIcon } from 'ui/svg/icons/France'
 import { IdCardWithMagnifyingGlass as InitialIdCardWithMagnifyingGlass } from 'ui/svg/icons/IdCardWithMagnifyingGlass'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const SelectIDOrigin: FunctionComponent = () => (
   <PageWithHeader
@@ -79,7 +79,7 @@ const IdCardWithMagnifyingGlass = styled(InitialIdCardWithMagnifyingGlass).attrs
   color: theme.designSystem.color.icon.brandPrimary,
 }))``
 
-const StyledTitle4 = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))({
+const StyledTitle4 = styled(Typo.Title4).attrs(setTextSemantic('h2'))({
   textAlign: 'center',
 })
 

--- a/src/features/identityCheck/pages/identification/ubble/SelectIDOrigin.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectIDOrigin.tsx
@@ -79,7 +79,7 @@ const IdCardWithMagnifyingGlass = styled(InitialIdCardWithMagnifyingGlass).attrs
   color: theme.designSystem.color.icon.brandPrimary,
 }))``
 
-const StyledTitle4 = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))({
+const StyledTitle4 = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))({
   textAlign: 'center',
 })
 

--- a/src/features/identityCheck/pages/identification/ubble/SelectIDStatus.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectIDStatus.tsx
@@ -22,7 +22,7 @@ import { IdCard as InitialIdCard } from 'ui/svg/icons/IdCard'
 import { LostId as InitialLostId } from 'ui/svg/icons/LostId'
 import { NoId as InitialNoId } from 'ui/svg/icons/NoId'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const SelectIDStatus: FunctionComponent = () => {
   const { data: subscription } = useGetStepperInfoQuery()
@@ -146,7 +146,7 @@ const Container = styled.View(({ theme }) => ({
   marginVertical: theme.designSystem.size.spacing.xxl,
 }))
 
-const StyledTitle4 = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))({
+const StyledTitle4 = styled(Typo.Title4).attrs(setTextSemantic('h2'))({
   textAlign: 'center',
 })
 

--- a/src/features/identityCheck/pages/identification/ubble/SelectIDStatus.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectIDStatus.tsx
@@ -146,7 +146,7 @@ const Container = styled.View(({ theme }) => ({
   marginVertical: theme.designSystem.size.spacing.xxl,
 }))
 
-const StyledTitle4 = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))({
+const StyledTitle4 = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))({
   textAlign: 'center',
 })
 

--- a/src/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.tsx
@@ -9,7 +9,7 @@ import { NoPhone } from 'ui/svg/icons/NoPhone'
 import { PhonePending as InitialPhonePending } from 'ui/svg/icons/PhonePending'
 import { Smartphone } from 'ui/svg/icons/Smartphone'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const SelectPhoneStatus: FunctionComponent = () => {
   return (
@@ -75,7 +75,7 @@ const PhonePending = styled(InitialPhonePending).attrs(({ theme }) => ({
   size: theme.illustrations.sizes.fullPage,
 }))``
 
-const StyledTitle4 = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))({
+const StyledTitle4 = styled(Typo.Title4).attrs(setTextSemantic('h2'))({
   textAlign: 'center',
 })
 const StyledBody = styled(Typo.Body)({

--- a/src/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.tsx
@@ -75,7 +75,7 @@ const PhonePending = styled(InitialPhonePending).attrs(({ theme }) => ({
   size: theme.illustrations.sizes.fullPage,
 }))``
 
-const StyledTitle4 = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))({
+const StyledTitle4 = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))({
   textAlign: 'center',
 })
 const StyledBody = styled(Typo.Body)({

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
@@ -82,7 +82,7 @@ export const SetPhoneNumberWithoutValidation = () => {
       scrollChildren={
         <ViewGap gap={8}>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getTextSemanticAttrs(2)}>Saisis ton numéro de téléphone</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Saisis ton numéro de téléphone</Typo.Title3>
             <Banner label="Ton numéro pourra être utilisé pour recevoir des infos sur tes futures réservations." />
           </ViewGap>
           <Form.MaxWidth>

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.tsx
@@ -24,7 +24,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { TextInput } from 'ui/designSystem/TextInput/TextInput'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const SetPhoneNumberWithoutValidation = () => {
   const { dispatch, phoneValidation } = useSubscriptionContext()
@@ -82,7 +82,7 @@ export const SetPhoneNumberWithoutValidation = () => {
       scrollChildren={
         <ViewGap gap={8}>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Saisis ton numéro de téléphone</Typo.Title3>
+            <Typo.Title3 {...setTextSemantic('h2')}>Saisis ton numéro de téléphone</Typo.Title3>
             <Banner label="Ton numéro pourra être utilisé pour recevoir des infos sur tes futures réservations." />
           </ViewGap>
           <Form.MaxWidth>

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -29,7 +29,7 @@ import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const snackbarMessage =
   'Nous avons eu un problème pour trouver l’adresse associée à ton code postal. Réessaie plus tard.'
@@ -149,7 +149,7 @@ export const SetAddress = () => {
       scrollChildren={
         <React.Fragment>
           <Form.MaxWidth>
-            <Typo.Title3 {...getTextSemanticAttrs('h2')}>{pageConfigByType[type].title}</Typo.Title3>
+            <Typo.Title3 {...setTextSemantic('h2')}>{pageConfigByType[type].title}</Typo.Title3>
             <Container>
               <SearchInput
                 onChangeText={onChangeAddress}

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -149,7 +149,7 @@ export const SetAddress = () => {
       scrollChildren={
         <React.Fragment>
           <Form.MaxWidth>
-            <Typo.Title3 {...getTextSemanticAttrs(2)}>{pageConfigByType[type].title}</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs('h2')}>{pageConfigByType[type].title}</Typo.Title3>
             <Container>
               <SearchInput
                 onChangeText={onChangeAddress}

--- a/src/features/identityCheck/pages/profile/SetCity.tsx
+++ b/src/features/identityCheck/pages/profile/SetCity.tsx
@@ -78,7 +78,7 @@ export const SetCity = () => {
       title={pageConfigByType[type].headerTitle}
       scrollChildren={
         <ViewGap gap={5}>
-          <Typo.Title3 {...getTextSemanticAttrs(2)}>Renseigne ta ville de résidence</Typo.Title3>
+          <Typo.Title3 {...getTextSemanticAttrs('h2')}>Renseigne ta ville de résidence</Typo.Title3>
           <Controller
             control={control}
             name="city"

--- a/src/features/identityCheck/pages/profile/SetCity.tsx
+++ b/src/features/identityCheck/pages/profile/SetCity.tsx
@@ -15,7 +15,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export type CityForm = { city: SuggestedCity }
 
@@ -78,7 +78,7 @@ export const SetCity = () => {
       title={pageConfigByType[type].headerTitle}
       scrollChildren={
         <ViewGap gap={5}>
-          <Typo.Title3 {...getTextSemanticAttrs('h2')}>Renseigne ta ville de résidence</Typo.Title3>
+          <Typo.Title3 {...setTextSemantic('h2')}>Renseigne ta ville de résidence</Typo.Title3>
           <Controller
             control={control}
             name="city"

--- a/src/features/identityCheck/pages/profile/SetName.tsx
+++ b/src/features/identityCheck/pages/profile/SetName.tsx
@@ -92,7 +92,7 @@ export const SetName = () => {
       title={pageConfigByType[type].headerTitle}
       scrollChildren={
         <Form.MaxWidth>
-          <Typo.Title3 {...getTextSemanticAttrs(2)}>{pageConfigByType[type].title}</Typo.Title3>
+          <Typo.Title3 {...getTextSemanticAttrs('h2')}>{pageConfigByType[type].title}</Typo.Title3>
           <BannerContainer>
             <Banner Icon={IdCard} label={pageConfigByType[type].bannerMessage} />
           </BannerContainer>

--- a/src/features/identityCheck/pages/profile/SetName.tsx
+++ b/src/features/identityCheck/pages/profile/SetName.tsx
@@ -20,7 +20,7 @@ import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { IdCard } from 'ui/svg/icons/IdCard'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type FormValues = {
   firstName: string
@@ -92,7 +92,7 @@ export const SetName = () => {
       title={pageConfigByType[type].headerTitle}
       scrollChildren={
         <Form.MaxWidth>
-          <Typo.Title3 {...getTextSemanticAttrs('h2')}>{pageConfigByType[type].title}</Typo.Title3>
+          <Typo.Title3 {...setTextSemantic('h2')}>{pageConfigByType[type].title}</Typo.Title3>
           <BannerContainer>
             <Banner Icon={IdCard} label={pageConfigByType[type].bannerMessage} />
           </BannerContainer>

--- a/src/features/identityCheck/pages/profile/SetPhoneNumber.tsx
+++ b/src/features/identityCheck/pages/profile/SetPhoneNumber.tsx
@@ -31,7 +31,7 @@ import { TextInput } from 'ui/designSystem/TextInput/TextInput'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const SetPhoneNumber = () => {
   const { params } = useRoute<UseRouteType<'SetPhoneNumber'>>()
@@ -86,7 +86,7 @@ export const SetPhoneNumber = () => {
       scrollChildren={
         <ViewGap gap={8}>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Saisis ton numéro de téléphone</Typo.Title3>
+            <Typo.Title3 {...setTextSemantic('h2')}>Saisis ton numéro de téléphone</Typo.Title3>
             <Banner label="Ton numéro pourra être utilisé pour recevoir des infos sur tes futures réservations." />
           </ViewGap>
           <Form.MaxWidth>

--- a/src/features/identityCheck/pages/profile/SetPhoneNumber.tsx
+++ b/src/features/identityCheck/pages/profile/SetPhoneNumber.tsx
@@ -86,7 +86,7 @@ export const SetPhoneNumber = () => {
       scrollChildren={
         <ViewGap gap={8}>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getTextSemanticAttrs(2)}>Saisis ton numéro de téléphone</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Saisis ton numéro de téléphone</Typo.Title3>
             <Banner label="Ton numéro pourra être utilisé pour recevoir des infos sur tes futures réservations." />
           </ViewGap>
           <Form.MaxWidth>

--- a/src/features/identityCheck/pages/profile/StatusFlatList.tsx
+++ b/src/features/identityCheck/pages/profile/StatusFlatList.tsx
@@ -15,7 +15,7 @@ import { Spinner } from 'ui/components/Spinner'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Page } from 'ui/pages/Page'
 import { Spacer, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const VIEWABILITY_CONFIG = { itemVisiblePercentThreshold: 100 }
 
@@ -108,7 +108,7 @@ export function StatusFlatList({
               <React.Fragment>
                 <HeaderHeightSpacer headerHeight={headerHeight} />
                 <Container>
-                  <Typo.Title3 {...getTextSemanticAttrs('h2')}>Sélectionne ton statut</Typo.Title3>
+                  <Typo.Title3 {...setTextSemantic('h2')}>Sélectionne ton statut</Typo.Title3>
                 </Container>
               </React.Fragment>
             }

--- a/src/features/identityCheck/pages/profile/StatusFlatList.tsx
+++ b/src/features/identityCheck/pages/profile/StatusFlatList.tsx
@@ -108,7 +108,7 @@ export function StatusFlatList({
               <React.Fragment>
                 <HeaderHeightSpacer headerHeight={headerHeight} />
                 <Container>
-                  <Typo.Title3 {...getTextSemanticAttrs(2)}>Sélectionne ton statut</Typo.Title3>
+                  <Typo.Title3 {...getTextSemanticAttrs('h2')}>Sélectionne ton statut</Typo.Title3>
                 </Container>
               </React.Fragment>
             }

--- a/src/features/offer/components/OfferAbout/OfferAbout.tsx
+++ b/src/features/offer/components/OfferAbout/OfferAbout.tsx
@@ -18,7 +18,7 @@ type Props = {
 export const OfferAbout: FunctionComponent<Props> = ({ offer, metadata, hasMetadata }) => {
   return (
     <ViewGap gap={2}>
-      <Typo.Title3 {...getTextSemanticAttrs(2)}>À propos</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs('h2')}>À propos</Typo.Title3>
       <ViewGap gap={2}>
         {hasMetadata ? <OfferMetadataList metadata={metadata} /> : null}
 

--- a/src/features/offer/components/OfferAbout/OfferAbout.tsx
+++ b/src/features/offer/components/OfferAbout/OfferAbout.tsx
@@ -7,7 +7,7 @@ import { OfferMetadataList } from 'features/offer/components/OfferMetadataList/O
 import { CollapsibleText } from 'ui/components/CollapsibleText/CollapsibleText'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   offer: OfferResponse
@@ -18,7 +18,7 @@ type Props = {
 export const OfferAbout: FunctionComponent<Props> = ({ offer, metadata, hasMetadata }) => {
   return (
     <ViewGap gap={2}>
-      <Typo.Title3 {...getTextSemanticAttrs('h2')}>À propos</Typo.Title3>
+      <Typo.Title3 {...setTextSemantic('h2')}>À propos</Typo.Title3>
       <ViewGap gap={2}>
         {hasMetadata ? <OfferMetadataList metadata={metadata} /> : null}
 

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
@@ -25,7 +25,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { Typo } from 'ui/theme'
 import { AVATAR_MEDIUM, AVATAR_SMALL } from 'ui/theme/constants'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   artists: OfferArtist[]
@@ -123,7 +123,7 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
     <ViewGap gap={4}>
       <SeeAllButtonContainer gap={3}>
         <TitleContainer>
-          <Typo.Title4 {...getTextSemanticAttrs('h2')}>{title}</Typo.Title4>
+          <Typo.Title4 {...setTextSemantic('h2')}>{title}</Typo.Title4>
         </TitleContainer>
         {artists.length > 1 ? (
           <View>

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
@@ -123,7 +123,7 @@ export const OfferArtistsSection: FunctionComponent<Props> = ({
     <ViewGap gap={4}>
       <SeeAllButtonContainer gap={3}>
         <TitleContainer>
-          <Typo.Title4 {...getTextSemanticAttrs(2)}>{title}</Typo.Title4>
+          <Typo.Title4 {...getTextSemanticAttrs('h2')}>{title}</Typo.Title4>
         </TitleContainer>
         {artists.length > 1 ? (
           <View>

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -153,7 +153,7 @@ export const OfferBody: FunctionComponent<Props> = ({
         </GroupWithoutGap>
 
         {prices.length > 0 ? (
-          <Typo.Title3 {...getTextSemanticAttrs(2)}>{displayedPrice}</Typo.Title3>
+          <Typo.Title3 {...getTextSemanticAttrs('h2')}>{displayedPrice}</Typo.Title3>
         ) : null}
 
         <OfferReactionSection

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -35,7 +35,7 @@ import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GroupTags } from 'ui/GroupTags/GroupTags'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   offer: OfferResponse
@@ -153,7 +153,7 @@ export const OfferBody: FunctionComponent<Props> = ({
         </GroupWithoutGap>
 
         {prices.length > 0 ? (
-          <Typo.Title3 {...getTextSemanticAttrs('h2')}>{displayedPrice}</Typo.Title3>
+          <Typo.Title3 {...setTextSemantic('h2')}>{displayedPrice}</Typo.Title3>
         ) : null}
 
         <OfferReactionSection

--- a/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
+++ b/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
@@ -53,7 +53,7 @@ export const ProposedBySection: FunctionComponent<ProposedBySectionProps> = ({
   return (
     <Wrapper>
       <ViewGap gap={4}>
-        <Typo.Title3 {...getTextSemanticAttrs(2)}>Proposé par</Typo.Title3>
+        <Typo.Title3 {...getTextSemanticAttrs('h2')}>Proposé par</Typo.Title3>
         {navigateTo ? (
           <InternalTouchableLink navigateTo={navigateTo} accessibilityLabel={name}>
             {content}

--- a/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
+++ b/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
@@ -12,7 +12,7 @@ import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { Venue } from 'ui/svg/icons/Venue'
 import { Typo } from 'ui/theme'
 import { AVATAR_SMALL } from 'ui/theme/constants'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type ProposedBySectionProps = {
   name: string
@@ -53,7 +53,7 @@ export const ProposedBySection: FunctionComponent<ProposedBySectionProps> = ({
   return (
     <Wrapper>
       <ViewGap gap={4}>
-        <Typo.Title3 {...getTextSemanticAttrs('h2')}>Proposé par</Typo.Title3>
+        <Typo.Title3 {...setTextSemantic('h2')}>Proposé par</Typo.Title3>
         {navigateTo ? (
           <InternalTouchableLink navigateTo={navigateTo} accessibilityLabel={name}>
             {content}

--- a/src/features/offer/components/OfferCine/OfferCineBlock.tsx
+++ b/src/features/offer/components/OfferCine/OfferCineBlock.tsx
@@ -16,7 +16,7 @@ import { AnchorNames } from 'ui/components/anchor/anchor-name'
 import { useScrollToAnchor } from 'ui/components/anchor/AnchorContext'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo, getSpacing } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   title: string
@@ -58,7 +58,7 @@ export const OfferCineBlock: FC<Props> = ({ title, onSeeVenuePress, offer }) => 
             showButton(!inView)
           }}>
           <TitleContainer>
-            <Typo.Title3 {...getTextSemanticAttrs('h2')}>{title}</Typo.Title3>
+            <Typo.Title3 {...setTextSemantic('h2')}>{title}</Typo.Title3>
           </TitleContainer>
         </InView>
       </Anchor>

--- a/src/features/offer/components/OfferCine/OfferCineBlock.tsx
+++ b/src/features/offer/components/OfferCine/OfferCineBlock.tsx
@@ -58,7 +58,7 @@ export const OfferCineBlock: FC<Props> = ({ title, onSeeVenuePress, offer }) => 
             showButton(!inView)
           }}>
           <TitleContainer>
-            <Typo.Title3 {...getTextSemanticAttrs(2)}>{title}</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs('h2')}>{title}</Typo.Title3>
           </TitleContainer>
         </InView>
       </Anchor>

--- a/src/features/offer/components/OfferCine/OfferCineBlockV2.tsx
+++ b/src/features/offer/components/OfferCine/OfferCineBlockV2.tsx
@@ -15,7 +15,7 @@ import { AnchorNames } from 'ui/components/anchor/anchor-name'
 import { useScrollToAnchor } from 'ui/components/anchor/AnchorContext'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo, getSpacing } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   title: string
@@ -77,7 +77,7 @@ export const OfferCineBlockV2: FC<Props> = ({
             showButton(!inView)
           }}>
           <TitleContainer>
-            <Typo.Title3 {...getTextSemanticAttrs('h2')}>{title}</Typo.Title3>
+            <Typo.Title3 {...setTextSemantic('h2')}>{title}</Typo.Title3>
           </TitleContainer>
         </InView>
       </Anchor>

--- a/src/features/offer/components/OfferCine/OfferCineBlockV2.tsx
+++ b/src/features/offer/components/OfferCine/OfferCineBlockV2.tsx
@@ -77,7 +77,7 @@ export const OfferCineBlockV2: FC<Props> = ({
             showButton(!inView)
           }}>
           <TitleContainer>
-            <Typo.Title3 {...getTextSemanticAttrs(2)}>{title}</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs('h2')}>{title}</Typo.Title3>
           </TitleContainer>
         </InView>
       </Anchor>

--- a/src/features/offer/components/OfferContent/ClubAdviceSection/ClubAdviceSectionBase.tsx
+++ b/src/features/offer/components/OfferContent/ClubAdviceSection/ClubAdviceSectionBase.tsx
@@ -30,7 +30,7 @@ export const ClubAdviceSectionBase = ({
     <View style={style}>
       <Gutter>
         <Row>
-          <StyledTitle3 {...getTextSemanticAttrs(3)}>{variantInfo.titleSection}</StyledTitle3>
+          <StyledTitle3 {...getTextSemanticAttrs('h3')}>{variantInfo.titleSection}</StyledTitle3>
           {showSectionTag && variantInfo.sectionTag ? (
             <TagContainer>{variantInfo.sectionTag}</TagContainer>
           ) : null}

--- a/src/features/offer/components/OfferContent/ClubAdviceSection/ClubAdviceSectionBase.tsx
+++ b/src/features/offer/components/OfferContent/ClubAdviceSection/ClubAdviceSectionBase.tsx
@@ -9,7 +9,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { Button } from 'ui/designSystem/Button/Button'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const ClubAdviceSectionBase = ({
   data,
@@ -30,7 +30,7 @@ export const ClubAdviceSectionBase = ({
     <View style={style}>
       <Gutter>
         <Row>
-          <StyledTitle3 {...getTextSemanticAttrs('h3')}>{variantInfo.titleSection}</StyledTitle3>
+          <StyledTitle3 {...setTextSemantic('h3')}>{variantInfo.titleSection}</StyledTitle3>
           {showSectionTag && variantInfo.sectionTag ? (
             <TagContainer>{variantInfo.sectionTag}</TagContainer>
           ) : null}

--- a/src/features/offer/components/OfferTile/OfferTile.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.tsx
@@ -13,7 +13,7 @@ import { NAVIGATION_METHOD } from 'shared/constants'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 import { PlaylistCardOffer } from './PlaylistCardOffer'
 
@@ -60,7 +60,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
     subcategoryId
   )
 
-  const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs('h3')
+  const headingProps = Platform.OS === 'web' ? {} : setTextSemantic('h3')
   const interactionTagLabel = getInteractionTagLabel(interactionTag)
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.OFFER, {
     ...offer,

--- a/src/features/offer/components/OfferTile/OfferTile.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.tsx
@@ -60,7 +60,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
     subcategoryId
   )
 
-  const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs(3)
+  const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs('h3')
   const interactionTagLabel = getInteractionTagLabel(interactionTag)
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.OFFER, {
     ...offer,

--- a/src/features/offer/components/OfferTitle/OfferTitle.tsx
+++ b/src/features/offer/components/OfferTitle/OfferTitle.tsx
@@ -18,7 +18,7 @@ export const OfferTitle: FunctionComponent<Props> = ({ offerName }) => {
       adjustsFontSizeToFit
       allowFontScaling={false}
       {...accessibilityAndTestId(`Nom de l’offre\u00a0: ${offerName}`)}
-      {...getTextSemanticAttrs(1)}>
+      {...getTextSemanticAttrs('h1')}>
       {offerName}
     </TitleComponent>
   )

--- a/src/features/offer/components/OfferTitle/OfferTitle.tsx
+++ b/src/features/offer/components/OfferTitle/OfferTitle.tsx
@@ -3,7 +3,7 @@ import { useTheme } from 'styled-components/native'
 
 import { accessibilityAndTestId } from 'libs/accessibilityAndTestId'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   offerName: string
@@ -18,7 +18,7 @@ export const OfferTitle: FunctionComponent<Props> = ({ offerName }) => {
       adjustsFontSizeToFit
       allowFontScaling={false}
       {...accessibilityAndTestId(`Nom de l’offre\u00a0: ${offerName}`)}
-      {...getTextSemanticAttrs('h1')}>
+      {...setTextSemantic('h1')}>
       {offerName}
     </TitleComponent>
   )

--- a/src/features/offer/components/OfferVenueBlock/OfferVenueBlock.tsx
+++ b/src/features/offer/components/OfferVenueBlock/OfferVenueBlock.tsx
@@ -49,7 +49,7 @@ export function OfferVenueBlock({
 
   return (
     <Wrapper>
-      <Typo.Title3 {...getTextSemanticAttrs(2)}>{title}</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs('h2')}>{title}</Typo.Title3>
 
       <Container>
         <VenueBlock

--- a/src/features/offer/components/OfferVenueBlock/OfferVenueBlock.tsx
+++ b/src/features/offer/components/OfferVenueBlock/OfferVenueBlock.tsx
@@ -13,7 +13,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { Duplicate } from 'ui/svg/icons/Duplicate'
 import { EditPen } from 'ui/svg/icons/EditPen'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   title: string
@@ -49,7 +49,7 @@ export function OfferVenueBlock({
 
   return (
     <Wrapper>
-      <Typo.Title3 {...getTextSemanticAttrs('h2')}>{title}</Typo.Title3>
+      <Typo.Title3 {...setTextSemantic('h2')}>{title}</Typo.Title3>
 
       <Container>
         <VenueBlock

--- a/src/features/onboarding/components/OnboardingCreditBlockTitle.tsx
+++ b/src/features/onboarding/components/OnboardingCreditBlockTitle.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   age: number
@@ -24,6 +24,6 @@ export const OnboardingCreditBlockTitle = ({
   return <TitleText>{deposit}</TitleText>
 }
 
-const TitleSecondary = styled(Typo.Title3).attrs(getTextSemanticAttrs('p'))(({ theme }) => ({
+const TitleSecondary = styled(Typo.Title3).attrs(setTextSemantic('p'))(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))

--- a/src/features/onboarding/pages/onboarding/OnboardingAgeInformation.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingAgeInformation.tsx
@@ -14,7 +14,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { ClockFilled } from 'ui/svg/icons/ClockFilled'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = NativeStackScreenProps<OnboardingStackParamList, 'OnboardingAgeInformation'>
 
@@ -72,7 +72,7 @@ export const OnboardingAgeInformation = ({ route }: Props): React.JSX.Element | 
   return (
     <TutorialPage title={`À ${userAge} ans, profite de ton pass Culture\u00a0!`} buttons={buttons}>
       <ViewGap gap={2}>
-        <Typo.Title4 {...getTextSemanticAttrs('h2')}>Comment ça marche&nbsp;?</Typo.Title4>
+        <Typo.Title4 {...setTextSemantic('h2')}>Comment ça marche&nbsp;?</Typo.Title4>
         <OnboardingTimeline age={userAge} />
       </ViewGap>
     </TutorialPage>

--- a/src/features/onboarding/pages/onboarding/OnboardingAgeInformation.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingAgeInformation.tsx
@@ -72,7 +72,7 @@ export const OnboardingAgeInformation = ({ route }: Props): React.JSX.Element | 
   return (
     <TutorialPage title={`À ${userAge} ans, profite de ton pass Culture\u00a0!`} buttons={buttons}>
       <ViewGap gap={2}>
-        <Typo.Title4 {...getTextSemanticAttrs(2)}>Comment ça marche&nbsp;?</Typo.Title4>
+        <Typo.Title4 {...getTextSemanticAttrs('h2')}>Comment ça marche&nbsp;?</Typo.Title4>
         <OnboardingTimeline age={userAge} />
       </ViewGap>
     </TutorialPage>

--- a/src/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.tsx
@@ -11,7 +11,7 @@ import { storage } from 'libs/storage'
 import { AccessibleUnorderedList } from 'ui/components/accessibility/AccessibleUnorderedList'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type AgeButtonProps = {
   startButtonTitle: string
@@ -85,7 +85,7 @@ const Separator = styled.View(({ theme }) => ({
   height: theme.designSystem.size.spacing.l,
 }))
 
-const StyledTitle4 = styled(Typo.Title4).attrs(getTextSemanticAttrs('p'))(({ theme }) => ({
+const StyledTitle4 = styled(Typo.Title4).attrs(setTextSemantic('p'))(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))
 

--- a/src/features/profile/components/AccessibilityFeatures/AccessibilityFeatures.tsx
+++ b/src/features/profile/components/AccessibilityFeatures/AccessibilityFeatures.tsx
@@ -43,4 +43,4 @@ export const AccessibilityFeatures = () => (
   </React.Fragment>
 )
 
-const TitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))``
+const TitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))``

--- a/src/features/profile/components/AccessibilityFeatures/AccessibilityFeatures.tsx
+++ b/src/features/profile/components/AccessibilityFeatures/AccessibilityFeatures.tsx
@@ -7,7 +7,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { VerticalUl } from 'ui/components/Ul'
 import { Link } from 'ui/designSystem/Link/Link'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const AccessibilityFeatures = () => (
   <React.Fragment>
@@ -43,4 +43,4 @@ export const AccessibilityFeatures = () => (
   </React.Fragment>
 )
 
-const TitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))``
+const TitleText = styled(Typo.Title4).attrs(setTextSemantic('h2'))``

--- a/src/features/profile/components/ProfileContentLayout/ProfileContentLayout.tsx
+++ b/src/features/profile/components/ProfileContentLayout/ProfileContentLayout.tsx
@@ -39,7 +39,7 @@ const Container = styled(ViewGap)(({ theme }) => ({
   marginTop: theme.designSystem.size.spacing.xl,
 }))
 
-const CaptionNeutralInfo = styled(Typo.BodyAccentXs).attrs(getTextSemanticAttrs(2))(
+const CaptionNeutralInfo = styled(Typo.BodyAccentXs).attrs(getTextSemanticAttrs('h2'))(
   ({ theme }) => ({
     color: theme.designSystem.color.text.subtle,
   })

--- a/src/features/profile/components/ProfileContentLayout/ProfileContentLayout.tsx
+++ b/src/features/profile/components/ProfileContentLayout/ProfileContentLayout.tsx
@@ -7,7 +7,7 @@ import { AccessibleUnorderedList } from 'ui/components/accessibility/AccessibleU
 import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Section = {
   section: string
@@ -39,11 +39,9 @@ const Container = styled(ViewGap)(({ theme }) => ({
   marginTop: theme.designSystem.size.spacing.xl,
 }))
 
-const CaptionNeutralInfo = styled(Typo.BodyAccentXs).attrs(getTextSemanticAttrs('h2'))(
-  ({ theme }) => ({
-    color: theme.designSystem.color.text.subtle,
-  })
-)
+const CaptionNeutralInfo = styled(Typo.BodyAccentXs).attrs(setTextSemantic('h2'))(({ theme }) => ({
+  color: theme.designSystem.color.text.subtle,
+}))
 
 const StyledSeparator = styled(Separator.Horizontal)(({ theme }) => ({
   marginTop: theme.designSystem.size.spacing.s,

--- a/src/features/profile/components/Tutorial/BonificationAllStep.tsx
+++ b/src/features/profile/components/Tutorial/BonificationAllStep.tsx
@@ -37,7 +37,7 @@ import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
 import { Warning } from 'ui/svg/icons/Warning'
 import { Typo } from 'ui/theme'
 import { SPACE } from 'ui/theme/constants'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   amount: string
@@ -268,7 +268,7 @@ const StyledBody = styled(Typo.Body)(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))
 
-const StyledTitle3 = styled(Typo.Title3).attrs(getTextSemanticAttrs('p'))(({ theme }) => ({
+const StyledTitle3 = styled(Typo.Title3).attrs(setTextSemantic('p'))(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))
 
@@ -276,7 +276,7 @@ const RowView = styled.View({
   flexDirection: 'row',
 })
 
-const StyledPlus = styled(Typo.Title2).attrs(getTextSemanticAttrs('p'))(({ theme }) => ({
+const StyledPlus = styled(Typo.Title2).attrs(setTextSemantic('p'))(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))
 

--- a/src/features/profile/components/Tutorial/BonificationFamilyQuotientStep.tsx
+++ b/src/features/profile/components/Tutorial/BonificationFamilyQuotientStep.tsx
@@ -28,7 +28,7 @@ import { Lock } from 'ui/svg/icons/Lock'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
 import { Typo } from 'ui/theme'
 import { SPACE } from 'ui/theme/constants'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   amount: string
@@ -163,7 +163,7 @@ const StyledBody = styled(Typo.Body)(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))
 
-const StyledTitle3 = styled(Typo.Title3).attrs(getTextSemanticAttrs('p'))(({ theme }) => ({
+const StyledTitle3 = styled(Typo.Title3).attrs(setTextSemantic('p'))(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))
 
@@ -187,6 +187,6 @@ const Separator = styled.View(({ theme }) => ({
   height: theme.designSystem.size.spacing.l,
 }))
 
-const StyledPlus = styled(Typo.Title2).attrs(getTextSemanticAttrs('p'))(({ theme }) => ({
+const StyledPlus = styled(Typo.Title2).attrs(setTextSemantic('p'))(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))

--- a/src/features/profile/components/Tutorial/BonificationHandicapStep.tsx
+++ b/src/features/profile/components/Tutorial/BonificationHandicapStep.tsx
@@ -28,7 +28,7 @@ import { HandicapMotor } from 'ui/svg/icons/HandicapMotor'
 import { Lock } from 'ui/svg/icons/Lock'
 import { Typo } from 'ui/theme'
 import { SPACE } from 'ui/theme/constants'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = { amount: string; isLoggedIn: boolean; user?: UserProfile }
 
@@ -158,7 +158,7 @@ const StyledBody = styled(Typo.Body)(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))
 
-const StyledTitle3 = styled(Typo.Title3).attrs(getTextSemanticAttrs('p'))(({ theme }) => ({
+const StyledTitle3 = styled(Typo.Title3).attrs(setTextSemantic('p'))(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))
 
@@ -182,6 +182,6 @@ const Separator = styled.View(({ theme }) => ({
   height: theme.designSystem.size.spacing.l,
 }))
 
-const StyledPlus = styled(Typo.Title2).attrs(getTextSemanticAttrs('p'))(({ theme }) => ({
+const StyledPlus = styled(Typo.Title2).attrs(setTextSemantic('p'))(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))

--- a/src/features/profile/components/Tutorial/Credit17Step.tsx
+++ b/src/features/profile/components/Tutorial/Credit17Step.tsx
@@ -10,7 +10,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { CakeOneCandle } from 'ui/svg/icons/CakeOneCandle'
 import { Lock } from 'ui/svg/icons/Lock'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const Credit17Step = ({ amount }) => (
   <InternalStep
@@ -38,7 +38,7 @@ const StyledBody = styled(Typo.Body)(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))
 
-const StyledTitle3 = styled(Typo.Title3).attrs(getTextSemanticAttrs('p'))(({ theme }) => ({
+const StyledTitle3 = styled(Typo.Title3).attrs(setTextSemantic('p'))(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))
 

--- a/src/features/profile/components/Tutorial/Credit18Step.tsx
+++ b/src/features/profile/components/Tutorial/Credit18Step.tsx
@@ -12,7 +12,7 @@ import { CakeTwoCandles } from 'ui/svg/icons/CakeTwoCandles'
 import { Clock } from 'ui/svg/icons/Clock'
 import { Lock } from 'ui/svg/icons/Lock'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const Credit18Step = ({ amount }) => (
   <InternalStep
@@ -52,7 +52,7 @@ const StyledBody = styled(Typo.Body)(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))
 
-const StyledTitle3 = styled(Typo.Title3).attrs(getTextSemanticAttrs('p'))(({ theme }) => ({
+const StyledTitle3 = styled(Typo.Title3).attrs(setTextSemantic('p'))(({ theme }) => ({
   color: theme.designSystem.color.text.brandSecondary,
 }))
 

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileBase.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileBase.tsx
@@ -267,6 +267,6 @@ export function AccessibilityDeclarationMobileBase({
   )
 }
 
-const TitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))``
+const TitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))``
 
-const SubtitleText = styled(Typo.BodyAccent).attrs(getTextSemanticAttrs(3))``
+const SubtitleText = styled(Typo.BodyAccent).attrs(getTextSemanticAttrs('h3'))``

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileBase.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationMobileBase.tsx
@@ -15,7 +15,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Link } from 'ui/designSystem/Link/Link'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Spacer, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   appVersion: string
@@ -267,6 +267,6 @@ export function AccessibilityDeclarationMobileBase({
   )
 }
 
-const TitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))``
+const TitleText = styled(Typo.Title4).attrs(setTextSemantic('h2'))``
 
-const SubtitleText = styled(Typo.BodyAccent).attrs(getTextSemanticAttrs('h3'))``
+const SubtitleText = styled(Typo.BodyAccent).attrs(setTextSemantic('h3'))``

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
@@ -20,7 +20,7 @@ import { Link } from 'ui/designSystem/Link/Link'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Spacer, Typo } from 'ui/theme'
 import { SPACE } from 'ui/theme/constants'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const appVersion = '1.395.0'
 const auditDate = '22 juillet 2026'
@@ -431,6 +431,6 @@ export const AccessibilityDeclarationWeb = () => {
   )
 }
 
-const TitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))``
+const TitleText = styled(Typo.Title4).attrs(setTextSemantic('h2'))``
 
-const SubtitleText = styled(Typo.BodyAccent).attrs(getTextSemanticAttrs('h3'))``
+const SubtitleText = styled(Typo.BodyAccent).attrs(setTextSemantic('h3'))``

--- a/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
+++ b/src/features/profile/pages/Accessibility/AccessibilityDeclarationWeb.tsx
@@ -431,6 +431,6 @@ export const AccessibilityDeclarationWeb = () => {
   )
 }
 
-const TitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs(2))``
+const TitleText = styled(Typo.Title4).attrs(getTextSemanticAttrs('h2'))``
 
-const SubtitleText = styled(Typo.BodyAccent).attrs(getTextSemanticAttrs(3))``
+const SubtitleText = styled(Typo.BodyAccent).attrs(getTextSemanticAttrs('h3'))``

--- a/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
+++ b/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
@@ -12,7 +12,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { SearchInput } from 'ui/designSystem/SearchInput/SearchInput'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 import { useSubmitChangeAddress } from './useSubmitChangeAddress'
 
@@ -44,7 +44,7 @@ export const ChangeAddress = () => {
       scrollChildren={
         <React.Fragment>
           <Form.MaxWidth>
-            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Renseigne ton adresse</Typo.Title3>
+            <Typo.Title3 {...setTextSemantic('h2')}>Renseigne ton adresse</Typo.Title3>
             <Container>
               <Controller
                 control={control}

--- a/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
+++ b/src/features/profile/pages/ChangeAddress/ChangeAddress.tsx
@@ -44,7 +44,7 @@ export const ChangeAddress = () => {
       scrollChildren={
         <React.Fragment>
           <Form.MaxWidth>
-            <Typo.Title3 {...getTextSemanticAttrs(2)}>Renseigne ton adresse</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Renseigne ton adresse</Typo.Title3>
             <Container>
               <Controller
                 control={control}

--- a/src/features/profile/pages/ChangeCity/ChangeCity.tsx
+++ b/src/features/profile/pages/ChangeCity/ChangeCity.tsx
@@ -21,7 +21,7 @@ export const ChangeCity = () => {
       scrollChildren={
         <React.Fragment>
           <Container>
-            <Typo.Title3 {...getTextSemanticAttrs(2)}>Renseigne ta ville de résidence</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Renseigne ta ville de résidence</Typo.Title3>
           </Container>
           <Controller
             control={control}

--- a/src/features/profile/pages/ChangeCity/ChangeCity.tsx
+++ b/src/features/profile/pages/ChangeCity/ChangeCity.tsx
@@ -6,7 +6,7 @@ import { CitySearchInput } from 'features/profile/components/CitySearchInput/Cit
 import { Button } from 'ui/designSystem/Button/Button'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 import { useSubmitChangeCity } from './useSubmitChangeCity'
 
@@ -21,7 +21,7 @@ export const ChangeCity = () => {
       scrollChildren={
         <React.Fragment>
           <Container>
-            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Renseigne ta ville de résidence</Typo.Title3>
+            <Typo.Title3 {...setTextSemantic('h2')}>Renseigne ta ville de résidence</Typo.Title3>
           </Container>
           <Controller
             control={control}

--- a/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.tsx
+++ b/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.tsx
@@ -73,7 +73,7 @@ export const ChangeEmailSetPassword = () => {
       scrollChildren={
         <StyledView paddingBottom={Platform.OS === 'ios' ? keyboardHeight : 0}>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getTextSemanticAttrs(2)}>Crée ton mot de passe</Typo.Title3>
+            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Crée ton mot de passe</Typo.Title3>
             <Typo.Body>
               Tu t’es inscrit via Google, tu ne possèdes donc pas de mot de passe actuellement.
             </Typo.Body>

--- a/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.tsx
+++ b/src/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.tsx
@@ -18,7 +18,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { showErrorSnackBar, showSuccessSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type FormValues = {
   newPassword: string
@@ -73,7 +73,7 @@ export const ChangeEmailSetPassword = () => {
       scrollChildren={
         <StyledView paddingBottom={Platform.OS === 'ios' ? keyboardHeight : 0}>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getTextSemanticAttrs('h2')}>Crée ton mot de passe</Typo.Title3>
+            <Typo.Title3 {...setTextSemantic('h2')}>Crée ton mot de passe</Typo.Title3>
             <Typo.Body>
               Tu t’es inscrit via Google, tu ne possèdes donc pas de mot de passe actuellement.
             </Typo.Body>

--- a/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
+++ b/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
@@ -182,7 +182,7 @@ export const ConsentSettings = () => {
                 setSettingsCookiesChoice={setCurrentCookieChoices}
                 offerId={offerId}
               />
-              <StyledTitle4 {...getTextSemanticAttrs(2)}>Tu as la main dessus</StyledTitle4>
+              <StyledTitle4 {...getTextSemanticAttrs('h2')}>Tu as la main dessus</StyledTitle4>
               <StyledBody>
                 Ton choix est enregistré pour 6 mois et tu peux changer d’avis à tout moment.
               </StyledBody>

--- a/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
+++ b/src/features/profile/pages/ConsentSettings/ConsentSettings.tsx
@@ -36,7 +36,7 @@ import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Close } from 'ui/svg/icons/Close'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const ConsentSettings = () => {
   const { popTo, addListener, dispatch } = useNavigation<UseNavigationType>()
@@ -182,7 +182,7 @@ export const ConsentSettings = () => {
                 setSettingsCookiesChoice={setCurrentCookieChoices}
                 offerId={offerId}
               />
-              <StyledTitle4 {...getTextSemanticAttrs('h2')}>Tu as la main dessus</StyledTitle4>
+              <StyledTitle4 {...setTextSemantic('h2')}>Tu as la main dessus</StyledTitle4>
               <StyledBody>
                 Ton choix est enregistré pour 6 mois et tu peux changer d’avis à tout moment.
               </StyledBody>

--- a/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.tsx
+++ b/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.tsx
@@ -14,7 +14,7 @@ import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { SadFace } from 'ui/svg/icons/SadFace'
 import { Spacer, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const VIEWABILITY_CONFIG = { itemVisiblePercentThreshold: 100 }
 
@@ -106,7 +106,7 @@ export function DeleteProfileReason() {
             <HeaderContainer>
               <StyledIcon />
               <TitlesContainer>
-                <Typo.Title3 {...getTextSemanticAttrs('h1')}>
+                <Typo.Title3 {...setTextSemantic('h1')}>
                   Pourquoi souhaites-tu supprimer ton compte&nbsp;?
                 </Typo.Title3>
                 <Typo.Body>

--- a/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.tsx
+++ b/src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.tsx
@@ -106,7 +106,7 @@ export function DeleteProfileReason() {
             <HeaderContainer>
               <StyledIcon />
               <TitlesContainer>
-                <Typo.Title3 {...getTextSemanticAttrs(1)}>
+                <Typo.Title3 {...getTextSemanticAttrs('h1')}>
                   Pourquoi souhaites-tu supprimer ton compte&nbsp;?
                 </Typo.Title3>
                 <Typo.Body>

--- a/src/features/profile/pages/FeedbackInApp/FeedbackInApp.tsx
+++ b/src/features/profile/pages/FeedbackInApp/FeedbackInApp.tsx
@@ -19,7 +19,7 @@ import { showSuccessSnackBar, showErrorSnackBar } from 'ui/designSystem/Snackbar
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Spacer, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type FormValue = {
   feedback: string
@@ -65,7 +65,7 @@ export const FeedbackInApp = () => {
       scrollChildren={
         <StyledViewGap gap={6}>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getTextSemanticAttrs('h1')}>
+            <Typo.Title3 {...setTextSemantic('h1')}>
               Comment pourrions-nous améliorer l’application&nbsp;?
             </Typo.Title3>
             <Typo.Body>

--- a/src/features/profile/pages/FeedbackInApp/FeedbackInApp.tsx
+++ b/src/features/profile/pages/FeedbackInApp/FeedbackInApp.tsx
@@ -65,7 +65,7 @@ export const FeedbackInApp = () => {
       scrollChildren={
         <StyledViewGap gap={6}>
           <ViewGap gap={4}>
-            <Typo.Title3 {...getTextSemanticAttrs(1)}>
+            <Typo.Title3 {...getTextSemanticAttrs('h1')}>
               Comment pourrions-nous améliorer l’application&nbsp;?
             </Typo.Title3>
             <Typo.Body>

--- a/src/features/profile/pages/LegalNotices/LegalNotices.tsx
+++ b/src/features/profile/pages/LegalNotices/LegalNotices.tsx
@@ -30,7 +30,7 @@ export function LegalNotices() {
       onGoBack={goBack}
       scrollChildren={
         <Container gap={5}>
-          <Typo.Title4 {...getTextSemanticAttrs(2)}>ÉDITEUR SAS pass Culture</Typo.Title4>
+          <Typo.Title4 {...getTextSemanticAttrs('h2')}>ÉDITEUR SAS pass Culture</Typo.Title4>
           <Typo.Body>
             Éditeur du site&nbsp;:&nbsp;
             <ExternalTouchableLink

--- a/src/features/profile/pages/LegalNotices/LegalNotices.tsx
+++ b/src/features/profile/pages/LegalNotices/LegalNotices.tsx
@@ -16,7 +16,7 @@ import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Typo } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export function LegalNotices() {
   const { goBack } = useGoBack(...getTabHookConfig('Profile'))
@@ -30,7 +30,7 @@ export function LegalNotices() {
       onGoBack={goBack}
       scrollChildren={
         <Container gap={5}>
-          <Typo.Title4 {...getTextSemanticAttrs('h2')}>ÉDITEUR SAS pass Culture</Typo.Title4>
+          <Typo.Title4 {...setTextSemantic('h2')}>ÉDITEUR SAS pass Culture</Typo.Title4>
           <Typo.Body>
             Éditeur du site&nbsp;:&nbsp;
             <ExternalTouchableLink

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -31,7 +31,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { showErrorSnackBar, showSuccessSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const NotificationsSettings = () => {
   const { isLoggedIn, user } = useAuthContext()
@@ -145,7 +145,7 @@ export const NotificationsSettings = () => {
               <Banner label="Tu dois être connecté pour activer les notifications et rester informé des bons plans sur le pass Culture." />
             </BannerContainer>
           )}
-          <Typo.Title4 {...getTextSemanticAttrs('h2')}>Type d’alerte</Typo.Title4>
+          <Typo.Title4 {...setTextSemantic('h2')}>Type d’alerte</Typo.Title4>
           <TextContainer>
             <Typo.Body>
               Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
@@ -177,7 +177,7 @@ export const NotificationsSettings = () => {
               </SectionWithSwitchContainer>
             )}
             <StyledSeparator />
-            <Typo.Title4 {...getTextSemanticAttrs('h2')}>Tes thèmes suivis</Typo.Title4>
+            <Typo.Title4 {...setTextSemantic('h2')}>Tes thèmes suivis</Typo.Title4>
             {!isLoggedIn || areNotificationsEnabled ? null : (
               <BannerThemeContainer>
                 <Banner label="Pour suivre un thème, tu dois accepter l’envoi d’e-mails ou de notifications." />

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -145,7 +145,7 @@ export const NotificationsSettings = () => {
               <Banner label="Tu dois être connecté pour activer les notifications et rester informé des bons plans sur le pass Culture." />
             </BannerContainer>
           )}
-          <Typo.Title4 {...getTextSemanticAttrs(2)}>Type d’alerte</Typo.Title4>
+          <Typo.Title4 {...getTextSemanticAttrs('h2')}>Type d’alerte</Typo.Title4>
           <TextContainer>
             <Typo.Body>
               Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
@@ -177,7 +177,7 @@ export const NotificationsSettings = () => {
               </SectionWithSwitchContainer>
             )}
             <StyledSeparator />
-            <Typo.Title4 {...getTextSemanticAttrs(2)}>Tes thèmes suivis</Typo.Title4>
+            <Typo.Title4 {...getTextSemanticAttrs('h2')}>Tes thèmes suivis</Typo.Title4>
             {!isLoggedIn || areNotificationsEnabled ? null : (
               <BannerThemeContainer>
                 <Banner label="Pour suivre un thème, tu dois accepter l’envoi d’e-mails ou de notifications." />

--- a/src/features/profile/pages/TrackEmailChange/TrackEmailChange.tsx
+++ b/src/features/profile/pages/TrackEmailChange/TrackEmailChange.tsx
@@ -11,7 +11,7 @@ export const TrackEmailChange = () => (
     title="Modifier mon e-mail"
     scrollChildren={
       <React.Fragment>
-        <Typo.Title3 {...getTextSemanticAttrs(2)}>Suivi de ton changement d’e-mail</Typo.Title3>
+        <Typo.Title3 {...getTextSemanticAttrs('h2')}>Suivi de ton changement d’e-mail</Typo.Title3>
         <TrackEmailChangeContent />
       </React.Fragment>
     }

--- a/src/features/profile/pages/TrackEmailChange/TrackEmailChange.tsx
+++ b/src/features/profile/pages/TrackEmailChange/TrackEmailChange.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { TrackEmailChangeContent } from 'features/profile/pages/TrackEmailChange/TrackEmailChangeContent'
 import { PageWithHeader } from 'ui/pages/PageWithHeader'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const TrackEmailChange = () => (
   <PageWithHeader
@@ -11,7 +11,7 @@ export const TrackEmailChange = () => (
     title="Modifier mon e-mail"
     scrollChildren={
       <React.Fragment>
-        <Typo.Title3 {...getTextSemanticAttrs('h2')}>Suivi de ton changement d’e-mail</Typo.Title3>
+        <Typo.Title3 {...setTextSemantic('h2')}>Suivi de ton changement d’e-mail</Typo.Title3>
         <TrackEmailChangeContent />
       </React.Fragment>
     }

--- a/src/features/profile/pages/Tutorial/TutorialPage.tsx
+++ b/src/features/profile/pages/Tutorial/TutorialPage.tsx
@@ -7,7 +7,7 @@ import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHe
 import { EmptyHeader } from 'ui/components/headers/EmptyHeader'
 import { Page } from 'ui/pages/Page'
 import { Spacer, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   title?: string
@@ -44,7 +44,7 @@ export const TutorialPage: FunctionComponent<Props> = ({
         <Container buttons={buttons}>
           {title ? (
             <TitleContainer>
-              <Typo.Title3 numberOfLines={numberOfLines} {...getTextSemanticAttrs('h1')}>
+              <Typo.Title3 numberOfLines={numberOfLines} {...setTextSemantic('h1')}>
                 {title}
               </Typo.Title3>
             </TitleContainer>

--- a/src/features/profile/pages/Tutorial/TutorialPage.tsx
+++ b/src/features/profile/pages/Tutorial/TutorialPage.tsx
@@ -44,7 +44,7 @@ export const TutorialPage: FunctionComponent<Props> = ({
         <Container buttons={buttons}>
           {title ? (
             <TitleContainer>
-              <Typo.Title3 numberOfLines={numberOfLines} {...getTextSemanticAttrs(1)}>
+              <Typo.Title3 numberOfLines={numberOfLines} {...getTextSemanticAttrs('h1')}>
                 {title}
               </Typo.Title3>
             </TitleContainer>

--- a/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.tsx
+++ b/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.tsx
@@ -54,8 +54,8 @@ export const ProfileTutorialAgeInformationCredit = () => {
       <StyledScrollView onScroll={onScroll} scrollEventThrottle={16}>
         <Placeholder height={headerHeight} />
         <Container gap={6}>
-          <Typo.Title3 {...getTextSemanticAttrs(1)}>{headerTitle}</Typo.Title3>
-          <Typo.BodyS {...getTextSemanticAttrs(2)}>
+          <Typo.Title3 {...getTextSemanticAttrs('h1')}>{headerTitle}</Typo.Title3>
+          <Typo.BodyS {...getTextSemanticAttrs('h2')}>
             De 17 à 18 ans, le pass Culture offre un crédit à dépenser dans l’application pour des
             activités culturelles.
           </Typo.BodyS>

--- a/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.tsx
+++ b/src/features/profile/pages/TutorialAgeInformationCredit/ProfileTutorialAgeInformationCredit.tsx
@@ -22,7 +22,7 @@ import { ContentHeader } from 'ui/components/headers/ContentHeader'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Page } from 'ui/pages/Page'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const headerTitle = 'Comment ça marche\u00a0?'
 
@@ -54,8 +54,8 @@ export const ProfileTutorialAgeInformationCredit = () => {
       <StyledScrollView onScroll={onScroll} scrollEventThrottle={16}>
         <Placeholder height={headerHeight} />
         <Container gap={6}>
-          <Typo.Title3 {...getTextSemanticAttrs('h1')}>{headerTitle}</Typo.Title3>
-          <Typo.BodyS {...getTextSemanticAttrs('h2')}>
+          <Typo.Title3 {...setTextSemantic('h1')}>{headerTitle}</Typo.Title3>
+          <Typo.BodyS {...setTextSemantic('h2')}>
             De 17 à 18 ans, le pass Culture offre un crédit à dépenser dans l’application pour des
             activités culturelles.
           </Typo.BodyS>

--- a/src/features/reactions/components/ReactionChoiceModalBodyWithRedirection/ReactionChoiceModalBodyWithRedirection.tsx
+++ b/src/features/reactions/components/ReactionChoiceModalBodyWithRedirection/ReactionChoiceModalBodyWithRedirection.tsx
@@ -67,7 +67,7 @@ export const ReactionChoiceModalBodyWithRedirection: FunctionComponent<Props> = 
         renderIllutration()
       )}
 
-      <StyledTitle3 {...getTextSemanticAttrs(2)}>
+      <StyledTitle3 {...getTextSemanticAttrs('h2')}>
         Qu’as-tu pensé de tes dernières réservations&nbsp;?
       </StyledTitle3>
     </Container>

--- a/src/features/reactions/components/ReactionChoiceModalBodyWithRedirection/ReactionChoiceModalBodyWithRedirection.tsx
+++ b/src/features/reactions/components/ReactionChoiceModalBodyWithRedirection/ReactionChoiceModalBodyWithRedirection.tsx
@@ -12,7 +12,7 @@ import { OfferImage } from 'ui/components/tiles/OfferImage'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { MultipleThumbs } from 'ui/svg/icons/MultipleThumbs'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   offerImages: OfferImageBasicProps[]
@@ -67,7 +67,7 @@ export const ReactionChoiceModalBodyWithRedirection: FunctionComponent<Props> = 
         renderIllutration()
       )}
 
-      <StyledTitle3 {...getTextSemanticAttrs('h2')}>
+      <StyledTitle3 {...setTextSemantic('h2')}>
         Qu’as-tu pensé de tes dernières réservations&nbsp;?
       </StyledTitle3>
     </Container>

--- a/src/features/search/components/AutocompleteSection/AutocompleteSection.tsx
+++ b/src/features/search/components/AutocompleteSection/AutocompleteSection.tsx
@@ -6,7 +6,7 @@ import { styled } from 'styled-components/native'
 import { Li } from 'ui/components/Li'
 import { VerticalUl } from 'ui/components/Ul'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props<T> = {
   title: string
@@ -29,7 +29,7 @@ export function AutocompleteSection<T>({ title, renderItem, ...props }: Props<T>
   )
 }
 
-const Title = styled(Typo.BodyAccentXs).attrs(getTextSemanticAttrs('h2'))(({ theme }) => ({
+const Title = styled(Typo.BodyAccentXs).attrs(setTextSemantic('h2'))(({ theme }) => ({
   color: theme.designSystem.color.text.subtle,
 }))
 

--- a/src/features/search/components/AutocompleteSection/AutocompleteSection.tsx
+++ b/src/features/search/components/AutocompleteSection/AutocompleteSection.tsx
@@ -29,7 +29,7 @@ export function AutocompleteSection<T>({ title, renderItem, ...props }: Props<T>
   )
 }
 
-const Title = styled(Typo.BodyAccentXs).attrs(getTextSemanticAttrs(2))(({ theme }) => ({
+const Title = styled(Typo.BodyAccentXs).attrs(getTextSemanticAttrs('h2'))(({ theme }) => ({
   color: theme.designSystem.color.text.subtle,
 }))
 

--- a/src/features/search/components/CategoriesListDumb/CategoriesListDumb.tsx
+++ b/src/features/search/components/CategoriesListDumb/CategoriesListDumb.tsx
@@ -10,7 +10,7 @@ import { Li } from 'ui/components/Li'
 import { Ul } from 'ui/components/Ul'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   sortedCategories: ListCategoryButtonProps
@@ -137,7 +137,7 @@ const CategoriesButtonsContainer = styled(Ul)(({ theme }) => ({
 
 const CategoriesTitleV2 = styled(Typo.Title4).attrs({
   children: 'Parcours les catégories',
-  ...getTextSemanticAttrs('h2'),
+  ...setTextSemantic('h2'),
 })(({ theme }) => ({
   width: '100%',
   marginTop: theme.designSystem.size.spacing.l,

--- a/src/features/search/components/CategoriesListDumb/CategoriesListDumb.tsx
+++ b/src/features/search/components/CategoriesListDumb/CategoriesListDumb.tsx
@@ -137,7 +137,7 @@ const CategoriesButtonsContainer = styled(Ul)(({ theme }) => ({
 
 const CategoriesTitleV2 = styled(Typo.Title4).attrs({
   children: 'Parcours les catégories',
-  ...getTextSemanticAttrs(2),
+  ...getTextSemanticAttrs('h2'),
 })(({ theme }) => ({
   width: '100%',
   marginTop: theme.designSystem.size.spacing.l,

--- a/src/features/search/components/FilterSwitchWithLabel/FilterSwitchWithLabel.tsx
+++ b/src/features/search/components/FilterSwitchWithLabel/FilterSwitchWithLabel.tsx
@@ -35,7 +35,7 @@ export const FilterSwitchWithLabel: FunctionComponent<Props> = ({
   const computedAccessibilityLabel = getComputedAccessibilityLabel(label, subtitle)
 
   const TitleWithSubtitle = useMemo(() => {
-    const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs(2)
+    const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs('h2')
 
     return (
       <View {...headingProps} accessibilityLabel={computedAccessibilityLabel} accessible>

--- a/src/features/search/components/FilterSwitchWithLabel/FilterSwitchWithLabel.tsx
+++ b/src/features/search/components/FilterSwitchWithLabel/FilterSwitchWithLabel.tsx
@@ -8,7 +8,7 @@ import FilterSwitch from 'ui/components/FilterSwitch'
 import { InputLabel } from 'ui/components/InputLabel/InputLabel'
 import { styledInputLabel } from 'ui/components/InputLabel/styledInputLabel'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   isActive: boolean
@@ -35,7 +35,7 @@ export const FilterSwitchWithLabel: FunctionComponent<Props> = ({
   const computedAccessibilityLabel = getComputedAccessibilityLabel(label, subtitle)
 
   const TitleWithSubtitle = useMemo(() => {
-    const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs('h2')
+    const headingProps = Platform.OS === 'web' ? {} : setTextSemantic('h2')
 
     return (
       <View {...headingProps} accessibilityLabel={computedAccessibilityLabel} accessible>

--- a/src/features/search/components/NoSearchResult/NoSearchResult.tsx
+++ b/src/features/search/components/NoSearchResult/NoSearchResult.tsx
@@ -112,7 +112,7 @@ const ContainerText = styled.View(({ theme }) => ({
 }))
 
 const Title = styled(Typo.Title4).attrs({
-  ...getTextSemanticAttrs(2),
+  ...getTextSemanticAttrs('h2'),
 })(({ theme }) => ({
   marginTop: theme.designSystem.size.spacing.l,
 }))

--- a/src/features/search/components/NoSearchResult/NoSearchResult.tsx
+++ b/src/features/search/components/NoSearchResult/NoSearchResult.tsx
@@ -10,7 +10,7 @@ import { SuggestedPlace } from 'libs/place/types'
 import { Button } from 'ui/designSystem/Button/Button'
 import { NoOffer } from 'ui/svg/icons/NoOffer'
 import { Typo, getSpacing } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type NoSearchResultProps = {
   setSelectedLocationMode: (locationMode: LocationMode) => void
@@ -112,7 +112,7 @@ const ContainerText = styled.View(({ theme }) => ({
 }))
 
 const Title = styled(Typo.Title4).attrs({
-  ...getTextSemanticAttrs('h2'),
+  ...setTextSemantic('h2'),
 })(({ theme }) => ({
   marginTop: theme.designSystem.size.spacing.l,
 }))

--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -252,7 +252,7 @@ export const SearchBox: React.FunctionComponent<Props> = ({
   return (
     <RowContainer>
       {accessibleHiddenTitle ? (
-        <HiddenAccessibleText {...getTextSemanticAttrs(1)}>
+        <HiddenAccessibleText {...getTextSemanticAttrs('h1')}>
           {accessibleHiddenTitle}
         </HiddenAccessibleText>
       ) : null}

--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -26,7 +26,7 @@ import { Button } from 'ui/designSystem/Button/Button'
 import { SearchInput } from 'ui/designSystem/SearchInput/SearchInput'
 import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const SEARCH_DEBOUNCE_MS = 500
 
@@ -252,7 +252,7 @@ export const SearchBox: React.FunctionComponent<Props> = ({
   return (
     <RowContainer>
       {accessibleHiddenTitle ? (
-        <HiddenAccessibleText {...getTextSemanticAttrs('h1')}>
+        <HiddenAccessibleText {...setTextSemantic('h1')}>
           {accessibleHiddenTitle}
         </HiddenAccessibleText>
       ) : null}

--- a/src/features/search/components/SearchCustomModalHeader.tsx
+++ b/src/features/search/components/SearchCustomModalHeader.tsx
@@ -12,7 +12,7 @@ import { CloseButton } from 'ui/components/headers/CloseButton'
 import { Button } from 'ui/designSystem/Button/Button'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Typo, getSpacing } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 interface Props {
   title: string
@@ -53,7 +53,7 @@ export const SearchCustomModalHeader: React.FC<Props> = ({
             />
           ) : null}
         </ButtonContainer>
-        <StyledTitle4 numberOfLines={numberOfLine} nativeID={titleId} {...getTextSemanticAttrs('h1')}>
+        <StyledTitle4 numberOfLines={numberOfLine} nativeID={titleId} {...setTextSemantic('h1')}>
           {title}
         </StyledTitle4>
         <ButtonContainer positionInHeader="right" testID="close-button-container">

--- a/src/features/search/components/SearchCustomModalHeader.tsx
+++ b/src/features/search/components/SearchCustomModalHeader.tsx
@@ -53,7 +53,7 @@ export const SearchCustomModalHeader: React.FC<Props> = ({
             />
           ) : null}
         </ButtonContainer>
-        <StyledTitle4 numberOfLines={numberOfLine} nativeID={titleId} {...getTextSemanticAttrs(1)}>
+        <StyledTitle4 numberOfLines={numberOfLine} nativeID={titleId} {...getTextSemanticAttrs('h1')}>
           {title}
         </StyledTitle4>
         <ButtonContainer positionInHeader="right" testID="close-button-container">

--- a/src/features/search/components/SearchHistory/SearchHistory.tsx
+++ b/src/features/search/components/SearchHistory/SearchHistory.tsx
@@ -55,7 +55,7 @@ const StyledVerticalUl = styled(VerticalUl)(({ theme }) => ({
   marginTop: theme.designSystem.size.spacing.l,
 }))
 
-const SearchHistoryTitleText = styled(Typo.BodyAccentXs).attrs(getTextSemanticAttrs(2))(
+const SearchHistoryTitleText = styled(Typo.BodyAccentXs).attrs(getTextSemanticAttrs('h2'))(
   ({ theme }) => ({
     color: theme.designSystem.color.text.subtle,
   })

--- a/src/features/search/components/SearchHistory/SearchHistory.tsx
+++ b/src/features/search/components/SearchHistory/SearchHistory.tsx
@@ -10,7 +10,7 @@ import { Touchable } from 'ui/components/touchable/Touchable'
 import { VerticalUl } from 'ui/components/Ul'
 import { Close as DefaultClose } from 'ui/svg/icons/Close'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   history: HistoryItem[]
@@ -55,7 +55,7 @@ const StyledVerticalUl = styled(VerticalUl)(({ theme }) => ({
   marginTop: theme.designSystem.size.spacing.l,
 }))
 
-const SearchHistoryTitleText = styled(Typo.BodyAccentXs).attrs(getTextSemanticAttrs('h2'))(
+const SearchHistoryTitleText = styled(Typo.BodyAccentXs).attrs(setTextSemantic('h2'))(
   ({ theme }) => ({
     color: theme.designSystem.color.text.subtle,
   })

--- a/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
+++ b/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
@@ -21,7 +21,7 @@ import { ImageTile } from 'ui/components/ImageTile'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Tag } from 'ui/designSystem/Tag/Tag'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface SearchVenueItemProps {
   venue: AlgoliaVenue
@@ -54,7 +54,7 @@ const UnmemoizedSearchVenueItem = ({
   const { lat, lng } = venue._geoloc
   const distance = getDistance({ lat, lng }, { userLocation, selectedPlace, selectedLocationMode })
 
-  const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs('h3')
+  const headingProps = Platform.OS === 'web' ? {} : setTextSemantic('h3')
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.VENUE, {
     ...venue,
     distance: distance ? `à ${distance}` : undefined,

--- a/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
+++ b/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
@@ -54,7 +54,7 @@ const UnmemoizedSearchVenueItem = ({
   const { lat, lng } = venue._geoloc
   const distance = getDistance({ lat, lng }, { userLocation, selectedPlace, selectedLocationMode })
 
-  const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs(3)
+  const headingProps = Platform.OS === 'web' ? {} : getTextSemanticAttrs('h3')
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.VENUE, {
     ...venue,
     distance: distance ? `à ${distance}` : undefined,

--- a/src/features/search/pages/ThematicSearch/ThematicSearchSubcategories.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearchSubcategories.tsx
@@ -16,7 +16,7 @@ import { SubcategoryButton } from 'ui/components/buttons/SubcategoryButton/Subca
 import { ContentHeader } from 'ui/components/headers/ContentHeader'
 import { Page } from 'ui/pages/Page'
 import { Spacer, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const TITLE = 'Tout parcourir'
 const MOBILE_MIN_WIDTH = '40%'
@@ -72,7 +72,7 @@ export const ThematicSearchSubcategories = () => {
     <Page>
       <StyledScrollView onScroll={onScroll} scrollEventThrottle={16}>
         <Placeholder height={headerHeight} />
-        <Title {...getTextSemanticAttrs('h1')}>{TITLE}</Title>
+        <Title {...setTextSemantic('h1')}>{TITLE}</Title>
         <SubcategoryButtonsContainer>
           {subcategoryButtonContent.map((item) => (
             <StyledSubcategoryButton

--- a/src/features/search/pages/ThematicSearch/ThematicSearchSubcategories.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearchSubcategories.tsx
@@ -72,7 +72,7 @@ export const ThematicSearchSubcategories = () => {
     <Page>
       <StyledScrollView onScroll={onScroll} scrollEventThrottle={16}>
         <Placeholder height={headerHeight} />
-        <Title {...getTextSemanticAttrs(1)}>{TITLE}</Title>
+        <Title {...getTextSemanticAttrs('h1')}>{TITLE}</Title>
         <SubcategoryButtonsContainer>
           {subcategoryButtonContent.map((item) => (
             <StyledSubcategoryButton

--- a/src/features/share/components/MessagingApps/MessagingApps.tsx
+++ b/src/features/share/components/MessagingApps/MessagingApps.tsx
@@ -36,7 +36,7 @@ export const MessagingApps = ({ shareContent, share, messagingAppAnalytics }: Pr
 
   return (
     <ViewGap gap={4}>
-      <Typo.Title3 {...getTextSemanticAttrs(2)}>{'Passe le bon plan\u00a0!'}</Typo.Title3>
+      <Typo.Title3 {...getTextSemanticAttrs('h2')}>{'Passe le bon plan\u00a0!'}</Typo.Title3>
       <IconsWrapper>
         <StyledUl>
           <InstalledMessagingApps

--- a/src/features/share/components/MessagingApps/MessagingApps.tsx
+++ b/src/features/share/components/MessagingApps/MessagingApps.tsx
@@ -11,7 +11,7 @@ import { ShareMessagingAppOther } from 'ui/components/ShareMessagingAppOther'
 import { Ul } from 'ui/components/Ul'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   shareContent: ShareContent
@@ -36,7 +36,7 @@ export const MessagingApps = ({ shareContent, share, messagingAppAnalytics }: Pr
 
   return (
     <ViewGap gap={4}>
-      <Typo.Title3 {...getTextSemanticAttrs('h2')}>{'Passe le bon plan\u00a0!'}</Typo.Title3>
+      <Typo.Title3 {...setTextSemantic('h2')}>{'Passe le bon plan\u00a0!'}</Typo.Title3>
       <IconsWrapper>
         <StyledUl>
           <InstalledMessagingApps

--- a/src/features/subscription/components/ThematicSubscriptionBlock.tsx
+++ b/src/features/subscription/components/ThematicSubscriptionBlock.tsx
@@ -37,7 +37,7 @@ export const ThematicSubscriptionBlock = ({
     <Container>
       <SubscriptionThematicIllustration thematic={thematic} size="medium" />
       <ContentContainer>
-        <Typo.BodyAccent {...getTextSemanticAttrs(2)}>{title}</Typo.BodyAccent>
+        <Typo.BodyAccent {...getTextSemanticAttrs('h2')}>{title}</Typo.BodyAccent>
         <Subtitle>{subtitle}</Subtitle>
         <ButtonContainerFlexStart>
           <Button

--- a/src/features/subscription/components/ThematicSubscriptionBlock.tsx
+++ b/src/features/subscription/components/ThematicSubscriptionBlock.tsx
@@ -10,7 +10,7 @@ import { ButtonContainerFlexStart } from 'ui/designSystem/Button/ButtonContainer
 import { Bell } from 'ui/svg/icons/Bell'
 import { BellFilled } from 'ui/svg/icons/BellFilled'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   thematic: SubscriptionTheme
@@ -37,7 +37,7 @@ export const ThematicSubscriptionBlock = ({
     <Container>
       <SubscriptionThematicIllustration thematic={thematic} size="medium" />
       <ContentContainer>
-        <Typo.BodyAccent {...getTextSemanticAttrs('h2')}>{title}</Typo.BodyAccent>
+        <Typo.BodyAccent {...setTextSemantic('h2')}>{title}</Typo.BodyAccent>
         <Subtitle>{subtitle}</Subtitle>
         <ButtonContainerFlexStart>
           <Button

--- a/src/features/venue/components/Placeholders/NoOfferPlaceholder.tsx
+++ b/src/features/venue/components/Placeholders/NoOfferPlaceholder.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { NoOffer } from 'ui/svg/icons/NoOffer'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   isOpenToPublic: boolean
@@ -13,7 +13,7 @@ type Props = {
 export const NoOfferPlaceholder = ({ isOpenToPublic }: Props) => (
   <Container gap={2}>
     <NoOfferIllustration />
-    <Text {...getTextSemanticAttrs('p')}>
+    <Text {...setTextSemantic('p')}>
       {isOpenToPublic
         ? 'Il n’y a pas encore d’offre disponible dans ce lieu'
         : 'Cette structure ne propose pas encore d’offre'}

--- a/src/features/venue/components/PracticalInformation/PracticalInformation.tsx
+++ b/src/features/venue/components/PracticalInformation/PracticalInformation.tsx
@@ -9,7 +9,7 @@ import { BasicAccessibilityInfo } from 'ui/components/accessibility/BasicAccessi
 import { DetailedAccessibilityInfo } from 'ui/components/accessibility/DetailedAccessibilityInfo'
 import { Separator } from 'ui/components/Separator'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 import { OpeningHours } from '../OpeningHours/OpeningHours'
 
@@ -135,7 +135,7 @@ const SectionComponent: FunctionComponent<{ title: string; children?: ReactNode 
   children,
 }) => (
   <StyledViewGap>
-    <Typo.BodyAccentXs {...getTextSemanticAttrs('h2')}>{title}</Typo.BodyAccentXs>
+    <Typo.BodyAccentXs {...setTextSemantic('h2')}>{title}</Typo.BodyAccentXs>
     {children}
   </StyledViewGap>
 )

--- a/src/features/venue/components/PracticalInformation/PracticalInformation.tsx
+++ b/src/features/venue/components/PracticalInformation/PracticalInformation.tsx
@@ -135,7 +135,7 @@ const SectionComponent: FunctionComponent<{ title: string; children?: ReactNode 
   children,
 }) => (
   <StyledViewGap>
-    <Typo.BodyAccentXs {...getTextSemanticAttrs(2)}>{title}</Typo.BodyAccentXs>
+    <Typo.BodyAccentXs {...getTextSemanticAttrs('h2')}>{title}</Typo.BodyAccentXs>
     {children}
   </StyledViewGap>
 )

--- a/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.tsx
+++ b/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.tsx
@@ -12,7 +12,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Button } from 'ui/designSystem/Button/Button'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   venue: VenueResponse
@@ -38,7 +38,7 @@ export const VenueAdvicesSection: FunctionComponent<Props> = ({
   return (
     <Container gap={4}>
       <Gutter>
-        <StyledTitle3 {...getTextSemanticAttrs('h3')} numberOfLines={2}>
+        <StyledTitle3 {...setTextSemantic('h3')} numberOfLines={2}>
           {`Les avis par “${venue.name}”`}
         </StyledTitle3>
       </Gutter>

--- a/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.tsx
+++ b/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.tsx
@@ -38,7 +38,7 @@ export const VenueAdvicesSection: FunctionComponent<Props> = ({
   return (
     <Container gap={4}>
       <Gutter>
-        <StyledTitle3 {...getTextSemanticAttrs(3)} numberOfLines={2}>
+        <StyledTitle3 {...getTextSemanticAttrs('h3')} numberOfLines={2}>
           {`Les avis par “${venue.name}”`}
         </StyledTitle3>
       </Gutter>

--- a/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.web.tsx
+++ b/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.web.tsx
@@ -15,7 +15,7 @@ import { TagVariant } from 'ui/designSystem/Tag/types'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
 import { Show } from 'ui/svg/icons/Show'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   venue: VenueResponse
@@ -44,7 +44,7 @@ export const VenueAdvicesSection: FunctionComponent<Props> = ({
   const TitleContent = (
     <Row>
       <StyledTitle3
-        {...getTextSemanticAttrs('h3')}
+        {...setTextSemantic('h3')}
         numberOfLines={2}
         enableNewTagProAdvices={enableNewTagProAdvices}>
         {`Les avis par “${venue.name}”`}

--- a/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.web.tsx
+++ b/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.web.tsx
@@ -44,7 +44,7 @@ export const VenueAdvicesSection: FunctionComponent<Props> = ({
   const TitleContent = (
     <Row>
       <StyledTitle3
-        {...getTextSemanticAttrs(3)}
+        {...getTextSemanticAttrs('h3')}
         numberOfLines={2}
         enableNewTagProAdvices={enableNewTagProAdvices}>
         {`Les avis par “${venue.name}”`}

--- a/src/features/venue/components/VenueBody/VenueBody.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.tsx
@@ -20,7 +20,7 @@ import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   venue: VenueResponse
@@ -93,7 +93,7 @@ export const VenueBody: FunctionComponent<Props> = ({
       <React.Fragment>
         {headlineOfferData ? (
           <MarginContainer>
-            <StyledTitle3 {...getTextSemanticAttrs('h2')}>À la une</StyledTitle3>
+            <StyledTitle3 {...setTextSemantic('h2')}>À la une</StyledTitle3>
             <HeadlineOffer
               navigateTo={{ screen: 'Offer', params: { id: headlineOfferData.id } }}
               {...headlineOfferData}

--- a/src/features/venue/components/VenueBody/VenueBody.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.tsx
@@ -93,7 +93,7 @@ export const VenueBody: FunctionComponent<Props> = ({
       <React.Fragment>
         {headlineOfferData ? (
           <MarginContainer>
-            <StyledTitle3 {...getTextSemanticAttrs(2)}>À la une</StyledTitle3>
+            <StyledTitle3 {...getTextSemanticAttrs('h2')}>À la une</StyledTitle3>
             <HeadlineOffer
               navigateTo={{ screen: 'Offer', params: { id: headlineOfferData.id } }}
               {...headlineOfferData}

--- a/src/features/venue/components/VenueOffers/VenueMovies.tsx
+++ b/src/features/venue/components/VenueOffers/VenueMovies.tsx
@@ -116,7 +116,7 @@ const Container = styled.View(({ theme }) => ({
     : theme.designSystem.size.spacing.xl,
 }))
 
-const StyledTitle3 = styled(Typo.Title3).attrs(getTextSemanticAttrs(2))(({ theme }) => ({
+const StyledTitle3 = styled(Typo.Title3).attrs(getTextSemanticAttrs('h2'))(({ theme }) => ({
   marginLeft: theme.designSystem.size.spacing.xl,
 }))
 

--- a/src/features/venue/components/VenueOffers/VenueMovies.tsx
+++ b/src/features/venue/components/VenueOffers/VenueMovies.tsx
@@ -18,7 +18,7 @@ import { useScrollToAnchor } from 'ui/components/anchor/AnchorContext'
 import { PassPlaylist } from 'ui/components/PassPlaylist'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 import { LENGTH_M, RATIO_HOME_IMAGE, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const cinemaCTAButtonName = 'Accéder aux séances'
 const playlistTitle = 'Les autres offres'
@@ -116,7 +116,7 @@ const Container = styled.View(({ theme }) => ({
     : theme.designSystem.size.spacing.xl,
 }))
 
-const StyledTitle3 = styled(Typo.Title3).attrs(getTextSemanticAttrs('h2'))(({ theme }) => ({
+const StyledTitle3 = styled(Typo.Title3).attrs(setTextSemantic('h2'))(({ theme }) => ({
   marginLeft: theme.designSystem.size.spacing.xl,
 }))
 

--- a/src/features/venue/components/VenueOffers/VenueMoviesV2.tsx
+++ b/src/features/venue/components/VenueOffers/VenueMoviesV2.tsx
@@ -18,7 +18,7 @@ import { useScrollToAnchor } from 'ui/components/anchor/AnchorContext'
 import { PassPlaylist } from 'ui/components/PassPlaylist'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 import { LENGTH_M, RATIO_HOME_IMAGE, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const cinemaCTAButtonName = 'Accéder aux séances'
 const playlistTitle = 'Les autres offres'
@@ -117,7 +117,7 @@ const Container = styled.View(({ theme }) => ({
     : theme.designSystem.size.spacing.xl,
 }))
 
-const StyledTitle3 = styled(Typo.Title3).attrs(getTextSemanticAttrs('h2'))(({ theme }) => ({
+const StyledTitle3 = styled(Typo.Title3).attrs(setTextSemantic('h2'))(({ theme }) => ({
   marginLeft: theme.designSystem.size.spacing.xl,
 }))
 

--- a/src/features/venue/components/VenueOffers/VenueMoviesV2.tsx
+++ b/src/features/venue/components/VenueOffers/VenueMoviesV2.tsx
@@ -117,7 +117,7 @@ const Container = styled.View(({ theme }) => ({
     : theme.designSystem.size.spacing.xl,
 }))
 
-const StyledTitle3 = styled(Typo.Title3).attrs(getTextSemanticAttrs(2))(({ theme }) => ({
+const StyledTitle3 = styled(Typo.Title3).attrs(getTextSemanticAttrs('h2'))(({ theme }) => ({
   marginLeft: theme.designSystem.size.spacing.xl,
 }))
 

--- a/src/features/venue/components/VenueOffers/VenueOffersList.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffersList.tsx
@@ -33,7 +33,7 @@ import { CustomListRenderItem } from 'ui/components/Playlist'
 import { SeeAllButton } from 'ui/components/SeeAllButton/SeeAllButton'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { getSpacing, LENGTH_M, RATIO_HOME_IMAGE, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const keyExtractor = (item: Offer) => item.objectID
 
@@ -218,7 +218,7 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
         <ArtistsPlaylistContainer gap={2}>
           <SeeAllButtonContainer gap={3}>
             <TitleContainer>
-              <Typo.Title3 {...getTextSemanticAttrs('h2')}>{playlistTitle}</Typo.Title3>
+              <Typo.Title3 {...setTextSemantic('h2')}>{playlistTitle}</Typo.Title3>
             </TitleContainer>
             {artists.length > 1 ? (
               <View>

--- a/src/features/venue/components/VenueOffers/VenueOffersList.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffersList.tsx
@@ -218,7 +218,7 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
         <ArtistsPlaylistContainer gap={2}>
           <SeeAllButtonContainer gap={3}>
             <TitleContainer>
-              <Typo.Title3 {...getTextSemanticAttrs(2)}>{playlistTitle}</Typo.Title3>
+              <Typo.Title3 {...getTextSemanticAttrs('h2')}>{playlistTitle}</Typo.Title3>
             </TitleContainer>
             {artists.length > 1 ? (
               <View>

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
@@ -20,7 +20,7 @@ import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { GroupTags } from 'ui/GroupTags/GroupTags'
 import { Typo, getSpacing } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   venue: VenueResponse
@@ -160,7 +160,7 @@ const TopContainer = styled.View<{ hasVolunteer?: boolean }>(({ theme, hasVolunt
   }
 })
 
-const VenueTitle = styled(Typo.Title3).attrs(getTextSemanticAttrs('h1'))``
+const VenueTitle = styled(Typo.Title3).attrs(setTextSemantic('h1'))``
 
 const MarginContainer = styled.View(({ theme }) => ({
   marginLeft: theme.isDesktopViewport ? getSpacing(13.5) : theme.designSystem.size.spacing.xl,

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
@@ -160,7 +160,7 @@ const TopContainer = styled.View<{ hasVolunteer?: boolean }>(({ theme, hasVolunt
   }
 })
 
-const VenueTitle = styled(Typo.Title3).attrs(getTextSemanticAttrs(1))``
+const VenueTitle = styled(Typo.Title3).attrs(getTextSemanticAttrs('h1'))``
 
 const MarginContainer = styled.View(({ theme }) => ({
   marginLeft: theme.isDesktopViewport ? getSpacing(13.5) : theme.designSystem.size.spacing.xl,

--- a/src/libs/network/OfflinePage.tsx
+++ b/src/libs/network/OfflinePage.tsx
@@ -15,7 +15,7 @@ import { BrokenConnection as InitialBrokenConnection } from 'ui/svg/BrokenConnec
 import { Bookings } from 'ui/svg/icons/Bookings'
 import { Connect } from 'ui/svg/icons/Connect'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const OfflinePage = () => {
   const { isLoggedIn } = useAuthContext()
@@ -71,11 +71,11 @@ const Container = styled(Page)({
   alignItems: 'center',
 })
 
-const StyledTitle2 = styled(Typo.Title2).attrs(() => getTextSemanticAttrs('h1'))({
+const StyledTitle2 = styled(Typo.Title2).attrs(() => setTextSemantic('h1'))({
   textAlign: 'center',
 })
 
-const StyledBody = styled(Typo.Body).attrs(() => getTextSemanticAttrs('h2'))({
+const StyledBody = styled(Typo.Body).attrs(() => setTextSemantic('h2'))({
   textAlign: 'center',
 })
 

--- a/src/libs/network/OfflinePage.tsx
+++ b/src/libs/network/OfflinePage.tsx
@@ -71,11 +71,11 @@ const Container = styled(Page)({
   alignItems: 'center',
 })
 
-const StyledTitle2 = styled(Typo.Title2).attrs(() => getTextSemanticAttrs(1))({
+const StyledTitle2 = styled(Typo.Title2).attrs(() => getTextSemanticAttrs('h1'))({
   textAlign: 'center',
 })
 
-const StyledBody = styled(Typo.Body).attrs(() => getTextSemanticAttrs(2))({
+const StyledBody = styled(Typo.Body).attrs(() => getTextSemanticAttrs('h2'))({
   textAlign: 'center',
 })
 

--- a/src/shared/verticalPlaylist/components/VerticalPlaylistOffersView.tsx
+++ b/src/shared/verticalPlaylist/components/VerticalPlaylistOffersView.tsx
@@ -158,7 +158,7 @@ export const VerticalPlaylistOffersView = ({
           <React.Fragment>
             <Placeholder height={headerHeight} />
 
-            <Typo.Title2 {...getTextSemanticAttrs(1)}>{title}</Typo.Title2>
+            <Typo.Title2 {...getTextSemanticAttrs('h1')}>{title}</Typo.Title2>
             {artist ? (
               <InternalTouchableLink
                 navigateTo={{ screen: 'Artist', params: { id: artist.id } }}

--- a/src/shared/verticalPlaylist/components/VerticalPlaylistOffersView.tsx
+++ b/src/shared/verticalPlaylist/components/VerticalPlaylistOffersView.tsx
@@ -30,7 +30,7 @@ import { Page } from 'ui/pages/Page'
 import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { RATIO_HOME_IMAGE, Spacer, Typo } from 'ui/theme'
 import { AVATAR_SMALL } from 'ui/theme/constants'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const isWeb = Platform.OS === 'web'
 const numColumns = 2
@@ -158,7 +158,7 @@ export const VerticalPlaylistOffersView = ({
           <React.Fragment>
             <Placeholder height={headerHeight} />
 
-            <Typo.Title2 {...getTextSemanticAttrs('h1')}>{title}</Typo.Title2>
+            <Typo.Title2 {...setTextSemantic('h1')}>{title}</Typo.Title2>
             {artist ? (
               <InternalTouchableLink
                 navigateTo={{ screen: 'Artist', params: { id: artist.id } }}

--- a/src/shared/verticalPlaylist/pages/VerticalPlaylistArtists.tsx
+++ b/src/shared/verticalPlaylist/pages/VerticalPlaylistArtists.tsx
@@ -47,7 +47,7 @@ export const VerticalPlaylistArtists = () => {
         ListHeaderComponent={
           <React.Fragment>
             <Placeholder height={headerHeight} />
-            <Typo.Title2 {...getTextSemanticAttrs(1)}>{title}</Typo.Title2>
+            <Typo.Title2 {...getTextSemanticAttrs('h1')}>{title}</Typo.Title2>
             {subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
             <TitleContainer>
               <NumberOfItems nbItems={nbItems} type="artists" />

--- a/src/shared/verticalPlaylist/pages/VerticalPlaylistArtists.tsx
+++ b/src/shared/verticalPlaylist/pages/VerticalPlaylistArtists.tsx
@@ -15,7 +15,7 @@ import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition
 import { ContentHeader } from 'ui/components/headers/ContentHeader'
 import { Page } from 'ui/pages/Page'
 import { Spacer, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const VerticalPlaylistArtists = () => {
   const headerHeight = useGetHeaderHeight()
@@ -47,7 +47,7 @@ export const VerticalPlaylistArtists = () => {
         ListHeaderComponent={
           <React.Fragment>
             <Placeholder height={headerHeight} />
-            <Typo.Title2 {...getTextSemanticAttrs('h1')}>{title}</Typo.Title2>
+            <Typo.Title2 {...setTextSemantic('h1')}>{title}</Typo.Title2>
             {subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
             <TitleContainer>
               <NumberOfItems nbItems={nbItems} type="artists" />

--- a/src/shared/verticalPlaylist/pages/VerticalPlaylistVenues.tsx
+++ b/src/shared/verticalPlaylist/pages/VerticalPlaylistVenues.tsx
@@ -79,7 +79,7 @@ export const VerticalPlaylistVenues = () => {
         ListHeaderComponent={
           <React.Fragment>
             <Placeholder height={headerHeight} />
-            <Typo.Title2 {...getTextSemanticAttrs(1)}>{title}</Typo.Title2>
+            <Typo.Title2 {...getTextSemanticAttrs('h1')}>{title}</Typo.Title2>
             {subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
             <TitleContainer>
               <NumberOfItems nbItems={nbItems} type="venues" />

--- a/src/shared/verticalPlaylist/pages/VerticalPlaylistVenues.tsx
+++ b/src/shared/verticalPlaylist/pages/VerticalPlaylistVenues.tsx
@@ -16,7 +16,7 @@ import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition
 import { ContentHeader } from 'ui/components/headers/ContentHeader'
 import { Page } from 'ui/pages/Page'
 import { Spacer, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const VerticalPlaylistVenues = () => {
   const { params } = useRoute<UseRouteType<'VerticalPlaylistVenues'>>()
@@ -79,7 +79,7 @@ export const VerticalPlaylistVenues = () => {
         ListHeaderComponent={
           <React.Fragment>
             <Placeholder height={headerHeight} />
-            <Typo.Title2 {...getTextSemanticAttrs('h1')}>{title}</Typo.Title2>
+            <Typo.Title2 {...setTextSemantic('h1')}>{title}</Typo.Title2>
             {subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
             <TitleContainer>
               <NumberOfItems nbItems={nbItems} type="venues" />

--- a/src/ui/components/Accordion.tsx
+++ b/src/ui/components/Accordion.tsx
@@ -137,7 +137,7 @@ export const Accordion = ({
           {...focusProps}
           {...accessibilityProps}>
           <StyledTitleContainer nativeID={accordionLabelId} style={titleStyle}>
-            <Title {...getTextSemanticAttrs(3)}>{title}</Title>
+            <Title {...getTextSemanticAttrs('h3')}>{title}</Title>
             <StyledArrowAnimatedView
               style={{ transform: [{ rotateZ: arrowAngle }] }}
               testID="accordionArrow">

--- a/src/ui/components/Accordion.tsx
+++ b/src/ui/components/Accordion.tsx
@@ -20,7 +20,7 @@ import { extractTextFromReactNode } from 'shared/extractTextFromReactNode/extrac
 import { ANIMATION_USE_NATIVE_DRIVER } from 'ui/components/animationUseNativeDriver'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 import { ArrowNext as DefaultArrowNext } from '../svg/icons/ArrowNext'
 import { Typo } from '../theme'
@@ -137,7 +137,7 @@ export const Accordion = ({
           {...focusProps}
           {...accessibilityProps}>
           <StyledTitleContainer nativeID={accordionLabelId} style={titleStyle}>
-            <Title {...getTextSemanticAttrs('h3')}>{title}</Title>
+            <Title {...setTextSemantic('h3')}>{title}</Title>
             <StyledArrowAnimatedView
               style={{ transform: [{ rotateZ: arrowAngle }] }}
               testID="accordionArrow">

--- a/src/ui/components/ActionCardBase.tsx
+++ b/src/ui/components/ActionCardBase.tsx
@@ -72,7 +72,7 @@ export const ActionCardBase: FunctionComponent<Props> = ({
         </DateText>
       ) : null}
       {title ? (
-        <Title testID="firstLine" numberOfLines={3} {...getTextSemanticAttrs(2)}>
+        <Title testID="firstLine" numberOfLines={3} {...getTextSemanticAttrs('h2')}>
           {title}
         </Title>
       ) : null}

--- a/src/ui/components/ActionCardBase.tsx
+++ b/src/ui/components/ActionCardBase.tsx
@@ -9,7 +9,7 @@ import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ArrowRight } from 'ui/svg/icons/ArrowRight'
 import { Typo } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type ActionCardLayout = 'split' | 'overlay'
 
@@ -72,12 +72,12 @@ export const ActionCardBase: FunctionComponent<Props> = ({
         </DateText>
       ) : null}
       {title ? (
-        <Title testID="firstLine" numberOfLines={3} {...getTextSemanticAttrs('h2')}>
+        <Title testID="firstLine" numberOfLines={3} {...setTextSemantic('h2')}>
           {title}
         </Title>
       ) : null}
       {subtitle ? (
-        <Subtitle testID="secondLine" numberOfLines={3} {...getTextSemanticAttrs('p')}>
+        <Subtitle testID="secondLine" numberOfLines={3} {...setTextSemantic('p')}>
           {subtitle}
         </Subtitle>
       ) : null}

--- a/src/ui/components/PassPlaylist.tsx
+++ b/src/ui/components/PassPlaylist.tsx
@@ -12,7 +12,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Tag } from 'ui/designSystem/Tag/Tag'
 import { TagVariant } from 'ui/designSystem/Tag/types'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 import { SeeAllButton } from './SeeAllButton/SeeAllButton'
 
@@ -144,7 +144,7 @@ const StyledViewGap = styled(ViewGap)<{ noMarginBottom?: boolean }>(
   })
 )
 
-const TitleLevel2 = styled(Typo.Title3).attrs(getTextSemanticAttrs('h2'))``
+const TitleLevel2 = styled(Typo.Title3).attrs(setTextSemantic('h2'))``
 
 const StyledSubtitle = styled(Typo.BodyAccentXs).attrs<{
   windowWidth?: number

--- a/src/ui/components/PassPlaylist.tsx
+++ b/src/ui/components/PassPlaylist.tsx
@@ -144,7 +144,7 @@ const StyledViewGap = styled(ViewGap)<{ noMarginBottom?: boolean }>(
   })
 )
 
-const TitleLevel2 = styled(Typo.Title3).attrs(getTextSemanticAttrs(2))``
+const TitleLevel2 = styled(Typo.Title3).attrs(getTextSemanticAttrs('h2'))``
 
 const StyledSubtitle = styled(Typo.BodyAccentXs).attrs<{
   windowWidth?: number

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonList.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonList.tsx
@@ -132,7 +132,7 @@ const Header = ({
   onBeforeSeeAllNavigate,
 }: HeaderProps) => (
   <HeaderContainer>
-    <Typo.Title4 {...getTextSemanticAttrs(2)}>Tout parcourir</Typo.Title4>
+    <Typo.Title4 {...getTextSemanticAttrs('h2')}>Tout parcourir</Typo.Title4>
     {shouldDisplaySeeAllButton && seeAllNavigateTo ? (
       <InternalTouchableLink
         as={Button}

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonList.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonList.tsx
@@ -12,7 +12,7 @@ import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { Ul } from 'ui/components/Ul'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type SubcategoryButtonListProps = {
   subcategoryButtonContent: SubcategoryButtonItem[]
@@ -132,7 +132,7 @@ const Header = ({
   onBeforeSeeAllNavigate,
 }: HeaderProps) => (
   <HeaderContainer>
-    <Typo.Title4 {...getTextSemanticAttrs('h2')}>Tout parcourir</Typo.Title4>
+    <Typo.Title4 {...setTextSemantic('h2')}>Tout parcourir</Typo.Title4>
     {shouldDisplaySeeAllButton && seeAllNavigateTo ? (
       <InternalTouchableLink
         as={Button}

--- a/src/ui/components/headers/ContentHeader.tsx
+++ b/src/ui/components/headers/ContentHeader.tsx
@@ -12,7 +12,7 @@ import { BlurryWrapper } from 'ui/components/BlurryWrapper/BlurryWrapper'
 import { Button } from 'ui/designSystem/Button/Button'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Typo, getSpacing } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type AnimatedBlurHeaderFullProps = {
   headerTitle?: string
@@ -73,7 +73,7 @@ export const ContentHeader = ({
         {LeftElement}
         <TitleContainer>
           <Title
-            {...getTextSemanticAttrs('h1')}
+            {...setTextSemantic('h1')}
             testID={titleTestID}
             style={{
               opacity: customHeaderTitleTransition ?? headerTransition,

--- a/src/ui/components/headers/ContentHeader.tsx
+++ b/src/ui/components/headers/ContentHeader.tsx
@@ -73,7 +73,7 @@ export const ContentHeader = ({
         {LeftElement}
         <TitleContainer>
           <Title
-            {...getTextSemanticAttrs(1)}
+            {...getTextSemanticAttrs('h1')}
             testID={titleTestID}
             style={{
               opacity: customHeaderTitleTransition ?? headerTransition,

--- a/src/ui/components/headers/PageHeaderWithoutPlaceholder.tsx
+++ b/src/ui/components/headers/PageHeaderWithoutPlaceholder.tsx
@@ -10,7 +10,7 @@ import { useGetHeaderHeightDS } from 'shared/header/useGetHeaderHeight'
 import { Button } from 'ui/designSystem/Button/Button'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Spacer, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   title?: string
@@ -102,7 +102,7 @@ const TitleContainer = styled.View({ flex: 1, alignItems: 'center' })
 
 const Title = styled(Typo.Title4).attrs<{ numberOfLines?: number }>(({ numberOfLines }) => ({
   numberOfLines,
-  ...getTextSemanticAttrs('h1'),
+  ...setTextSemantic('h1'),
 }))({
   textAlign: 'center',
 })

--- a/src/ui/components/headers/PageHeaderWithoutPlaceholder.tsx
+++ b/src/ui/components/headers/PageHeaderWithoutPlaceholder.tsx
@@ -102,7 +102,7 @@ const TitleContainer = styled.View({ flex: 1, alignItems: 'center' })
 
 const Title = styled(Typo.Title4).attrs<{ numberOfLines?: number }>(({ numberOfLines }) => ({
   numberOfLines,
-  ...getTextSemanticAttrs(1),
+  ...getTextSemanticAttrs('h1'),
 }))({
   textAlign: 'center',
 })

--- a/src/ui/components/modals/MarketingModal.tsx
+++ b/src/ui/components/modals/MarketingModal.tsx
@@ -12,7 +12,7 @@ import { RemoteIllustration } from 'ui/components/RemoteIllustration'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { getSpacing, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   visible: boolean
@@ -88,7 +88,7 @@ const Gradient = styled(LinearGradient).attrs<{ colors?: string[] }>(({ theme })
   marginTop: -GRADIENT_SIZE,
 })
 
-const Title = styled(Typo.Title3).attrs(() => getTextSemanticAttrs('h1'))({
+const Title = styled(Typo.Title3).attrs(() => setTextSemantic('h1'))({
   textAlign: 'center',
 })
 

--- a/src/ui/components/modals/MarketingModal.tsx
+++ b/src/ui/components/modals/MarketingModal.tsx
@@ -88,7 +88,7 @@ const Gradient = styled(LinearGradient).attrs<{ colors?: string[] }>(({ theme })
   marginTop: -GRADIENT_SIZE,
 })
 
-const Title = styled(Typo.Title3).attrs(() => getTextSemanticAttrs(1))({
+const Title = styled(Typo.Title3).attrs(() => getTextSemanticAttrs('h1'))({
   textAlign: 'center',
 })
 

--- a/src/ui/components/modals/ModalHeader.tsx
+++ b/src/ui/components/modals/ModalHeader.tsx
@@ -111,6 +111,6 @@ const HeaderActionContainer = styled.View<{ justifyContent: 'left' | 'right' }>(
   }
 )
 
-const Title = styled(Typo.Title4).attrs(() => getTextSemanticAttrs(1))({
+const Title = styled(Typo.Title4).attrs(() => getTextSemanticAttrs('h1'))({
   textAlign: 'center',
 })

--- a/src/ui/components/modals/ModalHeader.tsx
+++ b/src/ui/components/modals/ModalHeader.tsx
@@ -8,7 +8,7 @@ import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHe
 import { ModalSpacing } from 'ui/components/modals/enum'
 import { Button } from 'ui/designSystem/Button/Button'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 import { ModalIconProps } from './types'
 
@@ -111,6 +111,6 @@ const HeaderActionContainer = styled.View<{ justifyContent: 'left' | 'right' }>(
   }
 )
 
-const Title = styled(Typo.Title4).attrs(() => getTextSemanticAttrs('h1'))({
+const Title = styled(Typo.Title4).attrs(() => setTextSemantic('h1'))({
   textAlign: 'center',
 })

--- a/src/ui/designSystem/Button/ButtonBase.tsx
+++ b/src/ui/designSystem/Button/ButtonBase.tsx
@@ -12,7 +12,7 @@ import { useHandleHover } from 'libs/hooks/useHandleHover'
 import { getComputedAccessibilityLabel } from 'shared/accessibility/helpers/getComputedAccessibilityLabel'
 import { ColorsType } from 'theme/types'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 import { getButtonColors } from './Button.colors'
 import {
@@ -131,7 +131,7 @@ export const ButtonBase: FunctionComponent<ButtonBaseProps> = ({
           {leftIcon ? <IconWrapper style={iconAnimatedStyle}>{leftIcon}</IconWrapper> : null}
           {labelText ? (
             <LabelTypo
-              {...getTextSemanticAttrs('span')}
+              {...setTextSemantic('span')}
               style={labelStyle}
               numberOfLines={numberOfLines}
               ellipsizeMode={ellipsizeMode}>

--- a/src/ui/designSystem/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/ui/designSystem/CheckboxGroup/CheckboxGroup.tsx
@@ -21,7 +21,7 @@ import {
 } from 'ui/designSystem/CheckboxGroup/types'
 import { SelectableVariant } from 'ui/designSystem/types'
 import { Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const labelId = uuidv4()
 
@@ -64,7 +64,7 @@ export const CheckboxGroup = <T extends string = string>({
   }
 
   const headingAttrs = labelTagOverrideForAccessibility
-    ? getTextSemanticAttrs(labelTagOverrideForAccessibility)
+    ? setTextSemantic(labelTagOverrideForAccessibility)
     : {}
 
   return (

--- a/src/ui/designSystem/CheckboxGroup/types.ts
+++ b/src/ui/designSystem/CheckboxGroup/types.ts
@@ -7,6 +7,7 @@ import { ElementType } from 'react'
 
 import { CheckboxProps } from 'ui/designSystem/Checkbox/Checkbox'
 import { SelectableVariant } from 'ui/designSystem/types'
+import { TextSemanticLevel } from 'ui/theme/typographyAttrs/types'
 
 export type CheckboxGroupOptionSimple<T = string> = Omit<
   CheckboxProps,
@@ -37,7 +38,7 @@ export type CheckboxGroupDisplay = 'vertical' | 'horizontal'
 export type CheckboxGroupProps<T = string> = {
   label: string
   labelTag?: ElementType
-  labelTagOverrideForAccessibility?: 1 | 2 | 3
+  labelTagOverrideForAccessibility?: TextSemanticLevel
   description?: string
   error?: string
   options: CheckboxGroupOption<T>[]

--- a/src/ui/pages/GenericErrorPage.tsx
+++ b/src/ui/pages/GenericErrorPage.tsx
@@ -97,9 +97,9 @@ export const GenericErrorPage: FunctionComponent<Props> = ({
           <View>
             <IllustrationContainer>{renderIllustration()}</IllustrationContainer>
             <TextContainer gap={4}>
-              <StyledTitle {...getTextSemanticAttrs(1)}>{title}</StyledTitle>
+              <StyledTitle {...getTextSemanticAttrs('h1')}>{title}</StyledTitle>
               {subtitle ? (
-                <StyledSubtitle {...getTextSemanticAttrs(2)}>{subtitle}</StyledSubtitle>
+                <StyledSubtitle {...getTextSemanticAttrs('h2')}>{subtitle}</StyledSubtitle>
               ) : null}
             </TextContainer>
             {children ? <ChildrenContainer>{children}</ChildrenContainer> : null}

--- a/src/ui/pages/GenericErrorPage.tsx
+++ b/src/ui/pages/GenericErrorPage.tsx
@@ -12,7 +12,7 @@ import { Page } from 'ui/pages/Page'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { Typo } from 'ui/theme'
 import { illustrationSizes } from 'ui/theme/illustrationSizes'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type ButtonProps = {
   wording: string
@@ -97,9 +97,9 @@ export const GenericErrorPage: FunctionComponent<Props> = ({
           <View>
             <IllustrationContainer>{renderIllustration()}</IllustrationContainer>
             <TextContainer gap={4}>
-              <StyledTitle {...getTextSemanticAttrs('h1')}>{title}</StyledTitle>
+              <StyledTitle {...setTextSemantic('h1')}>{title}</StyledTitle>
               {subtitle ? (
-                <StyledSubtitle {...getTextSemanticAttrs('h2')}>{subtitle}</StyledSubtitle>
+                <StyledSubtitle {...setTextSemantic('h2')}>{subtitle}</StyledSubtitle>
               ) : null}
             </TextContainer>
             {children ? <ChildrenContainer>{children}</ChildrenContainer> : null}

--- a/src/ui/pages/GenericInfoPage.tsx
+++ b/src/ui/pages/GenericInfoPage.tsx
@@ -162,8 +162,8 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
               {animation ? animationContent : null}
             </IllustrationContainer>
             <TextContainer gap={4} flex={flexMobile}>
-              <StyledTitle2 {...getTextSemanticAttrs(1)}>{title}</StyledTitle2>
-              {subtitle ? <StyledBody {...getTextSemanticAttrs(2)}>{subtitle}</StyledBody> : null}
+              <StyledTitle2 {...getTextSemanticAttrs('h1')}>{title}</StyledTitle2>
+              {subtitle ? <StyledBody {...getTextSemanticAttrs('h2')}>{subtitle}</StyledBody> : null}
             </TextContainer>
 
             {children ? <ChildrenContainer>{children}</ChildrenContainer> : null}

--- a/src/ui/pages/GenericInfoPage.tsx
+++ b/src/ui/pages/GenericInfoPage.tsx
@@ -24,7 +24,7 @@ import { Page } from 'ui/pages/Page'
 import { AccessibleIcon, AccessibleRectangleIcon } from 'ui/svg/icons/types'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { illustrationSizes } from 'ui/theme/illustrationSizes'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export type ButtonProps = {
   wording: string
@@ -162,8 +162,8 @@ export const GenericInfoPage: React.FunctionComponent<Props> = ({
               {animation ? animationContent : null}
             </IllustrationContainer>
             <TextContainer gap={4} flex={flexMobile}>
-              <StyledTitle2 {...getTextSemanticAttrs('h1')}>{title}</StyledTitle2>
-              {subtitle ? <StyledBody {...getTextSemanticAttrs('h2')}>{subtitle}</StyledBody> : null}
+              <StyledTitle2 {...setTextSemantic('h1')}>{title}</StyledTitle2>
+              {subtitle ? <StyledBody {...setTextSemantic('h2')}>{subtitle}</StyledBody> : null}
             </TextContainer>
 
             {children ? <ChildrenContainer>{children}</ChildrenContainer> : null}

--- a/src/ui/pages/GenericOfficialPage.tsx
+++ b/src/ui/pages/GenericOfficialPage.tsx
@@ -6,7 +6,7 @@ import { Page } from 'ui/pages/Page'
 import { LogoPassCulture } from 'ui/svg/icons/LogoPassCulture'
 import { LogoFrenchRepublic } from 'ui/svg/LogoFrenchRepublic'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type Props = {
   noIndex?: boolean
@@ -49,7 +49,7 @@ export function GenericOfficialPage({
       <Content>
         {isTouch ? <TopTouch /> : null}
         <TitleContainer>
-          <Typo.Title2 {...getTextSemanticAttrs('h1')}>{title}</Typo.Title2>
+          <Typo.Title2 {...setTextSemantic('h1')}>{title}</Typo.Title2>
         </TitleContainer>
         {children}
         {isTouch ? <BottomTouch marginTop={getButtonSpaces()} /> : null}

--- a/src/ui/pages/GenericOfficialPage.tsx
+++ b/src/ui/pages/GenericOfficialPage.tsx
@@ -49,7 +49,7 @@ export function GenericOfficialPage({
       <Content>
         {isTouch ? <TopTouch /> : null}
         <TitleContainer>
-          <Typo.Title2 {...getTextSemanticAttrs(1)}>{title}</Typo.Title2>
+          <Typo.Title2 {...getTextSemanticAttrs('h1')}>{title}</Typo.Title2>
         </TitleContainer>
         {children}
         {isTouch ? <BottomTouch marginTop={getButtonSpaces()} /> : null}

--- a/src/ui/theme/isHeadingLevel.ts
+++ b/src/ui/theme/isHeadingLevel.ts
@@ -1,7 +1,9 @@
 import { TextSemanticLevel } from 'ui/theme/typographyAttrs/types'
 
+const HEADING_LEVELS = new Set(['h1', 'h2', 'h3', 'h4'])
+
 export const isHeadingLevel = (
-  level: unknown
-): level is Exclude<TextSemanticLevel, 'p' | 'span'> => {
-  return typeof level === 'number' && [1, 2, 3, 4].includes(level)
+  level: TextSemanticLevel | undefined
+): level is 'h1' | 'h2' | 'h3' | 'h4' => {
+  return HEADING_LEVELS.has(level ?? '')
 }

--- a/src/ui/theme/typography.tsx
+++ b/src/ui/theme/typography.tsx
@@ -27,10 +27,10 @@ const createStyledText = (
 }
 
 export const Typo = {
-  Title1: createStyledText('title1', 1),
-  Title2: createStyledText('title2', 2),
-  Title3: createStyledText('title3', 3),
-  Title4: createStyledText('title4', 4),
+  Title1: createStyledText('title1', 'h1'),
+  Title2: createStyledText('title2', 'h2'),
+  Title3: createStyledText('title3', 'h3'),
+  Title4: createStyledText('title4', 'h4'),
   Body: createStyledText('body'),
   BodyS: createStyledText('bodyS'),
   BodyXs: createStyledText('bodyXs'),

--- a/src/ui/theme/typography.tsx
+++ b/src/ui/theme/typography.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/native'
 import { theme } from 'theme'
 import { TextColorKey } from 'theme/types'
 import { isHeadingLevel } from 'ui/theme/isHeadingLevel'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 import { TextSemanticLevel } from 'ui/theme/typographyAttrs/types'
 
 const DEFAULT_COLOR_TEXT = 'default'
@@ -17,8 +17,8 @@ const createStyledText = (
   return styled(RNText).attrs<{ accessibilityLevel?: TextSemanticLevel }>(
     ({ accessibilityLevel }) => {
       const level = accessibilityLevel ?? defaultLevel
-      if (isHeadingLevel(level)) return getTextSemanticAttrs(level)
-      return getTextSemanticAttrs('p')
+      if (isHeadingLevel(level)) return setTextSemantic(level)
+      return setTextSemantic('p')
     }
   )<{ color?: TextColorKey }>(({ theme, color }) => ({
     ...theme.designSystem.typography[typographyStyle],

--- a/src/ui/theme/typography.web.tsx
+++ b/src/ui/theme/typography.web.tsx
@@ -42,7 +42,7 @@ const createStyledText = (
     const level = accessibilityLevel ?? defaultLevel
     let tag: React.ElementType = 'p'
     if (level === 'span') tag = 'span'
-    else if (isHeadingLevel(level)) tag = `h${level}`
+    else if (isHeadingLevel(level)) tag = level
     return <StyledText as={tag} numberOfLines={numberOfLines} {...props} />
   }
 
@@ -51,10 +51,10 @@ const createStyledText = (
 }
 
 export const Typo = {
-  Title1: createStyledText('title1', 1),
-  Title2: createStyledText('title2', 2),
-  Title3: createStyledText('title3', 3),
-  Title4: createStyledText('title4', 4),
+  Title1: createStyledText('title1', 'h1'),
+  Title2: createStyledText('title2', 'h2'),
+  Title3: createStyledText('title3', 'h3'),
+  Title4: createStyledText('title4', 'h4'),
   Body: createStyledText('body'),
   BodyS: createStyledText('bodyS'),
   BodyXs: createStyledText('bodyXs'),

--- a/src/ui/theme/typographyAttrs/getTextSemanticAttrs.native.test.ts
+++ b/src/ui/theme/typographyAttrs/getTextSemanticAttrs.native.test.ts
@@ -4,10 +4,10 @@ import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAt
 describe('getTextSemanticAttrs()', () => {
   it.each`
     headingLevel | accessibilityLevel | accessibilityRole
-    ${1}         | ${1}               | ${AccessibilityRole.HEADER}
-    ${2}         | ${2}               | ${AccessibilityRole.HEADER}
-    ${3}         | ${3}               | ${AccessibilityRole.HEADER}
-    ${4}         | ${4}               | ${AccessibilityRole.HEADER}
+    ${'h1'}      | ${'h1'}            | ${AccessibilityRole.HEADER}
+    ${'h2'}      | ${'h2'}            | ${AccessibilityRole.HEADER}
+    ${'h3'}      | ${'h3'}            | ${AccessibilityRole.HEADER}
+    ${'h4'}      | ${'h4'}            | ${AccessibilityRole.HEADER}
     ${'p'}       | ${'p'}             | ${AccessibilityRole.TEXT}
     ${'span'}    | ${'span'}          | ${AccessibilityRole.TEXT}
   `(

--- a/src/ui/theme/typographyAttrs/setTextSemantic.native.test.ts
+++ b/src/ui/theme/typographyAttrs/setTextSemantic.native.test.ts
@@ -1,7 +1,7 @@
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
-describe('getTextSemanticAttrs()', () => {
+describe('setTextSemantic()', () => {
   it.each`
     headingLevel | accessibilityLevel | accessibilityRole
     ${'h1'}      | ${'h1'}            | ${AccessibilityRole.HEADER}
@@ -11,9 +11,9 @@ describe('getTextSemanticAttrs()', () => {
     ${'p'}       | ${'p'}             | ${AccessibilityRole.TEXT}
     ${'span'}    | ${'span'}          | ${AccessibilityRole.TEXT}
   `(
-    "getTextSemanticAttrs($headingLevel) = {accessibilityRole: $accessibilityRole, accessibilityLevel: $accessibilityLevel, dir: 'ltr'}",
+    "setTextSemantic($headingLevel) = {accessibilityRole: $accessibilityRole, accessibilityLevel: $accessibilityLevel, dir: 'ltr'}",
     ({ headingLevel, accessibilityLevel, accessibilityRole }) => {
-      expect(getTextSemanticAttrs(headingLevel)).toEqual({ accessibilityRole, accessibilityLevel })
+      expect(setTextSemantic(headingLevel)).toEqual({ accessibilityRole, accessibilityLevel })
     }
   )
 })

--- a/src/ui/theme/typographyAttrs/setTextSemantic.ts
+++ b/src/ui/theme/typographyAttrs/setTextSemantic.ts
@@ -2,7 +2,7 @@ import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { isHeadingLevel } from 'ui/theme/isHeadingLevel'
 import { HeadingAttrs, TextSemanticLevel } from 'ui/theme/typographyAttrs/types'
 
-export const getTextSemanticAttrs = (level: TextSemanticLevel): HeadingAttrs => ({
+export const setTextSemantic = (level: TextSemanticLevel): HeadingAttrs => ({
   accessibilityRole: isHeadingLevel(level) ? AccessibilityRole.HEADER : AccessibilityRole.TEXT,
   accessibilityLevel: level,
 })

--- a/src/ui/theme/typographyAttrs/setTextSemantic.web.test.ts
+++ b/src/ui/theme/typographyAttrs/setTextSemantic.web.test.ts
@@ -1,6 +1,6 @@
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
-describe('getTextSemanticAttrs()', () => {
+describe('setTextSemantic()', () => {
   it.each`
     accessibilityLevel
     ${1}
@@ -10,7 +10,7 @@ describe('getTextSemanticAttrs()', () => {
     ${'p'}
     ${'span'}
   `('should return accessibilityLevel $accessibilityLevel', ({ accessibilityLevel }) => {
-    expect(getTextSemanticAttrs(accessibilityLevel)).toEqual({
+    expect(setTextSemantic(accessibilityLevel)).toEqual({
       accessibilityRole: undefined,
       accessibilityLevel,
     })

--- a/src/ui/theme/typographyAttrs/setTextSemantic.web.ts
+++ b/src/ui/theme/typographyAttrs/setTextSemantic.web.ts
@@ -1,6 +1,6 @@
 import { HeadingAttrs, TextSemanticLevel } from 'ui/theme/typographyAttrs/types'
 
-export const getTextSemanticAttrs = (level: TextSemanticLevel): HeadingAttrs => ({
+export const setTextSemantic = (level: TextSemanticLevel): HeadingAttrs => ({
   accessibilityRole: undefined,
   accessibilityLevel: level,
 })

--- a/src/ui/theme/typographyAttrs/types.ts
+++ b/src/ui/theme/typographyAttrs/types.ts
@@ -1,6 +1,6 @@
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 
-export type TextSemanticLevel = 1 | 2 | 3 | 4 | 'p' | 'span'
+export type TextSemanticLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'p' | 'span'
 
 export type HeadingAttrs = {
   accessibilityRole?: AccessibilityRole

--- a/src/web/BrowserNotSupportedPage.web.tsx
+++ b/src/web/BrowserNotSupportedPage.web.tsx
@@ -63,8 +63,8 @@ export const BrowserNotSupportedPage: React.FC<{
           />
         </IllustrationContainer>
         <TextContainer gap={4}>
-          <StyledTitle2 {...getTextSemanticAttrs(1)}>{message?.title}</StyledTitle2>
-          <Typo.Body {...getTextSemanticAttrs(2)}>{message?.description}</Typo.Body>
+          <StyledTitle2 {...getTextSemanticAttrs('h1')}>{message?.title}</StyledTitle2>
+          <Typo.Body {...getTextSemanticAttrs('h2')}>{message?.description}</Typo.Body>
 
           <AccessibleUnorderedList
             withPadding

--- a/src/web/BrowserNotSupportedPage.web.tsx
+++ b/src/web/BrowserNotSupportedPage.web.tsx
@@ -12,7 +12,7 @@ import { Validate } from 'ui/svg/icons/Validate'
 import { Typo } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
 import { illustrationSizes } from 'ui/theme/illustrationSizes'
-import { getTextSemanticAttrs } from 'ui/theme/typographyAttrs/getTextSemanticAttrs'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 import { supportedBrowsers } from 'web/supportedBrowsers'
 
 type SupportedBrowsers = typeof supportedBrowsers
@@ -63,8 +63,8 @@ export const BrowserNotSupportedPage: React.FC<{
           />
         </IllustrationContainer>
         <TextContainer gap={4}>
-          <StyledTitle2 {...getTextSemanticAttrs('h1')}>{message?.title}</StyledTitle2>
-          <Typo.Body {...getTextSemanticAttrs('h2')}>{message?.description}</Typo.Body>
+          <StyledTitle2 {...setTextSemantic('h1')}>{message?.title}</StyledTitle2>
+          <Typo.Body {...setTextSemantic('h2')}>{message?.description}</Typo.Body>
 
           <AccessibleUnorderedList
             withPadding


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43328

## Context

- Utilisation de string ('h1', 'h2', 'h3' ou 'h4') plutot que des numbers (1, 2, 3 ou 4) pour `getTextSemanticAttrs`
- Changement de `getTextSemanticAttrs` en `setTextSemantic`

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
