### PR TITLE
(PC-42513) fix(tracking): log appThemeStatus

### DIFF
--- a/src/features/cookies/helpers/startTrackingAcceptedCookies.native.test.ts
+++ b/src/features/cookies/helpers/startTrackingAcceptedCookies.native.test.ts
@@ -25,7 +25,8 @@ const mockLogAppThemeStatus = logAppThemeStatus as jest.Mock
 describe('startTrackingAcceptedCookies', () => {
   beforeEach(() => {
     resetHasLoggedAppThemeStatusForTests()
-    mockLogAppThemeStatus.mockClear()
+    mockLogAppThemeStatus.mockReset()
+    mockLogAppThemeStatus.mockResolvedValue(true)
   })
 
   it('should enable Google Analytics when Google Analytics cookies are accepted', () => {

--- a/src/features/cookies/helpers/startTrackingAcceptedCookies.ts
+++ b/src/features/cookies/helpers/startTrackingAcceptedCookies.ts
@@ -38,7 +38,9 @@ export const startTrackingAcceptedCookies = (
 
   if (acceptedGoogleAnalytics && !hasLoggedAppThemeStatus) {
     hasLoggedAppThemeStatus = true
-    void logAppThemeStatus()
+    void logAppThemeStatus().then((success) => {
+      if (!success) hasLoggedAppThemeStatus = false
+    })
   }
 
   const acceptedAdjust = acceptedCookies.includes(CookieNameEnum.ADJUST)

--- a/src/libs/styled/logAppThemeStatus.native.test.ts
+++ b/src/libs/styled/logAppThemeStatus.native.test.ts
@@ -79,7 +79,7 @@ describe('logAppThemeStatus', () => {
     getColorSchemeSpy.mockReturnValueOnce('light')
     ;(analytics.logAppThemeStatus as jest.Mock).mockRejectedValueOnce(error)
 
-    await expect(logAppThemeStatus()).resolves.toBeUndefined()
+    await expect(logAppThemeStatus()).resolves.toBe(false)
     expect(eventMonitoring.captureException).toHaveBeenCalledWith(error, {
       extra: { feature: 'logAppThemeStatus' },
     })

--- a/src/libs/styled/logAppThemeStatus.ts
+++ b/src/libs/styled/logAppThemeStatus.ts
@@ -15,7 +15,9 @@ export const logAppThemeStatus = async () => {
     const systemTheme = systemColorScheme === 'dark' ? ColorScheme.DARK : ColorScheme.LIGHT
 
     await analytics.logAppThemeStatus({ themeSetting, systemTheme, platform: Platform.OS })
+    return true
   } catch (error) {
     eventMonitoring.captureException(error, { extra: { feature: 'logAppThemeStatus' } })
+    return false
   }
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42513

## Context

Le tracker `logAppThemeStatus` n'est pas remonté dans environ 10% des sessions, on améliore ici la gestion du flag 
`hasLoggedAppThemeStatus` si `logAppThemeStatus` échoue silencieusement.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-09-08 at 16 47 32" src="https://github.com/user-attachments/assets/e987e9d4-17ca-4792-b83a-0dcf160025f7" />

