### PR TITLE
(PC-43361) fix(ui): avoid big empty space in iOS and Android on AvatarListItem

### DIFF
--- a/src/ui/components/Avatar/AvatarListItem.tsx
+++ b/src/ui/components/Avatar/AvatarListItem.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react'
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import { getLineHeightPx } from 'libs/parsers/getLineHeightPx'
@@ -44,11 +44,11 @@ export const AvatarListItem: FunctionComponent<AvatarListItemProps> = ({
   const contentToFooterGap = theme.designSystem.size.spacing.xl
   const artistNameLineHeight = getLineHeightPx(
     theme.designSystem.typography.bodyAccentS.lineHeight,
-    true
+    Platform.OS === 'web'
   )
   const artistRoleLineHeight = getLineHeightPx(
     theme.designSystem.typography.bodyAccentXs.lineHeight,
-    true
+    Platform.OS === 'web'
   )
   const contentHeight =
     (size ?? 0) +


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43361

## Context
L'objectif de cette PR est de fix le gros espace entre le rôle de l'artiste et le bouton Suivre sur iOS et Android.
Le bug survenait car le calcul était effectué par la valeur en `rem` en natif alors qu'on la reçoit déjà en `px`, on reçoit la valeur en `rem` uniquement en web.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-25 at 11 51 05" src="https://github.com/user-attachments/assets/7a018f7c-c4b0-4255-8eb1-d5449e7fd17a" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-25 at 11 51 11" src="https://github.com/user-attachments/assets/d984d004-5fda-4a42-aaf1-60ff5a075962" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-25 at 11 45 41" src="https://github.com/user-attachments/assets/0fdcc718-05d4-4e46-8e30-0b34e35a8e6e" />|
| Android          |<img width="1080" height="2400" alt="Screenshot_1787651452" src="https://github.com/user-attachments/assets/9737e8f2-30b3-4f4e-88f0-20ccbd002fca" /> <img width="1080" height="2400" alt="Screenshot_1787651458" src="https://github.com/user-attachments/assets/7ab99328-a92a-4cc1-a388-84237a0ef7dc" />|<img width="1080" height="2400" alt="Screenshot_1787651134" src="https://github.com/user-attachments/assets/3fabf2e9-466d-4850-8aef-f765a26fba5a" />|
| Phone - Chrome   |<img width="404" height="690" alt="Capture d’écran 2026-08-25 à 11 50 27" src="https://github.com/user-attachments/assets/b71d6dc8-873b-4840-82ea-bc6dac6076fa" />|<img width="400" height="683" alt="Capture d’écran 2026-08-25 à 11 48 44" src="https://github.com/user-attachments/assets/0f438099-f7b1-4814-b66e-133e97fbd134" />|
| Desktop - Chrome |<img width="1507" height="764" alt="Capture d’écran 2026-08-25 à 11 50 05" src="https://github.com/user-attachments/assets/3a0a459b-1173-43bd-adb9-6e79e1d91bcd" />|<img width="1508" height="763" alt="Capture d’écran 2026-08-25 à 11 48 59" src="https://github.com/user-attachments/assets/0fb6445f-07cd-40ed-9fec-ded814f56190" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
