### PR TITLE
(PC-43323) refactor(ui): display all possible tags in items in see all button pages

### DIFF
--- a/src/features/home/pages/VideoModulePage.native.test.tsx
+++ b/src/features/home/pages/VideoModulePage.native.test.tsx
@@ -6,6 +6,7 @@ import { VideoModulePage } from 'features/home/pages/VideoModulePage'
 import { useVideoOffersQuery } from 'features/home/queries/useVideoOffersQuery'
 import * as useGoBack from 'features/navigation/useGoBack'
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
 import { offersFixture } from 'shared/offer/offer.fixture'
 import { mockServer } from 'tests/mswServer'
@@ -44,6 +45,7 @@ jest.useFakeTimers()
 describe('VideoModulePage', () => {
   beforeEach(() => {
     mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', subcategoriesDataTest)
+    setFeatureFlags()
   })
 
   describe('When isMultiOffer is false', () => {

--- a/src/shared/verticalPlaylist/components/VerticalPlaylistOffersView.native.test.tsx
+++ b/src/shared/verticalPlaylist/components/VerticalPlaylistOffersView.native.test.tsx
@@ -5,6 +5,7 @@ import { mockArtist } from 'features/artist/fixtures/mockArtist'
 import { initialSearchState } from 'features/search/context/reducer'
 import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
 import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { Offer } from 'shared/offer/types'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen, userEvent } from 'tests/utils'
@@ -29,6 +30,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('<VerticalPlaylistOffersView />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   it('should render correctly', async () => {
     render(
       reactQueryProviderHOC(

--- a/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
@@ -7,6 +7,7 @@ import * as logClickOnProductAPI from 'libs/algolia/analytics/logClickOnOffer'
 import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
 import { analytics } from 'libs/analytics/provider'
 import { OfferAnalyticsParams } from 'libs/analytics/types'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
 import { UserProps } from 'libs/location/getDistance'
 import { LocationMode, Position } from 'libs/location/types'
 import {
@@ -101,6 +102,7 @@ describe('HorizontalOfferTile component', () => {
   beforeEach(() => {
     mockServer.getApi<SubcategoriesResponseModelv2>(`/v1/subcategories/v2`, subcategoriesDataTest)
     useLocationV2.setState(defaultLocationState)
+    setFeatureFlags()
   })
 
   it('should navigate to the offer when pressing an offer', async () => {

--- a/src/ui/components/tiles/HorizontalOfferTile.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.tsx
@@ -11,6 +11,8 @@ import { logClickOnOffer } from 'libs/algolia/analytics/logClickOnOffer'
 import { algoliaAnalyticsSelectors } from 'libs/algolia/store/algoliaAnalyticsStore'
 import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog'
 import { OfferAnalyticsParams } from 'libs/analytics/types'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { getDistance } from 'libs/location/getDistance'
 import { LocationMode } from 'libs/location/types'
 import {
@@ -73,6 +75,9 @@ export const HorizontalOfferTile = ({
     releaseDate,
     isDuo,
     bookingAllowedDatetime,
+    likes,
+    chroniclesCount,
+    proAdvicesCount,
   } = offerDetails
   const routes = useNavigationState((state) => state?.routes)
   const currentRoute = routes?.[routes?.length - 1]?.name
@@ -81,6 +86,8 @@ export const HorizontalOfferTile = ({
   const currency = useGetCurrencyToDisplay()
   const { data: euroToPacificFrancRate } = usePacificFrancToEuroRate()
   const prePopulateOffer = usePrePopulateOffer()
+  const enableProAdvicesTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_PRO_REVIEWS_PLAYLIST)
+  const enableSceneClubTag = useFeatureFlag(RemoteStoreFeatureFlags.WIP_SCENE_CLUB)
 
   const userPosition =
     currentRoute === 'SearchResults' &&
@@ -156,6 +163,10 @@ export const HorizontalOfferTile = ({
     theme,
     isComingSoonOffer: isAComingSoonOffer,
     subcategoryId,
+    likesCount: likes,
+    clubAdvicesCount: chroniclesCount,
+    proAdvicesCount: enableProAdvicesTag ? proAdvicesCount : undefined,
+    enableSceneClubTag,
   })
 
   const interactionTagLabel = getInteractionTagLabel(interactionTag)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43323

## Context
L'objectif de cette PR est d'afficher tous les tags que l'on retrouve dans les playlist sur les pages associées au bouton Tout voir des playlist pour plus de cohérence.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-25 at 14 22 33" src="https://github.com/user-attachments/assets/474415bb-a438-494d-a2d3-8e8d779453a6" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-25 at 14 22 15" src="https://github.com/user-attachments/assets/d7e4c9c3-9059-44ab-8f6c-6d5afafb60cb" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-25 at 14 21 40" src="https://github.com/user-attachments/assets/8ceffe9c-b676-4884-bfb9-b7600864a4a7" /> <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-25 at 14 21 29" src="https://github.com/user-attachments/assets/eed6c5c5-8274-42ef-828c-ea00b4cb88ec" />|
| Android          |<img width="1080" height="2400" alt="Screenshot_1787660529" src="https://github.com/user-attachments/assets/954c208d-7604-481b-924c-4823e2823005" /> <img width="1080" height="2400" alt="Screenshot_1787660524" src="https://github.com/user-attachments/assets/817f8a6d-9fc1-4218-9942-09411127984a" />|<img width="1080" height="2400" alt="Screenshot_1787660484" src="https://github.com/user-attachments/assets/e2976500-0164-48b0-aa21-e5c34aebb1d7" /> <img width="1080" height="2400" alt="Screenshot_1787660477" src="https://github.com/user-attachments/assets/9a3f17ea-ebf2-403f-b95e-e89683f3d6a8" />|
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
