### PR TITLE
(PC-43222) fix(SuspendedAccount): display suspended or deleted accoun…

### DIFF
--- a/src/api/apiHelpers.native.test.ts
+++ b/src/api/apiHelpers.native.test.ts
@@ -359,6 +359,12 @@ describe('[api] helpers', () => {
 
   describe('handleGeneratedApiResponse', () => {
     const navigateFromRef = jest.spyOn(NavigationRef, 'navigateFromRef')
+    const resetFromRef = jest.spyOn(NavigationRef, 'resetFromRef')
+    const getCurrentRouteNameFromRef = jest.spyOn(NavigationRef, 'getCurrentRouteNameFromRef')
+
+    beforeEach(() => {
+      getCurrentRouteNameFromRef.mockReturnValue(undefined)
+    })
 
     it('should return body when status is ok', async () => {
       const response = await respondWith('apiResponse')
@@ -431,7 +437,7 @@ describe('[api] helpers', () => {
 
       const result = await handleGeneratedApiResponse(response, optionsWithAccessToken)
 
-      expect(navigateFromRef).toHaveBeenCalledWith('LoginMethods', undefined)
+      expect(resetFromRef).toHaveBeenCalledWith('LoginMethods', undefined)
       expect(result).toEqual({})
     })
 
@@ -468,7 +474,17 @@ describe('[api] helpers', () => {
       const response = await respondWith('apiResponse', 401)
       const result = await handleGeneratedApiResponse(response, optionsWithAccessToken)
 
-      expect(navigateFromRef).toHaveBeenCalledWith('LoginMethods', undefined)
+      expect(resetFromRef).toHaveBeenCalledWith('LoginMethods', undefined)
+      expect(result).toEqual({})
+    })
+
+    it('should not navigate to LoginMethods on 401 if user is already on suspended account flow', async () => {
+      getCurrentRouteNameFromRef.mockReturnValueOnce('AccountStatusScreenHandler')
+      const response = await respondWith('apiResponse', 401)
+
+      const result = await handleGeneratedApiResponse(response, optionsWithAccessToken)
+
+      expect(resetFromRef).not.toHaveBeenCalled()
       expect(result).toEqual({})
     })
   })

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -2,6 +2,7 @@
 import { Platform } from 'react-native'
 import { v4 as uuidv4 } from 'uuid'
 
+import { navigateToLoginMethods } from 'features/navigation/navigateToLoginMethods'
 import { navigateFromRef } from 'features/navigation/navigationRef'
 import { env } from 'libs/environment/env'
 import { Headers } from 'libs/fetch'
@@ -21,10 +22,6 @@ import {
   REFRESH_TOKEN_IS_EXPIRED_ERROR,
   UNKNOWN_ERROR_WHILE_REFRESHING_ACCESS_TOKEN,
 } from './types'
-
-function navigateToLoginMethods(params?: Record<string, unknown>) {
-  navigateFromRef('LoginMethods', params)
-}
 
 export async function getAuthenticationHeaders(options?: RequestInit): Promise<Headers> {
   if (options?.credentials === 'omit') return {}

--- a/src/features/auth/context/AuthContext.native.test.tsx
+++ b/src/features/auth/context/AuthContext.native.test.tsx
@@ -25,7 +25,8 @@ import { AuthWrapper } from './AuthWrapper'
 const mockedUseNetInfo = useNetInfo as jest.Mock
 
 jest.spyOn(PackageJson, 'getAppVersion').mockReturnValue('1.10.5')
-const navigateFromRefSpy = jest.spyOn(NavigationRef, 'navigateFromRef')
+const resetFromRefSpy = jest.spyOn(NavigationRef, 'resetFromRef')
+const getCurrentRouteNameFromRefSpy = jest.spyOn(NavigationRef, 'getCurrentRouteNameFromRef')
 
 const MAX_AVERAGE_SESSION_DURATION_IN_MS = 60 * 60 * 1000
 const tokenExpirationDate = (CURRENT_DATE.getTime() + tokenRemainingLifetimeInMs) / 1000
@@ -42,6 +43,7 @@ jest
 describe('AuthContext', () => {
   beforeEach(async () => {
     mockdate.set(CURRENT_DATE)
+    getCurrentRouteNameFromRefSpy.mockReturnValue(undefined)
     await storage.clear('access_token')
     await clearRefreshToken()
     await storage.clear(QueryKeys.USER_PROFILE as unknown as StorageKey)
@@ -151,7 +153,7 @@ describe('AuthContext', () => {
 
       await act(async () => {})
 
-      expect(navigateFromRefSpy).not.toHaveBeenCalled()
+      expect(resetFromRefSpy).not.toHaveBeenCalled()
     })
 
     it('should navigate to LoginMethods with the force display message when the refresh token is expired', async () => {
@@ -173,7 +175,7 @@ describe('AuthContext', () => {
         jest.advanceTimersByTime(tokenRemainingLifetimeInMs)
       })
 
-      expect(navigateFromRefSpy).toHaveBeenCalledWith('LoginMethods', {
+      expect(resetFromRefSpy).toHaveBeenCalledWith('LoginMethods', {
         displayForcedLoginHelpMessage: true,
       })
     })
@@ -191,7 +193,7 @@ describe('AuthContext', () => {
       })
 
       await waitFor(() =>
-        expect(navigateFromRefSpy).toHaveBeenCalledWith('LoginMethods', {
+        expect(resetFromRefSpy).toHaveBeenCalledWith('LoginMethods', {
           displayForcedLoginHelpMessage: true,
         })
       )
@@ -217,6 +219,29 @@ describe('AuthContext', () => {
       })
 
       expect(await getRefreshToken()).toBe('')
+    })
+
+    it('should not navigate to LoginMethods when refresh token is expired on suspended account flow', async () => {
+      await storage.saveString('access_token', 'access_token')
+      await saveRefreshToken('token')
+      getCurrentRouteNameFromRefSpy.mockReturnValueOnce('AccountStatusScreenHandler')
+
+      const expiredToken = {
+        ...decodedTokenWithRemainingLifetime,
+        exp: (CURRENT_DATE.getTime() - 1) / 1000,
+      }
+      decodeTokenSpy.mockReturnValueOnce(expiredToken)
+      decodeTokenSpy.mockReturnValueOnce(expiredToken)
+      decodeTokenSpy.mockReturnValueOnce(expiredToken)
+
+      renderUseAuthContext()
+
+      await act(async () => {})
+      await act(async () => {
+        jest.advanceTimersByTime(tokenRemainingLifetimeInMs)
+      })
+
+      expect(resetFromRefSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/features/auth/context/AuthWrapper.tsx
+++ b/src/features/auth/context/AuthWrapper.tsx
@@ -4,8 +4,8 @@ import { AuthContext } from 'features/auth/context/AuthContext'
 import { useAdjustBeneficiaryEvent } from 'features/auth/helpers/useAdjustBeneficiaryEvent'
 import { useConnectServicesRequiringUserId } from 'features/auth/helpers/useConnectServicesRequiringUserId'
 import { useUserProfileInfoQuery } from 'features/auth/queries/useUserProfileInfoQuery'
-import { navigateFromRef } from 'features/navigation/navigationRef'
 // eslint-disable-next-line no-restricted-imports
+import { navigateToLoginMethods } from 'features/navigation/navigateToLoginMethods'
 import { useAppStateChange } from 'libs/appState'
 import { getTokenExpirationDate } from 'libs/jwt/getTokenExpirationDate'
 import { computeTokenRemainingLifetimeInMs, getTokenStatus } from 'libs/jwt/jwt'
@@ -15,9 +15,6 @@ import { storage } from 'libs/storage'
 const NAVIGATION_DELAY_FOR_EXPIRED_REFRESH_TOKEN_IN_MS = 1000
 
 const MAX_AVERAGE_SESSION_DURATION_IN_MS = 60 * 60 * 1000
-
-const navigateToLoginWithHelpMessage = () =>
-  navigateFromRef('LoginMethods', { displayForcedLoginHelpMessage: true })
 
 export const AuthWrapper = memo(function AuthWrapper({
   children,
@@ -51,7 +48,7 @@ export const AuthWrapper = memo(function AuthWrapper({
           setIsLoggedIn(false)
           // We need to delay this navigation to avoid conflit between this navigation and the initial screen defined by react-navigation on app launch
           navigationTimeoutRef.current = setTimeout(async () => {
-            navigateToLoginWithHelpMessage()
+            navigateToLoginMethods({ displayForcedLoginHelpMessage: true })
             await clearRefreshToken()
           }, NAVIGATION_DELAY_FOR_EXPIRED_REFRESH_TOKEN_IN_MS)
           return
@@ -69,7 +66,7 @@ export const AuthWrapper = memo(function AuthWrapper({
             ) {
               timeoutRef.current = globalThis.setTimeout(async () => {
                 setIsLoggedIn(false)
-                navigateToLoginWithHelpMessage()
+                navigateToLoginMethods({ displayForcedLoginHelpMessage: true })
                 await clearRefreshToken()
               }, remainingLifetimeInMs)
             }

--- a/src/features/auth/pages/suspendedAccount/AccountStatusScreenHandler/AccountStatusScreenHandler.native.test.tsx
+++ b/src/features/auth/pages/suspendedAccount/AccountStatusScreenHandler/AccountStatusScreenHandler.native.test.tsx
@@ -69,8 +69,13 @@ describe('<AccountStatusScreenHandler />', () => {
     expect(mockSignOut).toHaveBeenCalledTimes(1)
   })
 
-  it('should not call sign out function if user is redirect to reactivation success screen', () => {
-    mockUseCurrentRoute('AccountReactivationSuccess')
+  it.each`
+    routeName
+    ${'AccountReactivationSuccess'}
+    ${'SuspiciousLoginSuspendedAccount'}
+    ${'LoginMethods'}
+  `('should not call sign out function if $routeName', ({ routeName }) => {
+    mockUseCurrentRoute(routeName)
     render(<AccountStatusScreenHandler />)
 
     screen.unmount()

--- a/src/features/auth/pages/suspendedAccount/AccountStatusScreenHandler/AccountStatusScreenHandler.tsx
+++ b/src/features/auth/pages/suspendedAccount/AccountStatusScreenHandler/AccountStatusScreenHandler.tsx
@@ -11,6 +11,15 @@ import { DeleteProfileSuccess } from 'features/profile/pages/DeleteProfile/Delet
 import { SuspiciousLoginSuspendedAccount } from 'features/trustedDevice/pages/SuspiciousLoginSuspendedAccount'
 import { LoadingPage } from 'ui/pages/LoadingPage'
 
+const ROUTES_EXCLUDED_FROM_AUTO_SIGN_OUT = new Set([
+  'AccountReactivationSuccess',
+  'AccountStatusScreenHandler',
+  'SuspiciousLoginSuspendedAccount',
+  'Login',
+  'LoginMethods',
+  'LoginMethodsWithLastLoginInfo',
+])
+
 export const AccountStatusScreenHandler = () => {
   const { data: accountSuspensionStatus, isLoading } = useAccountSuspensionStatusQuery()
   const suspensionStatus = accountSuspensionStatus?.status
@@ -35,11 +44,10 @@ export const AccountStatusScreenHandler = () => {
 
   useEffect(() => {
     return () => {
-      const excludedRoutesFromSignOut =
-        currentRoute?.name &&
-        !['AccountReactivationSuccess', 'AccountStatusScreenHandler'].includes(currentRoute?.name)
+      const shouldSignOutOnCleanup =
+        currentRoute?.name && !ROUTES_EXCLUDED_FROM_AUTO_SIGN_OUT.has(currentRoute?.name)
 
-      if (excludedRoutesFromSignOut) {
+      if (shouldSignOutOnCleanup) {
         void signOut()
       }
     }

--- a/src/features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount.native.test.tsx
+++ b/src/features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount.native.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
-import { navigate } from '__mocks__/@react-navigation/native'
 import { GenericSuspendedAccount } from 'features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
+import { resetFromRef } from 'features/navigation/navigationRef'
 import { buildZendeskUrlForFraud } from 'features/profile/helpers/buildZendeskUrl'
 import { beneficiaryUser } from 'fixtures/user'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
@@ -18,6 +18,7 @@ jest.mock('features/auth/helpers/useLogoutRoutine', () => ({
 }))
 
 jest.mock('features/auth/context/AuthContext')
+jest.mock('features/navigation/navigationRef')
 jest.mock('libs/firebase/analytics/analytics')
 
 const mockDeviceMetrics = {
@@ -68,8 +69,7 @@ describe('<GenericSuspendedAccount />', () => {
     const homeButton = screen.getByText('Retourner à l’accueil')
     await user.press(homeButton)
 
-    expect(navigate).toHaveBeenNthCalledWith(
-      1,
+    expect(resetFromRef).toHaveBeenCalledWith(
       navigateToHomeConfig.screen,
       navigateToHomeConfig.params
     )

--- a/src/features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount.tsx
+++ b/src/features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount.tsx
@@ -39,8 +39,14 @@ export const GenericSuspendedAccount: React.FC<Props> = ({
       }}
       buttonTertiary={{
         wording: 'Retourner à l’accueil',
-        onBeforeNavigate: signOut,
-        navigateTo: { ...navigateToHomeConfig, params: { ...navigateToHomeConfig.params } },
+        navigateTo: {
+          ...navigateToHomeConfig,
+          withReset: true,
+          params: { ...navigateToHomeConfig.params },
+        },
+        onAfterNavigate: () => {
+          void signOut()
+        },
         icon: PlainArrowPrevious,
       }}>
       {children}

--- a/src/features/navigation/__mocks__/navigationRef.ts
+++ b/src/features/navigation/__mocks__/navigationRef.ts
@@ -30,5 +30,7 @@ export const navigationRef: typeof actualNavigationRef = {
 
 export const navigateFromRef = jest.fn()
 export const pushFromRef = jest.fn()
+export const resetFromRef = jest.fn()
 export const canGoBackFromRef = jest.fn()
 export const goBackFromRef = jest.fn()
+export const getCurrentRouteNameFromRef = jest.fn()

--- a/src/features/navigation/navigateToLoginMethods.ts
+++ b/src/features/navigation/navigateToLoginMethods.ts
@@ -1,0 +1,17 @@
+import { getCurrentRouteNameFromRef, resetFromRef } from 'features/navigation/navigationRef'
+
+const ROUTES_SHOULD_NOT_BE_FORCED_LOGIN = new Set([
+  'AccountStatusScreenHandler',
+  'SuspiciousLoginSuspendedAccount',
+  'FraudulentSuspendedAccount',
+])
+
+const shouldNotBeRedirectedToLogin = (currentRoute?: string | null): boolean => {
+  return !!currentRoute && ROUTES_SHOULD_NOT_BE_FORCED_LOGIN.has(currentRoute)
+}
+
+export const navigateToLoginMethods = (params?: Record<string, unknown>) => {
+  if (!shouldNotBeRedirectedToLogin(getCurrentRouteNameFromRef())) {
+    resetFromRef('LoginMethods', params)
+  }
+}

--- a/src/features/navigation/navigationRef.ts
+++ b/src/features/navigation/navigationRef.ts
@@ -51,3 +51,10 @@ export const goBackFromRef = () => {
     navigationRef.goBack()
   }
 }
+
+export const getCurrentRouteNameFromRef = (): string | undefined => {
+  if (navigationRef.isReady()) {
+    return navigationRef.getCurrentRoute()?.name
+  }
+  return undefined
+}

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import * as LogoutRoutine from 'features/auth/helpers/useLogoutRoutine'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
-import { navigateFromRef } from 'features/navigation/navigationRef'
+import { resetFromRef } from 'features/navigation/navigationRef'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { userEvent, render, screen } from 'tests/utils'
 
@@ -40,9 +40,10 @@ describe('DeleteProfileSuccess', () => {
 
     await userEvent.setup().press(screen.getByText(`Retourner à l’accueil`))
 
-    expect(navigateFromRef).toHaveBeenCalledWith(
+    expect(resetFromRef).toHaveBeenCalledWith(
       navigateToHomeConfig.screen,
       navigateToHomeConfig.params
     )
+    expect(signOutMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
+import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { remoteIllustrationUrls } from 'shared/illustrations/remoteIllustrations'
 import { Emoji } from 'ui/components/Emoji'
@@ -9,30 +10,41 @@ import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { ProfileDeletion } from 'ui/svg/icons/ProfileDeletion'
 import { Typo } from 'ui/theme'
 
-export const DeleteProfileSuccess = () => (
-  <GenericInfoPage
-    illustration={ProfileDeletion}
-    remoteIllustration={{
-      url: remoteIllustrationUrls.trashMosaic,
-      backgroundColor: 'negative01',
-    }}
-    title="Ton compte a été supprimé"
-    buttonPrimary={{
-      wording: 'Retourner à l’accueil',
-      navigateTo: { ...navigateToHomeConfig, params: { ...navigateToHomeConfig.params } },
-    }}>
-    <ViewGap gap={4}>
-      <StyledBody>
-        <Emoji.CryingFace withSpaceAfter />
-        On est super triste de te voir partir.
-      </StyledBody>
-      <StyledBody>
-        Tu peux malgré tout continuer à découvrir toute l’actu culturelle en consultant le
-        catalogue&nbsp;!
-      </StyledBody>
-    </ViewGap>
-  </GenericInfoPage>
-)
+export const DeleteProfileSuccess = () => {
+  const signOut = useLogoutRoutine()
+
+  return (
+    <GenericInfoPage
+      illustration={ProfileDeletion}
+      remoteIllustration={{
+        url: remoteIllustrationUrls.trashMosaic,
+        backgroundColor: 'negative01',
+      }}
+      title="Ton compte a été supprimé"
+      buttonPrimary={{
+        wording: 'Retourner à l’accueil',
+        navigateTo: {
+          ...navigateToHomeConfig,
+          withReset: true,
+          params: { ...navigateToHomeConfig.params },
+        },
+        onAfterNavigate: () => {
+          void signOut()
+        },
+      }}>
+      <ViewGap gap={4}>
+        <StyledBody>
+          <Emoji.CryingFace withSpaceAfter />
+          On est super triste de te voir partir.
+        </StyledBody>
+        <StyledBody>
+          Tu peux malgré tout continuer à découvrir toute l’actu culturelle en consultant le
+          catalogue&nbsp;!
+        </StyledBody>
+      </ViewGap>
+    </GenericInfoPage>
+  )
+}
 
 const StyledBody = styled(Typo.Body)({
   textAlign: 'center',


### PR DESCRIPTION
…t pages on login instead of infinite login bug

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43222

## Context
**Pb** : en cas de connexion avec un compte suspendu, à la reconnexion, l'écran de suspension apparait brièvement avant de rediriger vers la page de connexion de nouveau avec l'impossibilité de revenir en arrière. En cas de retentative de connexion cela recommence.
**Solution** : 
Ajout de routes qui ne devrait pas déclencher de signOut. Utilisation de resetFromRef pour éviter la redirection direct vers l'écran de connexion pour certains écrans. Sur l'écran de succès de suppression et ceux annoncant la suspension, ajout de sign-out (onAfterNavigate) et withReset: true sur la navigation vers l'accueil, afin de garantir un état propre après suppression/anonymisation du compte.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS    - supprimé          |     cf ticket          | https://github.com/user-attachments/assets/d0908640-730c-46c9-9d05-065bfe17569a|
| ios - suspendu        |    cf ticket                 |https://github.com/user-attachments/assets/3775c03e-227f-4a8c-b215-d98f1297cfaf|
| Desktop - supprimé  |      cf ticket               | https://github.com/user-attachments/assets/b049a130-658c-4d23-95d1-d706775f5ce5 |
| Desktop - suspendu |        cf ticket             | https://github.com/user-attachments/assets/18cba388-965a-41c0-a844-d35186e87cd3 |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
