### PR TITLE
(PC-42319) chore(e2e): add VenueMap and favorites flows

### DIFF
--- a/.maestro/testsV3/config.yaml
+++ b/.maestro/testsV3/config.yaml
@@ -7,5 +7,7 @@ flows:
   - search/*
   - booking/*
   - artist/*
+  - favorite/*
   - offer/*
+  - venue/*
   - web/*

--- a/.maestro/testsV3/favorite/AddAndDeleteFavorites.yml
+++ b/.maestro/testsV3/favorite/AddAndDeleteFavorites.yml
@@ -1,7 +1,6 @@
 appId: ${MAESTRO_APP_ID}
 tags:
   - favorite
-  - fix
 onFlowStart:
   - runScript: ../common/deeplinks/DeepLink.js
   - runScript:

--- a/.maestro/testsV3/favorite/AddAndDeleteFavorites.yml
+++ b/.maestro/testsV3/favorite/AddAndDeleteFavorites.yml
@@ -1,0 +1,155 @@
+appId: ${MAESTRO_APP_ID}
+tags:
+  - favorite
+  - fix
+onFlowStart:
+  - runScript: ../common/deeplinks/DeepLink.js
+  - runScript:
+      file: ../common/helpers/generateUser.js
+      env:
+        id_provider: 'UBBLE'
+        step: 'BENEFICIARY'
+        age: 18
+---
+- runFlow: ../common/lifecycle/LaunchApp.yml
+- runFlow: ../common/lifecycle/StopApp.yml
+- runFlow: ../common/deeplinks/DeeplinkBeneficiaryUser.yml
+- runFlow: ../common/navigation/GoToFavoritesFromTabBar.yml
+
+- assertVisible:
+    text: 'Mes favoris'
+    index: 0
+- repeat:
+    while:
+      notVisible: 'Découvrir le catalogue'
+    commands:
+      - tapOn: 'Supprimer.*'
+- tapOn: 'Découvrir le catalogue'
+
+- runFlow: ../common/navigation/GoToSearchFromTabBar.yml
+
+- assertVisible: 'Rechercher'
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - scrollUntilVisible:
+          element:
+            text: 'Catégorie Musique.*'
+      - tapOn: 'Catégorie Musique.*'
+      - tapOn: 'CDs'
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - scrollUntilVisible:
+          element:
+            text: 'MUSIQUE'
+      - tapOn: 'MUSIQUE'
+      - tapOn: 'CDs'
+
+- assertVisible: 'Rechercher'
+- runFlow:
+    when:
+      visible: 'Ma position'
+    commands:
+      - tapOn: 'Ma position'
+      - tapOn: 'Localisation – Liste - Élément 3 sur 3 - France entière.*'
+
+- swipe:
+    from:
+      text: 'Les offres'
+    direction: UP
+
+- extractTextWithAI:
+    query: "Le titre exacte d'une des offres CD visible dans les résultats de recherche dont le titre n'est pas cropé"
+    outputVariable: 'offer1'
+- tapOn: .*${offer1}.*
+
+- tapOn:
+    id: 'Mettre en favori'
+- tapOn:
+    id: 'Revenir en arrière'
+
+- scroll
+- extractTextWithAI:
+    query: "Le titre exacte d'une des offres CD visible dans les résultats de recherche dont le titre est différent de '${offer1}'"
+    outputVariable: 'offer2'
+- tapOn: .*${offer2}.*
+- tapOn:
+    id: 'Mettre en favori'
+- tapOn:
+    id: 'Revenir en arrière'
+
+- scroll
+- extractTextWithAI:
+    query: "Le titre exacte d'une des offres CD visible dans les résultats de recherche dont le titre est différent de '${offer1}' et '${offer2}'"
+    outputVariable: 'offer3'
+- tapOn: .*${offer3}.*
+- tapOn:
+    id: 'Mettre en favori'
+- tapOn:
+    id: 'Revenir en arrière'
+
+- runFlow: ../common/navigation/GoToFavoritesFromTabBar.yml
+
+- assertVisible: '3 favoris'
+- assertVisible:
+    id: 'Trier'
+- tapOn:
+    id: 'Trier'
+- assertVisible: 'Trier par'
+- assertVisible: '.*Ajouté récemment.*'
+- assertVisible: '.*Prix croissant.*'
+- assertVisible: '.*Proximité géographique.*'
+- tapOn: '.*Prix croissant.*'
+- tapOn: 'Valider'
+- assertVisible: '3 favoris'
+- tapOn:
+    id: 'Trier'
+- tapOn: '.*Proximité géographique.*'
+- runFlow:
+    when:
+      visible: 'Paramètres de localisation'
+    commands:
+      - tapOn: 'Fermer la modale'
+- tapOn: 'Valider'
+- assertVisible: '3 favoris'
+
+- assertVisible: '3 favoris'
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          text: 'Supprimer'
+          index: 0
+      - assertVisible: '2 favoris'
+      - tapOn:
+          text: 'Supprimer'
+          index: 0
+      - assertVisible: '1 favori'
+      - tapOn:
+          text: 'Supprimer'
+          index: 0
+      - assertVisible: "Retrouve toutes tes offres en un clin d’oeil"
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: 'Supprimer.*'
+          index: 0
+      - assertVisible: '2 favoris'
+      - tapOn:
+          text: 'Supprimer.*'
+          index: 0
+      - assertVisible: '1 favori'
+      - tapOn:
+          text: 'Supprimer.*'
+          index: 0
+      - assertVisible: "Retrouve toutes tes offres en un clin d’oeil"
+
+- runFlow: ../common/lifecycle/StopApp.yml

--- a/.maestro/testsV3/profile/AccessDeletionReactivation.yml
+++ b/.maestro/testsV3/profile/AccessDeletionReactivation.yml
@@ -1,6 +1,7 @@
 appId: ${MAESTRO_APP_ID}
 tags:
   - profile
+  - fix
 onFlowStart:
   - runScript: ../common/deeplinks/DeepLink.js
   - runScript:
@@ -49,14 +50,6 @@ onFlowStart:
 - tapOn: 'Je souhaite supprimer mes données personnelles'
 - runFlow: ../common/assertions/DeletionNotAllowed.yml
 
-- scrollUntilVisible:
-    element: 'Autre'
-
-- tapOn: 'Je pense que quelqu’un d’autre a accès à mon compte'
-- assertVisible: 'Sécurise ton compte'
-- assertVisible: 'Suspendre mon compte'
-- assertVisible: 'Ne pas sécuriser mon compte'
-- tapOn: 'Revenir en arrière'
 - scrollUntilVisible:
     element: 'Autre'
 

--- a/.maestro/testsV3/profile/AccessDeletionReactivation.yml
+++ b/.maestro/testsV3/profile/AccessDeletionReactivation.yml
@@ -1,7 +1,6 @@
 appId: ${MAESTRO_APP_ID}
 tags:
   - profile
-  - fix
 onFlowStart:
   - runScript: ../common/deeplinks/DeepLink.js
   - runScript:

--- a/.maestro/testsV3/venue/CheckVenueMap.yml
+++ b/.maestro/testsV3/venue/CheckVenueMap.yml
@@ -1,0 +1,92 @@
+appId: ${MAESTRO_APP_ID}
+tags:
+  - venue
+onFlowStart:
+  - runScript: ../common/deeplinks/DeepLink.js
+---
+- runFlow: ../common/lifecycle/LaunchApp.yml
+- runFlow: ../common/lifecycle/StopApp.yml
+- runFlow: ../common/deeplinks/DeeplinkToHome.yml
+
+- scrollUntilVisible:
+    element: 'A côté'
+- tapOn: 'A côté'
+
+- runFlow:
+    when:
+      visible: 'Localisation'
+    commands:
+      - tapOn:
+          text: '.*Choisir une zone géographique.*'
+          point: '50%,25%'
+      - tapOn:
+          id: 'styled-input-container'
+      - inputText: 'Paris'
+      - tapOn: 'Paris Paris'
+      - tapOn: 'Valider et voir sur la carte'
+
+- tapOn: 'A côté'
+
+- assertVisible:
+    text: 'Carte des lieux'
+    optional: true
+- tapOn: 'Sorties'
+- tapOn: 'Boutiques'
+- tapOn: 'Autres'
+- tapOn: 'Voir tous les filtres : 3 filtres actifs'
+- assertVisible: '.*Sorties.*'
+- assertVisible: '.*Boutiques.*'
+- assertVisible: '.*Autres.*'
+- tapOn: 'Réinitialiser'
+- tapOn: '.*Sorties.*'
+- tapOn: '.*Cinéma.*'
+- tapOn: 'Rechercher'
+- tapOn: 
+    text: 'Repère sur la carte'
+    optional: true
+- tapOn: 'Voir tous les filtres : 1 filtre actif'
+- tapOn: 'Réinitialiser'
+- tapOn: 'Rechercher'
+- tapOn: 'Revenir en arrière'
+
+- runFlow: ../common/navigation/GoToSearchFromTabBar.yml
+
+- assertVisible: 'Rechercher'
+- tapOn: 'Explore la carte'
+
+- runFlow:
+    when:
+      visible: 'Localisation'
+    commands:
+      - tapOn:
+          text: '.*Choisir une zone géographique.*'
+          point: '50%,25%'
+      - tapOn:
+          id: 'styled-input-container'
+      - inputText: 'Paris'
+      - tapOn: 'Paris Paris'
+      - tapOn: 'Valider et voir sur la carte'
+
+- assertVisible:
+    text: 'Carte des lieux'
+    optional: true
+- tapOn: 'Sorties'
+- tapOn: 'Boutiques'
+- tapOn: 'Autres'
+- tapOn: 'Voir tous les filtres : 3 filtres actifs'
+- assertVisible: '.*Sorties.*'
+- assertVisible: '.*Boutiques.*'
+- assertVisible: '.*Autres.*'
+- tapOn: 'Réinitialiser'
+- tapOn: '.*Sorties.*'
+- tapOn: '.*Cinéma.*'
+- tapOn: 'Rechercher'
+- tapOn: 
+    text: 'Repère sur la carte'
+    optional: true
+- tapOn: 'Voir tous les filtres : 1 filtre actif'
+- tapOn: 'Réinitialiser'
+- tapOn: 'Rechercher'
+- tapOn: 'Revenir en arrière'
+
+- runFlow: ../common/lifecycle/StopApp.yml


### PR DESCRIPTION
## 🎯 Related Ticket

[PC-42319](https://passculture.atlassian.net/browse/PC-42319)

> Migration de deux flows Maestro legacy (`VenueMapJourney`, `FavoriteJourney`) vers la nouvelle architecture `testsV3`, et correction d'un step devenu obsolète dans le flow de suppression/réactivation de compte.

### 🔧 Changements

#### Nouveaux tests
- **`venue/CheckVenueMap.yml`** : accès à la carte des lieux depuis l'accueil (module "A côté") et depuis la recherche, avec vérification des filtres (Sorties, Boutiques, Cinéma…)
- **`favorite/AddAndDeleteFavorites.yml`** : login en tant que bénéficiaire, ajout de 3 CDs en favoris via `extractTextWithAI`, vérification du tri (prix croissant, proximité géographique), suppression de tous les favoris
- **`config.yaml`** : enregistrement des dossiers `venue/*` et `favorite/*` dans le runner testsV3

#### Fix
- **`AccessDeletionReactivation.yml`** : suppression du bloc testant le step "Je pense que quelqu'un d'autre a accès à mon compte" qui n'existe plus dans le stepper de l'UI

### 🧪 Comment tester
```bash
yarn tests:e2e (choisir le tag favorite et/ou le tag venue)


[PC-42319]: https://passculture.atlassian.net/browse/PC-42319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