### PR TITLE
(PC-43423) fix(filters): use right typo for iOS in calendar date filter

### DIFF
--- a/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
+++ b/src/features/search/pages/modals/CalendarModal/CalendarModal.tsx
@@ -2,7 +2,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import { addMonths, addYears, format, parse } from 'date-fns'
 import React, { FunctionComponent, useCallback, useMemo, useRef } from 'react'
 import { SetValueConfig, useForm } from 'react-hook-form'
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
 import { CalendarList, DateData, LocaleConfig } from 'react-native-calendars'
 import styled, { useTheme } from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
@@ -300,9 +300,18 @@ export const CalendarModal: FunctionComponent<CalendarModalProps> = ({
           monthTextColor: designSystem.color.text.default,
           textSectionTitleColor: designSystem.color.text.subtle,
           backgroundColor: designSystem.color.background.default,
-          textDayFontFamily: designSystem.typography.body.fontFamily,
-          textMonthFontFamily: designSystem.typography.body.fontFamily,
-          textDayHeaderFontFamily: designSystem.typography.body.fontFamily,
+          textDayFontFamily:
+            Platform.OS === 'ios'
+              ? designSystem.typography.bodyItalic.fontFamily
+              : designSystem.typography.body.fontFamily,
+          textMonthFontFamily:
+            Platform.OS === 'ios'
+              ? designSystem.typography.bodyItalic.fontFamily
+              : designSystem.typography.body.fontFamily,
+          textDayHeaderFontFamily:
+            Platform.OS === 'ios'
+              ? designSystem.typography.bodyItalic.fontFamily
+              : designSystem.typography.body.fontFamily,
           textDayFontWeight: 500,
           textMonthFontWeight: 500,
           textDayHeaderFontWeight: 500,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43423

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="402" height="840" alt="Capture d’écran 2026-09-01 à 16 52 26" src="https://github.com/user-attachments/assets/59e71d67-119e-4987-b51b-9729fab9a421" />|<img width="405" height="839" alt="Capture d’écran 2026-09-01 à 16 52 11" src="https://github.com/user-attachments/assets/fe462afa-d30b-4442-94b9-ba0957943b10" />|
| Android          |<img width="374" height="815" alt="Capture d’écran 2026-09-01 à 16 52 36" src="https://github.com/user-attachments/assets/b285e1a0-fe3d-4a91-a9fd-a970e77aa42b" />|<img width="372" height="810" alt="Capture d’écran 2026-09-01 à 16 51 59" src="https://github.com/user-attachments/assets/058a7707-7ae3-46ec-9d01-027a53776094" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
