### PR TITLE
(PC-43113) fix(validateEmail): no error snackbar on success

### DIFF
--- a/src/features/auth/pages/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.native.test.tsx
+++ b/src/features/auth/pages/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.native.test.tsx
@@ -1,12 +1,13 @@
 import mockdate from 'mockdate'
 import React from 'react'
 
-import { navigate, replace, useRoute } from '__mocks__/@react-navigation/native'
+import { navigate, useRoute } from '__mocks__/@react-navigation/native'
 import { api } from 'api/api'
 import { ValidateEmailResponse } from 'api/gen'
 import { UserCreditType } from 'features/auth/helpers/getCreditType'
 import { UserEligibilityType } from 'features/auth/helpers/getEligibilityType'
 import * as LoginAndRedirectAPI from 'features/auth/pages/signup/helpers/useLoginAndRedirect'
+import { navigateFromRef } from 'features/navigation/navigationRef'
 import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { UserProfile } from 'features/share/types'
 import { nonBeneficiaryUser } from 'fixtures/user'
@@ -17,7 +18,10 @@ import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, render, screen, waitFor } from 'tests/utils'
 
-import { AfterSignupEmailValidationBuffer } from './AfterSignupEmailValidationBuffer'
+import {
+  AfterSignupEmailValidationBuffer,
+  clearEmailValidationCache,
+} from './AfterSignupEmailValidationBuffer'
 
 mockdate.set(new Date('2020-12-01T00:00:00Z'))
 
@@ -30,6 +34,7 @@ jest.useFakeTimers()
 const renderPage = () => render(reactQueryProviderHOC(<AfterSignupEmailValidationBuffer />))
 
 jest.mock('libs/firebase/analytics/analytics')
