### PR TITLE
(PC-43471) chore(prompt): add /pr-autoreview prompt for on-demand PR review

### DIFF
--- a/.github/prompts/pr-autoreview.prompt.md
+++ b/.github/prompts/pr-autoreview.prompt.md
@@ -1,0 +1,69 @@
+---
+agent: agent
+description: Review the current PR and rate it /10 on bugs, security, improvements, technical quality, and consistency with adjacent code.
+---
+
+# PR autoreview (pass Culture)
+
+## Context Gathering
+
+1. Determine the main branch, then diff against it:
+   - `MAIN=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')`
+   - `git fetch origin "$MAIN"`
+   - `git --no-pager diff "origin/$MAIN...HEAD"`
+2. Read adjacent code for each modified file.
+3. Check for new/modified tests related to changes.
+4. If dependency files changed, audit for known vulnerabilities with the matching tool:
+   - JS/TS (`package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`) → `npm audit` (or `yarn audit` / `pnpm audit`)
+
+## Evaluation Criteria
+
+Hints below are additional focus areas — use your own judgment to evaluate thoroughly.
+
+1. **Bugs** (weight: critical)
+2. **Security** (weight: critical)
+3. **Tests & Reliability** (weight: high)
+4. **Improvements** (weight: medium) — simpler libraries, unnecessary complexity, performance.
+5. **Technical Quality** (weight: medium) — AHA rule: only extract when used **>3 times**.
+6. **Consistency** (weight: low) — match patterns/naming/style of surrounding code.
+
+## Severity Levels
+
+- 🔴 **Blocker**: Must fix before merge.
+- 🟠 **Important**: Should fix.
+- 🟡 **Minor**: Nice to fix.
+
+## Scoring Rules
+
+- Any 🔴 → Overall capped at **5/10**.
+- Any 🟠 → Overall capped at **7/10**.
+- Bugs & Security count **2x** in weighted average.
+
+## Output Format
+
+```
+## PR Review — <PR title>
+
+| Criteria           | Status       | Comments |
+|--------------------|--------------|----------|
+| Bugs               | 🟢/🟡/🟠/🔴 |          |
+| Security           | 🟢/🟡/🟠/🔴 |          |
+| Tests & Reliability| 🟢/🟡/🟠/🔴 |          |
+| Improvements       | 🟢/🟡/🟠/🔴 |          |
+| Technical Quality  | 🟢/🟡/🟠/🔴 |          |
+| Consistency        | 🟢/🟡/🟠/🔴 |          |
+
+**Overall: X/10**
+
+### 🔴 Blockers
+### 🟠 Important
+### 🟡 Minor
+### 👍 What's Done Well
+### Suggestions
+```
+
+## Guidelines
+
+- Reference specific lines/files. Be actionable. Praise what's good.
+- Don't nitpick formatting if a linter is configured.
+- When unsure about a pattern, check similar code in the repo first.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,4 +42,5 @@
     "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.formatOnSave": true
   },
+  "chat.promptFiles": true
 }


### PR DESCRIPTION
## PR Review — feat: add /pr-autoreview prompt for on-demand Copilot PR review

| Criteria            | Status | Comments |
|---------------------|--------|----------|
| Bugs                | 🟢     |          |
| Security            | 🟢     |          |
| Tests & Reliability | 🟢     | Pas de tests à écrire pour du tooling/config |
| Improvements        | 🟢     |          |
| Technical Quality   | 🟡     | Voir ci-dessous |
| Consistency         | 🟢     |          |

**Overall: 9/10**

---

### 🟡 Minor

**`.github/prompts/pr-autoreview.prompt.md:2` — frontmatter `agent: agent` incertain**
La clé `agent` avec la valeur `agent` est sémantiquement redondante et non documentée officiellement. Le fix vient d'un message d'erreur VS Code ("rename `mode` to `agent`") mais la valeur correcte pourrait être `agent: true` voire simplement supprimer la clé. À vérifier une fois la PR ouverte : si Copilot n'interprète pas ce frontmatter, le prompt fonctionnera quand même, juste sans forçage du mode.

---

### 👍 What's Done Well

- `"chat.promptFiles": true` ajouté dans `settings.json` partagé : tous les devs bénéficient du `/pr-autoreview` sans config manuelle.
- Scope minimaliste : 2 fichiers, zéro impact production.
- Le skill est fidèlement adapté au repo (Python audit supprimé, JS/TS conservé).
- Aucune dépendance ajoutée, aucun secret exposé.

---

### Suggestions

Vérifier après merge que `/pr-autoreview` apparaît bien dans l'autocomplétion du chat Copilot. Si le frontmatter `agent: agent` pose problème, tenter `agent: true` ou simplement le retirer.