### PR TITLE
(PC-43391) refactor(ui): improve HorizontalOfferTile appearance

### DIFF
--- a/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
@@ -1905,11 +1905,12 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                           Livre
                         </Text>
                         <View
-                          gap={1}
+                          gap={2}
                           style={
                             {
+                              "alignItems": "center",
                               "flexDirection": "row",
-                              "gap": 4,
+                              "gap": 8,
                             }
                           }
                         >
@@ -2262,11 +2263,12 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                           Concert
                         </Text>
                         <View
-                          gap={1}
+                          gap={2}
                           style={
                             {
+                              "alignItems": "center",
                               "flexDirection": "row",
-                              "gap": 4,
+                              "gap": 8,
                             }
                           }
                         >
@@ -2615,11 +2617,12 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                           Concert
                         </Text>
                         <View
-                          gap={1}
+                          gap={2}
                           style={
                             {
+                              "alignItems": "center",
                               "flexDirection": "row",
-                              "gap": 4,
+                              "gap": 8,
                             }
                           }
                         >
@@ -2967,11 +2970,12 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                           Concert
                         </Text>
                         <View
-                          gap={1}
+                          gap={2}
                           style={
                             {
+                              "alignItems": "center",
                               "flexDirection": "row",
-                              "gap": 4,
+                              "gap": 8,
                             }
                           }
                         >

--- a/__snapshots__/shared/verticalPlaylist/components/VerticalPlaylistOffersView.native.test.tsx.native-snap
+++ b/__snapshots__/shared/verticalPlaylist/components/VerticalPlaylistOffersView.native.test.tsx.native-snap
@@ -672,11 +672,12 @@ exports[`<VerticalPlaylistOffersView /> should render correctly 1`] = `
                   Livre
                 </Text>
                 <View
-                  gap={1}
+                  gap={2}
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
-                      "gap": 4,
+                      "gap": 8,
                     }
                   }
                 >
@@ -942,11 +943,12 @@ exports[`<VerticalPlaylistOffersView /> should render correctly 1`] = `
                   Concert
                 </Text>
                 <View
-                  gap={1}
+                  gap={2}
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
-                      "gap": 4,
+                      "gap": 8,
                     }
                   }
                 >
@@ -1216,11 +1218,12 @@ exports[`<VerticalPlaylistOffersView /> should render correctly 1`] = `
                   Concert
                 </Text>
                 <View
-                  gap={1}
+                  gap={2}
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
-                      "gap": 4,
+                      "gap": 8,
                     }
                   }
                 >

--- a/src/ui/components/tiles/HorizontalOfferTile.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.tsx
@@ -217,14 +217,9 @@ export const HorizontalOfferTile = ({
                   {subtitle}
                 </Body>
               ))}
-            <PriceAndComingSoonTagContainer gap={1}>
+            <PriceAndComingSoonTagContainer gap={2}>
               {shouldDisplayPrice ? <Typo.BodyAccentS>{formattedPrice}</Typo.BodyAccentS> : null}
-              {interactionTag ? (
-                <React.Fragment>
-                  {shouldDisplayPrice ? <Typo.BodyAccentS>{'\u2022'}</Typo.BodyAccentS> : null}
-                  {interactionTag}
-                </React.Fragment>
-              ) : null}
+              {interactionTag}
             </PriceAndComingSoonTagContainer>
           </Column>
           {distanceToOffer ? (
@@ -283,4 +278,5 @@ const DistanceTag = styled(Tag)(({ theme }) => ({
 
 const PriceAndComingSoonTagContainer = styled(ViewGap)({
   flexDirection: 'row',
+  alignItems: 'center',
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43391

## Context
Amélioration visuelle du composant HorizontalOfferTile (prix et tag centré, retrait du point entre le prix et le tag).

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-03 at 09 28 58" src="https://github.com/user-attachments/assets/f9e771e8-f852-4c8e-8734-2a548bfd01b7" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-03 at 09 58 23" src="https://github.com/user-attachments/assets/ca0e0bb1-6ce9-4c55-aa7f-84bc42ccac90" />|
| Android          |               |       |
| Phone - Chrome   |<img width="396" height="681" alt="Capture d’écran 2026-09-03 à 09 28 01" src="https://github.com/user-attachments/assets/694a05cc-71be-4b40-8d90-ff4cd09761cb" />|<img width="384" height="672" alt="Capture d’écran 2026-09-03 à 09 54 18" src="https://github.com/user-attachments/assets/1f7c1f77-0170-43b7-aefe-a86a41edf870" />|
| Desktop - Chrome |<img width="1507" height="764" alt="Capture d’écran 2026-09-03 à 09 27 54" src="https://github.com/user-attachments/assets/aa6c7281-c5d8-47f3-ad63-3c11281af23f" />|<img width="1509" height="764" alt="Capture d’écran 2026-09-03 à 09 54 35" src="https://github.com/user-attachments/assets/804325b5-836f-42fd-a7e0-d7118401eed2" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
