### PR TITLE
(PC-42968) refactor(offers): handle screenings timezone from movie calendar endpoint

### DIFF
--- a/src/features/offer/components/MovieCalendar/MovieCalendarV2.native.test.tsx
+++ b/src/features/offer/components/MovieCalendar/MovieCalendarV2.native.test.tsx
@@ -1,0 +1,208 @@
+import { FlashListRef } from '@shopify/flash-list'
+import mockDate from 'mockdate'
+import React from 'react'
+
+import { MovieCalendarV2 } from 'features/offer/components/MovieCalendar/MovieCalendarV2'
+import { toMutable } from 'shared/types/toMutable'
+import type { CustomRenderOptions } from 'tests/utils'
+import { fireEvent, render, screen, userEvent } from 'tests/utils'
+
+const dummyDates = toMutable([
+  '2024-07-18', // Jeudi 18 juillet 2024
+  '2024-07-19', // Vendredi 19 juillet 2024
+  '2024-07-20', // Samedi 20 juillet 2024
+  '2024-07-21', // Dimanche 21 juillet 2024
+  '2024-07-22', // Lundi 22 juillet 2024
+  '2024-07-23', // Mardi 23 juillet 2024
+  '2024-07-24', // Mercredi 24 juillet 2024
+  '2024-07-25', // Jeudi 25 juillet 2024
+  '2024-07-26', // Vendredi 26 juillet 2024
+  '2024-07-27', // Samedi 27 juillet 2024
+  '2024-07-28', // Dimanche 28 juillet 2024
+  '2024-07-29', // Lundi 29 juillet 2024
+  '2024-07-30', // Mardi 30 juillet 2024
+  '2024-07-31', // Mercredi 31 juillet 2024
+  '2024-08-01', // Jeudi 1er août 2024
+] as const) satisfies string[]
+
+const DEFAULT_FLATLIST_WIDTH = 1000
+const DEFAULT_ITEM_WIDTH = 200
+
+const mockOnTabChange = jest.fn()
+
+const user = userEvent.setup()
+
+jest.useFakeTimers()
+
+describe('<MovieCalendarV2/>', () => {
+  describe('Dates format', () => {
+    it('should display the short days of weeks on a mobile screen', () => {
+      renderMovieCalendar(dummyDates, { isDesktopViewport: false })
+
+      expect(screen.getAllByText('Mar.').length).toBeGreaterThan(0)
+    })
+
+    it('should display the full days of weeks on a desktop screen', () => {
+      renderMovieCalendar(dummyDates, { isDesktopViewport: true })
+
+      expect(screen.getAllByText('Mardi').length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('Right arrow button', () => {
+    it('should appear when the component renders before any user interaction', () => {
+      renderMovieCalendar(dummyDates, { isDesktopViewport: true })
+
+      fireEvent.scroll(screen.getByTestId('movie-calendar-flat-list'), {
+        nativeEvent: {
+          contentOffset: { y: 0 },
+          contentSize: { height: 3000 },
+          layoutMeasurement: { height: 800 },
+        },
+      })
+
+      expect(screen.getByTestId('movie-calendar-right-arrow')).toBeOnTheScreen()
+    })
+
+    it('should not appear when the content reached the end', () => {
+      renderMovieCalendar(dummyDates, { isDesktopViewport: true })
+
+      fireEvent.scroll(screen.getByTestId('movie-calendar-flat-list'), {
+        nativeEvent: {
+          contentOffset: { x: 3000, y: 0 },
+          contentSize: { width: 3000 },
+          layoutMeasurement: { width: 800 },
+        },
+      })
+
+      expect(screen.queryByTestId('movie-calendar-right-arrow')).not.toBeOnTheScreen()
+    })
+  })
+
+  describe('Left arrow button', () => {
+    it('should not appear when the component renders before any user interaction', () => {
+      renderMovieCalendar(dummyDates, { isDesktopViewport: true })
+
+      fireEvent.scroll(screen.getByTestId('movie-calendar-flat-list'), {
+        nativeEvent: {
+          contentOffset: { x: 0, y: 0 },
+          contentSize: { width: 3000 },
+          layoutMeasurement: { width: 800 },
+        },
+      })
+
+      expect(screen.queryByTestId('movie-calendar-left-arrow')).not.toBeOnTheScreen()
+    })
+
+    it('should appear when the content is scrolled', () => {
+      renderMovieCalendar(dummyDates, { isDesktopViewport: true })
+
+      fireEvent.scroll(screen.getByTestId('movie-calendar-flat-list'), {
+        nativeEvent: {
+          contentOffset: { x: 100, y: 0 },
+          contentSize: { width: 3000 },
+          layoutMeasurement: { width: 800 },
+        },
+      })
+
+      expect(screen.getByTestId('movie-calendar-left-arrow')).toBeOnTheScreen()
+    })
+  })
+
+  describe('Animation', () => {
+    const mockFlatListRef = {
+      current: {
+        scrollToEnd: jest.fn(),
+        scrollToIndex: jest.fn(),
+        scrollToItem: jest.fn(),
+        scrollToOffset: jest.fn(),
+        recordInteraction: jest.fn(),
+        flashScrollIndicators: jest.fn(),
+        getScrollResponder: jest.fn(),
+        getNativeScrollRef: jest.fn(),
+        getScrollableNode: jest.fn(),
+        setNativeProps: jest.fn(),
+        context: undefined,
+        setState: jest.fn(),
+        forceUpdate: jest.fn(),
+        render: jest.fn(),
+        props: {
+          data: [],
+          renderItem: jest.fn(),
+        },
+        state: {},
+        refs: {},
+      },
+    }
+
+    const flatListWidth = 1000
+    const itemWidth = 200
+
+    beforeEach(() => {
+      mockDate.set(dummyDates[0])
+    })
+
+    it('should scroll to the middle element when an item is clicked', async () => {
+      const itemIndex = 5
+      const MOVIE_CALENDAR_PADDING = 24
+
+      renderMovieCalendar(
+        dummyDates,
+        { isDesktopViewport: false },
+        mockFlatListRef as unknown as React.RefObject<FlashListRef<string>>
+      )
+      mockFlatListRef.current.scrollToOffset = jest.fn()
+
+      const firstDateItem = await screen.findByLabelText('Mardi 23 Juillet')
+      await user.press(firstDateItem)
+
+      expect(mockOnTabChange).toHaveBeenCalledWith(dummyDates[itemIndex])
+      expect(mockFlatListRef.current.scrollToOffset).toHaveBeenCalledWith({
+        animated: true,
+        offset: MOVIE_CALENDAR_PADDING + itemWidth / 2 + itemIndex * itemWidth - flatListWidth / 2,
+      })
+    })
+
+    it('should scroll to the start when the offset is less than 0', async () => {
+      const itemIndex = 1
+      renderMovieCalendar(
+        dummyDates,
+        { isDesktopViewport: false },
+        mockFlatListRef as unknown as React.RefObject<FlashListRef<string>>
+      )
+      mockFlatListRef.current.scrollToOffset = jest.fn()
+
+      const firstDateItem = await screen.findByLabelText('Vendredi 19 Juillet')
+      await user.press(firstDateItem)
+
+      expect(mockOnTabChange).toHaveBeenCalledWith(dummyDates[itemIndex])
+      expect(mockFlatListRef.current.scrollToOffset).toHaveBeenCalledWith({
+        animated: true,
+        offset: 0,
+      })
+    })
+  })
+})
+
+const renderMovieCalendar = (
+  dates: string[],
+  theme?: CustomRenderOptions['theme'],
+  ref = React.createRef<FlashListRef<string> | null>()
+) => {
+  const MovieCalendarWrapper = () => {
+    return (
+      <MovieCalendarV2
+        dates={dates}
+        selectedDate={dates[0]}
+        onTabChange={mockOnTabChange}
+        listRef={ref}
+        listWidth={DEFAULT_FLATLIST_WIDTH}
+        onFlatListLayout={jest.fn()}
+        itemWidth={DEFAULT_ITEM_WIDTH}
+        onItemLayout={jest.fn()}
+      />
+    )
+  }
+
+  return render(<MovieCalendarWrapper />, { theme })
+}

--- a/src/features/offer/components/MovieCalendar/MovieCalendarV2.tsx
+++ b/src/features/offer/components/MovieCalendar/MovieCalendarV2.tsx
@@ -1,0 +1,163 @@
+import { FlashList, FlashListRef } from '@shopify/flash-list'
+import React, { Ref, useCallback } from 'react'
+import { LayoutChangeEvent, View } from 'react-native'
+import LinearGradient from 'react-native-linear-gradient'
+import styled, { useTheme } from 'styled-components/native'
+
+import { MovieCalendarBottomBar } from 'features/offer/components/MovieCalendar/components/MovieCalendarBottomBar'
+import { MovieCalendarDayV2 } from 'features/offer/components/MovieCalendar/components/MovieCalendarDayV2'
+import { AbsoluteRoundedButton } from 'ui/components/buttons/AbsoluteRoundedButton'
+import { useHorizontalFlatListScroll } from 'ui/hooks/useHorizontalFlatListScroll'
+import { getSpacing } from 'ui/theme'
+
+import { handleMovieCalendarScroll } from '../MoviesScreeningCalendar/helpers/handleMovieCalendarScroll'
+
+type Props = {
+  dates: string[]
+  selectedDate: string | undefined
+  onTabChange: (date: string) => void
+  listRef: Ref<FlashListRef<string>> | null
+  disabledDates?: string[]
+  listWidth?: number
+  onFlatListLayout?: (event: LayoutChangeEvent) => void
+  itemWidth?: number
+  onItemLayout?: (event: LayoutChangeEvent) => void
+}
+
+export const MovieCalendarV2: React.FC<Props> = ({
+  dates,
+  selectedDate,
+  onTabChange,
+  listRef,
+  listWidth,
+  onFlatListLayout,
+  itemWidth,
+  onItemLayout,
+  disabledDates,
+}) => {
+  const { isDesktopViewport, designSystem } = useTheme()
+  const {
+    handleScrollPrevious,
+    handleScrollNext,
+    onScroll,
+    onContentSizeChange,
+    onContainerLayout,
+    isEnd,
+    isStart,
+  } = useHorizontalFlatListScroll({
+    ref: listRef,
+    isActive: isDesktopViewport,
+  })
+  const MOVIE_CALENDAR_PADDING = designSystem.size.spacing.xl
+
+  const scrollToMiddleElement = useCallback(
+    (currentIndex: number) => {
+      if (!listWidth || !itemWidth) return
+      const { offset } = handleMovieCalendarScroll(
+        currentIndex,
+        listWidth,
+        itemWidth,
+        MOVIE_CALENDAR_PADDING
+      )
+
+      if (listRef && 'current' in listRef) {
+        listRef.current?.scrollToOffset({
+          animated: true,
+          offset,
+        })
+      }
+    },
+    [listWidth, itemWidth, MOVIE_CALENDAR_PADDING, listRef]
+  )
+
+  const onInternalTabChange = useCallback(
+    (date: string) => {
+      const currentIndex = dates.indexOf(date)
+      onTabChange(date)
+      scrollToMiddleElement(currentIndex)
+    },
+    [onTabChange, scrollToMiddleElement, dates]
+  )
+
+  return (
+    <View onLayout={onContainerLayout}>
+      <MovieCalendarBottomBar />
+      {isDesktopViewport && !isStart ? (
+        <AbsoluteRoundedButton
+          direction="left"
+          iconName="previous"
+          onPress={handleScrollPrevious}
+          accessibilityLabel="Faire défiler le calendrier vers la gauche"
+          testID="movie-calendar-left-arrow"
+        />
+      ) : null}
+      <View>
+        <FlashList
+          onLayout={onFlatListLayout}
+          ref={listRef}
+          data={dates}
+          horizontal
+          contentContainerStyle={{ paddingHorizontal: MOVIE_CALENDAR_PADDING }}
+          showsHorizontalScrollIndicator={false}
+          onScroll={onScroll}
+          onContentSizeChange={onContentSizeChange}
+          testID="movie-calendar-flat-list"
+          renderItem={({ item: date }) => (
+            <MovieCalendarDayV2
+              onLayout={onItemLayout}
+              date={date}
+              selectedDate={selectedDate}
+              onTabChange={onInternalTabChange}
+              disabled={disabledDates?.includes(date)}
+            />
+          )}
+        />
+        {isDesktopViewport ? (
+          <React.Fragment>
+            <FadeLeft /> <FadeRight />
+          </React.Fragment>
+        ) : null}
+      </View>
+      {isDesktopViewport && !isEnd ? (
+        <AbsoluteRoundedButton
+          direction="right"
+          iconName="next"
+          onPress={handleScrollNext}
+          accessibilityLabel="Faire défiler le calendrier vers la droite"
+          testID="movie-calendar-right-arrow"
+        />
+      ) : null}
+    </View>
+  )
+}
+
+const FadeComponent = styled(LinearGradient)(
+  ({ theme }) => `
+  position: absolute;
+  top: 0;
+  bottom: ${theme.designSystem.size.spacing.xs}px;
+  width: ${getSpacing(20)}px;
+`
+)
+
+const FadeLeft = styled(FadeComponent).attrs<{ colors?: string[] }>(({ theme }) => ({
+  colors: [
+    theme.designSystem.color.background.gradientMaximum,
+    theme.designSystem.color.background.gradientMinimum,
+  ],
+  start: { x: 0.2, y: 0.5 },
+  end: { x: 1, y: 0.5 },
+}))`
+  left: -1px;
+`
+
+const FadeRight = styled(FadeComponent).attrs<{ colors?: string[] }>(({ theme }) => ({
+  colors: [
+    theme.designSystem.color.background.gradientMinimum,
+    theme.designSystem.color.background.gradientMaximum,
+  ],
+  start: { x: 0, y: 0.5 },
+  end: { x: 0.8, y: 0.5 },
+}))`
+  right: -1px;
+`

--- a/src/features/offer/components/MovieCalendar/components/MovieCalendarDayV2.tsx
+++ b/src/features/offer/components/MovieCalendar/components/MovieCalendarDayV2.tsx
@@ -1,0 +1,105 @@
+import colorAlpha from 'color-alpha'
+import React, { useMemo } from 'react'
+import { View, ViewProps } from 'react-native'
+import styled from 'styled-components/native'
+
+import { MovieCalendarBottomBar } from 'features/offer/components/MovieCalendar/components/MovieCalendarBottomBar'
+import { useMovieCalendarDayV2 } from 'features/offer/components/MovieCalendar/hooks/useMovieCalendarDayV2'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
+import { getComputedAccessibilityLabel } from 'shared/accessibility/helpers/getComputedAccessibilityLabel'
+import { styledButton } from 'ui/components/buttons/styledButton'
+import { TouchableOpacity } from 'ui/components/TouchableOpacity'
+import { Typo } from 'ui/theme'
+
+type Props = {
+  date: string
+  onTabChange: (date: string) => void
+  selectedDate?: string
+  onLayout?: ViewProps['onLayout']
+  disabled?: boolean
+}
+
+export const MovieCalendarDayV2: React.FC<Props> = ({
+  date,
+  selectedDate,
+  onTabChange,
+  onLayout,
+  disabled,
+}) => {
+  const { weekDay, dayDate, month, accessibilityLabel, isSelected } = useMovieCalendarDayV2(
+    date,
+    selectedDate
+  )
+
+  const CalendarText = useMemo(() => {
+    if (disabled) {
+      return DisabledCalendarText
+    }
+    if (isSelected) {
+      return SelectedCalendarText
+    }
+    return DefaultCalendarText
+  }, [disabled, isSelected])
+
+  const computedAccessibilityLabel = getComputedAccessibilityLabel(
+    accessibilityLabel,
+    isSelected ? 'sélectionné' : undefined
+  )
+
+  return (
+    <CalendarCell
+      disabled={disabled}
+      onLayout={onLayout}
+      testID="movie-calendar-day"
+      onPress={() => onTabChange(date)}
+      accessibilityLabel={computedAccessibilityLabel}
+      accessibilityRole={AccessibilityRole.BUTTON}
+      accessible={!disabled}
+      accessibilityElementsHidden={disabled} // Hide element in iOS
+      importantForAccessibility={disabled ? 'no-hide-descendants' : 'auto'} // Hide element in Android
+    >
+      <CalendarTextView>
+        <CalendarText numberOfLines={1}>{weekDay}</CalendarText>
+        <CalendarText numberOfLines={1}>{dayDate}</CalendarText>
+        <CalendarText numberOfLines={1}>{month}</CalendarText>
+      </CalendarTextView>
+      {isSelected ? <SelectedBottomBar disabled={disabled} /> : null}
+    </CalendarCell>
+  )
+}
+
+const SelectedBottomBar = styled(MovieCalendarBottomBar)<{ disabled?: boolean }>(
+  ({ theme, disabled }) => ({
+    backgroundColor: disabled
+      ? theme.designSystem.color.background.disabled
+      : theme.designSystem.color.background.brandPrimary,
+    borderRadius: theme.designSystem.size.borderRadius.s,
+  })
+)
+
+const CalendarTextView = styled(View)(({ theme }) => ({
+  marginHorizontal: theme.designSystem.size.spacing.l,
+  marginBottom: theme.designSystem.size.spacing.s,
+}))
+
+const CalendarCell = styledButton(TouchableOpacity)({
+  justifyContent: 'center',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+  '&:hover': {
+    textDecorationLine: 'none',
+  },
+})
+
+const DefaultCalendarText = styled(Typo.BodyAccent)({
+  textAlign: 'center',
+})
+
+const SelectedCalendarText = styled(DefaultCalendarText)(({ theme }) => ({
+  color: theme.designSystem.color.text.brandPrimary,
+}))
+
+// UX decision: align with disabled background token for the muted state
+const DisabledCalendarText = styled(DefaultCalendarText)(({ theme }) => ({
+  color: colorAlpha(theme.designSystem.color.text.disabled, 0.4),
+}))

--- a/src/features/offer/components/MovieCalendar/hooks/useMovieCalendarDayV2.ts
+++ b/src/features/offer/components/MovieCalendar/hooks/useMovieCalendarDayV2.ts
@@ -1,0 +1,54 @@
+import { useMemo } from 'react'
+import { useTheme } from 'styled-components/native'
+
+import { DAYS, FullWeekDay, SHORT_DAYS, ShortWeekDay } from 'shared/date/days'
+import {
+  CAPITALIZED_MONTHS,
+  CAPITALIZED_SHORT_MONTHS,
+  CapitalizedMonth,
+  CapitalizedShortMonth,
+} from 'shared/date/months'
+
+export const useMovieCalendarDayV2 = (date: string, selectedDate: string | undefined) => {
+  const { isDesktopViewport } = useTheme()
+
+  const { dayDate, shortWeekDay, fullWeekDay, fullMonth, shortMonth } = useMemo(
+    () => extractDateV2(date),
+    [date]
+  )
+
+  const isSelected = useMemo(
+    () => (selectedDate ? date === selectedDate : false),
+    [selectedDate, date]
+  )
+
+  return {
+    accessibilityLabel: `${fullWeekDay} ${dayDate} ${fullMonth}`,
+    weekDay: isDesktopViewport ? fullWeekDay : shortWeekDay,
+    month: isDesktopViewport ? fullMonth : shortMonth,
+    dayDate,
+    isSelected,
+  }
+}
+
+type DayMapping = {
+  shortWeekDay: ShortWeekDay
+  fullWeekDay: FullWeekDay
+  dayDate: number
+  shortMonth: CapitalizedShortMonth
+  fullMonth: CapitalizedMonth
+}
+
+export const extractDateV2 = (date: string): DayMapping => {
+  const dateObj = new Date(date)
+  const dayIndex = dateObj.getDay()
+  const monthIndex = dateObj.getMonth()
+  const dayDate = dateObj.getDate()
+  return {
+    shortWeekDay: SHORT_DAYS[dayIndex],
+    fullWeekDay: DAYS[dayIndex],
+    dayDate,
+    shortMonth: CAPITALIZED_SHORT_MONTHS[monthIndex],
+    fullMonth: CAPITALIZED_MONTHS[monthIndex],
+  }
+}

--- a/src/features/offer/components/MoviesScreeningCalendarV2/MovieCalendarContextV2.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendarV2/MovieCalendarContextV2.tsx
@@ -1,0 +1,157 @@
+import { FlashListRef } from '@shopify/flash-list'
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useEffect,
+  useState,
+} from 'react'
+import { View, ViewStyle } from 'react-native'
+import { useTheme } from 'styled-components'
+
+import { MovieCalendarV2 } from 'features/offer/components/MovieCalendar/MovieCalendarV2'
+import { handleMovieCalendarScroll } from 'features/offer/components/MoviesScreeningCalendar/helpers/handleMovieCalendarScroll'
+import { formatDateToISOStringWithoutTime } from 'libs/parsers/formatDates'
+import { Anchor } from 'ui/components/anchor/Anchor'
+import { AnchorNames } from 'ui/components/anchor/anchor-name'
+import { useScrollToAnchor } from 'ui/components/anchor/AnchorContext'
+import { useLayout } from 'ui/hooks/useLayout'
+
+type MovieCalendarContextV2Type = {
+  selectedDate: string
+  goToDate: (date: string) => void
+  displayCalendar: (shouldDisplayCalendar: boolean) => void
+  displayDates: (dates: string[]) => void
+  disableDates: (dates: string[]) => void
+  dates: string[]
+}
+
+const MovieCalendarContextV2 = createContext<MovieCalendarContextV2Type | undefined>(undefined)
+
+export const MovieCalendarProviderV2: React.FC<{
+  children: React.ReactNode
+  containerStyle?: ViewStyle
+  initialDates?: string[]
+}> = ({ containerStyle, children, initialDates = [] }) => {
+  const [selectedDate, setSelectedDate] = useState<string>(
+    initialDates?.[0] ?? formatDateToISOStringWithoutTime(new Date())
+  )
+  const [dates, setDates] = useState<string[]>(initialDates)
+  const [disabledDates, setDisabledDates] = useState<string[]>([])
+  const flatListRef = useRef<FlashListRef<string> | null>(null)
+  const { width: flatListWidth, onLayout: onFlatListLayout } = useLayout()
+  const { width: itemWidth, onLayout: onItemLayout } = useLayout()
+  const scrollToAnchor = useScrollToAnchor()
+  const [isVisible, setIsVisible] = useState<boolean>(true)
+  const { designSystem } = useTheme()
+  const MOVIE_CALENDAR_PADDING = designSystem.size.spacing.xl
+  const layoutRef = useRef({ flatListWidth, itemWidth })
+
+  useEffect(() => {
+    layoutRef.current = { flatListWidth, itemWidth }
+  }, [flatListWidth, itemWidth])
+
+  useEffect(() => {
+    const currentIndex = dates.indexOf(selectedDate)
+
+    const { offset } = handleMovieCalendarScroll(
+      currentIndex,
+      layoutRef.current.flatListWidth,
+      layoutRef.current.itemWidth,
+      MOVIE_CALENDAR_PADDING
+    )
+
+    flatListRef.current?.scrollToOffset({
+      animated: true,
+      offset,
+    })
+  }, [selectedDate, dates, MOVIE_CALENDAR_PADDING])
+
+  useEffect(() => {
+    if (flatListRef?.current) {
+      flatListRef.current?.scrollToOffset({ offset: 0 })
+    }
+  }, [flatListRef])
+
+  const goToDate = useCallback(
+    (date: string) => {
+      scrollToAnchor('movie-calendar')
+      setSelectedDate(date)
+    },
+    [scrollToAnchor, setSelectedDate]
+  )
+
+  const displayDates = useCallback(
+    (dates: string[]) => {
+      setDates(dates)
+    },
+    [setDates]
+  )
+
+  const value = useMemo(
+    () => ({
+      dates,
+      selectedDate,
+      goToDate,
+      displayCalendar: setIsVisible,
+      displayDates,
+      disableDates: setDisabledDates,
+    }),
+    [dates, selectedDate, goToDate, displayDates]
+  )
+
+  return (
+    <MovieCalendarContextV2.Provider value={value}>
+      {isVisible ? (
+        <View style={containerStyle}>
+          <Anchor name={AnchorNames.MOVIE_CALENDAR}>
+            <MovieCalendarV2
+              dates={dates}
+              selectedDate={selectedDate}
+              disabledDates={disabledDates}
+              onTabChange={setSelectedDate}
+              listRef={flatListRef}
+              listWidth={flatListWidth}
+              onFlatListLayout={onFlatListLayout}
+              itemWidth={itemWidth}
+              onItemLayout={onItemLayout}
+            />
+          </Anchor>
+        </View>
+      ) : null}
+      {children}
+    </MovieCalendarContextV2.Provider>
+  )
+}
+
+export const useMovieCalendarV2 = (): MovieCalendarContextV2Type => {
+  const context = useContext(MovieCalendarContextV2)
+  if (context === undefined) {
+    throw new Error('useMovieCalendar must be used within a MovieCalendarProvider')
+  }
+  return context
+}
+
+export const useDisableCalendarDatesV2 = (dates: string[]) => {
+  const context = useContext(MovieCalendarContextV2)
+  if (context === undefined) {
+    throw new Error('useDisableCalendarDates must be used within a MovieCalendarProvider')
+  }
+
+  useEffect(() => {
+    context.disableDates(dates)
+  }, [context, dates])
+}
+
+export const useDisplayCalendarV2 = (shouldDisplayCalendar: boolean) => {
+  const context = useContext(MovieCalendarContextV2)
+  if (context === undefined) {
+    throw new Error('useDisplayCalendar must be used within a MovieCalendarProvider')
+  }
+
+  useEffect(() => {
+    context.displayCalendar(shouldDisplayCalendar)
+  }, [context, shouldDisplayCalendar])
+}

--- a/src/features/offer/components/MoviesScreeningCalendarV2/MovieOfferTileV2.native.test.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendarV2/MovieOfferTileV2.native.test.tsx
@@ -1,0 +1,197 @@
+import mockdate from 'mockdate'
+import React, { createRef } from 'react'
+import { ScrollView } from 'react-native'
+
+import {
+  Bookability,
+  CategoryIdEnum,
+  MovieScreenings,
+  NativeCategoryIdEnumv2,
+  SearchGroupNameEnumv2,
+  SubcategoryIdEnum,
+} from 'api/gen'
+import * as MovieCalendarContextV2 from 'features/offer/components/MoviesScreeningCalendarV2/MovieCalendarContextV2'
+import { MovieCalendarProviderV2 } from 'features/offer/components/MoviesScreeningCalendarV2/MovieCalendarContextV2'
+import { MovieOfferTileV2 } from 'features/offer/components/MoviesScreeningCalendarV2/MovieOfferTileV2'
+import { analytics } from 'libs/analytics/provider'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/tests/setFeatureFlags'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { render, screen, userEvent } from 'tests/utils'
+import { AnchorProvider } from 'ui/components/anchor/AnchorContext'
+
+jest.mock('libs/firebase/analytics/analytics')
+jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
+  return function createAnimatedComponent(Component: unknown) {
+    return Component
+  }
+})
+
+const MOCK_DATE = '2026-09-02'
+const MOCK_DATES = [
+  '2026-09-02',
+  '2026-09-03',
+  '2026-09-04',
+  '2026-09-05',
+  '2026-09-06',
+  '2026-09-08',
+  '2026-09-09',
+  '2026-09-10',
+  '2026-09-11',
+  '2026-09-12',
+  '2026-09-13',
+  '2026-09-14',
+  '2026-09-15',
+  '2026-09-16',
+  '2026-09-17',
+]
+
+const mockMovieScreenings = {
+  duration: 116,
+  genres: [],
+  last30DaysBookings: 0,
+  movieName: 'Harry Potter',
+  offerId: 113,
+  thumbUrl: null,
+  dayScreenings: [
+    {
+      beginningDatetime: '2026-09-02T14:47:09.705+02:00',
+      bookability: Bookability.BOOKABLE,
+      features: ['VO'],
+      price: 10.1,
+      stockId: 112,
+    },
+  ],
+  nextScreening: {
+    beginningDatetime: '2026-09-02T14:47:09.705+02:00',
+    bookability: Bookability.BOOKABLE,
+    features: ['VO'],
+    price: 10.1,
+    stockId: 112,
+  },
+}
+
+const mockDisplayCalendar = jest.fn()
+const mockGoToDate = jest.fn()
+jest.spyOn(MovieCalendarContextV2, 'useMovieCalendarV2').mockReturnValue({
+  selectedDate: MOCK_DATE,
+  goToDate: mockGoToDate,
+  displayCalendar: mockDisplayCalendar,
+  dates: [],
+  disableDates: jest.fn(),
+  displayDates: jest.fn(),
+})
+
+const mockUseSubcategoriesMapping = jest.fn()
+mockUseSubcategoriesMapping.mockReturnValue({
+  [SubcategoryIdEnum.SEANCE_CINE]: {
+    isEvent: false,
+    categoryId: CategoryIdEnum.CINEMA,
+    nativeCategoryId: NativeCategoryIdEnumv2.SEANCES_DE_CINEMA,
+  },
+})
+jest.mock('libs/subcategories/mappings', () => ({
+  useSubcategoriesMapping: () => mockUseSubcategoriesMapping(),
+}))
+
+const mockUseSearchGroupLabel = jest.fn()
+mockUseSearchGroupLabel.mockReturnValue(SearchGroupNameEnumv2.CINEMA)
+jest.mock('libs/subcategories/useSearchGroupLabel', () => ({
+  useSearchGroupLabel: () => mockUseSearchGroupLabel(),
+}))
+
+const mockOnPressOfferCTA = jest.fn()
+const mockUseOfferCTAButton = jest.fn()
+mockUseOfferCTAButton.mockReturnValue({
+  ctaWordingAndAction: {
+    onPress: jest.fn(),
+    bottomBannerText: 'CTA',
+    externalNav: {
+      url: '',
+    },
+    isDisabled: false,
+    wording: 'CTA',
+    navigateTo: {
+      screen: 'Offer',
+    },
+  },
+  showOfferModal: jest.fn(),
+  openModalOnNavigation: false,
+  onPress: mockOnPressOfferCTA,
+  CTAOfferModal: null,
+  movieScreeningUserData: {},
+})
+jest.mock('features/offer/components/OfferCTAButton/useOfferCTAButton', () => ({
+  useOfferCTAButton: () => mockUseOfferCTAButton(),
+}))
+
+jest.useFakeTimers()
+const user = userEvent.setup()
+
+describe('MovieOfferTileV2', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    setFeatureFlags()
+    mockdate.set(MOCK_DATE)
+  })
+
+  afterEach(() => {
+    mockdate.reset()
+  })
+
+  describe('with screening on selected date', () => {
+    it('should render offer component', async () => {
+      renderMovieOfferTile({ movieScreenings: mockMovieScreenings, venueId: 1 })
+
+      expect(await screen.findByText('Harry Potter')).toBeOnTheScreen()
+    })
+  })
+
+  it('should send log ConsultOffer event when on venue page and user clicks on an eventCard', async () => {
+    renderMovieOfferTile({ movieScreenings: mockMovieScreenings, venueId: 12 })
+    const eventCard = await screen.findByLabelText('14h47 - VO - 10,10 €')
+    await user.press(eventCard)
+
+    expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        offerId: '113',
+        from: 'venue',
+        venueId: 12,
+      })
+    )
+  })
+
+  describe('without screening on selected date', () => {
+    it('should not render offer component', () => {
+      renderMovieOfferTile({
+        movieScreenings: { ...mockMovieScreenings, dayScreenings: [] },
+        venueId: 12,
+      })
+
+      expect(screen.queryByText('Harry Potter')).not.toBeOnTheScreen()
+    })
+  })
+})
+
+const renderMovieOfferTile = ({
+  movieScreenings,
+  venueId,
+  isDesktopViewport = false,
+}: {
+  movieScreenings: MovieScreenings
+  venueId: number
+  isDesktopViewport?: boolean
+}) => {
+  render(
+    reactQueryProviderHOC(
+      <AnchorProvider scrollViewRef={createRef<ScrollView>()} handleCheckScrollY={() => 0}>
+        <MovieCalendarProviderV2 initialDates={MOCK_DATES}>
+          <MovieOfferTileV2 movieScreenings={movieScreenings} venueId={venueId} isLast={false} />
+        </MovieCalendarProviderV2>
+      </AnchorProvider>
+    ),
+    {
+      theme: { isDesktopViewport },
+    }
+  )
+}

