### PR TITLE
(PC-43500) refactor(app): trigger consistent ArtistPlaylisModule tracking

### DIFF
--- a/src/features/home/components/modules/ArtistPlaylistModule.native.test.tsx
+++ b/src/features/home/components/modules/ArtistPlaylistModule.native.test.tsx
@@ -187,6 +187,37 @@ describe('ArtistPlaylistModule', () => {
           offers: ['102280', '102272'],
         })
       })
+
+      it('should trigger analytics with from param as home when we click on "Voir tout" button', async () => {
+        renderArtistPlaylistModule({
+          data: { playlistItems: mockHitsItems, nbPlaylistResults: 10, moduleId: 'fakeModuleId' },
+        })
+
+        await user.press(await screen.findByText('Voir tout'))
+
+        expect(analytics.logClickSeeAll).toHaveBeenCalledWith({
+          from: 'home',
+          type: 'offers',
+          moduleId: 'fakeModuleId',
+          moduleName: 'Module title',
+        })
+      })
+
+      it('should trigger ConsultArtist log when pressing artist button', async () => {
+        renderArtistPlaylistModule({
+          data: { playlistItems: mockHitsItems, nbPlaylistResults: 10, moduleId: 'fakeModuleId' },
+          artistId: mockArtist.id,
+        })
+
+        await user.press(await screen.findByLabelText('Accéder à la page artiste de Avril Lavigne'))
+
+        expect(analytics.logConsultArtist).toHaveBeenCalledWith({
+          artistId: mockArtist.id,
+          artistName: mockArtist.name,
+          from: 'home',
+          originDetails: 'artistRecommendation',
+        })
+      })
     })
 
     describe('When route is Artist', () => {
@@ -207,6 +238,21 @@ describe('ArtistPlaylistModule', () => {
           moduleId: props.moduleId,
         })
       })
+
+      it('should trigger analytics with from param as artist when we click on "Voir tout" button', async () => {
+        renderArtistPlaylistModule({
+          data: { playlistItems: mockHitsItems, nbPlaylistResults: 10, moduleId: 'fakeModuleId' },
+        })
+
+        await user.press(await screen.findByText('Voir tout'))
+
+        expect(analytics.logClickSeeAll).toHaveBeenCalledWith({
+          from: 'artist',
+          type: 'offers',
+          moduleId: 'fakeModuleId',
+          moduleName: 'Module title',
+        })
+      })
     })
 
     it('should not trigger logEvent "ModuleDisplayedOnHomepage" when shouldModuleBeDisplayed is false', () => {
@@ -216,37 +262,6 @@ describe('ArtistPlaylistModule', () => {
       })
 
       expect(analytics.logModuleDisplayedOnHomepage).not.toHaveBeenCalled()
-    })
-
-    it('should trigger analytics when we click on "Voir tout" button', async () => {
-      renderArtistPlaylistModule({
-        data: { playlistItems: mockHitsItems, nbPlaylistResults: 10, moduleId: 'fakeModuleId' },
-      })
-
-      await user.press(await screen.findByText('Voir tout'))
-
-      expect(analytics.logClickSeeAll).toHaveBeenCalledWith({
-        from: 'home',
-        type: 'offers',
-        moduleId: 'fakeModuleId',
-        moduleName: 'Module title',
-      })
-    })
-
-    it('should trigger ConsultArtist log when pressing artist button', async () => {
-      renderArtistPlaylistModule({
-        data: { playlistItems: mockHitsItems, nbPlaylistResults: 10, moduleId: 'fakeModuleId' },
-        artistId: mockArtist.id,
-      })
-
-      await user.press(await screen.findByLabelText('Accéder à la page artiste de Avril Lavigne'))
-
-      expect(analytics.logConsultArtist).toHaveBeenCalledWith({
-        artistId: mockArtist.id,
-        artistName: mockArtist.name,
-        from: 'home',
-        originDetails: 'artistRecommendation',
-      })
     })
   })
 

