### PR TITLE
(PC-43481) fix(shared): preserve padding on search category label button

### DIFF
--- a/src/shared/categoryButton/NewCategoryButton.tsx
+++ b/src/shared/categoryButton/NewCategoryButton.tsx
@@ -147,8 +147,10 @@ const Label = styled(Typo.BodyAccentS).attrs({ numberOfLines: 4 })(({ theme }) =
   color: theme.designSystem.color.text.default,
   backgroundColor: theme.designSystem.color.text.inverted,
   borderRadius: theme.designSystem.size.borderRadius.s,
-  paddingVertical: theme.designSystem.size.spacing.xxs,
-  paddingHorizontal: theme.designSystem.size.spacing.xs,
+  paddingTop: theme.designSystem.size.spacing.xxs,
+  paddingBottom: theme.designSystem.size.spacing.xxs,
+  paddingLeft: theme.designSystem.size.spacing.xs,
+  paddingRight: theme.designSystem.size.spacing.xs,
 }))
 
 const CATEGORY_ICON_TOP = getSpacing(3.5)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43481

## Context

Le bug est survenu car `Typo.BodyAccent` est devenu un `p` au lieu d'un `div` en web.
Les `p` ne fonctionnent pas avec `paddingHorizontal` et `paddingVertical`.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-02 at 17 11 22" src="https://github.com/user-attachments/assets/a931447f-69a2-4e67-9a29-b354174b07a3" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-02 at 17 11 53" src="https://github.com/user-attachments/assets/cf409419-b0ab-4b44-880e-8b244b942820" />|
| Android          |               |       |
| Phone - Chrome   |<img width="382" height="677" alt="Capture d’écran 2026-09-02 à 17 11 36" src="https://github.com/user-attachments/assets/11d305c6-d164-4a92-be9d-ea9c5f51e79b" />|<img width="386" height="678" alt="Capture d’écran 2026-09-02 à 17 12 08" src="https://github.com/user-attachments/assets/b912b035-2999-40a2-bef2-7e414c9427bc" />|
| Desktop - Chrome |<img width="1507" height="765" alt="Capture d’écran 2026-09-02 à 17 11 27" src="https://github.com/user-attachments/assets/823837c8-76fa-4749-a99a-9ea22383c940" />|<img width="1508" height="762" alt="Capture d’écran 2026-09-02 à 17 12 00" src="https://github.com/user-attachments/assets/2136c27f-67d4-41f0-8c48-1f2632f1563a" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
