### PR TITLE
(PC-42818) feat(Bonification): improve ux for declined qf request

### DIFF
--- a/src/features/profile/components/Tutorial/BonificationAllStep.native.test.tsx
+++ b/src/features/profile/components/Tutorial/BonificationAllStep.native.test.tsx
@@ -21,6 +21,7 @@ function renderComponent(userOverrides = {}, propsOverrides = {}) {
       user={{
         ...beneficiaryUser,
         qfBonificationStatus: QFBonificationStatus.eligible,
+        disabilityBonificationStatus: DisabilityBonificationStatus.eligible,
         ...userOverrides,
       }}
       {...propsOverrides}
@@ -54,9 +55,9 @@ describe('BonificationAllStep', () => {
     })
 
     it('should navigate to refused screen when too many retries', async () => {
-      renderComponent({ remainingBonusAttempts: 0 })
+      renderComponent({ qfBonificationStatus: QFBonificationStatus.too_many_retries })
 
-      await userEvent.press(screen.getByLabelText('Faire une demande de bonus quotient familial'))
+      await userEvent.press(screen.getByLabelText('Vérifier ma demande de bonus quotient familial'))
 
       expect(navigate).toHaveBeenCalledWith(
         'SubscriptionStackNavigator',
@@ -139,7 +140,7 @@ describe('BonificationAllStep', () => {
       })
 
       await userEvent.press(
-        screen.getByLabelText('Faire une demande de bonus situation de handicap')
+        screen.getByLabelText('Vérifier ma demande de bonus situation de handicap')
       )
 
       expect(navigate).toHaveBeenCalledWith('SubscriptionStackNavigator', {
@@ -155,7 +156,7 @@ describe('BonificationAllStep', () => {
       })
 
       await userEvent.press(
-        screen.getByLabelText('Faire une demande de bonus situation de handicap')
+        screen.getByLabelText('Vérifier ma demande de bonus situation de handicap')
       )
 
       expect(navigate).toHaveBeenCalledWith('SubscriptionStackNavigator', {

--- a/src/features/profile/components/Tutorial/BonificationAllStep.tsx
+++ b/src/features/profile/components/Tutorial/BonificationAllStep.tsx
@@ -18,6 +18,7 @@ import { DefaultStepContainer } from 'features/profile/components/Tutorial/Defau
 import { PlainMoreSeparator } from 'features/profile/components/Tutorial/PlainMoreSeparator'
 import { getBonificationButtonContent } from 'features/profile/helpers/getBonificationButtonContent'
 import { getDisabilityBonificationRefusedType } from 'features/profile/helpers/getDisabilityBonificationRefusedType'
+import { getQFBonificationRefusedType } from 'features/profile/helpers/getQFBonificationRefusedType'
 import { UserProfile } from 'features/share/types'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
@@ -60,27 +61,30 @@ export const BonificationAllStep = ({ amount, isLoggedIn, resetBannerVisibility,
   // FAMILY QUOTIENT BONIFICATION
   const bonificationQFStatus: QFBonificationStatus | null | undefined = user?.qfBonificationStatus
 
-  const bonificationQFTooManyRetries = user?.remainingBonusAttempts === 0
-
   const isEligibleToQFBonification = bonificationQFStatus !== QFBonificationStatus.not_eligible
 
   const wasQFBonificationReceived = bonificationQFStatus === QFBonificationStatus.granted
 
-  const navigateToQFBonificationRefused = () => {
-    navigate(
-      ...getSubscriptionHookConfig('BonificationFamilyQuotientRefused', {
-        bonificationRefusedType: BonificationQFRefusedType.TOO_MANY_RETRIES,
-      })
-    )
-  }
+  const bonificationQFRefusedType = getQFBonificationRefusedType(bonificationQFStatus)
 
   const navigateToQFBonificationFlow = () => {
     navigate(...getSubscriptionHookConfig('BonificationExplanations'))
   }
 
+  const navigateToQFBonificationRefused = (bonificationRefusedType: BonificationQFRefusedType) => {
+    navigate(
+      ...getSubscriptionHookConfig('BonificationFamilyQuotientRefused', {
+        bonificationRefusedType,
+      })
+    )
+  }
+
   const onPressQFBonificationButton = () => {
-    if (bonificationQFTooManyRetries) navigateToQFBonificationRefused()
-    else navigateToQFBonificationFlow()
+    if (bonificationQFRefusedType) {
+      navigateToQFBonificationRefused(bonificationQFRefusedType)
+    } else {
+      navigateToQFBonificationFlow()
+    }
     resetBannerVisibility()
   }
 

--- a/src/features/profile/components/Tutorial/BonificationFamilyQuotientStep.tsx
+++ b/src/features/profile/components/Tutorial/BonificationFamilyQuotientStep.tsx
@@ -12,6 +12,7 @@ import { BlockDescriptionItem } from 'features/profile/components/Tutorial/Block
 import { DashedStepContainer } from 'features/profile/components/Tutorial/DashedStepContainer'
 import { PlainMoreSeparator } from 'features/profile/components/Tutorial/PlainMoreSeparator'
 import { getBonificationButtonContent } from 'features/profile/helpers/getBonificationButtonContent'
+import { getQFBonificationRefusedType } from 'features/profile/helpers/getQFBonificationRefusedType'
 import { UserProfile } from 'features/share/types'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
@@ -52,27 +53,30 @@ export const BonificationFamilyQuotientStep = ({
 
   const bonificationStatus: QFBonificationStatus | null | undefined = user?.qfBonificationStatus
 
-  const bonificationTooManyRetries = user?.remainingBonusAttempts === 0
-
   const isEligibleToBonification = bonificationStatus !== QFBonificationStatus.not_eligible
 
   const wasBonificationReceived = bonificationStatus === QFBonificationStatus.granted
 
-  const navigateToBonificationRefused = () => {
-    navigate(
-      ...getSubscriptionHookConfig('BonificationFamilyQuotientRefused', {
-        bonificationRefusedType: BonificationQFRefusedType.TOO_MANY_RETRIES,
-      })
-    )
-  }
+  const bonificationRefusedType = getQFBonificationRefusedType(bonificationStatus)
 
   const navigateToBonificationFlow = () => {
     navigate(...getSubscriptionHookConfig('BonificationExplanations'))
   }
 
+  const navigateToBonificationRefused = (bonificationRefusedType: BonificationQFRefusedType) => {
+    navigate(
+      ...getSubscriptionHookConfig('BonificationFamilyQuotientRefused', {
+        bonificationRefusedType,
+      })
+    )
+  }
+
   const onPressBonificationButton = () => {
-    if (bonificationTooManyRetries) navigateToBonificationRefused()
-    else navigateToBonificationFlow()
+    if (bonificationRefusedType) {
+      navigateToBonificationRefused(bonificationRefusedType)
+    } else {
+      navigateToBonificationFlow()
+    }
     resetBannerVisibility()
   }
 

--- a/src/features/profile/helpers/getBonificationButtonContent.native.test.ts
+++ b/src/features/profile/helpers/getBonificationButtonContent.native.test.ts
@@ -48,8 +48,8 @@ const cases = [
     type: BonificationType.FAMILY_QUOTIENT,
     status: QFBonificationStatus.not_eligible,
     expected: {
-      label: 'Faire une demande',
-      accessibilityLabel: 'Faire une demande de bonus quotient familial',
+      label: 'Vérifier ma demande',
+      accessibilityLabel: 'Vérifier ma demande de bonus quotient familial',
       disabled: false,
     },
   },
@@ -58,8 +58,8 @@ const cases = [
     type: BonificationType.DISABILITY,
     status: DisabilityBonificationStatus.not_eligible,
     expected: {
-      label: 'Faire une demande',
-      accessibilityLabel: 'Faire une demande de bonus situation de handicap',
+      label: 'Vérifier ma demande',
+      accessibilityLabel: 'Vérifier ma demande de bonus situation de handicap',
       disabled: false,
     },
   },
@@ -68,8 +68,8 @@ const cases = [
     type: BonificationType.FAMILY_QUOTIENT,
     status: null,
     expected: {
-      label: 'Faire une demande',
-      accessibilityLabel: 'Faire une demande de bonus quotient familial',
+      label: 'Vérifier ma demande',
+      accessibilityLabel: 'Vérifier ma demande de bonus quotient familial',
       disabled: false,
     },
   },
@@ -78,8 +78,8 @@ const cases = [
     type: BonificationType.DISABILITY,
     status: undefined,
     expected: {
-      label: 'Faire une demande',
-      accessibilityLabel: 'Faire une demande de bonus situation de handicap',
+      label: 'Vérifier ma demande',
+      accessibilityLabel: 'Vérifier ma demande de bonus situation de handicap',
       disabled: false,
     },
   },

--- a/src/features/profile/helpers/getBonificationButtonContent.ts
+++ b/src/features/profile/helpers/getBonificationButtonContent.ts
@@ -34,11 +34,17 @@ export const getBonificationButtonContent = (
         accessibilityLabel: `Bonus obtenu pour le ${bonificationLabel}`,
         disabled: true,
       }
-
-    default:
+    case QFBonificationStatus.eligible:
+    case DisabilityBonificationStatus.eligible:
       return {
         label: 'Faire une demande',
         accessibilityLabel: `Faire une demande de ${bonificationLabel}`,
+        disabled: false,
+      }
+    default:
+      return {
+        label: 'Vérifier ma demande',
+        accessibilityLabel: `Vérifier ma demande de ${bonificationLabel}`,
         disabled: false,
       }
   }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42818

## Context
Tentative d'ajout d'un test e2e : le wording du cta ne s'affiche pas correctement malgré la situation d'echec visible. Pas du à un FF. Pas du à un build trop vieux. 

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| qf              |  https://github.com/user-attachments/assets/926bb07e-7e83-478b-a837-e9bf5fa18543             | https://github.com/user-attachments/assets/be046b2f-1bec-4351-9d10-0bd4f52ed3b3      |
| qf & aah aeeh         |      https://github.com/user-attachments/assets/f8912dc4-6565-48f6-9b51-1e5946149f9b|  https://github.com/user-attachments/assets/45de6039-be35-49d0-b540-e16881ffb985|


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