--- a/src/features/home/components/modules/ArtistPlaylistModule.native.test.tsx
+++ b/src/features/home/components/modules/ArtistPlaylistModule.native.test.tsx
@@ -172,7 +172,7 @@ describe('ArtistPlaylistModule', () => {
         })
       })
 
-      it('should trigger logEvent "ModuleDisplayedOnHomepage" when shouldModuleBeDisplayed is true and route is Home', async () => {
+      it('should trigger logEvent "ModuleDisplayedOnHomepage" when shouldModuleBeDisplayed is true', async () => {
         renderArtistPlaylistModule()
 
         await screen.findByLabelText('Module title')
@@ -185,6 +185,26 @@ describe('ArtistPlaylistModule', () => {
           index: props.index,
           homeEntryId: props.homeEntryId,
           offers: ['102280', '102272'],
+        })
+      })
+    })
+
+    describe('When route is Artist', () => {
+      beforeEach(() => {
+        useRoute.mockReturnValue({
+          name: 'Artist',
+        })
+      })
+
+      it('should trigger logEvent "ModuleDisplayed" when shouldModuleBeDisplayed is true', async () => {
+        renderArtistPlaylistModule()
+
+        await screen.findByLabelText('Module title')
+
+        expect(analytics.logModuleDisplayed).toHaveBeenNthCalledWith(1, {
+          artistId: mockArtist.id,
+          displayedOn: 'artist',
+          moduleId: props.moduleId,
         })
       })
     })

