### PR TITLE
(PC-43230) fix(MapMarkers): map marker not clickable on map

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@batch.com/react-native-plugin": "11.1.0",
     "@d11/react-native-fast-image": "^8.13.0",
     "@emotion/is-prop-valid": "^1.3.1",
-    "@gorhom/bottom-sheet": "^5.2.6",
+    "@gorhom/bottom-sheet": "^5.2.14",
     "@hookform/resolvers": "^2.9.11",
     "@hot-updater/react-native": "^0.35.3",
     "@invertase/react-native-apple-authentication": "^2.5.1",

--- a/src/features/venueMap/components/VenueMapLabel/LabelContainer.tsx
+++ b/src/features/venueMap/components/VenueMapLabel/LabelContainer.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components/native'
 
-import { MARKER_LABEL_MARGIN_TOP, MARKER_SIZE } from 'features/venueMap/constant'
+import { MARKER_SIZE } from 'features/venueMap/constant'
 import { Size } from 'features/venueMap/types'
 import { getSpacing } from 'ui/theme'
 
@@ -12,6 +12,6 @@ export const LabelContainer = styled.View<{ labelSize: Size }>(({ theme, labelSi
     maxWidth: getSpacing(40),
     paddingHorizontal: theme.designSystem.size.spacing.s,
     paddingVertical: theme.designSystem.size.spacing.xs,
-    transform: `translateX(${MARKER_SIZE.width / 2 - labelSize.width / 2}px) translateY(${MARKER_SIZE.height + MARKER_LABEL_MARGIN_TOP}px)`,
+    transform: `translateX(${MARKER_SIZE.width / 2 - labelSize.width / 2}px)`,
   }
 })

--- a/src/features/venueMap/components/VenueMapLabel/VenueMapLabel.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapLabel/VenueMapLabel.native.test.tsx
@@ -25,7 +25,7 @@ describe('<VenueMapLabel />', () => {
     })
 
     expect(screen.getByTestId('label-container')).toHaveStyle({
-      transform: expect.arrayContaining([{ translateX: -28 }, { translateY: 54 }]),
+      transform: expect.arrayContaining([{ translateX: -28 }]),
     })
   })
 
@@ -45,7 +45,7 @@ describe('<VenueMapLabel />', () => {
     const expectedTranslateX = 22 - 80 / 2
 
     expect(screen.getByTestId('label-container')).toHaveStyle({
-      transform: expect.arrayContaining([{ translateX: expectedTranslateX }, { translateY: 54 }]),
+      transform: expect.arrayContaining([{ translateX: expectedTranslateX }]),
     })
   })
 })

--- a/src/features/venueMap/components/VenueMapView/Marker/Marker.tsx
+++ b/src/features/venueMap/components/VenueMapView/Marker/Marker.tsx
@@ -5,7 +5,7 @@ import { GeolocatedVenue } from 'features/venueMap/components/VenueMapView/types
 import { getActivityIconName } from 'features/venueMap/helpers/getActivityIconName/getActivityIconName'
 import { Marker as MapMarker, MapMarkerProps } from 'libs/maps/maps'
 
-import { LABEL_HEIGHT, MARKER_SIZE } from '../../../constant'
+import { MARKER_SIZE } from '../../../constant'
 import { VenueMapLabel } from '../../VenueMapLabel/VenueMapLabel'
 
 const PIN_MAX_Z_INDEX = 10_000
@@ -16,28 +16,28 @@ interface MarkerProps extends MapMarkerProps {
   showLabel: boolean
 }
 
-export const Marker = ({ venue, isSelected, showLabel, ...otherProps }: MarkerProps) => {
-  return (
-    <CustomMarker
-      anchor={{ x: 0.5, y: showLabel ? 0.6 : 1 }}
-      testID={`marker-${venue.venueId}${isSelected ? '-selected' : ''}`}
-      zIndex={isSelected ? PIN_MAX_Z_INDEX : undefined}
-      {...otherProps}>
+export const Marker = ({ venue, isSelected, showLabel, ...otherProps }: MarkerProps) => (
+  <MapMarker
+    anchor={{ x: 0.5, y: showLabel ? 0.6 : 1 }}
+    centerOffset={{ x: 1, y: 0 }}
+    testID={`marker-${venue.venueId}${isSelected ? '-selected' : ''}`}
+    zIndex={PIN_MAX_Z_INDEX}
+    {...otherProps}>
+    <MarkerImageView>
       <PinImage source={{ uri: getActivityIconName(isSelected, venue.activity) }} />
       {showLabel ? <VenueMapLabel venue={venue} /> : null}
-    </CustomMarker>
-  )
-}
-
-const CustomMarker = styled(MapMarker)({
-  alignItems: 'center',
-  minWidth: MARKER_SIZE.width,
-  height: MARKER_SIZE.height + LABEL_HEIGHT,
-  width: 'auto',
-})
+    </MarkerImageView>
+  </MapMarker>
+)
 
 const PinImage = styled.Image({
   width: MARKER_SIZE.width,
   height: MARKER_SIZE.height,
   resizeMode: 'contain',
+})
+
+const MarkerImageView = styled.View({
+  flex: 1,
+  display: 'flex',
+  padding: 4,
 })

--- a/src/features/venueMap/components/VenueMapView/Marker/Marker.tsx
+++ b/src/features/venueMap/components/VenueMapView/Marker/Marker.tsx
@@ -19,7 +19,6 @@ interface MarkerProps extends MapMarkerProps {
 export const Marker = ({ venue, isSelected, showLabel, ...otherProps }: MarkerProps) => (
   <MapMarker
     anchor={{ x: 0.5, y: showLabel ? 0.6 : 1 }}
-    centerOffset={{ x: 1, y: 0 }}
     testID={`marker-${venue.venueId}${isSelected ? '-selected' : ''}`}
     zIndex={PIN_MAX_Z_INDEX}
     {...otherProps}>
@@ -36,8 +35,6 @@ const PinImage = styled.Image({
   resizeMode: 'contain',
 })
 
-const MarkerImageView = styled.View({
-  flex: 1,
-  display: 'flex',
-  padding: 4,
-})
+const MarkerImageView = styled.View(({ theme }) => ({
+  padding: theme.designSystem.size.spacing.xs,
+}))

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
@@ -21,6 +21,7 @@ import { MARKER_LABEL_VISIBILITY_LIMIT } from 'features/venueMap/constant'
 import { getClusterColorByDominantActivity } from 'features/venueMap/helpers/venueMapCluster/getClusterColorByDominantActivity'
 import { zoomOutIfMapEmpty } from 'features/venueMap/helpers/zoomOutIfMapEmpty'
 import { MapView, Map, MapViewProps } from 'libs/maps/maps'
+import { useColorScheme } from 'libs/styled/useColorScheme'
 import { Button } from 'ui/designSystem/Button/Button'
 
 import { Marker } from './Marker/Marker'
@@ -71,6 +72,7 @@ export const VenueMapView = forwardRef<Map, VenueMapViewProps>(function VenueMap
   },
   ref
 ) {
+  const colorScheme = useColorScheme()
   const [labelVisible, setLabelVisible] = useState(false)
   const superClusterRef = useRef<Supercluster>(null)
   const mapRef = useRef<Map>(null)
@@ -137,6 +139,7 @@ export const VenueMapView = forwardRef<Map, VenueMapViewProps>(function VenueMap
         animationEnabled={false}
         testID="venue-map-view"
         customMapStyle={CUSTOM_MAP_STYLES}
+        userInterfaceStyle={colorScheme}
         {...mapProps}>
         {venues.map((venue) => (
           <Marker

--- a/src/features/venueMap/constant.ts
+++ b/src/features/venueMap/constant.ts
@@ -14,7 +14,6 @@ export const MARKER_LABEL_VISIBILITY_LIMIT = {
   altitude: 4000,
   zoom: 13,
 }
-export const LABEL_HEIGHT = 28
 
 export const CLUSTER_IMAGE_COLOR_NAME = {
   BLUE: 'blue',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5187,9 +5187,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gorhom/bottom-sheet@npm:^5.2.6":
-  version: 5.2.7
-  resolution: "@gorhom/bottom-sheet@npm:5.2.7"
+"@gorhom/bottom-sheet@npm:^5.2.14":
+  version: 5.2.14
+  resolution: "@gorhom/bottom-sheet@npm:5.2.14"
   dependencies:
     "@gorhom/portal": "npm:1.0.14"
     invariant: "npm:^2.2.4"
@@ -5205,7 +5205,7 @@ __metadata:
       optional: true
     "@types/react-native":
       optional: true
-  checksum: 10/370787f062149f0f8ce645f0d942ebd62ac0e75ad31746db8da9d1b6e19940ef811987b6cb9ef52cc1f920929db915ea9f5d5017ebfcd8211a59cf932c36ea95
+  checksum: 10/6d2008a7b47fcc26bd15d6fa6aa827a2df64a3b07754ddfc861a1a70f52762268f09f386e1d469d256ba0ed04602f9af99195fa01b799306750012fc4774e3bd
   languageName: node
   linkType: hard
 
@@ -11085,7 +11085,7 @@ __metadata:
     "@chromatic-com/storybook": "npm:^5.1.2"
     "@d11/react-native-fast-image": "npm:^8.13.0"
     "@emotion/is-prop-valid": "npm:^1.3.1"
-    "@gorhom/bottom-sheet": "npm:^5.2.6"
+    "@gorhom/bottom-sheet": "npm:^5.2.14"
     "@hookform/resolvers": "npm:^2.9.11"
     "@hot-updater/bare": "npm:^0.35.3"
     "@hot-updater/firebase": "npm:^0.35.3"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43230

## Context
Markers on the map are not clickable, detail of the venue is not shown anymore.

## Tasks
 - updated react-bottom-sheets to latest version
 - changed layout of Markers, we pass a child for the image now and with the label also being passed as child, the layout is not aligned with the virtual position of the marker, it is thus not clickable on the image (clickable outside with an offset of several pixels ...)
 - added dark mode based on user choice