--- a/src/features/offer/components/MoviesScreeningCalendarV2/MovieOfferTileV2.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendarV2/MovieOfferTileV2.tsx
@@ -3,10 +3,9 @@ import { View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { SubcategoryIdEnum, type MovieScreenings, type Screening } from 'api/gen'
-import { formatHour } from 'features/bookOffer/helpers/utils'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
-import { useMovieCalendar } from 'features/offer/components/MoviesScreeningCalendar/MovieCalendarContext'
-import { NextScreeningButton } from 'features/offer/components/MoviesScreeningCalendar/NextScreeningButton'
+import { useMovieCalendarV2 } from 'features/offer/components/MoviesScreeningCalendarV2/MovieCalendarContextV2'
+import { NextScreeningButtonV2 } from 'features/offer/components/MoviesScreeningCalendarV2/NextScreeningButtonV2'
 import { formatDuration } from 'features/offer/helpers/formatDuration/formatDuration'
 import {
   getEventCardIsEnabled,
@@ -14,10 +13,11 @@ import {
   getEventCardRightSubtitle,
 } from 'features/offer/helpers/screeningBlockInfo/screeningBlockInfo'
 import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsultOffer/triggerConsultOfferLog'
+import { formatDateWithTimeZoneOffset } from 'libs/parsers/formatDates'
 import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { BookOfferModal } from 'shared/offer/components/BookOfferModal/BookOfferModal'
-import { EventCardProps } from 'ui/components/eventCard/EventCard'
+import type { EventCardProps } from 'ui/components/eventCard/EventCard'
 import { EventCardList } from 'ui/components/eventCard/EventCardList'
 import { useModal } from 'ui/components/modals/useModal'
 import { HorizontalOfferTile } from 'ui/components/tiles/HorizontalOfferTile'
@@ -48,7 +48,7 @@ const transformScreening = (
       showModal()
     },
     isDisabled: !getEventCardIsEnabled(screening),
-    title: formatHour(screening.beginningDatetime).replace(':', 'h'),
+    title: formatDateWithTimeZoneOffset(screening.beginningDatetime, "HH'h'mm"),
     subtitleLeft: getEventCardLeftSubtitle(screening),
     subtitleRight: getEventCardRightSubtitle(screening, currency, euroToPacificFrancRate),
   }) as EventCardProps
