### PR TITLE
(PC-43530) fix(Bookings): replace FlatList with FlashList to fix display of ended bookings

### DIFF
--- a/__snapshots__/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx.native-snap
@@ -1,456 +1,106 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`EndedBookings should render correctly 1`] = `
-<RCTScrollView
-  ItemSeparatorComponent={
-    {
-      "$$typeof": Symbol(react.forward_ref),
-      "attrs": [],
-      "inlineStyle": e {
-        "rules": [
-          [Function],
-          [Function],
-        ],
-      },
-      "render": [Function],
-      "shouldForwardProp": undefined,
-      "styledComponentId": true,
-      "target": [Function],
-    }
-  }
-  ListEmptyComponent={<NoBookingsView />}
-  ListHeaderComponent={<Styled(View) />}
-  contentContainerStyle={
-    {
-      "flexGrow": 1,
-      "paddingBottom": 98,
-    }
-  }
-  data={
-    [
-      {
-        "activationCode": {
-          "code": "",
-          "expirationDate": null,
-        },
-        "canReact": true,
-        "cancellationDate": "2021-03-15T23:01:37.925926",
-        "cancellationReason": "BENEFICIARY",
-        "dateCreated": "2021-02-15T23:01:37.925926",
-        "dateUsed": null,
-        "expirationDate": null,
-        "id": 987,
-        "isArchivable": false,
-        "quantity": 10,
-        "stock": {
-          "beginningDatetime": "2021-03-14T20:00:00",
-          "isAutomaticallyUsed": false,
-          "offer": {
-            "address": {
-              "city": "Drancy",
-              "label": null,
-              "timezone": "Europe/Paris",
-            },
-            "id": 147874,
-            "imageUrl": "https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/CDBA",
-            "isDigital": true,
-            "isPermanent": false,
-            "name": "Harry Potter",
-            "subcategoryId": "SEANCE_CINE",
-            "venue": {
-              "id": 2185,
-              "name": "Maison de la Brique",
-              "timezone": "Europe/Paris",
-            },
-            "withdrawalDelay": null,
-            "withdrawalType": "on_site",
-          },
-        },
-        "totalAmount": 1900,
-        "userReaction": null,
-      },
-    ]
-  }
-  getItem={[Function]}
-  getItemCount={[Function]}
-  keyExtractor={[Function]}
-  onContentSizeChange={[Function]}
+<View
+  collapsable={false}
   onLayout={[Function]}
-  onMomentumScrollBegin={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  removeClippedSubviews={false}
-  renderItem={[Function]}
-  scrollEventThrottle={0.0001}
-  stickyHeaderIndices={[]}
-  viewabilityConfigCallbackPairs={[]}
+  style={
+    {
+      "flex": 1,
+      "overflow": "hidden",
+    }
+  }
 >
-  <View>
-    <View
-      collapsable={false}
-      onLayout={[Function]}
-    >
+  <RCTScrollView
+    collapsable={false}
+    contentContainerStyle={
+      {
+        "flexGrow": 1,
+        "paddingBottom": 98,
+      }
+    }
+    keyExtractor={[Function]}
+    maintainVisibleContentPosition={
+      {
+        "minIndexForVisible": 0,
+      }
+    }
+    onScroll={[Function]}
+    scrollEventThrottle={0.0001}
+  >
+    <View>
       <View
         style={
           {
-            "height": 24,
+            "height": 0,
+            "left": 0,
+            "position": "absolute",
+            "top": 1000000,
           }
         }
       />
-    </View>
-    <View
-      onFocusCapture={[Function]}
-      onLayout={[Function]}
-      style={null}
-    >
+      <View>
+        <View
+          style={
+            {
+              "height": 24,
+            }
+          }
+        />
+      </View>
       <View
         style={
           {
-            "flexDirection": "row",
-            "justifyContent": "space-between",
+            "height": 0,
+            "width": undefined,
+          }
+        }
+      />
+      <View
+        style={
+          {
+            "height": 0,
+            "marginLeft": undefined,
+            "marginTop": 0,
+            "opacity": 1,
+            "width": undefined,
           }
         }
       >
         <View
-          accessibilityLabel="Réservation annulée - le 15/03/2021 - Harry Potter"
-          accessibilityRole="button"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+          index={0}
+          onLayout={[Function]}
           style={
-            [
-              [
-                {
-                  "userSelect": "auto",
-                },
-                {},
-                {
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "paddingRight": 40,
-                },
-              ],
-              {
-                "opacity": 1,
-              },
-            ]
+            {
+              "flexDirection": "column",
+              "height": undefined,
+              "left": 0,
+              "maxHeight": undefined,
+              "maxWidth": undefined,
+              "minHeight": undefined,
+              "minWidth": undefined,
+              "position": "absolute",
+              "top": 0,
+              "width": 0,
+            }
           }
-          testID="Réservation annulée - le 15/03/2021 - Harry Potter"
         >
           <View
-            gap={4}
             style={
               {
-                "flexBasis": 0,
                 "flexDirection": "row",
-                "flexGrow": 1,
-                "flexShrink": 1,
-                "gap": 16,
+                "justifyContent": "space-between",
               }
             }
           >
             <View
-              size="small"
-              style={
-                {
-                  "backgroundColor": "#ffffff",
-                  "borderBottomLeftRadius": 4,
-                  "borderBottomRightRadius": 4,
-                  "borderTopLeftRadius": 4,
-                  "borderTopRightRadius": 4,
-                  "height": 96,
-                  "width": 64,
-                }
-              }
-              withShadow={true}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "overflow": "hidden",
-                    },
-                    {
-                      "backgroundColor": "#f1f1f4",
-                      "borderBottomLeftRadius": 4,
-                      "borderBottomRightRadius": 4,
-                      "borderTopLeftRadius": 4,
-                      "borderTopRightRadius": 4,
-                      "height": 96,
-                      "width": 64,
-                    },
-                  ]
-                }
-              >
-                <FastImageView
-                  defaultSource={null}
-                  resizeMode="cover"
-                  size="small"
-                  source={
-                    {
-                      "uri": "https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/CDBA",
-                    }
-                  }
-                  style={
-                    {
-                      "bottom": 0,
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    }
-                  }
-                />
-              </View>
-            </View>
-            <View
-              style={
-                {
-                  "flexBasis": 0,
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "paddingRight": 4,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "paddingBottom": 4,
-                  }
-                }
-              >
-                <Text
-                  accessibilityLevel="p"
-                  accessibilityRole="text"
-                  numberOfLines={2}
-                  shrink={true}
-                  style={
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 16,
-                      "lineHeight": 25.6,
-                    }
-                  }
-                >
-                  Harry Potter
-                </Text>
-              </View>
-              <View
-                gap={1}
-                style={
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                    "flexWrap": "wrap",
-                    "gap": 4,
-                  }
-                }
-              >
-                <View
-                  gap={1}
-                  noFullWidth={true}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row-reverse",
-                      "gap": 4,
-                      "justifyContent": "flex-end",
-                      "maxWidth": 500,
-                    }
-                  }
-                >
-                  <Text
-                    accessibilityLevel="p"
-                    accessibilityRole="text"
-                    color="error"
-                    noFullWidth={true}
-                    style={
-                      {
-                        "color": "#a20121",
-                        "flexShrink": 1,
-                        "fontFamily": "Montserrat-SemiBold",
-                        "fontSize": 12,
-                        "lineHeight": 19.2,
-                        "paddingLeft": 4,
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    Réservation annulée
-                  </Text>
-                  <View
-                    style={
-                      {
-                        "flexShrink": 0,
-                      }
-                    }
-                  >
-                    <View
-                      height={20}
-                      testID="rule-icon-"
-                      width={20}
-                    >
-                      <Text>
-                        rule-icon--SVG-Mock
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-                <Text
-                  accessibilityLevel="p"
-                  accessibilityRole="text"
-                  style={
-                    {
-                      "color": "#696a6f",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 12,
-                      "lineHeight": 19.2,
-                    }
-                  }
-                >
-                  le 15/03/2021
-                </Text>
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          gap={4}
-          style={
-            {
-              "gap": 16,
-            }
-          }
-        >
-          <View
-            accessibilityLabel="Partager l’offre Harry Potter"
-            accessibilityRole="button"
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": false,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              [
-                [
-                  {
-                    "userSelect": "auto",
-                  },
-                  {
-                    "alignItems": "center",
-                    "backgroundColor": "#ffffff",
-                    "borderBottomLeftRadius": 8,
-                    "borderBottomRightRadius": 8,
-                    "borderColor": "#90949d",
-                    "borderStyle": "solid",
-                    "borderTopLeftRadius": 8,
-                    "borderTopRightRadius": 8,
-                    "borderWidth": 1,
-                    "flexDirection": "row",
-                    "justifyContent": "center",
-                    "paddingBottom": 8,
-                    "paddingLeft": 8,
-                    "paddingRight": 8,
-                    "paddingTop": 8,
-                    "width": "auto",
-                  },
-                ],
-                {
-                  "opacity": 1,
-                },
-              ]
-            }
-            testID="Partager l’offre Harry Potter"
-          >
-            <View
-              gap={0}
-              hasIcon={true}
-              isMultiline={false}
-              style={
-                {
-                  "alignItems": "center",
-                  "columnGap": 0,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "flexShrink": 0,
-                  }
-                }
-              >
-                <View
-                  height={22}
-                  width={22}
-                >
-                  <Text>
-                    undefined-SVG-Mock
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View>
-            <View
-              accessibilityLabel="Réagis à ta réservation"
+              accessibilityLabel="Réservation annulée - le 15/03/2021 - Harry Potter"
               accessibilityRole="button"
               accessibilityState={
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -478,23 +128,13 @@ exports[`EndedBookings should render correctly 1`] = `
                     {
                       "userSelect": "auto",
                     },
