### PR TITLE
(PC-43329) feat(a11y): use span instead p in some buttons or links

### DIFF
--- a/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailAttemptsLeft.tsx
+++ b/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailAttemptsLeft.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
 import { Typo } from 'ui/theme'
+import { SPACE } from 'ui/theme/constants'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   attemptsLeft?: number
@@ -15,14 +17,16 @@ export const EmailAttemptsLeft: FunctionComponent<Props> = ({ attemptsLeft }) =>
   if (attemptsLeft < 2) {
     return (
       <StyledCaption>
-        Attention, il te reste&nbsp;: <StyledErrorText>{`${attemptsLeft} demande`}</StyledErrorText>
+        Attention, il te reste&nbsp;:{SPACE}
+        <StyledErrorText {...setTextSemantic('span')}>{`${attemptsLeft} demande`}</StyledErrorText>
       </StyledCaption>
     )
   }
   return (
     <StyledCaption>
-      Attention, il te reste&nbsp;:{' '}
-      <Typo.BodyAccentXs>{`${attemptsLeft} demandes`}</Typo.BodyAccentXs>
+      Attention, il te reste&nbsp;:{SPACE}
+      <Typo.BodyAccentXs
+        {...setTextSemantic('span')}>{`${attemptsLeft} demandes`}</Typo.BodyAccentXs>
     </StyledCaption>
   )
 }

