### PR TITLE
(PC-43346) fix(ui): prevent see all button wrapping and align it on t…

### DIFF
--- a/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/v1/SearchResults.native.test.tsx.native-snap
@@ -642,7 +642,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       gap={3}
                       style={
                         {
-                          "alignItems": "center",
+                          "alignItems": "baseline",
                           "flexDirection": "row",
                           "gap": 12,
                           "justifyContent": "space-between",
@@ -752,6 +752,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                               <Text
                                 accessibilityLevel="p"
                                 accessibilityRole="text"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {

--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -1787,6 +1787,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                 <View
                   style={
                     {
+                      "alignItems": "baseline",
                       "flexDirection": "row",
                     }
                   }
@@ -1848,7 +1849,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                   <View
                     style={
                       {
-                        "justifyContent": "center",
+                        "flexShrink": 0,
                         "marginRight": 24,
                       }
                     }
@@ -1932,6 +1933,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                           <Text
                             accessibilityLevel="p"
                             accessibilityRole="text"
+                            numberOfLines={1}
                             style={
                               [
                                 {

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -1112,6 +1112,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                         <View
                           style={
                             {
+                              "alignItems": "baseline",
                               "flexDirection": "row",
                             }
                           }
@@ -1173,7 +1174,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                           <View
                             style={
                               {
-                                "justifyContent": "center",
+                                "flexShrink": 0,
                                 "marginRight": 24,
                               }
                             }
@@ -1267,6 +1268,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                   <Text
                                     accessibilityLevel="p"
                                     accessibilityRole="text"
+                                    numberOfLines={1}
                                     style={
                                       [
                                         {
@@ -4545,6 +4547,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                         <View
                           style={
                             {
+                              "alignItems": "baseline",
                               "flexDirection": "row",
                             }
                           }
@@ -4606,7 +4609,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                           <View
                             style={
                               {
-                                "justifyContent": "center",
+                                "flexShrink": 0,
                                 "marginRight": 24,
                               }
                             }
@@ -4700,6 +4703,7 @@ exports[`<Venue /> should match snapshot with headline offer 1`] = `
                                   <Text
                                     accessibilityLevel="p"
                                     accessibilityRole="text"
+                                    numberOfLines={1}
                                     style={
                                       [
                                         {

--- a/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
+++ b/src/features/artist/components/ArtistSimilarArtists/ArtistSimilarArtists.tsx
@@ -93,5 +93,5 @@ const HeaderContainer = styled.View(({ theme }) => ({
 const TitleRow = styled(ViewGap)({
   flexDirection: 'row',
   justifyContent: 'space-between',
-  alignItems: 'center',
+  alignItems: 'baseline',
 })

--- a/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
+++ b/src/features/offer/components/OfferArtistsSection/OfferArtistsSection.tsx
@@ -223,5 +223,5 @@ const TitleContainer = styled.View({
 const SeeAllButtonContainer = styled(ViewGap)({
   flexDirection: 'row',
   justifyContent: 'space-between',
-  alignItems: 'center',
+  alignItems: 'baseline',
 })

--- a/src/features/search/components/SearchListHeader/ArtistSection.tsx
+++ b/src/features/search/components/SearchListHeader/ArtistSection.tsx
@@ -82,5 +82,5 @@ const TitleContainer = styled.View({
 const SeeAllButtonContainer = styled(ViewGap)({
   flexDirection: 'row',
   justifyContent: 'space-between',
-  alignItems: 'center',
+  alignItems: 'baseline',
 })

--- a/src/features/search/pages/SearchResults/v2/components/SearchPlaylists/ArtistsPlaylist.tsx
+++ b/src/features/search/pages/SearchResults/v2/components/SearchPlaylists/ArtistsPlaylist.tsx
@@ -90,5 +90,5 @@ const TitleContainer = styled.View({
 const SeeAllButtonContainer = styled(ViewGap)({
   flexDirection: 'row',
   justifyContent: 'space-between',
-  alignItems: 'center',
+  alignItems: 'baseline',
 })

--- a/src/ui/components/PassPlaylist.tsx
+++ b/src/ui/components/PassPlaylist.tsx
@@ -159,6 +159,7 @@ const StyledSubtitle = styled(Typo.BodyAccentXs).attrs<{
 
 const StyledView = styled.View({
   flexDirection: 'row',
+  alignItems: 'baseline',
 })
 
 const TagContainer = styled.View(({ theme }) => ({
@@ -169,7 +170,7 @@ const TagContainer = styled.View(({ theme }) => ({
 
 const SeeAllButtonContainer = styled.View<{ withMargin?: boolean }>(({ withMargin, theme }) => ({
   marginRight: withMargin ? theme.contentPage.marginHorizontal : undefined,
-  justifyContent: 'center',
+  flexShrink: 0,
 }))
 
 const TitleContainer = styled.View(({ theme }) => ({

--- a/src/ui/components/SeeAllButton/SeeAllInSearchButton.tsx
+++ b/src/ui/components/SeeAllButton/SeeAllInSearchButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { Button } from 'ui/designSystem/Button/Button'
@@ -22,6 +23,7 @@ export const SeeAllInSearchButton = ({
     onBeforeNavigate={onBeforeNavigate}
     accessibilityLabel={accessibilityLabel}
     wording="Voir tout"
+    numberOfLines={useNumberOfLine(1)}
     variant="tertiary"
     color="neutral"
     icon={EyeSophisticated}

--- a/src/ui/components/SeeAllButton/SeeAllInVerticalPlaylistButton.tsx
+++ b/src/ui/components/SeeAllButton/SeeAllInVerticalPlaylistButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { useNumberOfLine } from 'shared/accessibility/helpers/zoomHelpers'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { Button } from 'ui/designSystem/Button/Button'
@@ -21,6 +22,7 @@ export const SeeAllInVerticalPlaylistButton = ({
     onBeforeNavigate={onBeforeNavigate}
     accessibilityLabel={accessibilityLabel}
     wording="Voir tout"
+    numberOfLines={useNumberOfLine(1)}
     variant="tertiary"
     size="small"
   />


### PR DESCRIPTION
…itle baseline

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43346

## Context

Lorsque le titre d'une playlist est long, il occupe toute la largeur disponible et
compresse le bouton « Voir tout », dont le libellé passait alors sur deux lignes.
L'alignement vertical `center` des conteneurs décalait par ailleurs le bouton par
rapport au titre.

Changements :

- `SeeAllInSearchButton` et `SeeAllInVerticalPlaylistButton` : ajout de
  `numberOfLines={1}` pour empêcher le retour à la ligne du libellé « Voir tout ».
- `PassPlaylist` : `alignItems: 'baseline'` sur la ligne titre + bouton, et
  `flexShrink: 0` sur le conteneur du bouton pour qu'il ne soit plus compressé par
  un titre long.
- Alignement `baseline` appliqué de la même façon sur les autres en-têtes de
  playlists d'artistes : `ArtistSimilarArtists`, `OfferArtistsSection`,
  `ArtistSection` (search) et `ArtistsPlaylist` (search v2).
- Mise à jour du snapshot `SearchResults` impacté.