+                    {},
                     {
-                      "alignItems": "center",
-                      "backgroundColor": "#ffffff",
-                      "borderBottomLeftRadius": 8,
-                      "borderBottomRightRadius": 8,
-                      "borderColor": "#90949d",
-                      "borderStyle": "solid",
-                      "borderTopLeftRadius": 8,
-                      "borderTopRightRadius": 8,
-                      "borderWidth": 1,
+                      "flexBasis": 0,
                       "flexDirection": "row",
-                      "justifyContent": "center",
-                      "paddingBottom": 8,
-                      "paddingLeft": 8,
-                      "paddingRight": 8,
-                      "paddingTop": 8,
-                      "width": "auto",
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                      "paddingRight": 40,
                     },
                   ],
                   {
@@ -502,51 +142,402 @@ exports[`EndedBookings should render correctly 1`] = `
                   },
                 ]
               }
-              testID="Réagis à ta réservation"
+              testID="Réservation annulée - le 15/03/2021 - Harry Potter"
             >
               <View
-                gap={0}
-                hasIcon={true}
-                isMultiline={false}
+                gap={4}
                 style={
                   {
-                    "alignItems": "center",
-                    "columnGap": 0,
+                    "flexBasis": 0,
                     "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "gap": 16,
                   }
                 }
               >
                 <View
+                  size="small"
                   style={
                     {
-                      "flexShrink": 0,
+                      "backgroundColor": "#ffffff",
+                      "borderBottomLeftRadius": 4,
+                      "borderBottomRightRadius": 4,
+                      "borderTopLeftRadius": 4,
+                      "borderTopRightRadius": 4,
+                      "height": 96,
+                      "width": 64,
+                    }
+                  }
+                  withShadow={true}
+                >
+                  <View
+                    style={
+                      [
+                        {
+                          "overflow": "hidden",
+                        },
+                        {
+                          "backgroundColor": "#f1f1f4",
+                          "borderBottomLeftRadius": 4,
+                          "borderBottomRightRadius": 4,
+                          "borderTopLeftRadius": 4,
+                          "borderTopRightRadius": 4,
+                          "height": 96,
+                          "width": 64,
+                        },
+                      ]
+                    }
+                  >
+                    <FastImageView
+                      defaultSource={null}
+                      resizeMode="cover"
+                      size="small"
+                      source={
+                        {
+                          "uri": "https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/CDBA",
+                        }
+                      }
+                      style={
+                        {
+                          "bottom": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                        }
+                      }
+                    />
+                  </View>
+                </View>
+                <View
+                  style={
+                    {
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                      "paddingRight": 4,
                     }
                   }
                 >
                   <View
-                    height={22}
-                    width={22}
+                    style={
+                      {
+                        "paddingBottom": 4,
+                      }
+                    }
                   >
-                    <Text>
-                      undefined-SVG-Mock
+                    <Text
+                      accessibilityLevel="p"
+                      accessibilityRole="text"
+                      numberOfLines={2}
+                      shrink={true}
+                      style={
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        }
+                      }
+                    >
+                      Harry Potter
+                    </Text>
+                  </View>
+                  <View
+                    gap={1}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "flexWrap": "wrap",
+                        "gap": 4,
+                      }
+                    }
+                  >
+                    <View
+                      gap={1}
+                      noFullWidth={true}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row-reverse",
+                          "gap": 4,
+                          "justifyContent": "flex-end",
+                          "maxWidth": 500,
+                        }
+                      }
+                    >
+                      <Text
+                        accessibilityLevel="p"
+                        accessibilityRole="text"
+                        color="error"
+                        noFullWidth={true}
+                        style={
+                          {
+                            "color": "#a20121",
+                            "flexShrink": 1,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 12,
+                            "lineHeight": 19.2,
+                            "paddingLeft": 4,
+                            "textAlign": "center",
+                          }
+                        }
+                      >
+                        Réservation annulée
+                      </Text>
+                      <View
+                        style={
+                          {
+                            "flexShrink": 0,
+                          }
+                        }
+                      >
+                        <View
+                          height={20}
+                          testID="rule-icon-"
+                          width={20}
+                        >
+                          <Text>
+                            rule-icon--SVG-Mock
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                    <Text
+                      accessibilityLevel="p"
+                      accessibilityRole="text"
+                      style={
+                        {
+                          "color": "#696a6f",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        }
+                      }
+                    >
+                      le 15/03/2021
                     </Text>
                   </View>
                 </View>
               </View>
             </View>
             <View
-              height={12}
-              testID="smallBadge"
-              width={12}
+              gap={4}
+              style={
+                {
+                  "gap": 16,
+                }
+              }
             >
-              <Text>
-                smallBadge-SVG-Mock
-              </Text>
+              <View
+                accessibilityLabel="Partager l’offre Harry Potter"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  [
+                    [
+                      {
+                        "userSelect": "auto",
+                      },
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderBottomLeftRadius": 8,
+                        "borderBottomRightRadius": 8,
+                        "borderColor": "#90949d",
+                        "borderStyle": "solid",
+                        "borderTopLeftRadius": 8,
+                        "borderTopRightRadius": 8,
+                        "borderWidth": 1,
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                        "paddingBottom": 8,
+                        "paddingLeft": 8,
+                        "paddingRight": 8,
+                        "paddingTop": 8,
+                        "width": "auto",
+                      },
+                    ],
+                    {
+                      "opacity": 1,
+                    },
+                  ]
+                }
+                testID="Partager l’offre Harry Potter"
+              >
+                <View
+                  gap={0}
+                  hasIcon={true}
+                  isMultiline={false}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "columnGap": 0,
+                      "flexDirection": "row",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flexShrink": 0,
+                      }
+                    }
+                  >
+                    <View
+                      height={22}
+                      width={22}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+              <View>
+                <View
+                  accessibilityLabel="Réagis à ta réservation"
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "alignItems": "center",
+                          "backgroundColor": "#ffffff",
+                          "borderBottomLeftRadius": 8,
+                          "borderBottomRightRadius": 8,
+                          "borderColor": "#90949d",
+                          "borderStyle": "solid",
+                          "borderTopLeftRadius": 8,
+                          "borderTopRightRadius": 8,
+                          "borderWidth": 1,
+                          "flexDirection": "row",
+                          "justifyContent": "center",
+                          "paddingBottom": 8,
+                          "paddingLeft": 8,
+                          "paddingRight": 8,
+                          "paddingTop": 8,
+                          "width": "auto",
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="Réagis à ta réservation"
+                >
+                  <View
+                    gap={0}
+                    hasIcon={true}
+                    isMultiline={false}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "columnGap": 0,
+                        "flexDirection": "row",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flexShrink": 0,
+                        }
+                      }
+                    >
+                      <View
+                        height={22}
+                        width={22}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+                <View
+                  height={12}
+                  testID="smallBadge"
+                  width={12}
+                >
+                  <Text>
+                    smallBadge-SVG-Mock
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
       </View>
+      <View>
+        <View
+          style={
+            {
+              "height": 24,
+            }
+          }
+        />
+      </View>
     </View>
-  </View>
-</RCTScrollView>
+  </RCTScrollView>
+</View>
 `;

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.tsx
@@ -1,6 +1,6 @@
+import { FlashList } from '@shopify/flash-list'
 import { UseQueryResult } from '@tanstack/react-query'
 import React, { FunctionComponent, useCallback, useState } from 'react'
-import { FlatList, ListRenderItem } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import {
@@ -119,7 +119,7 @@ export const EndedBookings: FunctionComponent<Props> = ({ useEndedBookingsQuery 
     [hideReactionModal, onSaveReaction, requestReview]
   )
 
-  const renderItem: ListRenderItem<BookingListItemResponse> = useCallback(
+  const renderItem = useCallback(
     ({ item }) => {
       return enableNewBookings ? (
         <EndedBookingListItemWrapper booking={item} handleShowReactionModal={openReactionModal} />
@@ -136,7 +136,7 @@ export const EndedBookings: FunctionComponent<Props> = ({ useEndedBookingsQuery 
 
   return (
     <React.Fragment>
-      <FlatList
+      <FlashList
         contentContainerStyle={contentContainerStyle(designSystem)}
         data={endedBookings ?? []}
         keyExtractor={keyExtractor}
@@ -144,6 +144,7 @@ export const EndedBookings: FunctionComponent<Props> = ({ useEndedBookingsQuery 
         ItemSeparatorComponent={enableNewBookings ? null : StyledSeparator}
         ListHeaderComponent={hasEndedBookings ? <Placeholder /> : null}
         ListEmptyComponent={<NoBookingsView />}
+        ListFooterComponent={hasEndedBookings ? <Placeholder /> : null}
       />
 
       {shareContent ? (


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43530

## Context

Le remplacement de FlatList par FlashList suffit à fixer le problème. Alors on s'en contente surtout qu'on veut privilégier son utilisation à travers la codebase pour ses meilleures performances.
Seul le typage de `renderItem` posait problème, alors on laisse TS inférer.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |  |  |
| Android          |               |       |
| Phone - Chrome   | https://github.com/user-attachments/assets/5faa611a-a978-4cdb-b4be-4d91f79fb50f | https://github.com/user-attachments/assets/638d7cb1-ce77-4102-9793-f8dec03c7be4 |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md