### PR TITLE
(PC-43390) fix(offer): web advices truncation

### DIFF
--- a/src/features/offer/components/OfferContent/ClubAdviceSection/ClubAdviceSection.web.test.tsx
+++ b/src/features/offer/components/OfferContent/ClubAdviceSection/ClubAdviceSection.web.test.tsx
@@ -12,6 +12,12 @@ jest.spyOn(reactNavigationNative, 'useNavigation').mockReturnValue({
   push: jest.fn(),
 })
 
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
 describe('ClubAdviceSection', () => {
   it('should render correctly in mobile', () => {
     render(

--- a/src/features/offer/pages/Offer/Offer.web.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.web.test.tsx
@@ -69,6 +69,12 @@ const defaultUseCookies = {
 }
 jest.spyOn(Cookies, 'useCookies').mockReturnValue(defaultUseCookies)
 
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
 describe('<Offer/>', () => {
   describe('Accessibility', () => {
     beforeEach(() => {

--- a/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.web.test.tsx
+++ b/src/features/venue/components/VenueAdvicesSection/VenueAdvicesSection.web.test.tsx
@@ -5,6 +5,12 @@ import { venueDataTest } from 'features/venue/fixtures/venueDataTest'
 import { proAdvicesCardDataFixture } from 'features/venue/fixtures/venueProAdvices.fixture'
 import { render, screen } from 'tests/utils/web'
 
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
 describe('VenueAdvicesSection', () => {
   it('should display see all advices button below the list in mobile', () => {
     render(

--- a/src/ui/theme/typography.web.tsx
+++ b/src/ui/theme/typography.web.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback, useRef } from 'react'
 import styled from 'styled-components'
 
 // eslint-disable-next-line local-rules/no-theme-from-theme
@@ -6,6 +6,10 @@ import { theme } from 'theme'
 import { TextColorKey } from 'theme/types'
 import { isHeadingLevel } from 'ui/theme/isHeadingLevel'
 import { TextSemanticLevel } from 'ui/theme/typographyAttrs/types'
+
+type WebLayoutChangeEvent = {
+  nativeEvent: { layout: { x: number; y: number; width: number; height: number } }
+}
 
 const DEFAULT_COLOR_TEXT = 'default'
 
@@ -36,14 +40,42 @@ const createStyledText = (
     accessibilityLevel?: TextSemanticLevel
     numberOfLines?: number
     color?: TextColorKey
+    onLayout?: (event: WebLayoutChangeEvent) => void
   }
 
-  const Component = ({ accessibilityLevel, numberOfLines, ...props }: Props) => {
+  const Component = ({ accessibilityLevel, numberOfLines, onLayout, ...props }: Props) => {
     const level = accessibilityLevel ?? defaultLevel
     let tag: React.ElementType = 'p'
     if (level === 'span') tag = 'span'
     else if (isHeadingLevel(level)) tag = level
-    return <StyledText as={tag} numberOfLines={numberOfLines} {...props} />
+
+    const observerRef = useRef<ResizeObserver | null>(null)
+
+    const setRef = useCallback(
+      (node: HTMLElement | null) => {
+        if (observerRef.current) {
+          observerRef.current.disconnect()
+          observerRef.current = null
+        }
+
+        if (node && onLayout) {
+          const emit = () => {
+            const rect = node.getBoundingClientRect()
+            onLayout({
+              nativeEvent: {
+                layout: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+              },
+            })
+          }
+          emit() // equivalent to the first onLayout call upon mounting on the RN side
+          observerRef.current = new ResizeObserver(emit)
+          observerRef.current.observe(node)
+        }
+      },
+      [onLayout]
+    )
+
+    return <StyledText as={tag} ref={setRef} numberOfLines={numberOfLines} {...props} />
   }
 
   Component.displayName = typographyStyle


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43390

## Context
L'objectif de cette PR est de refaire fonctionner la troncature en web suite à la transformation des `Typo` en `p` au lieu de `div` en web. Le calcul de la troncature se fait au `onLayout` et celui-ci n'est jamais déclenché en web sur un `p`. 
Pour corriger le problème, on recrée manuellement le comportement de `onLayout` en web dans `Typo` avec un `ResizeObserver` qui mesure la hauteur réelle du texte et appelle le callback `onLayout` de la même façon que si l'on utilisait toujours un `div`.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |<img width="401" height="683" alt="Capture d’écran 2026-08-27 à 12 40 32" src="https://github.com/user-attachments/assets/22082d19-1120-4e22-89c1-202046de9b41" /> <img width="397" height="685" alt="Capture d’écran 2026-08-27 à 12 41 30" src="https://github.com/user-attachments/assets/d5eb9a2e-c3c1-4c8c-900f-77bfa32e5322" />|<img width="396" height="692" alt="Capture d’écran 2026-08-27 à 11 31 21" src="https://github.com/user-attachments/assets/dcdfaba4-8241-472f-8bd4-1d65d05b24b2" /> <img width="400" height="685" alt="Capture d’écran 2026-08-27 à 11 31 08" src="https://github.com/user-attachments/assets/7acb7b26-1c60-4ffb-8f13-a59753e11f74" />|
| Desktop - Chrome |<img width="1916" height="926" alt="Capture d’écran 2026-08-27 à 12 40 44" src="https://github.com/user-attachments/assets/a79880c8-fb0a-43a0-8862-1d8b93328e66" /> <img width="1913" height="927" alt="Capture d’écran 2026-08-27 à 12 41 07" src="https://github.com/user-attachments/assets/dbdd793a-b210-4d30-9921-79a09935e22a" />|<img width="1508" height="763" alt="Capture d’écran 2026-08-27 à 11 29 07" src="https://github.com/user-attachments/assets/c7832b76-dd8a-4dce-b6c2-d155ac7b6052" /> <img width="1508" height="762" alt="Capture d’écran 2026-08-27 à 11 30 59" src="https://github.com/user-attachments/assets/0442e628-6fec-4158-b430-f3f2155a3964" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