@@ -58,9 +58,11 @@ export const MovieOfferTileV2: FC<MovieOfferTileV2Props> = ({
   venueId,
   isLast,
 }) => {
-  const { goToDate } = useMovieCalendar()
+  const { goToDate } = useMovieCalendarV2()
   const { offerId, nextScreening } = movieScreenings
-  const nextScreeningDate = nextScreening ? new Date(nextScreening.beginningDatetime) : null
+  const nextScreeningDate = nextScreening
+    ? formatDateWithTimeZoneOffset(nextScreening.beginningDatetime, 'yyyy-MM-dd')
+    : null
 
   const currency = useGetCurrencyToDisplay()
   const { data: euroToPacificFrancRate } = usePacificFrancToEuroRate()
@@ -70,7 +72,7 @@ export const MovieOfferTileV2: FC<MovieOfferTileV2Props> = ({
   return (
     <React.Fragment>
       <StyledView>
-        {movieScreenings.dayScreenings ? (
+        {movieScreenings.dayScreenings?.length ? (
           <HorizontalOfferTile
             offer={{
               offer: {
@@ -91,7 +93,7 @@ export const MovieOfferTileV2: FC<MovieOfferTileV2Props> = ({
       </StyledView>
       {nextScreeningDate && !movieScreenings.dayScreenings?.length ? (
         <View>
-          <NextScreeningButton
+          <NextScreeningButtonV2
             date={nextScreeningDate}
             onPress={() => goToDate(nextScreeningDate)}
           />

--- a/src/features/offer/components/MoviesScreeningCalendarV2/MoviesScreeningCalendarV2.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendarV2/MoviesScreeningCalendarV2.tsx
@@ -1,6 +1,7 @@
-import React, { FunctionComponent } from 'react'
+import { addDays } from 'date-fns'
+import React, { FunctionComponent, useState } from 'react'
 
-import { MovieCalendarProvider } from 'features/offer/components/MoviesScreeningCalendar/MovieCalendarContext'
+import { MovieCalendarProviderV2 } from 'features/offer/components/MoviesScreeningCalendarV2/MovieCalendarContextV2'
 import { VenueCalendarV2 } from 'features/offer/components/MoviesScreeningCalendarV2/VenueCalendarV2'
 import { useVenueMoviesCalendarQuery } from 'features/offer/queries/useVenueMoviesCalendarQuery'
 
@@ -9,13 +10,19 @@ type Props = {
 }
 
 export const MoviesScreeningCalendarV2: FunctionComponent<Props> = ({ venueId }) => {
-  const { data: moviesCalendar, isLoading } = useVenueMoviesCalendarQuery({ venueId })
+  const [calendarStartDatetime] = useState<Date>(new Date())
+  const calendarEndDatetime = addDays(calendarStartDatetime, 15)
+  const { data: moviesCalendar, isLoading } = useVenueMoviesCalendarQuery({
+    venueId,
+    from: calendarStartDatetime,
+    to: calendarEndDatetime,
+  })
   const { calendar } = moviesCalendar || { calendar: [] }
-  const dates = calendar?.map((dayMovieScreenings) => new Date(dayMovieScreenings.date))
+  const dates = calendar?.map((dayMovieScreenings) => dayMovieScreenings.date)
 
   return !!dates && !isLoading ? (
-    <MovieCalendarProvider initialDates={dates}>
+    <MovieCalendarProviderV2 initialDates={dates}>
       <VenueCalendarV2 calendar={calendar} venueId={venueId} />
-    </MovieCalendarProvider>
+    </MovieCalendarProviderV2>
   ) : null
 }

--- a/src/features/offer/components/MoviesScreeningCalendarV2/NextScreeningButtonV2.native.test.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendarV2/NextScreeningButtonV2.native.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+import { render, screen } from 'tests/utils'
+
+import { NextScreeningButtonV2 } from './NextScreeningButtonV2'
+
+describe('NextScreeningButtonV2', () => {
+  it('should display date properly', async () => {
+    const dateToDisplay = '2026-09-02'
+    render(<NextScreeningButtonV2 date={dateToDisplay} onPress={jest.fn()} />)
+
+    expect(await screen.findByText('Mercredi 2 septembre')).toBeOnTheScreen()
+  })
+})

--- a/src/features/offer/components/MoviesScreeningCalendarV2/NextScreeningButtonV2.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendarV2/NextScreeningButtonV2.tsx
@@ -1,0 +1,62 @@
+import React, { FC } from 'react'
+import styled, { useTheme } from 'styled-components/native'
+
+import { extractDateV2 } from 'features/offer/components/MovieCalendar/hooks/useMovieCalendarDayV2'
+import { accessibilityRoleInternalNavigation } from 'shared/accessibility/helpers/accessibilityRoleInternalNavigation'
+import { styledButton } from 'ui/components/buttons/styledButton'
+import { Touchable } from 'ui/components/touchable/Touchable'
+import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
+import { Typo } from 'ui/theme'
+
+type Props = { onPress: () => void; date: string }
+
+const NEXT_SCREENING_WORDING = 'Prochaine séance\u00a0:'
+
+export const NextScreeningButtonV2: FC<Props> = ({ onPress, date }) => {
+  const { dayDate, fullWeekDay, fullMonth } = extractDateV2(date)
+  const { designSystem, icons } = useTheme()
+  const NEXT_SCREENING_DATE = `${fullWeekDay} ${dayDate} ${fullMonth.toLocaleLowerCase()}`
+  const accessibilityLabel = `${NEXT_SCREENING_WORDING} ${NEXT_SCREENING_DATE}`
+
+  return (
+    <StyledTouchable
+      onPress={onPress}
+      accessibilityRole={accessibilityRoleInternalNavigation()}
+      accessibilityLabel={accessibilityLabel}>
+      <Container>
+        <Typo.BodyXs>{NEXT_SCREENING_WORDING}</Typo.BodyXs>
+        <DateContainer>
+          <PlainArrowNext
+            color={designSystem.color.icon.brandSecondary}
+            size={icons.sizes.extraSmall}
+          />
+          <StyledBodyAccentXs>{NEXT_SCREENING_DATE}</StyledBodyAccentXs>
+        </DateContainer>
+      </Container>
+    </StyledTouchable>
+  )
+}
+
+const StyledTouchable = styledButton(Touchable)({
+  '&:hover': {
+    textDecorationLine: 'none',
+  },
+})
+
+const Container = styled.View(({ theme }) => ({
+  width: '100%',
+  alignItems: 'center',
+  backgroundColor: theme.designSystem.color.background.subtle,
+  borderRadius: theme.designSystem.size.borderRadius.m,
+  padding: theme.designSystem.size.spacing.l,
+}))
+
+const DateContainer = styled.View(({ theme }) => ({
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: theme.designSystem.size.spacing.s,
+}))
+
+const StyledBodyAccentXs = styled(Typo.BodyAccentXs)(({ theme }) => ({
+  color: theme.designSystem.color.text.brandSecondary,
+}))

--- a/src/features/offer/components/MoviesScreeningCalendarV2/VenueCalendarV2.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendarV2/VenueCalendarV2.tsx
@@ -4,11 +4,10 @@ import styled from 'styled-components/native'
 
 import { DayMovieScreenings } from 'api/gen'
 import {
-  useDisplayCalendar,
-  useMovieCalendar,
-} from 'features/offer/components/MoviesScreeningCalendar/MovieCalendarContext'
+  useDisplayCalendarV2,
+  useMovieCalendarV2,
+} from 'features/offer/components/MoviesScreeningCalendarV2/MovieCalendarContextV2'
 import { MovieOfferTileV2 } from 'features/offer/components/MoviesScreeningCalendarV2/MovieOfferTileV2'
-import { formatDateToISOStringWithoutTime } from 'libs/parsers/formatDates'
 
 type Props = {
   calendar: DayMovieScreenings[]
@@ -16,7 +15,7 @@ type Props = {
 }
 
 export const VenueCalendarV2: FunctionComponent<Props> = ({ calendar, venueId }) => {
-  const { selectedDate, disableDates } = useMovieCalendar()
+  const { selectedDate, disableDates } = useMovieCalendarV2()
   const shouldDisplayCalendar = calendar.some((dayMovieScreenings) =>
     dayMovieScreenings.screenings.some(
       (movieScreenings) => movieScreenings.dayScreenings.length > 0
@@ -29,15 +28,15 @@ export const VenueCalendarV2: FunctionComponent<Props> = ({ calendar, venueId })
           (movieScreenings) => movieScreenings.dayScreenings.length === 0
         )
       )
-      .map((dayMovieScreenings) => new Date(dayMovieScreenings.date))
+      .map((dayMovieScreenings) => dayMovieScreenings.date)
   )
+
   const selectedDateMovies = calendar.find(
-    (dayMovieScreenings) =>
-      dayMovieScreenings.date === formatDateToISOStringWithoutTime(selectedDate)
+    (dayMovieScreenings) => dayMovieScreenings.date === selectedDate
   )
   const dayScreenings = selectedDateMovies?.screenings
 
-  useDisplayCalendar(shouldDisplayCalendar)
+  useDisplayCalendarV2(shouldDisplayCalendar)
 
   const getIsLast = (index: number) => {
     const length = selectedDateMovies?.screenings.length ?? 0

--- a/src/features/offer/components/MoviesScreeningCalendarV2/VenueCalendarV2.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendarV2/VenueCalendarV2.tsx
@@ -4,11 +4,10 @@ import styled from 'styled-components/native'
 
 import { DayMovieScreenings } from 'api/gen'
 import {
-  useDisplayCalendar,
-  useMovieCalendar,
-} from 'features/offer/components/MoviesScreeningCalendar/MovieCalendarContext'
+  useDisplayCalendarV2,
+  useMovieCalendarV2,
+} from 'features/offer/components/MoviesScreeningCalendarV2/MovieCalendarContextV2'
 import { MovieOfferTileV2 } from 'features/offer/components/MoviesScreeningCalendarV2/MovieOfferTileV2'
-import { formatDateToISOStringWithoutTime } from 'libs/parsers/formatDates'
 
 type Props = {
   calendar: DayMovieScreenings[]
@@ -16,7 +15,7 @@ type Props = {
 }
 
 export const VenueCalendarV2: FunctionComponent<Props> = ({ calendar, venueId }) => {
-  const { selectedDate, disableDates } = useMovieCalendar()
+  const { selectedDate, disableDates } = useMovieCalendarV2()
   const shouldDisplayCalendar = calendar.some((dayMovieScreenings) =>
     dayMovieScreenings.screenings.some(
       (movieScreenings) => movieScreenings.dayScreenings.length > 0
@@ -24,20 +23,20 @@ export const VenueCalendarV2: FunctionComponent<Props> = ({ calendar, venueId })
   )
   disableDates(
     calendar
-      .filter((dayMovieScreenings) =>
+      .filter((dayMovieScreenings, index) =>
         dayMovieScreenings.screenings.every(
-          (movieScreenings) => movieScreenings.dayScreenings.length === 0
+          (movieScreenings) => movieScreenings.dayScreenings.length === 0 && index !== 0
         )
       )
-      .map((dayMovieScreenings) => new Date(dayMovieScreenings.date))
+      .map((dayMovieScreenings) => dayMovieScreenings.date)
   )
+
   const selectedDateMovies = calendar.find(
-    (dayMovieScreenings) =>
-      dayMovieScreenings.date === formatDateToISOStringWithoutTime(selectedDate)
+    (dayMovieScreenings) => dayMovieScreenings.date === selectedDate
   )
   const dayScreenings = selectedDateMovies?.screenings
 
-  useDisplayCalendar(shouldDisplayCalendar)
+  useDisplayCalendarV2(shouldDisplayCalendar)
 
   const getIsLast = (index: number) => {
     const length = selectedDateMovies?.screenings.length ?? 0

--- a/src/features/offer/components/OfferCine/CineBlockV2.tsx
+++ b/src/features/offer/components/OfferCine/CineBlockV2.tsx
@@ -2,12 +2,13 @@ import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
 import { VenueScreenings } from 'api/gen'
-import { useMovieCalendar } from 'features/offer/components/MoviesScreeningCalendar/MovieCalendarContext'
-import { NextScreeningButton } from 'features/offer/components/MoviesScreeningCalendar/NextScreeningButton'
+import { useMovieCalendarV2 } from 'features/offer/components/MoviesScreeningCalendarV2/MovieCalendarContextV2'
+import { NextScreeningButtonV2 } from 'features/offer/components/MoviesScreeningCalendarV2/NextScreeningButtonV2'
 import { OfferEventCardListV2 } from 'features/offer/components/OfferEventCardList/OfferEventCardListV2'
 import { VenueBlock } from 'features/offer/components/OfferVenueBlock/VenueBlock'
 import { LocationMode } from 'libs/location/types'
 import { locationStore } from 'libs/locationV2/location.store'
+import { formatDateWithTimeZoneOffset } from 'libs/parsers/formatDates'
 import { humanizeDistance } from 'libs/parsers/formatDistance'
 
 type CineBlockV2Props = {
@@ -23,12 +24,12 @@ export const CineBlockV2: FunctionComponent<CineBlockV2Props> = ({
   onSeeVenuePress,
   withDivider,
 }) => {
-  const { goToDate } = useMovieCalendar()
+  const { goToDate } = useMovieCalendarV2()
   const locationMode = locationStore.hooks.useLocationMode()
 
   const distance = humanizeDistance(venueScreenings.distance).replace('.', ',')
   const nextDate = venueScreenings.nextScreening?.beginningDatetime
-    ? new Date(venueScreenings.nextScreening?.beginningDatetime)
+    ? formatDateWithTimeZoneOffset(venueScreenings.nextScreening?.beginningDatetime, 'yyyy-MM-dd')
     : null
   const showNextScreeningButton = venueScreenings.dayScreenings.length === 0 && !!nextDate
 
@@ -50,7 +51,7 @@ export const CineBlockV2: FunctionComponent<CineBlockV2Props> = ({
         />
 
         {showNextScreeningButton ? (
-          <NextScreeningButton date={nextDate} onPress={() => goToDate(nextDate)} />
+          <NextScreeningButtonV2 date={nextDate} onPress={() => goToDate(nextDate)} />
         ) : (
           <OfferEventCardListV2 venueScreenings={venueScreenings} offerId={offerId} />
         )}

--- a/src/features/offer/components/OfferCine/OfferCineBlockV2.tsx
+++ b/src/features/offer/components/OfferCine/OfferCineBlockV2.tsx
@@ -1,11 +1,12 @@
 import { useRoute } from '@react-navigation/native'
+import { addDays } from 'date-fns'
 import React, { FC, useCallback, useEffect } from 'react'
 import { ViewStyle } from 'react-native'
 import { InView } from 'react-native-intersection-observer'
 import styled, { useTheme } from 'styled-components/native'
 
 import { UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
-import { MovieCalendarProvider } from 'features/offer/components/MoviesScreeningCalendar/MovieCalendarContext'
+import { MovieCalendarProviderV2 } from 'features/offer/components/MoviesScreeningCalendarV2/MovieCalendarContextV2'
 import { OfferCineContentV2 } from 'features/offer/components/OfferCine/OfferCineContentV2'
 import { useOfferCTA } from 'features/offer/components/OfferContent/OfferCTAProvider'
 import { useOfferMovieCalendarQuery } from 'features/offer/queries/useMovieCalendarQuery'
@@ -39,15 +40,19 @@ export const OfferCineBlockV2: FC<Props> = ({
   offerVenueLongitude,
 }) => {
   const theme = useTheme()
+  const calendarStartDatetime = new Date()
+  const calendarEndDatetime = addDays(calendarStartDatetime, 15)
   const { data: movieCalendar, isLoading } = useOfferMovieCalendarQuery({
     offerId,
     allocineId,
     visa,
     offerVenueLatitude,
     offerVenueLongitude,
+    from: calendarStartDatetime,
+    to: calendarEndDatetime,
   })
   const { calendar } = movieCalendar ?? { calendar: [] }
-  const calendarDates = calendar?.map((dayVenueScreenings) => new Date(dayVenueScreenings.date))
+  const calendarDates = calendar?.map((dayVenueScreenings) => dayVenueScreenings.date)
   const route = useRoute<UseRouteType<'ClubAdvices'>>()
   const from = route.params?.from
   const { setButton, showButton } = useOfferCTA()
@@ -81,14 +86,16 @@ export const OfferCineBlockV2: FC<Props> = ({
           </TitleContainer>
         </InView>
       </Anchor>
-      <MovieCalendarProvider initialDates={calendarDates} containerStyle={getCalendarStyle(theme)}>
+      <MovieCalendarProviderV2
+        initialDates={calendarDates}
+        containerStyle={getCalendarStyle(theme)}>
         <OfferCineContentV2
           offerId={offerId}
           calendar={calendar}
           isLoading={isLoading || !offerId}
           onSeeVenuePress={onSeeVenuePress}
         />
-      </MovieCalendarProvider>
+      </MovieCalendarProviderV2>
     </Container>
   )
 }

--- a/src/features/offer/components/OfferCine/OfferCineContentV2.tsx
+++ b/src/features/offer/components/OfferCine/OfferCineContentV2.tsx
@@ -5,14 +5,13 @@ import styled from 'styled-components/native'
 import { DayVenueScreenings } from 'api/gen'
 import { ExpandingFlatList } from 'features/offer/components/ExpandingFlatlist/ExpandingFlatList'
 import {
-  useDisableCalendarDates,
-  useDisplayCalendar,
-  useMovieCalendar,
-} from 'features/offer/components/MoviesScreeningCalendar/MovieCalendarContext'
+  useDisableCalendarDatesV2,
+  useDisplayCalendarV2,
+  useMovieCalendarV2,
+} from 'features/offer/components/MoviesScreeningCalendarV2/MovieCalendarContextV2'
 import { CineBlockSkeleton } from 'features/offer/components/OfferCine/CineBlockSkeleton'
 import { CineBlockV2 } from 'features/offer/components/OfferCine/CineBlockV2'
 import { INITIAL_LIST_SIZE, expandList, hasReachedEnd } from 'features/offer/helpers/expandableList'
-import { formatDateToISOStringWithoutTime } from 'libs/parsers/formatDates'
 import { Button } from 'ui/designSystem/Button/Button'
 import { PlainMore } from 'ui/svg/icons/PlainMore'
 import { Typo } from 'ui/theme'
@@ -30,23 +29,21 @@ export const OfferCineContentV2: FC<Props> = ({
   isLoading,
   onSeeVenuePress,
 }) => {
-  const { selectedDate } = useMovieCalendar()
-  const venues =
-    calendar?.find((value) => value.date === formatDateToISOStringWithoutTime(selectedDate))
-      ?.screenings || []
+  const { selectedDate } = useMovieCalendarV2()
+  const venues = calendar?.find((value) => value.date === selectedDate)?.screenings || []
   const disabledDates = calendar
     .filter((dayVenueScreenings) =>
       dayVenueScreenings.screenings.every((screenings) => screenings.dayScreenings.length === 0)
     )
-    .map((dayVenueScreenings) => new Date(dayVenueScreenings.date))
+    .map((dayVenueScreenings) => dayVenueScreenings.date)
 
   const [displayedLen, setDisplayedLen] = useState(INITIAL_LIST_SIZE)
   const hasAnyScreening = calendar.some((dayVenueScreenings) =>
     dayVenueScreenings.screenings.some((screenings) => screenings.dayScreenings.length > 0)
   )
 
-  useDisplayCalendar(hasAnyScreening)
-  useDisableCalendarDates(disabledDates)
+  useDisplayCalendarV2(hasAnyScreening)
+  useDisableCalendarDatesV2(disabledDates)
 
   useEffect(() => {
     setDisplayedLen(INITIAL_LIST_SIZE)

--- a/src/features/offer/components/OfferCine/OfferCineContentV2.tsx
+++ b/src/features/offer/components/OfferCine/OfferCineContentV2.tsx
@@ -5,14 +5,13 @@ import styled from 'styled-components/native'
 import { DayVenueScreenings } from 'api/gen'
 import { ExpandingFlatList } from 'features/offer/components/ExpandingFlatlist/ExpandingFlatList'
 import {
-  useDisableCalendarDates,
-  useDisplayCalendar,
-  useMovieCalendar,
-} from 'features/offer/components/MoviesScreeningCalendar/MovieCalendarContext'
+  useDisableCalendarDatesV2,
+  useDisplayCalendarV2,
+  useMovieCalendarV2,
+} from 'features/offer/components/MoviesScreeningCalendarV2/MovieCalendarContextV2'
 import { CineBlockSkeleton } from 'features/offer/components/OfferCine/CineBlockSkeleton'
 import { CineBlockV2 } from 'features/offer/components/OfferCine/CineBlockV2'
 import { INITIAL_LIST_SIZE, expandList, hasReachedEnd } from 'features/offer/helpers/expandableList'
-import { formatDateToISOStringWithoutTime } from 'libs/parsers/formatDates'
 import { Button } from 'ui/designSystem/Button/Button'
 import { PlainMore } from 'ui/svg/icons/PlainMore'
 import { Typo } from 'ui/theme'
@@ -30,23 +29,23 @@ export const OfferCineContentV2: FC<Props> = ({
   isLoading,
   onSeeVenuePress,
 }) => {
-  const { selectedDate } = useMovieCalendar()
-  const venues =
-    calendar?.find((value) => value.date === formatDateToISOStringWithoutTime(selectedDate))
-      ?.screenings || []
+  const { selectedDate } = useMovieCalendarV2()
+  const venues = calendar?.find((value) => value.date === selectedDate)?.screenings || []
   const disabledDates = calendar
-    .filter((dayVenueScreenings) =>
-      dayVenueScreenings.screenings.every((screenings) => screenings.dayScreenings.length === 0)
+    .filter((dayVenueScreenings, index) =>
+      dayVenueScreenings.screenings.every(
+        (screenings) => screenings.dayScreenings.length === 0 && index !== 0
+      )
     )
-    .map((dayVenueScreenings) => new Date(dayVenueScreenings.date))
+    .map((dayVenueScreenings) => dayVenueScreenings.date)
 
   const [displayedLen, setDisplayedLen] = useState(INITIAL_LIST_SIZE)
   const hasAnyScreening = calendar.some((dayVenueScreenings) =>
     dayVenueScreenings.screenings.some((screenings) => screenings.dayScreenings.length > 0)
   )
 
-  useDisplayCalendar(hasAnyScreening)
-  useDisableCalendarDates(disabledDates)
+  useDisplayCalendarV2(hasAnyScreening)
+  useDisableCalendarDatesV2(disabledDates)
 
   useEffect(() => {
     setDisplayedLen(INITIAL_LIST_SIZE)

--- a/src/features/offer/components/OfferEventCardList/OfferEventCardListV2.tsx
+++ b/src/features/offer/components/OfferEventCardList/OfferEventCardListV2.tsx
@@ -2,13 +2,13 @@ import React, { FC, useCallback, useState } from 'react'
 import { View } from 'react-native'
 
 import { Screening, VenueScreenings } from 'api/gen'
-import { formatHour } from 'features/bookOffer/helpers/utils'
 import { StepperOrigin } from 'features/navigation/navigators/RootNavigator/types'
 import {
   getEventCardIsEnabled,
   getEventCardLeftSubtitle,
   getEventCardRightSubtitle,
 } from 'features/offer/helpers/screeningBlockInfo/screeningBlockInfo'
+import { formatDateWithTimeZoneOffset } from 'libs/parsers/formatDates'
 import { usePacificFrancToEuroRate } from 'queries/settings/useSettings'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { BookOfferModal } from 'shared/offer/components/BookOfferModal/BookOfferModal'
@@ -35,7 +35,7 @@ export const OfferEventCardListV2: FC<Props> = ({ venueScreenings, offerId }) =>
           modalSettings.showModal()
         },
         isDisabled: !getEventCardIsEnabled(screening),
-        title: formatHour(screening.beginningDatetime).replace(':', 'h'),
+        title: formatDateWithTimeZoneOffset(screening.beginningDatetime, "HH'h'mm"),
         subtitleLeft: getEventCardLeftSubtitle(screening),
         subtitleRight: getEventCardRightSubtitle(screening, currency, euroToPacificFrancRate),
       }) as EventCardProps,

--- a/src/features/offer/queries/useMovieCalendarQuery.ts
+++ b/src/features/offer/queries/useMovieCalendarQuery.ts
@@ -17,10 +17,12 @@ type props = {
   visa?: string | null
   offerVenueLatitude?: number | null
   offerVenueLongitude?: number | null
+  from: Date
+  to: Date
 }
 
 export const useOfferMovieCalendarQuery = <TData = MovieCalendarResponse>(
-  { offerId, allocineId, visa, offerVenueLatitude, offerVenueLongitude }: props,
+  { offerId, allocineId, visa, offerVenueLatitude, offerVenueLongitude, from, to }: props,
   options?: {
     enabled: boolean
     select?: (data: MovieCalendarResponse) => TData
@@ -44,8 +46,24 @@ export const useOfferMovieCalendarQuery = <TData = MovieCalendarResponse>(
       const allocineIdParam = allocineId ?? undefined
       const visaParam = allocineId ? undefined : (visa ?? undefined)
       return isLoggedIn
-        ? api.getNativeV1MovieCalendarMe(latitude, longitude, allocineIdParam, visaParam, radius)
-        : api.getNativeV1MovieCalendar(latitude, longitude, allocineIdParam, visaParam, radius)
+        ? api.getNativeV1MovieCalendarMe(
+            latitude,
+            longitude,
+            allocineIdParam,
+            visaParam,
+            radius,
+            from.toISOString(), // auto convert date to utc timezone
+            to.toISOString() // auto convert date to utc timezone
+          )
+        : api.getNativeV1MovieCalendar(
+            latitude,
+            longitude,
+            allocineIdParam,
+            visaParam,
+            radius,
+            from.toISOString(), // auto convert date to utc timezone
+            to.toISOString() // auto convert date to utc timezone
+          )
     },
     queryKey: [
       QueryKeys.OFFER_MOVIE_CALENDAR,

--- a/src/features/offer/queries/useVenueMoviesCalendarQuery.ts
+++ b/src/features/offer/queries/useVenueMoviesCalendarQuery.ts
@@ -7,10 +7,12 @@ import { QueryKeys } from 'libs/queryKeys'
 
 type props = {
   venueId: number
+  from: Date
+  to: Date
 }
 
 export const useVenueMoviesCalendarQuery = <TData = VenueMovieCalendarResponse>(
-  { venueId }: props,
+  { venueId, from, to }: props,
   options?: {
     enabled: boolean
     select?: (data: VenueMovieCalendarResponse) => TData
@@ -21,10 +23,10 @@ export const useVenueMoviesCalendarQuery = <TData = VenueMovieCalendarResponse>(
   return useQuery<VenueMovieCalendarResponse, Error, TData>({
     queryFn: async () => {
       return isLoggedIn
-        ? api.getNativeV1VenuevenueIdMovieCalendarMe(venueId)
-        : api.getNativeV1VenuevenueIdMovieCalendar(venueId)
+        ? api.getNativeV1VenuevenueIdMovieCalendarMe(venueId, from.toISOString(), to.toISOString()) // auto convert dates to utc timezone
+        : api.getNativeV1VenuevenueIdMovieCalendar(venueId, from.toISOString(), to.toISOString()) // auto convert date to utc timezone
     },
-    queryKey: [QueryKeys.VENUE_MOVIES_CALENDAR, user?.id, venueId],
+    queryKey: [QueryKeys.VENUE_MOVIES_CALENDAR, user?.id, venueId, from, to],
     select: options?.select,
     enabled: options?.enabled,
   })

--- a/src/libs/parsers/formatDates.ts
+++ b/src/libs/parsers/formatDates.ts
@@ -1,5 +1,5 @@
 import { isAfter, isFirstDayOfMonth } from 'date-fns'
-import { utcToZonedTime } from 'date-fns-tz'
+import { formatInTimeZone, utcToZonedTime } from 'date-fns-tz'
 
 import { DAYS } from 'shared/date/days'
 import { CAPITALIZED_SHORT_MONTHS, FullMonth, MONTHS, SHORT_MONTHS } from 'shared/date/months'
@@ -298,11 +298,26 @@ export const isTomorrow = (someDate: Date) => {
 
 export const localizeUTCDate = (someDate: Date | string) => {
   const utcDate = new Date(someDate)
-  const timeZoneOffest = new Date(someDate).getTimezoneOffset()
-  return utcDate.setMinutes(utcDate.getMinutes() - timeZoneOffest)
+  const timeZoneOffset = new Date(someDate).getTimezoneOffset()
+  return utcDate.setMinutes(utcDate.getMinutes() - timeZoneOffset)
 }
 
 export const getTimeZonedDate = ({ date, timezone }: { date: Date | string; timezone: string }) => {
   const utcDate = new Date(date)
   return utcToZonedTime(utcDate, timezone)
+}
+
+const getIsoOffset = (isoFormattedDate: string): string | null => {
+  // Matches trailing 'Z' or offset like '+05:30' / '-04:00'
+  const regex = /(Z|[+-]\d{2}:?\d{2})$/
+  const match = regex.exec(isoFormattedDate)
+  return match ? match[0] : null
+}
+
+export const formatDateWithTimeZoneOffset = (
+  isoFormattedDate: string,
+  outputFormat: string
+): string => {
+  const offset = getIsoOffset(isoFormattedDate) ?? 'utc'
+  return formatInTimeZone(isoFormattedDate, offset, outputFormat)
 }


### PR DESCRIPTION

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-42968

## Context

Handle movie calendar screenings' timezone in venue and offer pages
requires this PR: https://github.com/pass-culture/pass-culture-main/pull/24194 

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