--- a/src/features/home/components/modules/ArtistPlaylistModule.native.test.tsx
+++ b/src/features/home/components/modules/ArtistPlaylistModule.native.test.tsx
@@ -2,7 +2,7 @@ import mockdate from 'mockdate'
 import React from 'react'
 import { NativeScrollEvent, NativeSyntheticEvent } from 'react-native'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { navigate, useRoute } from '__mocks__/@react-navigation/native'
 import { api } from 'api/api'
 import { mockArtist } from 'features/artist/fixtures/mockArtist'
 import {
@@ -165,19 +165,27 @@ describe('ArtistPlaylistModule', () => {
       expect(analytics.logAllTilesSeen).toHaveBeenCalledTimes(1)
     })
 
-    it('should trigger logEvent "ModuleDisplayedOnHomepage" when shouldModuleBeDisplayed is true', async () => {
-      renderArtistPlaylistModule()
+    describe('When route is Home', () => {
+      beforeEach(() => {
+        useRoute.mockReturnValue({
+          name: 'Home',
+        })
+      })
 
-      await screen.findByLabelText('Module title')
+      it('should trigger logEvent "ModuleDisplayedOnHomepage" when shouldModuleBeDisplayed is true and route is Home', async () => {
+        renderArtistPlaylistModule()
 
-      expect(analytics.logModuleDisplayedOnHomepage).toHaveBeenNthCalledWith(1, {
-        call_id: undefined,
-        hybridModuleOffsetIndex: undefined,
-        moduleId: props.moduleId,
-        moduleType: ContentTypes.ARTIST_PLAYLIST,
-        index: props.index,
-        homeEntryId: props.homeEntryId,
-        offers: ['102280', '102272'],
+        await screen.findByLabelText('Module title')
+
+        expect(analytics.logModuleDisplayedOnHomepage).toHaveBeenNthCalledWith(1, {
+          call_id: undefined,
+          hybridModuleOffsetIndex: undefined,
+          moduleId: props.moduleId,
+          moduleType: ContentTypes.ARTIST_PLAYLIST,
+          index: props.index,
+          homeEntryId: props.homeEntryId,
+          offers: ['102280', '102272'],
+        })
       })
     })
 

--- a/src/features/home/components/modules/ArtistPlaylistModule.tsx
+++ b/src/features/home/components/modules/ArtistPlaylistModule.tsx
@@ -81,7 +81,7 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
   }
   const searchTabConfig = getSearchPropConfig('SearchResults', searchParams)
 
-  const moduleName = displayParameters.title ?? parameters?.title
+  const moduleName = displayParameters.title
 
   const logHasSeenAllTilesOnce = useFunctionOnce(() =>
     analytics.logAllTilesSeen({
@@ -123,7 +123,7 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
     !isArtistLoading &&
     !hasArtistError
 
-  useEffect(() => {
+  const triggerLogModuleDisplayedOnHomepage = useCallback(() => {
     if (shouldModuleBeDisplayed) {
       void analytics.logModuleDisplayedOnHomepage({
         moduleId,
@@ -134,6 +134,10 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
       })
     }
   }, [homeEntryId, index, moduleId, playlistItems, shouldModuleBeDisplayed])
+
+  useEffect(() => {
+    triggerLogModuleDisplayedOnHomepage()
+  }, [triggerLogModuleDisplayedOnHomepage])
 
   if (!shouldModuleBeDisplayed) return null
 
@@ -152,10 +156,10 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
     },
   }
 
-  const onArtistPress = (artistId: string, artistName: string) => {
+  const onArtistPress = (id: string, name: string) => {
     void analytics.logConsultArtist({
-      artistId,
-      artistName,
+      artistId: id,
+      artistName: name,
       from: 'home',
       originDetails: 'artistRecommendation',
     })

--- a/src/features/home/components/modules/ArtistPlaylistModule.tsx
+++ b/src/features/home/components/modules/ArtistPlaylistModule.tsx
@@ -8,6 +8,7 @@ import {
   ModuleData,
   ArtistPlaylistModule as ArtistPlaylistModuleType,
 } from 'features/home/types'
+import { Referrals } from 'features/navigation/navigators/RootNavigator/types'
 import { getSearchPropConfig } from 'features/navigation/navigators/SearchStackNavigator/getSearchPropConfig'
 import { OfferTileWrapper } from 'features/offer/components/OfferTile/OfferTileWrapper'
 import { useAdaptOffersPlaylistParameters } from 'libs/algolia/fetchAlgolia/fetchMultipleOffers/helpers/useAdaptOffersPlaylistParameters'
@@ -61,6 +62,7 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
   const route = useRoute()
   const isHomeScreen = route.name === 'Home'
   const isArtistScreen = route.name === 'Artist'
+  const from: Referrals = isArtistScreen ? 'artist' : 'home'
 
   const { designSystem } = useTheme()
   const adaptedPlaylistParameters = useAdaptOffersPlaylistParameters()
@@ -97,7 +99,7 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
   )
 
   const onBeforeNavigate = () =>
-    analytics.logClickSeeAll({ type: 'offers', moduleName, moduleId, from: 'home' })
+    analytics.logClickSeeAll({ type: 'offers', moduleName, moduleId, from })
 
   const renderItem: CustomListRenderItem<Offer> = useCallback(
     ({ item, width, height }) => {
@@ -111,13 +113,13 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
           originDetails="artistRecommendation"
           width={width}
           height={height}
-          analyticsFrom="home"
+          analyticsFrom={from}
           hasSmallLayout
         />
       )
     },
 
-    [moduleName, moduleId, homeEntryId, artist?.name]
+    [moduleName, moduleId, homeEntryId, artist?.name, from]
   )
 
   const { itemWidth, itemHeight } = getPlaylistItemDimensionsFromLayout('three-items')
@@ -180,7 +182,7 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
     void analytics.logConsultArtist({
       artistId: id,
       artistName: name,
-      from: 'home',
+      from,
       originDetails: 'artistRecommendation',
     })
   }

--- a/src/features/home/components/modules/ArtistPlaylistModule.tsx
+++ b/src/features/home/components/modules/ArtistPlaylistModule.tsx
@@ -140,9 +140,24 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
     }
   }, [homeEntryId, index, isHomeScreen, moduleId, playlistItems, shouldModuleBeDisplayed])
 
-  useEffect(() => {
+  const triggerModuleDisplayed = useCallback(() => {
+    if (shouldModuleBeDisplayed && isArtistScreen) {
+      void analytics.logModuleDisplayed({
+        moduleId,
+        displayedOn: 'artist',
+        artistId,
+      })
+    }
+  }, [artistId, isArtistScreen, moduleId, shouldModuleBeDisplayed])
+
+  const triggerModuleBeDisplayed = useCallback(() => {
     triggerLogModuleDisplayedOnHomepage()
-  }, [triggerLogModuleDisplayedOnHomepage])
+    triggerModuleDisplayed()
+  }, [triggerLogModuleDisplayedOnHomepage, triggerModuleDisplayed])
+
+  useEffect(() => {
+    triggerModuleBeDisplayed()
+  }, [triggerModuleBeDisplayed])
 
   if (!shouldModuleBeDisplayed) return null
 

--- a/src/features/home/components/modules/ArtistPlaylistModule.tsx
+++ b/src/features/home/components/modules/ArtistPlaylistModule.tsx
@@ -1,3 +1,4 @@
+import { useRoute } from '@react-navigation/native'
 import React, { useCallback, useEffect } from 'react'
 import { Platform, ViewToken } from 'react-native'
 import { styled, useTheme } from 'styled-components/native'
@@ -57,6 +58,10 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
     onViewableItemsChanged,
     disableArtistNavigation,
   } = props
+  const route = useRoute()
+  const isHomeScreen = route.name === 'Home'
+  const isArtistScreen = route.name === 'Artist'
+
   const { designSystem } = useTheme()
   const adaptedPlaylistParameters = useAdaptOffersPlaylistParameters()
   const {
@@ -124,7 +129,7 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
     !hasArtistError
 
   const triggerLogModuleDisplayedOnHomepage = useCallback(() => {
-    if (shouldModuleBeDisplayed) {
+    if (shouldModuleBeDisplayed && isHomeScreen) {
       void analytics.logModuleDisplayedOnHomepage({
         moduleId,
         moduleType: ContentTypes.ARTIST_PLAYLIST,
@@ -133,7 +138,7 @@ export const ArtistPlaylistModule = (props: ArtistPlaylistModuleProps) => {
         offers: (playlistItems as Offer[]).map((item) => item.objectID),
       })
     }
-  }, [homeEntryId, index, moduleId, playlistItems, shouldModuleBeDisplayed])
+  }, [homeEntryId, index, isHomeScreen, moduleId, playlistItems, shouldModuleBeDisplayed])
 
   useEffect(() => {
     triggerLogModuleDisplayedOnHomepage()

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -507,8 +507,12 @@ export const logEventAnalytics = {
     analytics.logEvent({ firebase: AnalyticsEvent.LOGIN_CLICKED }, params),
   logLogout: () => analytics.logEvent({ firebase: AnalyticsEvent.LOGOUT }),
   logModifyMail: () => analytics.logEvent({ firebase: AnalyticsEvent.MODIFY_MAIL }),
-  logModuleDisplayed: (params: { moduleId: string; displayedOn: Referrals; venueId?: number }) =>
-    analytics.logEvent({ firebase: AnalyticsEvent.MODULE_DISPLAYED }, params),
+  logModuleDisplayed: (params: {
+    moduleId: string
+    displayedOn: Referrals
+    venueId?: number
+    artistId?: string
+  }) => analytics.logEvent({ firebase: AnalyticsEvent.MODULE_DISPLAYED }, params),
   logModuleDisplayedOnHomepage: (params: {
     moduleId: string
     moduleType: ContentTypes


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-43500

## Context
Le tracking n'était pas cohérent depuis l'ajout du module `ArtistPlaylist` sur la page artiste. 
Cette PR permet d'avoir un param `from` cohérent suivant la page dans laquelle il est utilisé (home ou artiste).
De plus, le log `ModuleDisplayedOnHomepage` est uniquement déclenché depuis la home et le log `ModuleDisplayed` depuis la page artiste.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the [best practices][3] and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
[3]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/development/best-practices.md
