### PR TITLE
(PC-43396) chore(SearchFilters): add E2E tests

### DIFF
--- a/.maestro/testsV3/search/SearchWithPriceFilter.yml
+++ b/.maestro/testsV3/search/SearchWithPriceFilter.yml
@@ -1,0 +1,40 @@
+appId: ${MAESTRO_APP_ID}
+tags:
+  - search
+onFlowStart:
+  - runScript: ../common/deeplinks/DeepLink.js
+---
+- runFlow: ../common/lifecycle/LaunchApp.yml
+- runFlow: ../common/lifecycle/StopApp.yml
+- runFlow: ../common/deeplinks/DeeplinkToHome.yml
+
+- runFlow: ../common/navigation/GoToSearchFromTabBar.yml
+
+- assertVisible: 'Rechercher'
+
+- runFlow:
+    commands:
+      - assertVisible: 'Parcours les catégories'
+      - scroll
+      - tapOn: 'Spectacles'
+
+- tapOn: 'Voir tous les filtres : 1 filtre actif'
+- assertVisible: 'Prix'
+
+- tapOn: 'Prix'
+- assertVisible: 'Prix minimum.*'
+- assertVisible: 'Prix maximum.*'
+- assertVisible: 'Appliquer le filtre'
+- tapOn:
+    id: 'Entrée pour le prix maximum'
+
+- assertVisible: 'Prix minimum.*'
+- assertVisible: 'Prix maximum.*'
+- assertVisible: 'Appliquer le filtre'
+
+- inputText: '50'
+- tapOn: 'Appliquer le filtre'
+- assertVisible: '50 € et moins'
+- tapOn: 'Rechercher'
+
+- runFlow: ../common/lifecycle/StopApp.yml


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43396

## Context

Suite au bug d'ouverture du clavier corrigé dans cette PR : https://github.com/pass-culture/pass-culture-app-native/pull/10080, on ajoute ici un test end-to-end pour tester l'utilisation du filtre de prix avec la vérification de la visibilité des champs texte et des CTA après l'ouverture du clavier.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
