### PR TITLE
(PC-43497) fix(app): use TouchableOpacity rather than Touchable with focus visible

### DIFF
--- a/src/features/offer/components/MovieCalendar/components/MovieCalendarDay.tsx
+++ b/src/features/offer/components/MovieCalendar/components/MovieCalendarDay.tsx
@@ -6,8 +6,7 @@ import styled from 'styled-components/native'
 import { MovieCalendarBottomBar } from 'features/offer/components/MovieCalendar/components/MovieCalendarBottomBar'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { getComputedAccessibilityLabel } from 'shared/accessibility/helpers/getComputedAccessibilityLabel'
-import { styledButton } from 'ui/components/buttons/styledButton'
-import { Touchable } from 'ui/components/touchable/Touchable'
+import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { Typo } from 'ui/theme'
 
 import { useMovieCalendarDay } from '../hooks/useMovieCalendarDay'
@@ -83,13 +82,10 @@ const CalendarTextView = styled(View)(({ theme }) => ({
   marginBottom: theme.designSystem.size.spacing.s,
 }))
 
-const CalendarCell = styledButton(Touchable)({
+const CalendarCell = styled(TouchableOpacity)({
   justifyContent: 'center',
   alignItems: 'center',
   flexWrap: 'wrap',
-  '&:hover': {
-    textDecorationLine: 'none',
-  },
 })
 
 const DefaultCalendarText = styled(Typo.BodyAccent)({

--- a/src/features/search/components/AutocompleteItem/AutocompleteItem.tsx
+++ b/src/features/search/components/AutocompleteItem/AutocompleteItem.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
-import { styledButton } from 'ui/components/buttons/styledButton'
-import { Touchable } from 'ui/components/touchable/Touchable'
+import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 
 type Props = {
   icon: React.ReactNode
@@ -25,7 +24,7 @@ export function AutocompleteItem({ icon, onPress, children, testID }: Props) {
 
 const IconWrapper = styled.View({ flexShrink: 0 })
 
-const ItemTouchable = styledButton(Touchable)(({ theme }) => ({
+const ItemTouchable = styled(TouchableOpacity)(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'center',
   marginBottom: theme.designSystem.size.spacing.l,

--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
@@ -25,8 +25,7 @@ import { env } from 'libs/environment/env'
 import { useSearchGroupLabel } from 'libs/subcategories'
 import { useSubcategoriesQuery } from 'queries/subcategories/useSubcategoriesQuery'
 import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
-import { styledButton } from 'ui/components/buttons/styledButton'
-import { Touchable } from 'ui/components/touchable/Touchable'
+import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { MagnifyingGlassFilled } from 'ui/svg/icons/MagnifyingGlassFilled'
 import { Typo } from 'ui/theme'
 
@@ -249,7 +248,7 @@ const Suggestion: FunctionComponent<{ categoryToDisplay: string }> = ({ category
 
 const MagnifyingGlassIconContainer = styled.View({ flexShrink: 0 })
 
-const AutocompleteItemTouchable = styledButton(Touchable)(({ theme }) => ({
+const AutocompleteItemTouchable = styled(TouchableOpacity)(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'center',
   marginBottom: theme.designSystem.size.spacing.l,

--- a/src/features/search/components/SearchHistoryItem/SearchHistoryItem.tsx
+++ b/src/features/search/components/SearchHistoryItem/SearchHistoryItem.tsx
@@ -5,8 +5,7 @@ import { HistoryItemHighlight } from 'features/search/components/Highlight/Highl
 import { Highlighted, HistoryItem } from 'features/search/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
-import { styledButton } from 'ui/components/buttons/styledButton'
-import { Touchable } from 'ui/components/touchable/Touchable'
+import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ClockFilled } from 'ui/svg/icons/ClockFilled'
 import { Typo } from 'ui/theme'
 
@@ -56,7 +55,7 @@ const Container = styled.View({
   flex: 1,
 })
 
-const HistoryItemTouchable = styledButton(Touchable)({
+const HistoryItemTouchable = styled(TouchableOpacity)({
   flexDirection: 'row',
   alignItems: 'center',
 })

--- a/src/ui/theme/customFocusOutline/touchableFocusOutline.web.tsx
+++ b/src/ui/theme/customFocusOutline/touchableFocusOutline.web.tsx
@@ -14,4 +14,11 @@ const focusStyle = () => {
 }
 
 export const touchableFocusOutline = ({ theme, isFocus }: TouchableFocusOutlineProps) =>
-  isFocus ? { ...focusStyle(), outlineColor: theme.designSystem.color.outline.default } : {}
+  isFocus
+    ? {
+        ...focusStyle(),
+        outlineColor: theme.designSystem.color.outline.default,
+        outlineWidth: theme.outline.width,
+        outlineStyle: theme.outline.style,
+      }
+    : {}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43497

## Context
L'utilisation de `Touchable` a eu des effets de bord sur l'utilisation du calendrier sur la page offre (lorsqu'une date était sélectionnée par clic on scrollait au début du calendrier).
Cette PR remet à ces endroits l'utilisation de `TouchableOpacity` avec un focus visible en modifiant directement `touchableFocusOnline`.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |<img width="1509" height="763" alt="Capture d’écran 2026-09-02 à 11 55 11" src="https://github.com/user-attachments/assets/2382f491-ae44-4e21-bf7d-990525fc90cb" /> <img width="1510" height="765" alt="Capture d’écran 2026-09-02 à 11 55 22" src="https://github.com/user-attachments/assets/4cb0681f-6541-40f9-b2c6-d76b6592018d" /> <img width="1505" height="764" alt="Capture d’écran 2026-09-02 à 11 55 41" src="https://github.com/user-attachments/assets/77db3977-e256-4eec-8f62-ca3b3186ed68" /> <img width="1501" height="759" alt="Capture d’écran 2026-09-02 à 11 56 07" src="https://github.com/user-attachments/assets/34d18678-657c-4a40-9154-55b34bc07ddb" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