--- a/src/features/bonification/pages/BonificationExplanations.tsx
+++ b/src/features/bonification/pages/BonificationExplanations.tsx
@@ -73,9 +73,11 @@ export const BonificationExplanations = () => {
             </StyledTitle3>
             <Typo.Body>
               Ce bonus de
-              <Typo.BodyAccent>{SPACE + formattedBonificationAmount + SPACE}</Typo.BodyAccent>
+              <Typo.BodyAccent {...setTextSemantic('span')}>
+                {SPACE + formattedBonificationAmount + SPACE}
+              </Typo.BodyAccent>
               est réservé aux jeunes dont la famille ou les tuteurs légaux ont un
-              <Typo.BodyAccent>
+              <Typo.BodyAccent {...setTextSemantic('span')}>
                 {` quotient familial inférieur ou égal à ${familyQuotientLevel}.`}
               </Typo.BodyAccent>
             </Typo.Body>
@@ -113,8 +115,11 @@ export const BonificationExplanations = () => {
           />
           {enableHandicapBonification ? null : (
             <StyledBodyS>
-              Si tu es en <Typo.BodyAccentS>situation de handicap</Typo.BodyAccentS>, un peu de
-              patience, ton cas sera pris en compte prochainement.
+              Si tu es en{SPACE}
+              <Typo.BodyAccentS {...setTextSemantic('span')}>
+                situation de handicap
+              </Typo.BodyAccentS>
+              , un peu de patience, ton cas sera pris en compte prochainement.
             </StyledBodyS>
           )}
         </ViewGap>

--- a/src/features/bonification/pages/BonificationFamilyQuotientRefused.tsx
+++ b/src/features/bonification/pages/BonificationFamilyQuotientRefused.tsx
@@ -32,6 +32,7 @@ import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
 import { SadFace } from 'ui/svg/icons/SadFace'
 import { Typo } from 'ui/theme'
 import { SPACE } from 'ui/theme/constants'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 const notFoundPageConfig: PageConfigEntry = {
   Illustration: ErrorIllustration,
@@ -176,7 +177,7 @@ export const BonificationFamilyQuotientRefused = () => {
   const buttonsSurtitle = showNumberOfRemainingRetries ? (
     <StyledBodyXs>
       Attention, il te reste&nbsp;:{SPACE}
-      <StyledBodyXsDark lastRemainingRetry={lastRemainingRetry}>
+      <StyledBodyXsDark lastRemainingRetry={lastRemainingRetry} {...setTextSemantic('span')}>
         {remainingBonusAttempts}
         {remainingBonusAttempts
           ? plural(remainingBonusAttempts, { plural: ' demandes', singular: ' demande' })

--- a/src/features/home/components/Trend.tsx
+++ b/src/features/home/components/Trend.tsx
@@ -5,6 +5,7 @@ import { TrendBlock, TrendNavigationProps } from 'features/home/types'
 import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHelpers'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Typo, getSpacing } from 'ui/theme'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type TrendProps = TrendBlock &
   TrendNavigationProps & {
@@ -20,7 +21,9 @@ export const Trend = ({ image, title, ...rest }: TrendProps) => {
   return (
     <Item key={title} accessibilityLabel={title} {...rest}>
       <ItemIcon source={image} />
-      <StyledText numberOfLines={numberOfLines}>{title}</StyledText>
+      <StyledText {...setTextSemantic('span')} numberOfLines={numberOfLines}>
+        {title}
+      </StyledText>
     </Item>
   )
 }

--- a/src/features/location/components/LocationWidget.tsx
+++ b/src/features/location/components/LocationWidget.tsx
@@ -12,6 +12,7 @@ import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { LocationPointerAppV2 } from 'ui/svg/icons/LocationPointerAppV2'
 import { getSpacing, Typo } from 'ui/theme'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const LOCATION_TITLE_MAX_WIDTH = getSpacing(25)
 
@@ -53,7 +54,9 @@ export const LocationWidget: FunctionComponent<Props> = ({ screenOrigin }) => {
         onPress={onPress}
         accessibilityLabel={computedAccessibilityLabel}>
         <IconContainer isActive={isWidgetHighlighted}>{locationIcon}</IconContainer>
-        <StyledCaption numberOfLines={numberOfLines}>{locationTitle}</StyledCaption>
+        <StyledCaption {...setTextSemantic('span')} numberOfLines={numberOfLines}>
+          {locationTitle}
+        </StyledCaption>
       </StyledTouchable>
     </WidgetContainer>
   )

--- a/src/features/location/components/LocationWidgetBadge.tsx
+++ b/src/features/location/components/LocationWidgetBadge.tsx
@@ -12,6 +12,7 @@ import { useMobileFontScaleToDisplay } from 'shared/accessibility/helpers/zoomHe
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { LocationPointer } from 'ui/svg/icons/LocationPointer'
 import { Typo } from 'ui/theme'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export const LocationWidgetBadge = () => {
   const { navigate } = useNavigation<UseNavigationType>()
@@ -43,7 +44,9 @@ export const LocationWidgetBadge = () => {
         ) : (
           <LocationPointerDefault testID="location pointer default" />
         )}
-        <LocationTitle numberOfLines={numberOfLines}>{locationTitle}</LocationTitle>
+        <LocationTitle {...setTextSemantic('span')} numberOfLines={numberOfLines}>
+          {locationTitle}
+        </LocationTitle>
       </LocationButton>
     </Container>
   )

--- a/src/features/offer/components/OfferVenueButton/OfferVenueButton.tsx
+++ b/src/features/offer/components/OfferVenueButton/OfferVenueButton.tsx
@@ -7,6 +7,7 @@ import { analytics } from 'libs/analytics/provider'
 import { HeroButtonList } from 'ui/components/buttons/HeroButtonList'
 import { LocationBuildingFilled } from 'ui/svg/icons/LocationBuildingFilled'
 import { Typo } from 'ui/theme'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   venue: OfferVenueResponse
@@ -17,9 +18,13 @@ export function OfferVenueButton({ venue }: Readonly<Props>) {
 
   return (
     <HeroButtonList
-      Title={<Typo.BodyAccent>{venue.name}</Typo.BodyAccent>}
+      Title={<Typo.BodyAccent {...setTextSemantic('span')}>{venue.name}</Typo.BodyAccent>}
       Subtitle={
-        venue.city ? <SubtitleText testID="subtitle">{venue.city}</SubtitleText> : undefined
+        venue.city ? (
+          <SubtitleText {...setTextSemantic('span')} testID="subtitle">
+            {venue.city}
+          </SubtitleText>
+        ) : undefined
       }
       Icon={
         <LocationBuildingFilled color={designSystem.color.icon.default} size={icons.sizes.small} />

--- a/src/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.tsx
+++ b/src/features/onboarding/pages/onboarding/OnboardingAgeSelectionFork.tsx
@@ -67,9 +67,9 @@ export const OnboardingAgeSelectionFork: FunctionComponent = () => {
             onBeforeNavigate={button.onBeforeNavigate}
             navigateTo={button.navigateTo}
             accessibilityLabel={`${button.startButtonTitle}${button.age}${button.endButtonTitle}`}>
-            <StyledBody>
+            <StyledBody {...setTextSemantic('span')}>
               {button.startButtonTitle}
-              <StyledTitle4>{button.age}</StyledTitle4>
+              <StyledTitle4 {...setTextSemantic('span')}>{button.age}</StyledTitle4>
               {button.endButtonTitle}
             </StyledBody>
           </AgeButton>

--- a/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.tsx
+++ b/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.tsx
@@ -5,6 +5,7 @@ import { Touchable } from 'ui/components/touchable/Touchable'
 import { Typo } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 import { getHoverStyle } from 'ui/theme/getHoverStyle/getHoverStyle'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type IsSelectedProps = {
   isSelected?: boolean
@@ -36,7 +37,9 @@ export const SingleFilterButton: FunctionComponent<SingleFilterButtonProps> = ({
       isSelected={isSelected}
       onPress={onPress}
       accessibilityLabel={accessibilityLabel}>
-      <Typo.BodyAccentXs testID={filterButtonLabel}>{label}</Typo.BodyAccentXs>
+      <Typo.BodyAccentXs {...setTextSemantic('span')} testID={filterButtonLabel}>
+        {label}
+      </Typo.BodyAccentXs>
       {icon}
     </TouchableContainer>
   )

--- a/src/features/search/components/FilterRow/FilterRow.tsx
+++ b/src/features/search/components/FilterRow/FilterRow.tsx
@@ -8,6 +8,7 @@ import { Touchable } from 'ui/components/touchable/Touchable'
 import { ArrowNext as DefaultArrowNext } from 'ui/svg/icons/ArrowNext'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { Typo } from 'ui/theme'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   icon?: React.FunctionComponent<AccessibleIcon>
@@ -58,14 +59,22 @@ export const FilterRow = ({
       ) : null}
       <TextContainer>
         <TitleAndComplement>
-          <Title numberOfLines={2}>{title}</Title>
+          <Title {...setTextSemantic('span')} numberOfLines={2}>
+            {title}
+          </Title>
           {complement ? (
             <ComplementContainer>
-              <ComplementLabel numberOfLines={1}>{complement}</ComplementLabel>
+              <ComplementLabel {...setTextSemantic('span')} numberOfLines={1}>
+                {complement}
+              </ComplementLabel>
             </ComplementContainer>
           ) : null}
         </TitleAndComplement>
-        {description ? <Description numberOfLines={1}>{description}</Description> : null}
+        {description ? (
+          <Description {...setTextSemantic('span')} numberOfLines={1}>
+            {description}
+          </Description>
+        ) : null}
       </TextContainer>
       <ArrowNext accessibilityLabel="Affiner la recherche" />
     </TouchableRow>

--- a/src/features/search/components/SearchHistoryItem/SearchHistoryItem.tsx
+++ b/src/features/search/components/SearchHistoryItem/SearchHistoryItem.tsx
@@ -8,6 +8,7 @@ import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ClockFilled } from 'ui/svg/icons/ClockFilled'
 import { Typo } from 'ui/theme'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   item: Highlighted<HistoryItem>
@@ -31,16 +32,18 @@ export function SearchHistoryItem({ item, queryHistory, onPress }: Props) {
         <ClockIconContainer>
           <ClockFilledIcon />
         </ClockIconContainer>
-        <StyledText numberOfLines={numberOfLines}>
+        <StyledText {...setTextSemantic('span')} numberOfLines={numberOfLines}>
           {queryHistory === '' ? (
-            <Typo.BodyItalic testID="withoutUsingHighlight">{item.query}</Typo.BodyItalic>
+            <Typo.BodyItalic {...setTextSemantic('span')} testID="withoutUsingHighlight">
+              {item.query}
+            </Typo.BodyItalic>
           ) : (
             <HistoryItemHighlight historyItem={item} />
           )}
           {shouldDisplaySearchGroupOrNativeCategory ? (
             <React.Fragment>
-              <Typo.BodyItalic> dans </Typo.BodyItalic>
-              <Typo.BodyItalicAccent>
+              <Typo.BodyItalic {...setTextSemantic('span')}> dans </Typo.BodyItalic>
+              <Typo.BodyItalicAccent {...setTextSemantic('span')}>
                 {item.nativeCategoryLabel ?? item.categoryLabel}
               </Typo.BodyItalicAccent>
             </React.Fragment>

--- a/src/features/search/components/SelectionLabel/SelectionLabel.tsx
+++ b/src/features/search/components/SelectionLabel/SelectionLabel.tsx
@@ -5,6 +5,7 @@ import { accessibleCheckboxProps } from 'shared/accessibilityProps/accessibleChe
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { Validate } from 'ui/svg/icons/Validate'
 import { Typo } from 'ui/theme'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 import { HiddenCheckbox } from 'ui/web/inputs/HiddenCheckbox'
 
 interface Props {
@@ -26,7 +27,7 @@ export const SelectionLabel: React.FC<Props> = ({ label, selected, onPress }) =>
         </IconContainer>
       ) : undefined}
       <LabelContainer selected={selected}>
-        <Label numberOfLines={1} selected={selected}>
+        <Label {...setTextSemantic('span')} numberOfLines={1} selected={selected}>
           {label}
         </Label>
       </LabelContainer>

--- a/src/shared/categoryButton/CategoryButton.tsx
+++ b/src/shared/categoryButton/CategoryButton.tsx
@@ -13,6 +13,7 @@ import {
 import { Typo, getSpacing } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 import { getHoverStyle } from 'ui/theme/getHoverStyle/getHoverStyle'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export type CategoryButtonProps = {
   label: string
@@ -52,9 +53,7 @@ export const CategoryButton: FunctionComponent<CategoryButtonProps> = ({
       borderColor={borderColor}
       style={style}
       height={effectiveHeight}>
-      {/* <LabelContainer> */}
-      <Label>{label.toUpperCase()}</Label>
-      {/* </LabelContainer> */}
+      <Label {...setTextSemantic('span')}>{label.toUpperCase()}</Label>
     </TouchableContainer>
   )
 }

--- a/src/shared/categoryButton/NewCategoryButton.tsx
+++ b/src/shared/categoryButton/NewCategoryButton.tsx
@@ -16,6 +16,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Typo, getSpacing } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 import { getHoverStyle } from 'ui/theme/getHoverStyle/getHoverStyle'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type CategoryButtonProps = {
   label: string
@@ -68,13 +69,15 @@ export const NewCategoryButton: FunctionComponent<CategoryButtonProps> = ({
       height={effectiveHeight}>
       {shouldUseAccessibleLayout ? (
         <AccessibleLabelContainer>
-          <Label>{label}</Label>
+          <Label {...setTextSemantic('span')}>{label}</Label>
         </AccessibleLabelContainer>
       ) : (
         <Container gap={2}>
           <LabelContainer>
             {labelPartsToDisplay.map((labelPart) => (
-              <Label key={labelPart}>{labelPart}</Label>
+              <Label key={labelPart} {...setTextSemantic('span')}>
+                {labelPart}
+              </Label>
             ))}
           </LabelContainer>
           {illustrationUrlToDisplay ? (

--- a/src/ui/components/IconWithCaption.tsx
+++ b/src/ui/components/IconWithCaption.tsx
@@ -4,6 +4,7 @@ import styled, { useTheme } from 'styled-components/native'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { Typo } from 'ui/theme'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface IconWithCaptionProps {
   Icon: React.FC<AccessibleIcon>
@@ -31,7 +32,10 @@ export const IconWithCaption = ({
           size={icons.sizes.standard}
         />
       </IconContainer>
-      <Caption testID={testID ? `caption-${testID}` : undefined} disabled={isDisabled}>
+      <Caption
+        {...setTextSemantic('span')}
+        testID={testID ? `caption-${testID}` : undefined}
+        disabled={isDisabled}>
         {caption}
       </Caption>
     </Container>

--- a/src/ui/components/ModuleBanner/SystemBanner.tsx
+++ b/src/ui/components/ModuleBanner/SystemBanner.tsx
@@ -19,6 +19,7 @@ import { AccessibleIcon } from 'ui/svg/icons/types'
 import { Typo } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 import { getHoverStyle } from 'ui/theme/getHoverStyle/getHoverStyle'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type TouchableProps =
   | {
@@ -133,11 +134,15 @@ export const SystemBanner: FunctionComponent<Props> = ({
           </IconContainer>
         ) : null}
         <DescriptionContainer gap={1}>
-          <Typo.BodyAccent color={color}>{title}</Typo.BodyAccent>
+          <Typo.BodyAccent {...setTextSemantic('span')} color={color}>
+            {title}
+          </Typo.BodyAccent>
           {React.isValidElement(subtitle) ? (
             subtitle
           ) : (
-            <Typo.Body color={color}>{subtitle}</Typo.Body>
+            <Typo.Body {...setTextSemantic('span')} color={color}>
+              {subtitle}
+            </Typo.Body>
           )}
         </DescriptionContainer>
         <View>

--- a/src/ui/components/SectionRowContent.tsx
+++ b/src/ui/components/SectionRowContent.tsx
@@ -6,6 +6,7 @@ import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
 import { ArrowNext as DefaultArrowNext } from 'ui/svg/icons/ArrowNext'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { Typo } from 'ui/theme'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 export type SectionRowContentProps = {
   title: string
@@ -40,7 +41,9 @@ export const SectionRowContent = ({
   const Title = renderTitle ? (
     renderTitle(title)
   ) : (
-    <Typo.BodyAccent numberOfLines={titleNumberOfLines}>{title}</Typo.BodyAccent>
+    <Typo.BodyAccent {...setTextSemantic('span')} numberOfLines={titleNumberOfLines}>
+      {title}
+    </Typo.BodyAccent>
   )
 
   return (

--- a/src/ui/components/SocialNetworkCard.tsx
+++ b/src/ui/components/SocialNetworkCard.tsx
@@ -4,9 +4,11 @@ import styled from 'styled-components/native'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { analytics } from 'libs/analytics/provider'
 import { capitalize } from 'libs/formatter/capitalize'
+import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { getSpacing, Typo } from 'ui/theme'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 import { SocialNetwork, SocialNetworkIconsMap } from './socials/types'
 
@@ -15,6 +17,7 @@ interface SocialNetworkCardProps {
 }
 
 function SocialNetworkCardComponent(props: SocialNetworkCardProps) {
+  const numberOfLines = useNumberOfLine(2)
   const { network } = props
   const { icon: Icon, link, fallbackLink } = SocialNetworkIconsMap[network]
   const name = capitalize(network)
@@ -25,7 +28,7 @@ function SocialNetworkCardComponent(props: SocialNetworkCardProps) {
 
   const onBeforeNavigate = () => {
     const network = name === 'X' ? 'Twitter' : name
-    analytics.logClickSocialNetwork(network)
+    void analytics.logClickSocialNetwork(network)
   }
 
   return (
@@ -38,7 +41,9 @@ function SocialNetworkCardComponent(props: SocialNetworkCardProps) {
         <NetworkIconBox>
           <StyledIcon />
         </NetworkIconBox>
-        <Typo.BodyAccentXs numberOfLines={2}>{name}</Typo.BodyAccentXs>
+        <Typo.BodyAccentXs {...setTextSemantic('span')} numberOfLines={numberOfLines}>
+          {name}
+        </Typo.BodyAccentXs>
       </Container>
     </ExternalTouchableLink>
   )

--- a/src/ui/components/StepButton/StepButton.tsx
+++ b/src/ui/components/StepButton/StepButton.tsx
@@ -14,6 +14,7 @@ import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { getSpacing, Typo } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 interface Props {
   step: StepDetails
@@ -97,8 +98,14 @@ const ButtonContent: FunctionComponent<ButtonContentProps> = ({
 
   return (
     <StyleContainer LeftIcon={<Icon />} RightIcon={withRightIcon ? undefined : () => null}>
-      <StyledButtonText stepState={stepState}>{label}</StyledButtonText>
-      {subtitle ? <StepSubtitle stepState={stepState}>{subtitle}</StepSubtitle> : null}
+      <StyledButtonText {...setTextSemantic('span')} stepState={stepState}>
+        {label}
+      </StyledButtonText>
+      {subtitle ? (
+        <StepSubtitle {...setTextSemantic('span')} stepState={stepState}>
+          {subtitle}
+        </StepSubtitle>
+      ) : null}
     </StyleContainer>
   )
 }

--- a/src/ui/components/radioSelector/RadioSelector.tsx
+++ b/src/ui/components/radioSelector/RadioSelector.tsx
@@ -7,6 +7,7 @@ import { accessibleRadioProps } from 'shared/accessibilityProps/accessibleRadioP
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { useSpaceBarAction } from 'ui/hooks/useSpaceBarAction'
 import { Typo } from 'ui/theme'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type RightContentProps =
   | { rightText: string; rightElement?: never }
@@ -62,6 +63,7 @@ export const RadioSelector = ({
         <Container gap={4}>
           <LeftContent>
             <Label
+              {...setTextSemantic('span')}
               disabled={disabled}
               testID={testID ? `${testID}-label` : undefined}
               isHover={isHover}>
@@ -69,13 +71,18 @@ export const RadioSelector = ({
             </Label>
             {
               description ? (
-                <Description disabled={disabled}>{description}</Description>
+                <Description {...setTextSemantic('span')} disabled={disabled}>
+                  {description}
+                </Description>
               ) : null /* conditionally render description since it applies a margin even when nothing is displayed */
             }
           </LeftContent>
           <RightContent>
             {rightText ? (
-              <RightText disabled={disabled} testID={testID ? `${testID}-right-text` : undefined}>
+              <RightText
+                {...setTextSemantic('span')}
+                disabled={disabled}
+                testID={testID ? `${testID}-right-text` : undefined}>
                 {rightText}
               </RightText>
             ) : null}

--- a/src/ui/designSystem/Banner/components/BannerLink.tsx
+++ b/src/ui/designSystem/Banner/components/BannerLink.tsx
@@ -13,6 +13,7 @@ import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { Typo } from 'ui/theme'
+import { setTextSemantic } from 'ui/theme/typographyAttrs/setTextSemantic'
 
 type ButtonTextWithIconProps = {
   wording: string
@@ -49,7 +50,7 @@ export function BannerLink({
       <IconWrapper>
         <Icon size={designSystem.size.icon.s} />
       </IconWrapper>
-      <Typo.BodyAccentXs>{wording}</Typo.BodyAccentXs>
+      <Typo.BodyAccentXs {...setTextSemantic('span')}>{wording}</Typo.BodyAccentXs>
     </InlineTouchable>
   )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43329

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
