### PR TITLE
(PC-43612) fix(eslint): remove @bam.tech/await-user-event rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -223,8 +223,14 @@ module.exports = [
               importNames: ['default'],
               message: 'use ui/svg/AccessibleSvg instead',
             },
-            { name: '@bam.tech/react-native-batch', message: 'use libs/react-native-batch instead' },
-            { name: '@react-native-community/netinfo', message: 'use libs/network/netinfo instead' },
+            {
+              name: '@bam.tech/react-native-batch',
+              message: 'use libs/react-native-batch instead',
+            },
+            {
+              name: '@react-native-community/netinfo',
+              message: 'use libs/network/netinfo instead',
+            },
             {
               name: 'libs/react-device-detect',
               message:
@@ -391,7 +397,7 @@ module.exports = [
       'no-undef': 'off',
       'no-redeclare': 'off',
       'require-await': 'warn',
-      'eqeqeq': 'warn',
+      eqeqeq: 'warn',
       'no-else-return': 'warn',
       'no-nested-ternary': 'warn',
       'no-return-await': 'warn',
@@ -466,7 +472,7 @@ module.exports = [
         'testing-library/prefer-screen-queries': ['error'],
         'testing-library/no-await-sync-events': 'off', // TODO(PC-25292): enable when its issues are fixed
         'jest/no-conditional-in-test': 'off', // TODO(PC-25293): enable when its issues are fixed
-        '@bam.tech/await-user-event': 'warn',
+        '@bam.tech/await-user-event': 'off',
         '@bam.tech/prefer-user-event': 'warn',
       },
     }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43612

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