+jest.mock('features/navigation/navigationRef')
 
 describe('<AfterSignupEmailValidationBuffer />', () => {
   beforeEach(() =>
@@ -53,6 +58,8 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
 
   afterEach(() => {
     navigate.mockRestore()
+    jest.mocked(navigateFromRef).mockClear()
+    clearEmailValidationCache()
   })
 
   describe('when timestamp is NOT expired', () => {
@@ -68,11 +75,11 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
 
       renderPage()
 
-      await act(async () => {})
-
-      expect(loginAndRedirectMock).toHaveBeenCalledWith({
-        accessToken: 'access_token',
-        refreshToken: 'refresh_token',
+      await waitFor(() => {
+        expect(loginAndRedirectMock).toHaveBeenCalledWith({
+          accessToken: 'access_token',
+          refreshToken: 'refresh_token',
+        })
       })
     })
 
@@ -87,10 +94,11 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
 
       await waitFor(
         () => {
-          expect(screen.getByTestId('snackbar-error')).toBeOnTheScreen()
+          expect(screen.getAllByTestId('snackbar-error')).toHaveLength(1)
           expect(screen.getByText('Ce lien de validation n’est plus valide')).toBeOnTheScreen()
-          expect(replace).toHaveBeenCalledTimes(1)
-          expect(replace).toHaveBeenCalledWith(...homeNavigationConfig)
+          expect(apiValidateEmailSpy).toHaveBeenCalledTimes(1)
+          expect(navigateFromRef).toHaveBeenCalledTimes(1)
+          expect(navigateFromRef).toHaveBeenCalledWith(...homeNavigationConfig)
         },
         { timeout: 10_000 }
       )
@@ -116,8 +124,8 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
 
       await waitFor(
         () => {
-          expect(replace).toHaveBeenCalledTimes(1)
-          expect(replace).toHaveBeenCalledWith('SignupConfirmationExpiredLink', {
+          expect(navigateFromRef).toHaveBeenCalledTimes(1)
+          expect(navigateFromRef).toHaveBeenCalledWith('SignupConfirmationExpiredLink', {
             email: 'john@wick.com',
           })
         },
@@ -155,6 +163,17 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
         },
         emailValidationToken: 'reerereskjlmkdlsf',
       })
+    })
+
+    it('should reuse the validation request after a remount', async () => {
+      const { unmount } = renderPage()
+      unmount()
+
+      renderPage()
+
+      await act(async () => {})
+
+      expect(apiValidateEmailSpy).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/features/auth/pages/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.tsx
+++ b/src/features/auth/pages/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.tsx
@@ -1,67 +1,91 @@
-import { useNavigation, useRoute } from '@react-navigation/native'
-import React, { useEffect, useRef } from 'react'
+import { useRoute } from '@react-navigation/native'
+import React, { useEffect } from 'react'
 
-import { ValidateEmailResponse } from 'api/gen'
+import { ValidateEmailRequest, ValidateEmailResponse } from 'api/gen'
 import { useLoginAndRedirect } from 'features/auth/pages/signup/helpers/useLoginAndRedirect'
 import { useValidateEmailMutation } from 'features/auth/queries/useValidateEmailMutation'
-import { UseNavigationType, UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
+import { navigateFromRef } from 'features/navigation/navigationRef'
+import { UseRouteType } from 'features/navigation/navigators/RootNavigator/types'
 import { homeNavigationConfig } from 'features/navigation/TabBar/helpers'
 import { isTimestampExpired } from 'libs/dates'
 import { deviceInfoStoreSelectors } from 'shared/store/deviceInfoStore'
 import { showErrorSnackBar } from 'ui/designSystem/Snackbar/snackBar.store'
 import { LoadingPage } from 'ui/pages/LoadingPage'
 
-export function AfterSignupEmailValidationBuffer() {
-  const { replace } = useNavigation<UseNavigationType>()
-  const timeoutRef = useRef<number>(undefined)
-  const delayedReplace: typeof replace = (...args) => {
-    timeoutRef.current = setTimeout(() => {
-      replace(...args)
-    }, 2000)
+const validationPromises = new Map<string, Promise<ValidateEmailResponse>>()
+
+export const clearEmailValidationCache = () => validationPromises.clear()
+
+type ValidateEmail = (body: ValidateEmailRequest) => Promise<ValidateEmailResponse>
+
+const validateEmailOnce = ({
+  emailValidationToken,
+  deviceInfo,
+  validateEmail,
+  onSuccess,
+  onError,
+}: ValidateEmailRequest & {
+  validateEmail: ValidateEmail
+  onSuccess: (response: ValidateEmailResponse) => void | Promise<void>
+  onError: (error: unknown) => void
+}) => {
+  let validationPromise = validationPromises.get(emailValidationToken)
+
+  if (!validationPromise) {
+    validationPromise = validateEmail({ emailValidationToken, deviceInfo })
+    validationPromises.set(emailValidationToken, validationPromise)
   }
+
+  return validationPromise
+    .then((response) => {
+      return onSuccess(response)
+    })
+    .catch((error) => {
+      validationPromises.delete(emailValidationToken)
+      onError(error)
+    })
+}
+
+export function AfterSignupEmailValidationBuffer() {
   const loginAndRedirect = useLoginAndRedirect()
-
   const { params } = useRoute<UseRouteType<'AfterSignupEmailValidationBuffer'>>()
-
   const deviceInfo = deviceInfoStoreSelectors.selectDeviceInfo()
+  const token = params.token
+  const email = params.email
+  const expirationTimestamp = params.expiration_timestamp
 
-  useEffect(() => {
-    if (!params?.token || !deviceInfo.deviceId || !params?.email || !params?.expiration_timestamp) {
-      return
-    }
-
-    beforeEmailValidation()
-
-    return () => {
-      clearTimeout(timeoutRef.current)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [deviceInfo?.deviceId])
-
-  const { mutate: validateEmail } = useValidateEmailMutation(
-    onEmailValidationSuccess,
-    onEmailValidationFailure
+  const { mutateAsync: validateEmailAsync } = useValidateEmailMutation(
+    () => {},
+    () => {}
   )
 
-  function beforeEmailValidation() {
-    if (isTimestampExpired(params.expiration_timestamp)) {
-      delayedReplace('SignupConfirmationExpiredLink', { email: params.email })
-      return
-    }
-    validateEmail({
-      emailValidationToken: params.token,
-      deviceInfo,
-    })
-  }
+  useEffect(
+    function validateEmail() {
+      const deviceId = deviceInfo.deviceId
 
-  async function onEmailValidationSuccess(props: ValidateEmailResponse) {
-    await loginAndRedirect(props)
-  }
+      if (!token || !deviceId || !email || !expirationTimestamp) {
+        return
+      }
 
-  function onEmailValidationFailure() {
-    showErrorSnackBar('Ce lien de validation n’est plus valide')
-    delayedReplace(...homeNavigationConfig)
-  }
+      if (isTimestampExpired(expirationTimestamp)) {
+        navigateFromRef('SignupConfirmationExpiredLink', { email })
+        return
+      }
+
+      void validateEmailOnce({
+        emailValidationToken: token,
+        deviceInfo,
+        validateEmail: validateEmailAsync,
+        onSuccess: loginAndRedirect,
+        onError: () => {
+          showErrorSnackBar('Ce lien de validation n’est plus valide')
+          navigateFromRef(...homeNavigationConfig)
+        },
+      })
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [token, email, expirationTimestamp, deviceInfo.deviceId]
+  )
 
   return <LoadingPage />
 }

--- a/src/features/auth/pages/signup/helpers/useLoginAndRedirect.ts
+++ b/src/features/auth/pages/signup/helpers/useLoginAndRedirect.ts
@@ -7,19 +7,12 @@ import { useLoginRoutine } from 'features/auth/helpers/useLoginRoutine'
 import { UseNavigationType } from 'features/navigation/navigators/RootNavigator/types'
 import { getSubscriptionHookConfig } from 'features/navigation/navigators/SubscriptionStackNavigator/getSubscriptionHookConfig'
 import { LoginRoutineMethod, LoginType } from 'libs/analytics/logEventAnalytics'
-// eslint-disable-next-line no-restricted-imports
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 
 export const useLoginAndRedirect = () => {
   const disableActivation = useFeatureFlag(RemoteStoreFeatureFlags.DISABLE_ACTIVATION)
   const { replace } = useNavigation<UseNavigationType>()
-  const delayedReplace: typeof replace = useCallback(
-    (...args) => {
-      setTimeout(() => replace(...args), 2000)
-    },
-    [replace]
-  )
 
   const loginRoutine = useLoginRoutine()
 
@@ -38,7 +31,7 @@ export const useLoginAndRedirect = () => {
         const user = await api.getNativeV1Me()
 
         if (disableActivation) {
-          delayedReplace(...getSubscriptionHookConfig('DisableActivation'))
+          replace(...getSubscriptionHookConfig('DisableActivation'))
           return
         }
 
@@ -46,7 +39,7 @@ export const useLoginAndRedirect = () => {
           user.isEligibleForBeneficiaryUpgrade &&
           user.eligibility === EligibilityType['age-17-18']
         ) {
-          delayedReplace('VerifyEligibility')
+          replace('VerifyEligibility')
           return
         }
 
@@ -54,16 +47,16 @@ export const useLoginAndRedirect = () => {
           user.eligibilityStartDatetime &&
           new Date(user.eligibilityStartDatetime) >= new Date()
         ) {
-          delayedReplace('NotYetUnderageEligibility', {
+          replace('NotYetUnderageEligibility', {
             eligibilityStartDatetime: user.eligibilityStartDatetime.toString(),
           })
           return
         }
-        delayedReplace('AccountCreated')
+        replace('AccountCreated')
       } catch {
-        delayedReplace('AccountCreated')
+        replace('AccountCreated')
       }
     },
-    [delayedReplace, disableActivation, loginRoutine]
+    [replace, disableActivation, loginRoutine]
   )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43113

## Context

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
