### PR TITLE
(PC-43350) fix(security): semgrep subprocess-shell-true

### DIFF
--- a/scripts/set_resolution.py
+++ b/scripts/set_resolution.py
@@ -98,28 +98,28 @@ def set_resolutions(dependencies_data: str, manifest: str, package_json: str):
 
 
 def run_yarn():
-    subprocess.run(["yarn"], shell=True)
+    subprocess.run(["yarn"])
 
 
 def pull_master():
-    subprocess.run(["git switch master"], shell=True)
-    subprocess.run(["git pull"], shell=True)
+    subprocess.run(["git switch master"])
+    subprocess.run(["git pull"])
 
 
 def create_git_branch(branch: str):
-    subprocess.run([f"git switch -c {branch}"], shell=True)
+    subprocess.run([f"git switch -c {branch}"])
 
 
 def stage_modifications():
-    subprocess.run(["git add package.json yarn.lock"], shell=True)
+    subprocess.run(["git add package.json yarn.lock"])
 
 
 def commit_modifications(branch: str):
-    subprocess.run([f'git commit -m "({branch}) build(yarn): update dep"'], shell=True)
+    subprocess.run([f'git commit -m "({branch}) build(yarn): update dep"'])
 
 
 def push_modifications(branch: str):
-    subprocess.run([f"git push origin {branch}"], shell=True)
+    subprocess.run([f"git push origin {branch}"])
 
 
 def get_dependabot_alerts(manifest: str):


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43350

## Context

Correction d'une alerte semgrep, avec remplacement simple de valeur booléenne 

J'avais fais 2 tests pour assurer la correction.
Un qui injecte une erreur,  l'autre qui s'assure que l'erreur ne revient pas.
Si l'idée peut être intéressante pour valider la correction, il ne faut pas pousser les tests sur nos branches (cf. @tconte-pass)

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [NA] Made sure my feature is working on web.
- [NA] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [NA] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [NA] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [X] I am aware of all the [best practices][3] and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
